### PR TITLE
Add buildMutable method to DocumentRevisionBuilder

### DIFF
--- a/sync-core/src/main/java/com/cloudant/sync/datastore/DocumentRevisionBuilder.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/DocumentRevisionBuilder.java
@@ -200,6 +200,17 @@ public class DocumentRevisionBuilder {
     }
 
     /**
+     * Builds and returns the {@link com.cloudant.sync.datastore.MutableDocumentRevision} for this builder.
+     * @return {@link com.cloudant.sync.datastore.MutableDocumentRevision} for this builder.
+     */
+    public MutableDocumentRevision buildMutable() {
+        MutableDocumentRevision revision = new MutableDocumentRevision(this.revId);
+        revision.body = this.body;
+        revision.docId = this.docId;
+        return revision;
+    }
+
+    /**
      * Builds a BasicDocumentRevision from a Map of values from a CouchDB instance
      * @param documentURI The URI of the document
      * @param map The map of key value pairs fom the CouchDB server

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/MutableDocumentRevision.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/MutableDocumentRevision.java
@@ -17,7 +17,7 @@ public class MutableDocumentRevision implements DocumentRevision
     }
 
     // ctor with revision id: this revision has been saved (eg mutable copy)
-    public MutableDocumentRevision(String sourceRevisionId) {
+    protected MutableDocumentRevision(String sourceRevisionId) {
         this.attachments = new HashMap<String, Attachment>();
         this.sourceRevisionId = sourceRevisionId;
     }

--- a/sync-core/src/test/java/com/cloudant/sync/datastore/DocumentRevisionBuilderTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/datastore/DocumentRevisionBuilderTest.java
@@ -56,6 +56,46 @@ public class DocumentRevisionBuilderTest extends ReplicationTestBase {
     }
 
     @Test
+    public void buildsMutableRevision(){
+        DocumentRevisionBuilder builder = new DocumentRevisionBuilder();
+        builder.setBody(DocumentBodyFactory.create(body));
+        builder.setDocId("someIdHere");
+        builder.setRevId("3-750dac460a6cc41e6999f8943b8e603e");
+
+        MutableDocumentRevision revision = builder.buildMutable();
+        Assert.assertEquals("someIdHere",revision.docId);
+        Assert.assertEquals(body,revision.body.asMap());
+        Assert.assertEquals("3-750dac460a6cc41e6999f8943b8e603e", revision.getSourceRevisionId());
+        Assert.assertNull(revision.getRevision());
+    }
+
+    @Test
+    public void buildMutableRevisionMissingRevId() {
+        DocumentRevisionBuilder builder = new DocumentRevisionBuilder();
+        builder.setBody(DocumentBodyFactory.create(body));
+        builder.setDocId("someIdHere");
+
+        MutableDocumentRevision revision = builder.buildMutable();
+        Assert.assertEquals("someIdHere",revision.docId);
+        Assert.assertEquals(body,revision.body.asMap());
+        Assert.assertNull(revision.getSourceRevisionId());
+        Assert.assertNull(revision.getRevision());
+    }
+
+    @Test
+    public void buildMutableRevisionMissingDocId() {
+        DocumentRevisionBuilder builder = new DocumentRevisionBuilder();
+        builder.setBody(DocumentBodyFactory.create(body));
+        builder.setRevId("3-750dac460a6cc41e6999f8943b8e603e");
+
+        MutableDocumentRevision revision = builder.buildMutable();
+        Assert.assertNull(revision.docId);
+        Assert.assertEquals(body,revision.body.asMap());
+        Assert.assertEquals("3-750dac460a6cc41e6999f8943b8e603e", revision.getSourceRevisionId());
+        Assert.assertNull(revision.getRevision());
+    }
+
+    @Test
     public void buildRevisionFromMapValidMapDelectedDoc() throws Exception {
 
         documentRev.put("_deleted", Boolean.TRUE);


### PR DESCRIPTION
- Added buildMutable method to documentRevisionBuilder
- Changed visibility of MutableDocumentRevision sourceRev  constructor
  to protected
