### PR TITLE
27990 Filtered Pull Replication (step two)

### DIFF
--- a/fixture/animaldb/animaldb_animal0.json
+++ b/fixture/animaldb/animaldb_animal0.json
@@ -1,0 +1,10 @@
+{
+   "_id": "zebra",
+   "wiki_page": "http://en.wikipedia.org/wiki/Plains_zebra",
+   "min_length": 2,
+   "max_length": 2.5,
+   "min_weight": 175,
+   "max_weight": 387,
+   "class": "mammal",
+   "diet": "herbivore"
+}

--- a/fixture/animaldb/animaldb_animal1.json
+++ b/fixture/animaldb/animaldb_animal1.json
@@ -1,0 +1,11 @@
+{
+   "_id": "aardvark",
+   "min_weight": 40,
+   "max_weight": 65,
+   "min_length": 1,
+   "max_length": 2.2,
+   "latin_name": "Orycteropus afer",
+   "wiki_page": "http://en.wikipedia.org/wiki/Aardvark",
+   "class": "mammal",
+   "diet": "omnivore"
+}

--- a/fixture/animaldb/animaldb_animal2.json
+++ b/fixture/animaldb/animaldb_animal2.json
@@ -1,0 +1,11 @@
+{
+   "_id": "badger",
+   "wiki_page": "http://en.wikipedia.org/wiki/Badger",
+   "min_weight": 7,
+   "max_weight": 30,
+   "min_length": 0.6,
+   "max_length": 0.9,
+   "latin_name": "Meles meles",
+   "class": "mammal",
+   "diet": "omnivore"
+}

--- a/fixture/animaldb/animaldb_animal3.json
+++ b/fixture/animaldb/animaldb_animal3.json
@@ -1,0 +1,10 @@
+{
+   "_id": "elephant",
+   "wiki_page": "http://en.wikipedia.org/wiki/African_elephant",
+   "min_weight": 4700,
+   "max_weight": 6050,
+   "min_length": 3.2,
+   "max_length": 4,
+   "class": "mammal",
+   "diet": "herbivore"
+}

--- a/fixture/animaldb/animaldb_animal4.json
+++ b/fixture/animaldb/animaldb_animal4.json
@@ -1,0 +1,10 @@
+{
+   "_id": "giraffe",
+   "min_weight": 830,
+   "min_length": 5,
+   "max_weight": 1600,
+   "max_length": 6,
+   "wiki_page": "http://en.wikipedia.org/wiki/Giraffe",
+   "class": "mammal",
+   "diet": "herbivore"
+}

--- a/fixture/animaldb/animaldb_animal5.json
+++ b/fixture/animaldb/animaldb_animal5.json
@@ -1,0 +1,9 @@
+{
+   "_id": "kookaburra",
+   "min_length": 0.28,
+   "max_length": 0.42,
+   "wiki_page": "http://en.wikipedia.org/wiki/Kookaburra",
+   "class": "bird",
+   "diet": "carnivore",
+   "latin_name": "Dacelo novaeguineae"
+}

--- a/fixture/animaldb/animaldb_animal6.json
+++ b/fixture/animaldb/animaldb_animal6.json
@@ -1,0 +1,10 @@
+{
+   "_id": "lemur",
+   "wiki_page": "http://en.wikipedia.org/wiki/Ring-tailed_lemur",
+   "min_weight": 2.2,
+   "max_weight": 2.2,
+   "min_length": 0.95,
+   "max_length": 1.1,
+   "class": "mammal",
+   "diet": "omnivore"
+}

--- a/fixture/animaldb/animaldb_animal7.json
+++ b/fixture/animaldb/animaldb_animal7.json
@@ -1,0 +1,11 @@
+{
+   "_id": "llama",
+   "min_weight": 130,
+   "max_weight": 200,
+   "min_length": 1.7,
+   "max_length": 1.8,
+   "latin_name": "Lama glama",
+   "wiki_page": "http://en.wikipedia.org/wiki/Llama",
+   "class": "mammal",
+   "diet": "herbivore"
+}

--- a/fixture/animaldb/animaldb_animal8.json
+++ b/fixture/animaldb/animaldb_animal8.json
@@ -1,0 +1,11 @@
+{
+   "_id": "panda",
+   "wiki_page": "http://en.wikipedia.org/wiki/Panda",
+   "min_weight": 73,
+   "max_weight": 115,
+   "min_length": 1.2,
+   "max_length": 1.8,
+   "class": "mammal",
+   "chinese_name": "熊猫",
+   "diet": "carnivore"
+}

--- a/fixture/animaldb/animaldb_animal9.json
+++ b/fixture/animaldb/animaldb_animal9.json
@@ -1,0 +1,11 @@
+{
+   "_id": "snipe",
+   "min_weight": 0.08,
+   "max_weight": 0.14,
+   "min_length": 0.25,
+   "max_length": 0.27,
+   "latin_name": "Gallinago gallinago",
+   "wiki_page": "http://en.wikipedia.org/wiki/Common_Snipe",
+   "class": "bird",
+   "diet": "omnivore"
+}

--- a/fixture/animaldb/animaldb_filter.json
+++ b/fixture/animaldb/animaldb_filter.json
@@ -1,0 +1,10 @@
+{
+   "_id": "_design/animal",
+   "filters": {
+       "bird": "function(doc, req) { if(doc.class && doc.class == 'bird') { return true; } return false; }",
+       "mammal": "function(doc, req) { if(doc.class && doc.class == 'mammal') { return true; } return false; }",
+       "by_class": "function(doc, req) { if(doc.class && doc.class == req.query.class) { return true; } return false; }",
+       "small": "function(doc, req) { if(doc.max_length && doc.max_length <= req.query.max_length) { return true; } return false; }",
+       "by_chinese_name": "function(doc, req) { if(doc.chinese_name && doc.chinese_name == req.query.chinese_name) { return true; } return false; }"
+   }
+}

--- a/src/main/java/com/cloudant/mazha/CouchClient.java
+++ b/src/main/java/com/cloudant/mazha/CouchClient.java
@@ -136,7 +136,17 @@ public class CouchClient {
     }
 
     public ChangesResult changes(String since, Integer limit) {
+        return this.changes(null, null, since, limit);
+    }
+
+    public ChangesResult changes(String filterName, Map<String, String> filterParameters, String since, Integer limit) {
         Map<String, Object> options = getDefaultChangeFeeOptions();
+        if(filterName != null) {
+            options.put("filter", filterName);
+            if(filterParameters != null) {
+                options.putAll(filterParameters);
+            }
+        }
         if(since != null) {
             options.put("since", since);
         }

--- a/src/main/java/com/cloudant/sync/replication/CouchClientWrapper.java
+++ b/src/main/java/com/cloudant/sync/replication/CouchClientWrapper.java
@@ -14,9 +14,16 @@
 
 package com.cloudant.sync.replication;
 
-import com.cloudant.mazha.*;
-import com.cloudant.sync.datastore.DocumentRevision;
 import com.cloudant.common.Log;
+import com.cloudant.mazha.ChangesResult;
+import com.cloudant.mazha.CouchClient;
+import com.cloudant.mazha.CouchConfig;
+import com.cloudant.mazha.CouchException;
+import com.cloudant.mazha.DocumentRevs;
+import com.cloudant.mazha.OkOpenRevision;
+import com.cloudant.mazha.OpenRevision;
+import com.cloudant.mazha.Response;
+import com.cloudant.sync.datastore.DocumentRevision;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 
@@ -106,6 +113,15 @@ class CouchClientWrapper implements CouchDB {
     @Override
     public ChangesResult changes(String lastSequence, int limit) {
         return couchClient.changes(lastSequence, limit);
+    }
+
+    @Override
+    public ChangesResult changes(Replication.Filter filter, String lastSequence, int limit) {
+        if(filter == null) {
+            return couchClient.changes(lastSequence, limit);
+        } else {
+            return couchClient.changes(filter.name, filter.parameters, lastSequence, limit);
+        }
     }
 
     /**

--- a/src/main/java/com/cloudant/sync/replication/CouchDB.java
+++ b/src/main/java/com/cloudant/sync/replication/CouchDB.java
@@ -46,6 +46,7 @@ interface CouchDB {
     public void putCheckpoint(String checkpointId, String sequence);
 
     public ChangesResult changes(String lastSequence, int limit);
+    public ChangesResult changes(Replication.Filter filter,String lastSequence, int limit);
     public List<DocumentRevs> getRevisions(String documentId, String... revisionId);
     public void bulk(List<DocumentRevision> revisions);
     public void bulkSerializedDocs(List<String> serializedDocs);

--- a/src/main/java/com/cloudant/sync/replication/PullReplication.java
+++ b/src/main/java/com/cloudant/sync/replication/PullReplication.java
@@ -14,6 +14,7 @@ public class PullReplication extends Replication {
 
     public URI source;
     public Datastore target;
+    public Filter filter;
 
     @Override
     public void validate() {
@@ -24,7 +25,11 @@ public class PullReplication extends Replication {
 
     @Override
     public String getReplicatorName() {
-        return String.format("%s <-- %s ", target.getDatastoreName(), source);
+        if(filter == null) {
+            return String.format("%s <-- %s ", target.getDatastoreName(), source);
+        } else {
+            return String.format("%s <-- %s (%s)", target.getDatastoreName(), source, filter.name);
+        }
     }
 
     public String getSourceDbName() {

--- a/src/main/java/com/cloudant/sync/replication/Replication.java
+++ b/src/main/java/com/cloudant/sync/replication/Replication.java
@@ -1,9 +1,15 @@
 package com.cloudant.sync.replication;
 
 import com.cloudant.mazha.CouchConfig;
+import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Manages information about a replication. It could be "pull" or "push",
@@ -21,17 +27,134 @@ import java.net.URI;
  */
 abstract class Replication {
 
+    /**
+     * Username of the replication's CouchDB/Cloudant DB. Each replication
+     * would involves a CouchDB/Cloudant Db, and this is the username
+     * for that database.
+     */
     public String username;
+
+    /**
+     * Password of the replication's CouchDB/Cloudant DB.
+     */
     public String password;
 
+    /**
+     * Validate the replication itself, and throw
+     * {@code IllegalArgumentException} is the replication is not valid.
+     */
     public abstract void validate();
 
+    /**
+     * Name of the replication.
+     *
+     * @return name of the replication.
+     */
     public abstract String getReplicatorName();
 
+    /**
+     * Create the {@code ReplicationStrategy} that can use to conduct the
+     * replication.
+     *
+     * @return the correct ReplicationStrategy that can use to conduct
+     *         the replication.
+     */
     public abstract ReplicationStrategy createReplicationStrategy();
 
+    /**
+     * Describe "Filter Function" used in {@code PullReplication}.
+     * It includes the name of the function, and the query
+     * parameters for the function.
+     *
+     * The name includes doc name and filter function name. For example
+     * "filterDoc/filterFunctionName" is a filter from doc "filterDoc"
+     * and the function name is "filterFunctionName".
+     *
+     * {@code
+     *     Filter filter = new Filter("filterDoc/filterFunctionName")
+     * }
+     *
+     * Query parameter is a {@code Map<String, String>}.
+     * Integer value should be put as String as well. For example:
+     *
+     * {@code
+     *     Filter filter = new Filter("doc/filterName"),
+     *         ImmutableMap.of("max_age", "10"));
+     * }
+     *
+     * @see com.cloudant.sync.replication.PullReplication
+     * http://docs.couchdb.org/en/1.4.x/replication.html#controlling-which-documents-to-replicate
+     * http://docs.couchdb.org/en/1.4.x/ddocs.html#filterfun
+     */
+    public static class Filter {
+
+        /**
+         * Name of the "Filter Function", indicates which function will
+         * be called for this filter.
+         */
+        public final String name;
+
+        /**
+         * Query parameters, which will be put as part of the "request"
+         * when filter function is called.
+         *
+         * @see @see http://docs.couchdb.org/en/1.4.x/ddocs.html#filterfun
+         */
+        public final ImmutableMap<String, String> parameters;
+
+        /**
+         * Construct a filter without any parameters
+         *
+         * @param name of the filter function
+         */
+        public Filter(String name) {
+            this.name = name;
+            this.parameters = null;
+        }
+
+        /**
+         * Construct a filter with filter function name and query parameters.
+         * The query parameters should not be escaped.
+         *
+         * @param name filter function name
+         * @param parameters filter function parameters
+         */
+        public Filter(String name, Map<String, String> parameters) {
+            this.name = name;
+            ImmutableMap.Builder builder = new ImmutableMap.Builder<String, String>();
+            builder.putAll(parameters);
+            this.parameters = builder.build();
+        }
+
+        /**
+         * Generated {@code String} should not be used in URL as request
+         * query as they are not properly escaped.
+         *
+         * Filter parameters are sorted by key so that the  generated
+         * String are the same for different calls. This is imporant
+         * because the String is part of the replication id.
+         *
+         * @return String can use to display the filter name and parameters.
+         *
+         * @see BasicPullStrategy#getReplicationId()
+         */
+        public String toQueryString() {
+            if(this.parameters == null) {
+                return String.format("filter=%s", this.name);
+            } else {
+                List<String> queries = new ArrayList<String>();
+                for(Map.Entry<String, String> parameter : this.parameters.entrySet()) {
+                    queries.add(String.format("%s=%s", parameter.getKey(), parameter.getValue()));
+                }
+                Collections.sort(queries);
+                return String.format("filter=%s&%s", this.name,
+                        Joiner.on('&').skipNulls().join(queries));
+            }
+        }
+    }
+
     CouchConfig createCouchConfig(URI uri, String username, String password) {
-        int port = uri.getPort() < 0 ? this.getDefaultPort(uri.getScheme()) : uri.getPort();
+        int port = uri.getPort() < 0 ? getDefaultPort(uri.getScheme()) : uri.getPort();
         return new CouchConfig(uri.getScheme(), uri.getHost(),  port, username, password);
     }
 

--- a/src/test/java/com/cloudant/mazha/AnimalDb.java
+++ b/src/test/java/com/cloudant/mazha/AnimalDb.java
@@ -1,0 +1,28 @@
+package com.cloudant.mazha;
+
+import com.cloudant.mazha.json.JSONHelper;
+import org.apache.commons.io.FileUtils;
+import org.junit.Assert;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.StringReader;
+
+public class AnimalDb {
+
+    public static void populate(CouchClient client) {
+        try {
+            JSONHelper jsonHelper =  new JSONHelper();
+            for(int i = 0 ; i < 10 ; i ++) {
+                String animal = FileUtils.readFileToString(new File("fixture/animaldb/animaldb_animal" + i + ".json"));
+                Response response = client.create(jsonHelper.fromJson(new StringReader(animal)));
+                Assert.assertTrue(response.getOk());
+            }
+            String filter = FileUtils.readFileToString(new File("fixture/animaldb/animaldb_filter.json"));
+            Response response = client.create(jsonHelper.fromJson(new StringReader(filter)));
+            Assert.assertTrue(response.getOk());
+        } catch (IOException e) {
+            Assert.fail(e.getMessage());
+        }
+    }
+}

--- a/src/test/java/com/cloudant/mazha/CouchClientFilteredChangesTest.java
+++ b/src/test/java/com/cloudant/mazha/CouchClientFilteredChangesTest.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2013 Cloudant, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.mazha;
+
+import com.cloudant.common.RequireRunningCouchDB;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.Map;
+
+import static org.hamcrest.Matchers.hasSize;
+
+@Category(RequireRunningCouchDB.class)
+public class CouchClientFilteredChangesTest extends CouchClientTestBase {
+
+    @Before
+    public void setUp() {
+        super.setUp();
+        AnimalDb.populate(client);
+    }
+
+    @Test
+    public void changes_filteredWoParameter() {
+        String filter = "animal/bird";
+        ChangesResult changes = client.changes(filter, null, null, 5);
+        Assert.assertThat(changes.getResults(), hasSize(2));
+    }
+
+    @Test
+    public void changes_filteredWoParameterAndMoreThanLimitNumberOfDocs() {
+        String filter = "animal/mammal";
+        ChangesResult firstChangeSet = client.changes(filter, null, null, 5);
+        Assert.assertThat(firstChangeSet.getResults(), hasSize(5));
+
+        ChangesResult secondChangeSet = client.changes(filter, null, firstChangeSet.getLastSeq(), 5);
+        Assert.assertThat(secondChangeSet.getResults(), hasSize(3));
+    }
+
+    @Test
+    public void changes_filteredWithParameter() {
+        String filter = "animal/by_class";
+        Map<String, String> parameters = ImmutableMap.of("class", "mammal");
+        ChangesResult changes = client.changes(filter, parameters, null, 100);
+        Assert.assertThat(changes.getResults(), hasSize(8));
+    }
+}

--- a/src/test/java/com/cloudant/sync/replication/ReplicationTestBase.java
+++ b/src/test/java/com/cloudant/sync/replication/ReplicationTestBase.java
@@ -81,6 +81,8 @@ public abstract class ReplicationTestBase extends CouchTestBase {
 
     PullReplication createPullReplication() throws URISyntaxException {
         PullReplication pullReplication = new PullReplication();
+        pullReplication.username = this.getCouchConfig().getUsername();
+        pullReplication.password = this.getCouchConfig().getPassword();
         pullReplication.source = this.getURI();
         pullReplication.target = this.datastore;
         return pullReplication;
@@ -88,6 +90,8 @@ public abstract class ReplicationTestBase extends CouchTestBase {
 
     PushReplication createPushReplication() throws URISyntaxException {
         PushReplication pushReplication = new PushReplication();
+        pushReplication.username = this.getCouchConfig().getUsername();
+        pushReplication.password = this.getCouchConfig().getPassword();
         pushReplication.target = this.getURI();
         pushReplication.source = this.datastore;
         return pushReplication;


### PR DESCRIPTION
1. Add class "Filter" add "filter" field in class "PullReplication".
2. Add filtered replication support to "BasicPullStrategy". Now
   developer can create a filterd replication by adding a filter
   to "PullReplication" when call "ReplicatorFactory.oneway(PullReplication)".
3. Add tests. It worths pointing out how the tests are
   implemented: a) Create a db called "animalDB",
   (see fixture/animaldb_animal*.json for documents), which also includes
   predefined filters (see fixture/animaldb/animaldb_filter.json),
   b) filtered pull replication c) check the replicated documents
