### PR TITLE
Add library version and os info to user agent String

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -149,3 +149,10 @@ task listJars << {
     configurations.testCompile.each { File file -> println file.name }
 }
 
+//for Ant filter for "processResources" task
+import org.apache.tools.ant.filters.ReplaceTokens
+processResources {
+    filter ReplaceTokens, tokens: [
+            "version": project.version
+    ]
+}

--- a/src/main/java/com/cloudant/mazha/CouchConfig.java
+++ b/src/main/java/com/cloudant/mazha/CouchConfig.java
@@ -25,8 +25,6 @@ import java.net.URISyntaxException;
 
 public class CouchConfig {
 
-    private static final String user_agent = "Cloudant Sync";
-
     private static final String couchdb_protocol = "http";
     private static final String couchdb_host= "127.0.0.1";
     private static final int couchdb_port = 5984;
@@ -39,9 +37,6 @@ public class CouchConfig {
 	private final int port;
 	private final String username;
 	private final String password;
-
-	// optional
-    private String userAgent = user_agent;
 
     // Timeout to wait for a response, in milliseconds. Defaults to 0 (no timeout).
 	private int socketTimeout = 30000;
@@ -104,14 +99,6 @@ public class CouchConfig {
 		this.username = username;
 		this.password = password;
 	}
-
-    public String getUserAgent() {
-        return userAgent;
-    }
-
-    public void setUserAgent(String ua) {
-        this.userAgent = ua;
-    }
 
     public String getProtocol() {
 		return protocol;

--- a/src/main/java/com/cloudant/sync/util/Misc.java
+++ b/src/main/java/com/cloudant/sync/util/Misc.java
@@ -14,6 +14,8 @@
 
 package com.cloudant.sync.util;
 
+import android.os.Build;
+
 import java.util.UUID;
 
 /**
@@ -30,5 +32,9 @@ public class Misc {
     public static boolean isRunningOnAndroid() {
         String javaRuntime = System.getProperty("java.runtime.name", "");
         return javaRuntime.toLowerCase().contains(ANDROID_RUNTIME);
+    }
+
+    public static String androidVersion() {
+        return String.format("Android %s %s", Build.VERSION.CODENAME, Build.VERSION.SDK_INT);
     }
 }

--- a/src/main/resources/mazha.properties
+++ b/src/main/resources/mazha.properties
@@ -1,0 +1,1 @@
+user.agent=CloudantSync/@version@


### PR DESCRIPTION
To help debug from the server side,  library version and device/os
info are added to user agent. The user agent is used for all the
http requests issued by HttpRequests.

The basic user agent is defined in properties file as:
user.agent=CloudantSync/@version@, where "@version@" replaced by
current build version in build.

The android version (if running on android) or desktop os info
are also appended to the user agent string.
