### PR TITLE
Work-around for base64 issues:

### DIFF
--- a/src/main/java/com/cloudant/android/Base64InputStreamFactory.java
+++ b/src/main/java/com/cloudant/android/Base64InputStreamFactory.java
@@ -1,0 +1,19 @@
+package com.cloudant.android;
+
+import com.cloudant.sync.util.Misc;
+
+import java.io.InputStream;
+
+/**
+ * Created by tomblench on 07/07/2014.
+ */
+public class Base64InputStreamFactory {
+    // TODO load these with class.forName()
+    public static InputStream get(InputStream is) {
+        if (Misc.isRunningOnAndroid()) {
+            return new android.util.Base64InputStream(is, 0);
+        } else {
+            return new org.apache.commons.codec.binary.Base64InputStream(is);
+        }
+    }
+}

--- a/src/main/java/com/cloudant/android/Base64OutputStreamFactory.java
+++ b/src/main/java/com/cloudant/android/Base64OutputStreamFactory.java
@@ -1,0 +1,20 @@
+package com.cloudant.android;
+
+import com.cloudant.sync.util.Misc;
+
+import java.io.OutputStream;
+
+/**
+ * Created by tomblench on 07/07/2014.
+ */
+public class Base64OutputStreamFactory {
+
+    // TODO load these with class.forName()
+    public static OutputStream get(OutputStream os) {
+        if (Misc.isRunningOnAndroid()) {
+            return new android.util.Base64OutputStream(os, 0);
+        } else {
+            return new org.apache.commons.codec.binary.Base64OutputStream(os, true, 0, null);
+        }
+    }
+}

--- a/src/main/java/com/cloudant/sync/datastore/BasicDatastore.java
+++ b/src/main/java/com/cloudant/sync/datastore/BasicDatastore.java
@@ -17,6 +17,7 @@
 
 package com.cloudant.sync.datastore;
 
+import com.cloudant.android.Base64InputStreamFactory;
 import com.cloudant.common.Log;
 import com.cloudant.sync.notifications.DatabaseClosed;
 import com.cloudant.sync.notifications.DocumentCreated;
@@ -36,12 +37,9 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.google.common.eventbus.EventBus;
 
-import org.apache.commons.codec.binary.Base64InputStream;
 import org.apache.commons.io.FilenameUtils;
 
 import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.sql.SQLException;
@@ -877,7 +875,7 @@ class BasicDatastore implements Datastore, DatastoreExtended {
                             continue;
                         }
                         String data = (String) ((Map<String, Object>) attachments.get(att)).get("data");
-                        InputStream is = new Base64InputStream(new ByteArrayInputStream(data.getBytes()));
+                        InputStream is = Base64InputStreamFactory.get(new ByteArrayInputStream(data.getBytes()));
                         String type = (String) ((Map<String, Object>) attachments.get(att)).get("content_type");
                         // inline attachments are automatically decompressed, so we don't have to worry about that
                         UnsavedStreamAttachment usa = new UnsavedStreamAttachment(is, att, type);

--- a/src/main/java/com/cloudant/sync/datastore/RevisionHistoryHelper.java
+++ b/src/main/java/com/cloudant/sync/datastore/RevisionHistoryHelper.java
@@ -14,6 +14,7 @@
 
 package com.cloudant.sync.datastore;
 
+import com.cloudant.android.Base64OutputStreamFactory;
 import com.cloudant.common.CouchConstants;
 import com.cloudant.common.Log;
 import com.cloudant.mazha.DocumentRevs;
@@ -21,11 +22,10 @@ import com.cloudant.sync.replication.PushAttachmentsInline;
 import com.cloudant.sync.util.CouchUtils;
 import com.google.common.base.Preconditions;
 
-import org.apache.commons.codec.binary.Base64OutputStream;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -225,7 +225,7 @@ public class RevisionHistoryHelper {
                         theAtt.put("follows", false);
                         // base64 encode this attachment
                         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                        Base64OutputStream bos = new Base64OutputStream(baos, true, 0, null);
+                        OutputStream bos = Base64OutputStreamFactory.get(baos);
                         InputStream fis = savedAtt.getInputStream();
                         int bufSiz = 1024;
                         byte[] buf = new byte[bufSiz];


### PR DESCRIPTION
Android uses an old version of commons-codec (1.2?) which doesn't have
Base64{Input,Output}Stream. Their version always takes priority so we can't use a newer version. So,
if running on android, use the android.util libraries for this purpose.

NB once the 31028-java-desktop-build branch is moved, the classes will need to be loaded by
class.forName() to de-couple them.
