### PR TITLE
Allow the same chars for datastore names as CDTDatastore

### DIFF
--- a/sync-core/src/main/java/com/cloudant/sync/datastore/DatastoreManager.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/DatastoreManager.java
@@ -59,7 +59,7 @@ public class DatastoreManager {
     /**
      * The regex used to validate a datastore name, {@value}.
      */
-    protected static final String LEGAL_CHARACTERS = "^[a-zA-Z]+[a-zA-Z0-9_]*";
+    protected static final String LEGAL_CHARACTERS = "^[a-zA-Z]+[a-zA-Z0-9_\\Q-$()/\\E]*";
 
     private final EventBus eventBus = new EventBus();
 
@@ -126,9 +126,9 @@ public class DatastoreManager {
      */
     public Datastore openDatastore(String dbName) {
         Preconditions.checkArgument(dbName.matches(LEGAL_CHARACTERS),
-                "Database name can only contain letter, underscore and digit, " +
-                        "and start with letter: " + dbName);
-
+                "A database must be named with all lowercase letters (a-z), digits (0-9),"
+                  + " or any of the _$()+-/ characters. The name has to start with a"
+                  + " lowercase letter (a-z).");
         if (!openedDatastores.containsKey(dbName)) {
             synchronized (openedDatastores) {
                 if (!openedDatastores.containsKey(dbName)) {
@@ -207,7 +207,7 @@ public class DatastoreManager {
     }
 
     private String getDatastoreDirectory(String dbName) {
-        return FilenameUtils.concat(this.path, dbName);
+        return FilenameUtils.concat(this.path, dbName.replace("/","."));
     }
 
     /**

--- a/sync-core/src/test/java/com/cloudant/sync/datastore/BasicDatastoreCRUDTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/datastore/BasicDatastoreCRUDTest.java
@@ -20,6 +20,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.IOException;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -543,6 +544,16 @@ public class BasicDatastoreCRUDTest extends BasicDatastoreTestBase {
         // Test count and offsets for descending and ascending
         getAllDocuments_testCountAndOffset(objectCount, documentRevisions, false);
         getAllDocuments_testCountAndOffset(objectCount, reversedObjects, true);
+    }
+
+    @Test
+    public void createDbWithSlashAndCreateDocument() throws IOException {
+            Datastore datastore = datastoreManager.openDatastore("dbwith/aslash");
+            MutableDocumentRevision rev = new MutableDocumentRevision();
+            rev.body = bodyOne;
+            BasicDocumentRevision doc = datastore.createDocumentFromRevision(rev);
+            validateNewlyCreatedDocument(doc);
+            datastore.close();
     }
 
     private void getAllDocuments_testCountAndOffset(int objectCount, List<BasicDocumentRevision> expectedDocumentRevisions, boolean descending) {

--- a/sync-core/src/test/java/com/cloudant/sync/datastore/DatastoreManagerTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/datastore/DatastoreManagerTest.java
@@ -56,8 +56,8 @@ public class DatastoreManagerTest {
         Assert.assertTrue("Aalfd_sn9".matches(DatastoreManager.LEGAL_CHARACTERS));
         Assert.assertTrue("a_alf_dsn9".matches(DatastoreManager.LEGAL_CHARACTERS));
         Assert.assertFalse("0Aalfdsn9".matches(DatastoreManager.LEGAL_CHARACTERS));
-        Assert.assertFalse("Aa-lfdsn9".matches(DatastoreManager.LEGAL_CHARACTERS));
-        Assert.assertFalse("Aa/lfdsn9".matches(DatastoreManager.LEGAL_CHARACTERS));
+        Assert.assertTrue("Aa-lfdsn9".matches(DatastoreManager.LEGAL_CHARACTERS));
+        Assert.assertTrue("Aa/lfdsn9".matches(DatastoreManager.LEGAL_CHARACTERS));
         Assert.assertFalse("Aa lfdsn9".matches(DatastoreManager.LEGAL_CHARACTERS));
         Assert.assertFalse("".matches(DatastoreManager.LEGAL_CHARACTERS));
     }
@@ -119,5 +119,22 @@ public class DatastoreManagerTest {
         Map m = new HashMap<String, Object>();
         m.put("name", name);
         return new BasicDocumentBody(m);
+    }
+
+    @Test
+    public void createDatastoreWithForwardSlashChar() throws Exception {
+        Datastore ds = manager.openDatastore("datastore/mynewdatastore");
+        try {
+            String dbDir = TEST_PATH + "/datastore.mynewdatastore";
+            Assert.assertTrue(new File(dbDir).exists());
+            Assert.assertTrue(new File(dbDir).isDirectory());
+            String dbFile = dbDir + "/db.sync";
+            Assert.assertTrue(new File(dbFile).exists());
+            Assert.assertTrue(new File(dbFile).isFile());
+        } finally {
+            ds.close();
+        }
+
+
     }
 }

--- a/sync-core/src/test/java/com/cloudant/sync/replication/CouchClientWrapperTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/replication/CouchClientWrapperTest.java
@@ -316,4 +316,17 @@ public class CouchClientWrapperTest extends CouchTestBase {
 
         return objects;
     }
+
+    @Test
+    public void accessAndUpdateRemoteDbWithSlashInName() throws Exception {
+        //do a little set up for this specific test
+        remoteDb = new CouchClientWrapper("myslash/encoded_db", super.getCouchConfig());
+        CouchClientWrapperDbUtils.deleteDbQuietly(remoteDb);
+        remoteDb.createDatabase();
+        Bar bar1 = new Bar();
+        Response res1 = remoteDb.create(bar1);
+        Assert.assertNotNull(res1);
+        Assert.assertTrue(res1.getOk());
+
+    }
 }


### PR DESCRIPTION
Allow the same chars for datastore names as CDTDatastore
URLEncode db names for use with the filesystem
