### PR TITLE
Rename: IndexFunction -> Indexer

### DIFF
--- a/doc/index-querying.md
+++ b/doc/index-querying.md
@@ -37,7 +37,7 @@ An index is typed to aid in querying. Currently there are two types:
 
 #### Defining an index
 
-The `FieldIndexFunction` class allows indexing a document by a top-level
+The `FieldIndexer` class allows indexing a document by a top-level
 field (those existing at the root of the JSON document).
 
 We'll use this document as our example:
@@ -59,7 +59,7 @@ class is also used for queries. It's simple to create:
 IndexManager indexManager = new IndexManager(datastore);
 ```
 
-To create an index on the `firstname` field using the `FieldIndexFunction`,
+To create an index on the `firstname` field using the `FieldIndexer`,
 we define the index using:
 
 ```java
@@ -76,7 +76,7 @@ themselves are persisted to disk and updated incrementally -- the
 `IndexManager` just needs to be told about them at startup time.
 
 `ensureIndexed(String name, String field)` is a convienience method to
-create an index using a `FieldIndexFunction` on the defined field that
+create an index using a `FieldIndexer` on the defined field that
 is of type `IndexType.STRING`. A longer form is used for using your
 own indexing functions, see below.
 
@@ -141,23 +141,23 @@ for (DocumentRevision revision : result) {
 
 ### Index Functions
 
-As noted above, an index uses an `IndexFunction` instance to map a
+As noted above, an index uses an `Indexer` instance to map a
 document to the values that should be indexed for the document. The
-`IndexFunction` interface defines a single function:
+`Indexer` interface defines a single function:
 
 ```java
 public List<Object> indexedValues(String indexName, Map map);
 ```
 
-For example, the included `FieldIndexFunction` used earlier is
+For example, the included `FieldIndexer` used earlier is
 defined as:
 
 ```java
-public class FieldIndexFunction implements IndexFunction<Object> {
+public class FieldIndexer implements Indexer<Object> {
 
     private String fieldName;
 
-    public FieldIndexFunction(String fieldName) {
+    public FieldIndexer(String fieldName) {
         this.fieldName = fieldName;
     }
 
@@ -176,7 +176,7 @@ The longer form of the `ensureIndexed` function allows you to provide
 your own index function:
 
 ```java
-public void ensureIndexed(String indexName, IndexType type, IndexFunction indexFunction)
+public void ensureIndexed(String indexName, IndexType type, Indexer Indexer)
             throws IndexExistsException
 ```
 
@@ -184,7 +184,7 @@ For example, to use this long form to define the field index on `firstname`
 used earlier:
 
 ```java
-FieldIndexFunction f = new FieldIndexFunction("firstname");
+FieldIndexer f = new FieldIndexer("firstname");
 indexManager.ensureIndexed("default", IndexType.STRING, f);
 ```
 
@@ -231,7 +231,7 @@ Assume all the songs are in the following format:
 
 ```
 
-First build the indexes on "album" and "artist" using the `FieldIndexFunction`:
+First build the indexes on "album" and "artist" using the `FieldIndexer`:
 
 
 ```java
@@ -257,6 +257,6 @@ for (DocumentRevision revision : result) {
 //   Viva la Vida
 ```
 
-Note that `FieldIndexFunction` doesn't transform the values, so queries
+Note that `FieldIndexer` doesn't transform the values, so queries
 need to use the exact term and case (e.g., you can't use "coldplay" or
 "cold").

--- a/src/main/java/com/cloudant/sync/indexing/FieldIndexer.java
+++ b/src/main/java/com/cloudant/sync/indexing/FieldIndexer.java
@@ -20,7 +20,7 @@ import java.util.Map;
 
 /**
  * <p>
- * FieldIndexFunction is a simple {@link IndexFunction} which extracts
+ * FieldIndexer is a simple {@link Indexer} which extracts
  * values from a document based on the fieldName given to it.
  * </p>
  * <p>
@@ -39,15 +39,15 @@ import java.util.Map;
  * {@code indexedValues} will return ["world"]. For "foo", it
  * will return ["bar", "baz"].
  */
-public class FieldIndexFunction implements IndexFunction<Object> {
+public class FieldIndexer implements Indexer<Object> {
 
     private String fieldName;
 
     /**
-     * Creates a {@code FieldIndexFunction} object that will return the
+     * Creates a {@code FieldIndexer} object that will return the
      * value for {@code fieldName}.
      */
-    public FieldIndexFunction(String fieldName) {
+    public FieldIndexer(String fieldName) {
         this.fieldName = fieldName;
     }
 

--- a/src/main/java/com/cloudant/sync/indexing/Index.java
+++ b/src/main/java/com/cloudant/sync/indexing/Index.java
@@ -20,7 +20,7 @@ package com.cloudant.sync.indexing;
  * to list of values, and then you can query over them efficiently.
  * </p>
  * <p>
- * The mapping is defined using {@link IndexFunction}. {@code IndexFunction}
+ * The mapping is defined using {@link Indexer}. {@code Indexer}
  * returns a list of {@code Object}. The type of these object must be supported
  * by {@link IndexType}
  * </p>
@@ -29,7 +29,7 @@ package com.cloudant.sync.indexing;
  * </p>
  *
  * @see IndexManager
- * @see IndexFunction
+ * @see Indexer
  * @see IndexType
  * @see com.cloudant.sync.datastore.Datastore
  */

--- a/src/main/java/com/cloudant/sync/indexing/Indexer.java
+++ b/src/main/java/com/cloudant/sync/indexing/Indexer.java
@@ -19,7 +19,7 @@ import java.util.Map;
 
 /**
  * <p>
- * This interface defines the IndexFunction object used to
+ * This interface defines the Indexer object used to
  * map from document to indexed values by the
  * {@link IndexManager} object.
  * </p>
@@ -30,10 +30,10 @@ import java.util.Map;
  * </p>
  *
  * <p>
- * For an example, see {@link FieldIndexFunction}.
+ * For an example, see {@link FieldIndexer}.
  * </p>
  */
-public interface IndexFunction<T> {
+public interface Indexer<T> {
 
     /**
      * <p>

--- a/src/test/java/com/cloudant/sync/indexing/FieldIndexerTest.java
+++ b/src/test/java/com/cloudant/sync/indexing/FieldIndexerTest.java
@@ -25,11 +25,11 @@ import java.util.HashMap;
 import java.util.Map;
 
 @RunWith(JUnit4.class)
-public class FieldIndexFunctionTest {
+public class FieldIndexerTest {
 
     @Test
     public void constructor() {
-        FieldIndexFunction fif = new FieldIndexFunction("FieldName");
+        FieldIndexer fif = new FieldIndexer("FieldName");
         Assert.assertNotNull(fif);
     }
 
@@ -38,7 +38,7 @@ public class FieldIndexFunctionTest {
         String fieldName = "FieldName";
         String expected = "an expected value";
 
-        FieldIndexFunction fif = new FieldIndexFunction(fieldName);
+        FieldIndexer fif = new FieldIndexer(fieldName);
 
         Map map = new HashMap<String, String>();
         map.put("hello", "world");
@@ -69,7 +69,7 @@ public class FieldIndexFunctionTest {
 
     private void assertFieldExtractionWorks(Object expected) {
         String fieldName = "simple_field_string";
-        FieldIndexFunction fif = new FieldIndexFunction(fieldName);
+        FieldIndexer fif = new FieldIndexer(fieldName);
         Map map = new HashMap<String, String>();
         map.put(fieldName, expected);
         Assert.assertEquals(Arrays.asList(expected), fif.indexedValues("null", map));

--- a/src/test/java/com/cloudant/sync/indexing/IndexManagerIndexTest.java
+++ b/src/test/java/com/cloudant/sync/indexing/IndexManagerIndexTest.java
@@ -213,7 +213,7 @@ public class IndexManagerIndexTest {
         DocumentRevision obj1 = datastore.createDocument(dbBodies.get(1));
         DocumentRevision obj2 = datastore.createDocument(dbBodies.get(2));
 
-        final class TestIF implements IndexFunction<String> {
+        final class TestIF implements Indexer<String> {
             public List<String> indexedValues(String indexName, Map map) {
                 return Arrays.asList("fred");
             }
@@ -239,7 +239,7 @@ public class IndexManagerIndexTest {
         DocumentRevision obj1 = datastore.createDocument(dbBodies.get(1));
         DocumentRevision obj2 = datastore.createDocument(dbBodies.get(2));
 
-        final class TestIF implements IndexFunction<String> {
+        final class TestIF implements Indexer<String> {
             public List<String> indexedValues(String indexName, Map map) {
                 return null;
             }


### PR DESCRIPTION
To be consistent with iOS code, rename "IndexFunction" -> "Indexer". There are no functionality changes. 

https://cloudant.fogbugz.com/f/cases/27972/Change-indexFunction-to-indexer
