### PR TITLE
Correctly close SQLite Database

### DIFF
--- a/AndroidTest/app/src/main/java/cloudant/com/androidtest/JUnitXMLFormatter.java
+++ b/AndroidTest/app/src/main/java/cloudant/com/androidtest/JUnitXMLFormatter.java
@@ -44,14 +44,10 @@ public class JUnitXMLFormatter implements XMLConstants {
             //default to a file under a dir
             outputFile = new File(outputFile,"TestResults.xml");
         }
-
         try {
-            BufferedOutputStream buffer = new BufferedOutputStream(new FileOutputStream(outputFile));
             builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
         } catch(ParserConfigurationException e){
             //do nothing
-        } catch (FileNotFoundException e){
-            // TODO should do something about that
         }
     }
 

--- a/AndroidTest/app/src/main/java/cloudant/com/androidtest/MyActivity.java
+++ b/AndroidTest/app/src/main/java/cloudant/com/androidtest/MyActivity.java
@@ -1,7 +1,6 @@
 package cloudant.com.androidtest;
 
 import android.app.ListActivity;
-import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.Menu;
@@ -13,10 +12,6 @@ import android.widget.ListView;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-
-import com.cloudant.common.PerformanceTest;
-import com.cloudant.common.RequireRunningCouchDB;
-import com.cloudant.common.SystemTest;
 
 import org.junit.experimental.categories.Categories;
 import org.junit.runner.JUnitCore;

--- a/sync-core/src/main/java/com/cloudant/sync/indexing/IndexManager.java
+++ b/sync-core/src/main/java/com/cloudant/sync/indexing/IndexManager.java
@@ -562,4 +562,9 @@ public class IndexManager {
     public void finalize() {
         this.sqlDb.close();
     }
+
+
+    public void close(){
+        this.sqlDb.close();
+    }
 }

--- a/sync-core/src/main/java/com/cloudant/sync/util/TypedDatastore.java
+++ b/sync-core/src/main/java/com/cloudant/sync/util/TypedDatastore.java
@@ -196,4 +196,8 @@ public class TypedDatastore<T extends Document> {
 
         this.datastore.deleteDocument(documentId, revisionId);
     }
+
+    public void close(){
+        this.datastore.close();
+    }
 }

--- a/sync-core/src/test/java/com/cloudant/sync/datastore/BasicDBCoreObservableTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/datastore/BasicDBCoreObservableTest.java
@@ -51,6 +51,7 @@ public class BasicDBCoreObservableTest {
     @After
     public void tearDown() {
         TestUtils.deleteTempTestingDir(this.database_dir);
+        core.close();
     }
 
     @Test

--- a/sync-core/src/test/java/com/cloudant/sync/datastore/DatabaseNotificationsMoreTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/datastore/DatabaseNotificationsMoreTest.java
@@ -50,25 +50,37 @@ public class DatabaseNotificationsMoreTest {
     @Test
     public void notification_database_opened() {
         Datastore ds = datastoreManager.openDatastore("test123");
-        Assert.assertThat(databaseCreated, hasSize(1));
-        Assert.assertThat(databaseOpened, hasSize(1));
-        Assert.assertEquals("test123", databaseCreated.get(0).dbName);
-        Assert.assertEquals("test123", databaseOpened.get(0).dbName);
+        try {
+            Assert.assertThat(databaseCreated, hasSize(1));
+            Assert.assertThat(databaseOpened, hasSize(1));
+            Assert.assertEquals("test123", databaseCreated.get(0).dbName);
+            Assert.assertEquals("test123", databaseOpened.get(0).dbName);
+        } finally {
+            ds.close();
+        }
     }
 
     @Test
     public void notification_database_openedTwice() {
         Datastore ds = datastoreManager.openDatastore("test123");
-        Assert.assertNotNull(ds);
-        Assert.assertThat(databaseCreated, hasSize(1));
-        Assert.assertThat(databaseOpened, hasSize(1));
-        Assert.assertEquals("test123", databaseCreated.get(0).dbName);
-        Assert.assertEquals("test123", databaseOpened.get(0).dbName);
+        Datastore ds1 = null ;
+        try {
+            Assert.assertNotNull(ds);
+            Assert.assertThat(databaseCreated, hasSize(1));
+            Assert.assertThat(databaseOpened, hasSize(1));
+            Assert.assertEquals("test123", databaseCreated.get(0).dbName);
+            Assert.assertEquals("test123", databaseOpened.get(0).dbName);
 
-        Datastore ds1 = datastoreManager.openDatastore("test123");
-        Assert.assertThat(databaseCreated, hasSize(1));
-        Assert.assertThat(databaseOpened, hasSize(1));
-        Assert.assertNotNull(ds1);
+            ds1 = datastoreManager.openDatastore("test123");
+            Assert.assertThat(databaseCreated, hasSize(1));
+            Assert.assertThat(databaseOpened, hasSize(1));
+            Assert.assertNotNull(ds1);
+        } finally {
+            ds.close();
+            if(ds1 != null){
+                ds1.close();
+            }
+        }
     }
 
     @Test
@@ -92,11 +104,15 @@ public class DatabaseNotificationsMoreTest {
         // DatabaseCreated event should NOT be fired.
         this.clearAllEventList();
         Datastore ds1 = datastoreManager.openDatastore("test123");
-        Assert.assertNotNull(ds1);
-        Assert.assertThat(databaseCreated, hasSize(0));
-        Assert.assertThat(databaseOpened, hasSize(1));
-        Assert.assertThat(databaseClosed, hasSize(0));
-        Assert.assertEquals("test123", databaseOpened.get(0).dbName);
+        try {
+            Assert.assertNotNull(ds1);
+            Assert.assertThat(databaseCreated, hasSize(0));
+            Assert.assertThat(databaseOpened, hasSize(1));
+            Assert.assertThat(databaseClosed, hasSize(0));
+            Assert.assertEquals("test123", databaseOpened.get(0).dbName);
+        } finally {
+            ds1.close();
+        }
     }
 
     private void clearAllEventList() {

--- a/sync-core/src/test/java/com/cloudant/sync/datastore/DatabaseNotificationsTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/datastore/DatabaseNotificationsTest.java
@@ -43,17 +43,25 @@ public class DatabaseNotificationsTest {
     @Test
     public void notification_database_opened() {
         databaseOpened = new CountDownLatch(1);
-        datastoreManager.openDatastore("test123");
-        boolean ok = NotificationTestUtils.waitForSignal(databaseOpened);
-        Assert.assertTrue("Didn't receive database opened event", ok);
+        Datastore ds = datastoreManager.openDatastore("test123");
+        try {
+            boolean ok = NotificationTestUtils.waitForSignal(databaseOpened);
+            Assert.assertTrue("Didn't receive database opened event", ok);
+        } finally {
+            ds.close();
+        }
     }
 
     @Test
     public void notification_database_created() {
         databaseCreated = new CountDownLatch(1);
-        datastoreManager.openDatastore("test123");
-        boolean ok = NotificationTestUtils.waitForSignal(databaseCreated);
-        Assert.assertTrue("Didn't receive database created event", ok);
+        Datastore ds = datastoreManager.openDatastore("test123");
+        try {
+            boolean ok = NotificationTestUtils.waitForSignal(databaseCreated);
+            Assert.assertTrue("Didn't receive database created event", ok);
+        } finally {
+            ds.close();
+        }
     }
 
     @Test
@@ -73,20 +81,28 @@ public class DatabaseNotificationsTest {
     public void notification_database_closed() {
         databaseClosed = new CountDownLatch((1));
         Datastore ds = datastoreManager.openDatastore("testDatabaseClosed");
-        ds.getEventBus().register(this);
-        ds.close();
-        boolean ok = NotificationTestUtils.waitForSignal(databaseClosed);
-        Assert.assertTrue("Did not received database closed event", ok);
+        try {
+            ds.getEventBus().register(this);
+            ds.close();
+            boolean ok = NotificationTestUtils.waitForSignal(databaseClosed);
+            Assert.assertTrue("Did not received database closed event", ok);
+        } finally {
+            ds.close();
+        }
     }
 
     @Test
     public void notification_databaseClosed_databaseManagerShouldPostDatabaseClosedEvent() {
         databaseClosed = new CountDownLatch((1));
         Datastore ds = datastoreManager.openDatastore("testDatabaseClosed");
-        datastoreManager.getEventBus().register(this);
-        ds.close();
-        boolean ok = NotificationTestUtils.waitForSignal(databaseClosed);
-        Assert.assertTrue("Did not received database closed event", ok);
+        try {
+            datastoreManager.getEventBus().register(this);
+            ds.close();
+            boolean ok = NotificationTestUtils.waitForSignal(databaseClosed);
+            Assert.assertTrue("Did not received database closed event", ok);
+        } finally {
+            ds.close();
+        }
     }
 
     @Subscribe

--- a/sync-core/src/test/java/com/cloudant/sync/datastore/DatastoreManagerTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/datastore/DatastoreManagerTest.java
@@ -64,20 +64,27 @@ public class DatastoreManagerTest {
 
     @Test
     public void openDatastore_name_dbShouldBeCreated() {
-        createAndAssertDatastore();
+        Datastore ds = createAndAssertDatastore();
+        ds.close();
     }
 
     private Datastore createAndAssertDatastore() {
         Datastore ds = manager.openDatastore("mydatastore");
         Assert.assertNotNull(ds);
+        boolean assertsFailed = true;
+        try {
+            String dbDir = TEST_PATH + "/mydatastore";
+            Assert.assertTrue(new File(dbDir).exists());
+            Assert.assertTrue(new File(dbDir).isDirectory());
 
-        String dbDir = TEST_PATH + "/mydatastore";
-        Assert.assertTrue(new File(dbDir).exists());
-        Assert.assertTrue(new File(dbDir).isDirectory());
-
-        String dbFile = dbDir + "/db.sync";
-        Assert.assertTrue(new File(dbFile).exists());
-        Assert.assertTrue(new File(dbFile).isFile());
+            String dbFile = dbDir + "/db.sync";
+            Assert.assertTrue(new File(dbFile).exists());
+            Assert.assertTrue(new File(dbFile).isFile());
+            assertsFailed = false;
+        } finally {
+            if(assertsFailed)
+                ds.close();
+        }
         return ds;
     }
 

--- a/sync-core/src/test/java/com/cloudant/sync/datastore/MultipartAttachmentWriterTests.java
+++ b/sync-core/src/test/java/com/cloudant/sync/datastore/MultipartAttachmentWriterTests.java
@@ -68,6 +68,7 @@ public class MultipartAttachmentWriterTests {
 
     @After
     public void tearDown() throws Exception {
+        datastore.close();
         TestUtils.deleteTempTestingDir(datastore_manager_dir);
     }
 

--- a/sync-core/src/test/java/com/cloudant/sync/indexing/IndexManagerQueryTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/indexing/IndexManagerQueryTest.java
@@ -59,6 +59,8 @@ public class IndexManagerQueryTest {
 
     @After
     public void tearDown() throws Exception {
+        indexManager.close();
+        datastore.close();
         TestUtils.deleteDatabaseQuietly(database);
         TestUtils.deleteTempTestingDir(datastoreManagerPath);
     }

--- a/sync-core/src/test/java/com/cloudant/sync/replication/BasicPullStrategyTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/replication/BasicPullStrategyTest.java
@@ -63,6 +63,7 @@ public class BasicPullStrategyTest extends ReplicationTestBase {
     @After
     public void tearDown() throws Exception {
         super.tearDown();
+        this.barTypedDatastore.close();
     }
 
     @Test
@@ -186,6 +187,7 @@ public class BasicPullStrategyTest extends ReplicationTestBase {
 
         Assert.assertEquals(0, replication.getDocumentCounter());
         Assert.assertEquals(1, replication.getBatchCounter());
+
     }
 
     private List<String> findRevisionOfLeafs(DocumentRevisionTree docTree) {
@@ -352,16 +354,20 @@ public class BasicPullStrategyTest extends ReplicationTestBase {
         Assert.assertEquals(0, datastore.getDocumentCount());
 
         IndexManager im = new IndexManager(datastore);
-        im.ensureIndexed("diet", "diet");
+        try {
+            im.ensureIndexed("diet", "diet");
 
-        AnimalDb.populateWithoutFilter(remoteDb.couchClient);
-        this.pull();
+            AnimalDb.populateWithoutFilter(remoteDb.couchClient);
+            this.pull();
 
-        Assert.assertEquals(10, datastore.getDocumentCount());
+            Assert.assertEquals(10, datastore.getDocumentCount());
 
-        QueryBuilder qb = new QueryBuilder();
-        QueryResult qr = im.query(qb.index("diet").equalTo("herbivore").build());
-        Assert.assertEquals(4, qr.size());
+            QueryBuilder qb = new QueryBuilder();
+            QueryResult qr = im.query(qb.index("diet").equalTo("herbivore").build());
+            Assert.assertEquals(4, qr.size());
+        } finally {
+            im.close();
+        }
 
     }
 

--- a/sync-core/src/test/java/com/cloudant/sync/replication/ReplicationTestBase.java
+++ b/sync-core/src/test/java/com/cloudant/sync/replication/ReplicationTestBase.java
@@ -45,6 +45,8 @@ public abstract class ReplicationTestBase extends CouchTestBase {
 
     @After
     public void tearDown() throws Exception {
+        datastore.close();
+        datastoreWrapper.getDbCore().close();
         TestUtils.deleteDatabaseQuietly(database);
         cleanUpTempFiles();
     }


### PR DESCRIPTION
- In the android SQLite database wrapper the close method only closes when the thread calling close is the thread that created the database.
- For JavaSE behaviour is unchanged. Each thread closes connection to the db
- IndexManagerIndexTest now uses datastore.close() to close the db
