### PR TITLE
Don't pull attachments we already have for a given revpos:

### DIFF
--- a/src/main/java/com/cloudant/mazha/CouchClient.java
+++ b/src/main/java/com/cloudant/mazha/CouchClient.java
@@ -303,12 +303,12 @@ public class CouchClient {
         // only pull attachments inline if we're configured to
         if (pullAttachmentsInline) {
             options.put("attachments", true);
+            if (attsSince != null) {
+                options.put("atts_since", getJson().toJson(attsSince));
+            }
         } else {
             options.put("attachments", false);
             options.put("att_encoding_info", true);
-        }
-        if (attsSince != null) {
-            options.put("atts_since", getJson().toJson(attsSince));
         }
         options.put("open_revs", getJson().toJson(revisions));
         return this.getDocument(id, options, new TypeReference<List<OpenRevision>>() {

--- a/src/test/java/com/cloudant/sync/replication/AttachmentsPullTest.java
+++ b/src/test/java/com/cloudant/sync/replication/AttachmentsPullTest.java
@@ -164,8 +164,8 @@ public class AttachmentsPullTest extends ReplicationTestBase {
     @Test
     public void dontPullAttachmentAlreadyPulled() {
         try {
-            // create a rev with an attachment, then update it without attachment
-            // ensure updated version no longer has attachment associated with it locally
+            // create a rev with an attachment, then update it keeping attachment
+            // TODO we need to somehow check the attachment wasn't re-downloaded
             createRevisionAndBigTextAttachment();
             pull();
             DocumentRevision docRev1 = datastore.getDocument(id, rev);


### PR DESCRIPTION
- Don't send atts_since when not pulling attachments inline (it doesn't make sense and will cause
  the attachments to be inlined anyway)
- Don't check "stub" value when not pulling attachments inline (they will always be stubbed, by
  definition)
- Use revpos of rev being added to determine whether we already have the attachments. Do this by
  looking back through the documentRevs object to see if we have the attachment for that generation
  in our bit of the tree.
