### PR TITLE
30105 Update indexes at query time

### DIFF
--- a/src/main/java/com/cloudant/sync/indexing/IndexManager.java
+++ b/src/main/java/com/cloudant/sync/indexing/IndexManager.java
@@ -17,7 +17,6 @@ package com.cloudant.sync.indexing;
 import com.cloudant.android.Log;
 import com.cloudant.sync.datastore.*;
 import com.cloudant.sync.notifications.DatabaseClosed;
-import com.cloudant.sync.notifications.DocumentModified;
 import com.cloudant.sync.sqlite.ContentValues;
 import com.cloudant.sync.sqlite.Cursor;
 import com.cloudant.sync.sqlite.SQLDatabase;
@@ -99,8 +98,6 @@ public class IndexManager {
                 + File.separator + "indexes.sqlite";
         this.sqlDb = SQLDatabaseFactory.openSqlDatabase(filename);
         SQLDatabaseFactory.updateSchema(this.sqlDb, SCHEMA_INDEX, VERSION);
-        // subscribe to some events
-        this.datastore.getEventBus().register(this);
     }
 
     /**
@@ -421,6 +418,8 @@ public class IndexManager {
 
     public QueryResult query(Map<String, Map<String, Object>> queryWithOptions) {
 
+        updateAllIndexes();
+
         Map<String, Object> query = queryWithOptions.get("query");
         Map<String, Object> options = queryWithOptions.get("options");
 
@@ -505,6 +504,9 @@ public class IndexManager {
      *
      */
     public List uniqueValues(String indexName) {
+
+        updateAllIndexes();
+
         List values = new ArrayList();
 
         Index index = this.getIndex(indexName);
@@ -534,10 +536,6 @@ public class IndexManager {
     public void onDatastoreClosed(DatabaseClosed databaseClosed) {
         this.getDatabase().close();
     }
-
-    // subscriber to generic DocumentModified events which will update all indexes
-    @Subscribe
-    public void onDocumentModified(DocumentModified documentModified) { this.updateAllIndexes(); }
 
     static void validateIndexName(String name) {
         if(!pattern.matcher(name).matches()) {

--- a/src/test/java/com/cloudant/sync/indexing/IndexManagerIndexTest.java
+++ b/src/test/java/com/cloudant/sync/indexing/IndexManagerIndexTest.java
@@ -589,14 +589,14 @@ public class IndexManagerIndexTest {
         Index index = createAndGetIndex("title", "title", IndexType.STRING);
         // create
         DocumentRevision obj1 = datastore.createDocument(dbBodies.get(1));
-        this.assertIndexed(database, index, obj1.getId(), "Politik");
+        this.assertNotIndexed(database, index, obj1.getId());
         // update
         Map<String,Object> map = obj1.getBody().asMap();
         map.put("title", "Another Green Day");
         DocumentBody body = DocumentBodyFactory.create(map);
         DocumentRevision obj2 = datastore.updateDocument(obj1.getId(), obj1.getRevision(), body);
         Assert.assertEquals(obj1.getId(), obj2.getId());
-        this.assertIndexed(database, index, obj2.getId(), "Another Green Day");
+        this.assertNotIndexed(database, index, obj2.getId());
         // delete
         datastore.deleteDocument(obj2.getId(), obj2.getRevision());
         this.assertNotIndexed(database, index, obj2.getId());


### PR DESCRIPTION
For performance reasons, don't update indexes on
document CRUD events. It's more efficient to
update them at query time.

This effectively reverts:
pull request #18 from cloudant/27388-indexing-up-to-date

And places updateAllIndexes() calls in query() and
uniqueValues().
