### PR TITLE
Don't return deleted docs for conflicts

### DIFF
--- a/sync-core/src/main/java/com/cloudant/sync/datastore/BasicDatastore.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/BasicDatastore.java
@@ -1332,7 +1332,7 @@ class BasicDatastore implements Datastore, DatastoreExtended {
         }
         DocumentRevision newWinner = null;
         try {
-            newWinner = resolver.resolve(docId, docTree.leafRevisions());
+            newWinner = resolver.resolve(docId, docTree.leafRevisions(true));
         } catch (Exception e) {
             Log.e(LOG_TAG, "Exception when calling ConflictResolver", e);
         }

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/DocumentRevisionTree.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/DocumentRevisionTree.java
@@ -340,15 +340,32 @@ public class DocumentRevisionTree {
         return res;
     }
 
+
     /**
      * <p>Returns the leaf revisions</p>
      *
-     * @return the set of the DocumentRevision
+     * <p>This is the same as calling
+     * {@link com.cloudant.sync.datastore.DocumentRevisionTree#leafRevisions(boolean)} with
+     * <code>false</code> as the parameter</p>
+     *
+     * @return a list of {@link com.cloudant.sync.datastore.DocumentRevision} objects.
      */
-    public List<BasicDocumentRevision> leafRevisions() {
+    public List<BasicDocumentRevision> leafRevisions(){
+        return this.leafRevisions(false);
+    }
+    /**
+     * <p>Returns the leaf revisions</p>
+     *
+     * @param excludeDeleted if true, exclude deleted leaf revisions from list
+     * @return a list of {@link com.cloudant.sync.datastore.DocumentRevision} objects.
+     */
+    public List<BasicDocumentRevision> leafRevisions(boolean excludeDeleted) {
         List<BasicDocumentRevision> res = new ArrayList<BasicDocumentRevision>();
         for(DocumentRevisionNode obj : leafs()) {
-            res.add(obj.getData());
+            BasicDocumentRevision revision = obj.getData();
+            if (!excludeDeleted || (excludeDeleted && !revision.isDeleted())){
+                res.add(revision);
+            }
         }
         return res;
     }


### PR DESCRIPTION
Don't return deleted docs for conflict resolution. Deleted documents are not normally
in conflict, in CDTDatastore conflict resolution does not return deleted leaves.

Modify test which expects a winning rev to be deleted to expect no rev provided as
a conflict is deleted.
