### PR TITLE
Do not allow empty SQL as input for SQLDatabase.execSQL()

### DIFF
--- a/src/main/java/com/cloudant/sync/datastore/DatastoreConstants.java
+++ b/src/main/java/com/cloudant/sync/datastore/DatastoreConstants.java
@@ -41,11 +41,11 @@ class DatastoreConstants {
     // First-time initialization:
     // (Note: Declaring revs.sequence as AUTOINCREMENT means the values will always be
     // monotonically increasing, never reused. See <http://www.sqlite4java.org/autoinc.html>)
-    public static final String SCHEMA_VERSION_3 =
+    public static final String[] SCHEMA_VERSION_3 = {
             "    CREATE TABLE docs ( " +
             "        doc_id INTEGER PRIMARY KEY, " +
-            "        docid TEXT UNIQUE NOT NULL); " +
-            "    CREATE INDEX docs_docid ON docs(docid); " +
+            "        docid TEXT UNIQUE NOT NULL); ",
+            "    CREATE INDEX docs_docid ON docs(docid); ",
             "    CREATE TABLE revs ( " +
             "        sequence INTEGER PRIMARY KEY AUTOINCREMENT, " +
             "        doc_id INTEGER NOT NULL REFERENCES docs(doc_id) ON DELETE CASCADE, " +
@@ -54,58 +54,59 @@ class DatastoreConstants {
             "        deleted BOOLEAN DEFAULT 0, " +
             "        available BOOLEAN DEFAULT 1, " +
             "        revid TEXT NOT NULL, " +
-            "        json BLOB); " +
-            "    CREATE INDEX revs_by_id ON revs(revid, doc_id); " +
-            "    CREATE INDEX revs_current ON revs(doc_id, current); " +
-            "    CREATE INDEX revs_parent ON revs(parent); " +
+            "        json BLOB); ",
+            "    CREATE INDEX revs_by_id ON revs(revid, doc_id); ",
+            "    CREATE INDEX revs_current ON revs(doc_id, current); ",
+            "    CREATE INDEX revs_parent ON revs(parent); ",
             "    CREATE TABLE localdocs ( " +
             "        docid TEXT UNIQUE NOT NULL, " +
             "        revid TEXT NOT NULL, " +
-            "        json BLOB); " +
-            "    CREATE INDEX localdocs_by_docid ON localdocs(docid); " +
+            "        json BLOB); ",
+            "    CREATE INDEX localdocs_by_docid ON localdocs(docid); ",
             "    CREATE TABLE views ( " +
             "        view_id INTEGER PRIMARY KEY, " +
             "        name TEXT UNIQUE NOT NULL," +
             "        version TEXT, " +
-            "        lastsequence INTEGER DEFAULT 0); " +
-            "    CREATE INDEX views_by_name ON views(name); " +
+            "        lastsequence INTEGER DEFAULT 0); ",
+            "    CREATE INDEX views_by_name ON views(name); ",
             "    CREATE TABLE maps ( " +
             "        view_id INTEGER NOT NULL REFERENCES views(view_id) ON DELETE CASCADE, " +
             "        sequence INTEGER NOT NULL REFERENCES revs(sequence) ON DELETE CASCADE, " +
             "        key TEXT NOT NULL, " +
             "        collation_key BLOB NOT NULL, " +
-            "        value TEXT); " +
-            "    CREATE INDEX maps_keys on maps(view_id, collation_key); " +
+            "        value TEXT); ",
+            "    CREATE INDEX maps_keys on maps(view_id, collation_key); ",
             "    CREATE TABLE attachments ( " +
             "        sequence INTEGER NOT NULL REFERENCES revs(sequence) ON DELETE CASCADE, " +
             "        filename TEXT NOT NULL, " +
             "        key BLOB NOT NULL, " +
             "        type TEXT, " +
             "        length INTEGER NOT NULL, " +
-            "        revpos INTEGER DEFAULT 0); " +
-            "    CREATE INDEX attachments_by_sequence on attachments(sequence, filename); " +
+            "        revpos INTEGER DEFAULT 0); ",
+            "    CREATE INDEX attachments_by_sequence on attachments(sequence, filename); ",
             "    CREATE TABLE replicators ( " +
             "        remote TEXT NOT NULL, " +
             "        startPush BOOLEAN, " +
             "        last_sequence TEXT, " +
-            "        UNIQUE (remote, startPush)); ";
+            "        UNIQUE (remote, startPush)); " };
 
-    private static final String SCHEMA_VERSION_4 =
+    private static final String[] SCHEMA_VERSION_4 = {
             "CREATE TABLE info ( " +
             "    key TEXT PRIMARY KEY, " +
-            "    value TEXT); " +
-            "INSERT INTO INFO (key, value) VALUES ('privateUUID', '%s'); " +
-            "INSERT INTO INFO (key, value) VALUES ('publicUUID',  '%s'); ";
+            "    value TEXT); ",
+            "INSERT INTO INFO (key, value) VALUES ('privateUUID', '%s'); ",
+            "INSERT INTO INFO (key, value) VALUES ('publicUUID',  '%s'); " };
 
     /**
      * Returns SCHEMA_VERSION_4 with new UUIDs
+     *
      * @return SCHEMA_VERSION_4 with new UUIDs
      */
-    public static String getSCHEMA_VERSION_4() {
-        return String.format(
-            DatastoreConstants.SCHEMA_VERSION_4,
-            Misc.createUUID(),
-            Misc.createUUID()
-        );
+    public static String[] getSCHEMA_VERSION_4() {
+        String[] result = new String[SCHEMA_VERSION_4.length];
+        result[0] = SCHEMA_VERSION_4[0];
+        result[1] = String.format(SCHEMA_VERSION_4[1], Misc.createUUID()) ;
+        result[2] = String.format(SCHEMA_VERSION_4[2], Misc.createUUID()) ;
+        return result;
     }
 }

--- a/src/main/java/com/cloudant/sync/indexing/IndexManager.java
+++ b/src/main/java/com/cloudant/sync/indexing/IndexManager.java
@@ -78,11 +78,11 @@ public class IndexManager {
     private static final Pattern pattern = Pattern.compile(INDEX_FIELD_NAME_PATTERN);
 
     public static final int VERSION = 1;
-    public static final String SCHEMA_INDEX =
+    public static final String[] SCHEMA_INDEX = {
             "CREATE TABLE _t_cloudant_sync_indexes_metadata ( " +
                     "        name TEXT NOT NULL, " +       // name of the index
                     "        type TEXT NOT NULL, " +
-                    "        last_sequence INTEGER NOT NULL); ";
+                    "        last_sequence INTEGER NOT NULL); " };
 
     private static final String SQL_SELECT_UNIQUE = "SELECT DISTINCT value FROM %s";
 

--- a/src/main/java/com/cloudant/sync/sqlite/SQLDatabaseFactory.java
+++ b/src/main/java/com/cloudant/sync/sqlite/SQLDatabaseFactory.java
@@ -21,6 +21,7 @@ import com.cloudant.sync.sqlite.android.AndroidSQLite;
 import com.cloudant.sync.sqlite.sqlite4java.SQLiteWrapper;
 import com.cloudant.sync.util.Misc;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 
 import java.io.File;
 import java.io.IOException;
@@ -71,7 +72,7 @@ public class SQLDatabaseFactory {
      *
      * @see com.cloudant.sync.sqlite.SQLDatabase#getVersion()
      */
-    public static void updateSchema(SQLDatabase database, String schema, int version)
+    public static void updateSchema(SQLDatabase database, String[] schema, int version)
             throws SQLException {
         Preconditions.checkArgument(version > 0, "Schema version number must be positive");
 
@@ -84,11 +85,11 @@ public class SQLDatabaseFactory {
         }
     }
 
-    private static int executeStatements(SQLDatabase database, String statements, int version)
+    private static int executeStatements(SQLDatabase database, String[] statements, int version)
             throws SQLException {
         try {
             database.beginTransaction();
-            for (String statement : statements.split(";")) {
+            for (String statement : statements) {
                 database.execSQL(statement);
             }
             database.execSQL("PRAGMA user_version = " + version + ";");

--- a/src/main/java/com/cloudant/sync/sqlite/android/AndroidSQLite.java
+++ b/src/main/java/com/cloudant/sync/sqlite/android/AndroidSQLite.java
@@ -18,6 +18,8 @@ import android.database.sqlite.SQLiteDatabase;
 import com.cloudant.sync.sqlite.ContentValues;
 import com.cloudant.sync.sqlite.Cursor;
 import com.cloudant.sync.sqlite.SQLDatabase;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 
 import java.sql.SQLException;
 
@@ -71,11 +73,15 @@ public class AndroidSQLite implements SQLDatabase {
 
     @Override
     public void execSQL(String sql) throws SQLException {
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(sql.trim()),
+                "Input SQL can not be empty String.");
         this.database.execSQL(sql);
     }
 
     @Override
     public void execSQL(String sql, Object[] bindArgs) throws SQLException {
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(sql.trim()),
+                "Input SQL can not be empty String.");
         this.database.execSQL(sql, bindArgs);
     }
 

--- a/src/main/java/com/cloudant/sync/sqlite/sqlite4java/SQLiteWrapper.java
+++ b/src/main/java/com/cloudant/sync/sqlite/sqlite4java/SQLiteWrapper.java
@@ -231,9 +231,11 @@ public class SQLiteWrapper implements SQLDatabase {
     }
 
     @Override
-    public void execSQL(String statement) throws SQLException {
+    public void execSQL(String sql) throws SQLException {
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(sql.trim()),
+                "Input SQL can not be empty String.");
         try {
-            getConnection().exec(statement);
+            getConnection().exec(sql);
         } catch (SQLiteException e) {
             throw new SQLException(e);
         }
@@ -241,6 +243,8 @@ public class SQLiteWrapper implements SQLDatabase {
 
     @Override
     public void execSQL(String sql, Object[] bindArgs) throws SQLException {
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(sql.trim()),
+                "Input SQL can not be empty String.");
         SQLiteStatement stmt = null;
         try {
             stmt = this.getConnection().prepare(sql);

--- a/src/test/java/com/cloudant/sync/datastore/SQLDatabaseFactoryTest.java
+++ b/src/test/java/com/cloudant/sync/datastore/SQLDatabaseFactoryTest.java
@@ -33,25 +33,25 @@ public class SQLDatabaseFactoryTest {
     String database_dir;
     private String database_file = "database_initializer_test";
 
-    String SCHEMA_1 =
+    String[] SCHEMA_1 = {
             "    CREATE TABLE person ( " +
             "        id INTEGER PRIMARY KEY, " +
-            "        name TEXT UNIQUE NOT NULL); " +
-            "    CREATE INDEX person_id ON person(id); " +
+            "        name TEXT UNIQUE NOT NULL); ",
+            "    CREATE INDEX person_id ON person(id); ",
             "    CREATE TABLE address ( " +
             "        id INTEGER PRIMARY KEY AUTOINCREMENT, " +
             "        person INTEGER NOT NULL REFERENCES person(id) ON DELETE CASCADE, " +
-            "        address TEXT NOT NULL); " +
-            "    CREATE INDEX address_id ON address(id); " +
-            "    CREATE INDEX address_person ON address(person); " +
-            "    PRAGMA user_version = 1";
+            "        address TEXT NOT NULL); ",
+            "    CREATE INDEX address_id ON address(id); ",
+            "    CREATE INDEX address_person ON address(person); ",
+            "    PRAGMA user_version = 1" };
 
 
-    String SCHEMA_2 =
+    String[] SCHEMA_2 = {
             "    CREATE TABLE email ( " +
             "        person INTEGER PRIMARY KEY REFERENCES person(id), " +
-            "        email TEXT UNIQUE NOT NULL); " +
-            "    PRAGMA user_version = 2";
+            "        email TEXT UNIQUE NOT NULL); ",
+            "    PRAGMA user_version = 2" };
 
     SQLiteWrapper database = null;
 

--- a/src/test/java/com/cloudant/sync/sqlite/sqlite4java/SQLiteWrapperTest.java
+++ b/src/test/java/com/cloudant/sync/sqlite/sqlite4java/SQLiteWrapperTest.java
@@ -420,7 +420,10 @@ public class SQLiteWrapperTest {
         SQLDatabaseTestUtils.assertTablesExist(this.database, "docs", "revs");
     }
 
-
+    @Test(expected = IllegalArgumentException.class)
+    public void execSQL_emptySQL_exception() throws SQLException {
+        database.execSQL(" ");
+    }
 
     @Test
     public void execSQL_someCreateTablesStatements_NA() throws Exception {


### PR DESCRIPTION
A issue is reported here: https://github.com/cloudant/sync-android/issues/7 was caused empty "String" is used as input for "SQLdatabase.execSQL()". To fix the issue:

1  In, "SQLDatabaseFactory.executeStatements()", empty SQL String will be skipped. 
2 In both "AndroidSQLite" (on Android) and "SQLiteWrapper", non-empty String is a pre-condition now. 
