### PR TITLE
Support compressed data downloads

### DIFF
--- a/sync-core/src/main/java/com/cloudant/sync/datastore/Attachment.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/Attachment.java
@@ -78,4 +78,14 @@ public abstract class Attachment implements Comparable<Attachment>{
         Gzip
     }
 
+    public static Encoding getEncodingFromString(String encodingString){
+        if(encodingString == null || encodingString.isEmpty() || encodingString.equalsIgnoreCase("Plain")){
+            return Encoding.Plain;
+        } else if(encodingString.equalsIgnoreCase("gzip")){
+            return Encoding.Gzip;
+        } else {
+            throw new IllegalArgumentException("Unsupported encoding");
+        }
+    }
+
 }

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/SavedHttpAttachment.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/SavedHttpAttachment.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.Map;
+import java.util.zip.GZIPInputStream;
 
 
 /**
@@ -35,6 +36,7 @@ public class SavedHttpAttachment extends Attachment {
     private URI attachmentURI;
     private int size;
     private byte[] data;
+    private Encoding encoding;
 
 
     /**
@@ -51,6 +53,8 @@ public class SavedHttpAttachment extends Attachment {
          Boolean stub = (Boolean) attachmentData.get("stub");
          Number length = (Number)attachmentData.get("length");
          String data = (String)attachmentData.get("data");
+         String encoding =  (String)attachmentData.get("encoding");
+         this.encoding = Attachment.getEncodingFromString(encoding);
          if(!stub){
             byte[] dataArray =  data.getBytes();
             InputStream is = Base64InputStreamFactory.get(new ByteArrayInputStream(dataArray));
@@ -71,7 +75,11 @@ public class SavedHttpAttachment extends Attachment {
     public InputStream getInputStream() throws IOException {
         if( data == null) {
             HttpRequests requests = new HttpRequests(new BasicHttpParams(), null, null);
-            return requests.get(attachmentURI);
+            if(encoding == Encoding.Gzip) {
+                return new GZIPInputStream(requests.getCompressed(attachmentURI));
+            } else {
+                return requests.get(attachmentURI);
+            }
         } else {
             return new ByteArrayInputStream(data);
         }

--- a/sync-core/src/main/java/com/cloudant/sync/replication/CouchClientWrapper.java
+++ b/sync-core/src/main/java/com/cloudant/sync/replication/CouchClientWrapper.java
@@ -250,7 +250,7 @@ public class CouchClientWrapper implements CouchDB {
     @Override
     public UnsavedStreamAttachment getAttachmentStream(String id, String rev, String attachmentName, String contentType, String encodingStr) {
         InputStream is = this.couchClient.getAttachmentStream(id, rev, attachmentName);
-        Attachment.Encoding encoding = encodingStr != null && encodingStr.equals("gzip") ? Attachment.Encoding.Gzip : Attachment.Encoding.Plain;
+        Attachment.Encoding encoding = Attachment.getEncodingFromString(encodingStr);
         UnsavedStreamAttachment usa = new UnsavedStreamAttachment(is, attachmentName, contentType, encoding);
         return usa;
     }


### PR DESCRIPTION
Support downloading of compressed attachments if that
attachment can be compressed as determined by the
att_encoding_info=true doc query parameter
