### PR TITLE
Only update registered indexes when calling updateAllIndexes (31844)

### DIFF
--- a/src/main/java/com/cloudant/sync/indexing/IndexManager.java
+++ b/src/main/java/com/cloudant/sync/indexing/IndexManager.java
@@ -244,11 +244,20 @@ public class IndexManager {
      * changes the the {@code Datastore} since the last indexed sequence
      * number to be added to all the indexes that this {@code IndexManager}
      * knows about.</p>
+     *
+     * <p>Only indexes registered using {@link com.cloudant.sync.indexing.IndexManager#ensureIndexed(String, IndexType, IndexFunction)}
+     * or an overloaded version on this IndexManager object will be updated (as
+     * otherwise the update function isn't defined).</p>
      */
     public void updateAllIndexes() {
         Set<Index> all = this.getAllIndexes();
         for (Index index : all) {
-            updateIndex(index.getName());
+            // Be sure to only update indexes which have been registered
+            // using ensureIndexed this session.
+            String name = index.getName();
+            if (this.indexFunctionMap.containsKey(name)) {
+                updateIndex(name);
+            }
         }
     }
 

--- a/src/test/java/com/cloudant/sync/indexing/IndexManagerIndexTest.java
+++ b/src/test/java/com/cloudant/sync/indexing/IndexManagerIndexTest.java
@@ -678,6 +678,28 @@ public class IndexManagerIndexTest {
         }
     }
 
+    /**
+     * Test to be sure that calling updateAllIndexes doesn't throw
+     * an exception for indexes that exist in the database but haven't
+     * yet been registered with that IndexManager object.
+     */
+    @Test
+    public void index_UpdateAllIndexesDoesNotFailForUnregisteredIndexes()
+            throws IndexExistsException, SQLException, ConflictException,
+                    IOException {
+        IndexManager im1 = new IndexManager(datastore);
+        im1.ensureIndexed("title", "title", IndexType.STRING);
+
+        // create
+        Map<String,Object> map = new HashMap<String, Object>();
+        map.put("title", "Another Green Day");
+        DocumentBody body = DocumentBodyFactory.create(map);
+        datastore.createDocument(body);
+
+        IndexManager im2 = new IndexManager(datastore);
+        im2.updateAllIndexes();
+    }
+
     private void assertNotIndexed(SQLDatabase database,
                                Index index,
                                String docId) throws SQLException {


### PR DESCRIPTION
Previously, IndexManager would try to update all indexes that exist
in the index database. This would cause an exception for those which
hadn't been registered this session with ensureIndexed as the
indexing function for those indexes wasn't known.

This patch just excludes unregistered indexes from the update process,
and adds a regression test.
