### PR TITLE
Fix documentation errors on jdk8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,11 @@ subprojects {
 // see http://issues.gradle.org/browse/GRADLE-1876
 // run javadoc over union of all projects
 task docs(type: Javadoc) {
+
+    options.encoding = "UTF-8"
+    options.docEncoding = "UTF-8"
+    options.charSet = "UTF-8"
+
     options.showFromPublic()
     title = "sync-android ${version} API"
     source subprojects.collect {project -> project.sourceSets.main.allJava.matching{exclude "**/*sql*/**", "**/common/**", "**/android/**", "**/mazha/**" }}

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/DatastoreExtended.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/DatastoreExtended.java
@@ -91,7 +91,7 @@ public interface DatastoreExtended extends Datastore {
      * @param prevRevisionId revision id of the document's current winning
      *                       revision
      * @param body body of the new revision
-     * @return @{code DocumentRevision} for the updated revision
+     * @return {@code DocumentRevision} for the updated revision
      */
     public BasicDocumentRevision updateLocalDocument(String documentId, String prevRevisionId, DocumentBody body);
 
@@ -255,7 +255,6 @@ public interface DatastoreExtended extends Datastore {
      * @param rev The revision this attachment is associated with
      * @return A prepared attachment, ready to be added to the datastore
      * @throws IOException
-     * @throws SQLException
      */
     public PreparedAttachment prepareAttachment(Attachment att, BasicDocumentRevision rev) throws IOException;
 

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/DocumentRevisionTree.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/DocumentRevisionTree.java
@@ -35,7 +35,7 @@ import java.util.*;
  * revision IDs to their generation numbers:</p>
  *
  * <pre>
- *     1 -> 2 -> 3
+ *     1 → 2 → 3
  * </pre>
  *
  * <p>A full revision ID looks like {@code 1-aedlfksenef}, that is the
@@ -59,8 +59,8 @@ import java.util.*;
  * a branched tree containing the edits from both A and B:</p>
  *
  * <pre>
- *     1 ->  2  -> 3 -> 4
- *       \-> 2^ -> 3^
+ *     1 → 2  → 3 → 4
+ *      \→ 2^ → 3^
  * </pre>
  *
  * <p>At this point we have a conflicted document: two or more branches
@@ -83,8 +83,8 @@ import java.util.*;
  * conflicted:</p>
  *
  * <pre>
- *     1 ->  2  -> 3  -> 4 -> 5
- *       \-> 2^ -> 3^ -> (4^ deleted)
+ *     1 →  2  → 3  → 4 → 5
+ *      \→  2^ → 3^ → (4^ deleted)
  * </pre>
  *
  * <p>Finally, a document may have multiple document trees. This can happen if
@@ -92,9 +92,9 @@ import java.util.*;
  * these two datastores are replicated:</p>
  *
  * <pre>
- *     1  -> 2  -> 3
- *     1* -> 2* -> 3* -> 4*
- *       \-> 2^ -> 3^
+ *     1  → 2  → 3
+ *     1* → 2* → 3* → 4*
+ *       \→ 2^ → 3^
  * </pre>
  *
  * <p>As an aside, this document has three conflicting revisions, which should
@@ -151,7 +151,7 @@ public class DocumentRevisionTree {
     private List<DocumentRevisionNode> leafs = new ArrayList<DocumentRevisionNode>();
 
     // All the DocumentRevisionTree revisions from all the trees.
-    // Map: sequence number -> DocumentRevisionNode
+    // Map: sequence number → DocumentRevisionNode
     private Map<Long, DocumentRevisionNode> sequenceMap = new TreeMap<Long, DocumentRevisionNode>();
 
     /**

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/DocumentRevsList.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/DocumentRevsList.java
@@ -31,21 +31,21 @@ import java.util.List;
  *
  * <pre>
  * Case 1: they are from same three.
- *   1 -> 2 -> 3
+ *   1 → 2 → 3
  *     \
- *     -> 2 -> 3*
+ *     → 2 → 3*
  *
  * Case 2: they are from different trees
- *   1 -> 2  -> 3
+ *   1  → 2  → 3
  *
- *   1* -> 2* -> 3*
+ *   1* → 2* → 3*
  * </pre>
  *
  * The list can be iterated in the order of minimum generation id (min-generation). Each
  * <code>DocumentRevs</code> has a list of revisions ids (aka revision history), and "start".
  * The "start" number is largest generation. So the min-generation is:
  * <pre>
- *   DocumentRevs.getRevisions().getStart() -> DocumentRevs.getRevisions().getIds().size() + 1.
+ *   DocumentRevs.getRevisions().getStart() → DocumentRevs.getRevisions().getIds().size() + 1.
  * </pre>
  * This is very important since it decides which <code>DocumentRevs</code> is inserted to db first.
  * <p>

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/SavedHttpAttachment.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/SavedHttpAttachment.java
@@ -40,15 +40,15 @@ public class SavedHttpAttachment extends Attachment {
 
 
     /**
-     * Creates a SavedHttpAttachment with the provided properties
+     * Creates a SavedHttpAttachment (a fully initialised attachment)
+     * with the provided properties
      * @param name The name of the attachment eg bonsai-boston.jpg
      * @param attachmentData The json attachment data from a couchDB instance
      * @param attachmentURI The URI at which the attachment can be downloaded
-     * @return a Fully initialsed Attachment with data if provided
      * @throws IOException if there is an error decoding the attachment data
      */
-    public  SavedHttpAttachment(String name, Map<String,Object> attachmentData, URI attachmentURI)
-            throws IOException {
+    public SavedHttpAttachment(String name, Map<String,Object> attachmentData, URI attachmentURI)
+           throws IOException {
          super(name, (String)attachmentData.get("content_type"), Encoding.Plain);
          Boolean stub = (Boolean) attachmentData.get("stub");
          Number length = (Number)attachmentData.get("length");

--- a/sync-core/src/main/java/com/cloudant/sync/replication/PushAttachmentsInline.java
+++ b/sync-core/src/main/java/com/cloudant/sync/replication/PushAttachmentsInline.java
@@ -9,10 +9,9 @@ package com.cloudant.sync.replication;
  *     <li>False: Always push attachments separately as an HTTP binary PUT</li>
  *     <li>Small: Push small attachments inline, and large attachments separately.
  *         Uses SavedAttachment.isLarge() to determine whether attachment is small or large.</li>
- *     </li>True: Always push attachments inline as a base64-encoded string.</li>
+ *     <li>True: Always push attachments inline as a base64-encoded string.</li>
  * </ul>
  *
- * @see com.cloudant.sync.datastore.SavedAttachment#isLarge()
  */
 
 public enum PushAttachmentsInline {

--- a/sync-core/src/main/java/com/cloudant/sync/replication/Replication.java
+++ b/sync-core/src/main/java/com/cloudant/sync/replication/Replication.java
@@ -53,7 +53,7 @@ public abstract class Replication {
      * constructor:</p>
      *
      * <pre>
-     * Map<String, String> params = new HashMap();
+     * Map&lt;String, String&gt; params = new HashMap();
      * map.put("max_age", "10");
      * map.put("name", "john");
      * Filter filter = new Filter("doc/filterName", map);


### PR DESCRIPTION
Originally this PR was to address jdk7 issues, but the javadoc errors only occur when building for jdk8. It's still worth fixing these errors as they are mistakes in HTML markup.
