### PR TITLE
Fix replicator ID uniqueness:

### DIFF
--- a/sync-core/src/main/java/com/cloudant/sync/replication/ReplicationStrategy.java
+++ b/sync-core/src/main/java/com/cloudant/sync/replication/ReplicationStrategy.java
@@ -24,4 +24,6 @@ interface ReplicationStrategy extends Runnable {
     
     EventBus getEventBus();
 
+    String getReplicationId();
+
 }

--- a/sync-core/src/test/java/com/cloudant/sync/replication/BasicPushStrategyTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/replication/BasicPushStrategyTest.java
@@ -74,7 +74,7 @@ public class BasicPushStrategyTest extends ReplicationTestBase {
     private void assertPushReplicationStatus(int documentCounter, int batchCounter, String lastSequence) {
         Assert.assertEquals("DocumentRevisionTree counter", documentCounter, replicator.getDocumentCounter());
         Assert.assertEquals("Batch counter", batchCounter, replicator.getBatchCounter());
-        Assert.assertEquals("Last sequence", lastSequence, remoteDb.getCheckpoint(datastoreWrapper.getIdentifier()));
+        Assert.assertEquals("Last sequence", lastSequence, remoteDb.getCheckpoint(this.replicator.getReplicationId()));
     }
 
     @Test
@@ -299,9 +299,9 @@ public class BasicPushStrategyTest extends ReplicationTestBase {
         assertPushReplicationStatus(1, 2, "1");
 
         CouchClientWrapper wrapper = new CouchClientWrapper(this.couchClient);
-        System.out.println("Checkpoint: " + wrapper.getCheckpoint(this.datastoreWrapper.getIdentifier()));
-        wrapper.putCheckpoint(this.datastore.getPublicIdentifier(), "0");
-        System.out.println("Checkpoint: " + wrapper.getCheckpoint(this.datastoreWrapper.getIdentifier()));
+        System.out.println("Checkpoint: " + wrapper.getCheckpoint(this.replicator.getReplicationId()));
+        wrapper.putCheckpoint(this.replicator.getReplicationId(), "0");
+        System.out.println("Checkpoint: " + wrapper.getCheckpoint(this.replicator.getReplicationId()));
 
         this.push();
         assertPushReplicationStatus(0, 2, "1");

--- a/sync-core/src/test/java/com/cloudant/sync/replication/ReplicatorIdTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/replication/ReplicatorIdTest.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2015 Cloudant, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.replication;
+
+import com.google.common.collect.ImmutableMap;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+/**
+ * Created by tomblench on 10/12/14.
+ */
+public class ReplicatorIdTest extends ReplicationTestBase {
+
+    // source/target switched, so ids should be different
+    @Test
+    public void pullNotEqualToPush() throws URISyntaxException {
+        PullReplication pull = this.createPullReplication();
+        PushReplication push = this.createPushReplication();
+
+        Assert.assertNotEquals(pull.createReplicationStrategy().getReplicationId(),
+                push.createReplicationStrategy().getReplicationId());
+    }
+
+    // two pull reps identical
+    @Test
+    public void pullsEqual() throws URISyntaxException {
+        PullReplication pull1 = this.createPullReplication();
+        PullReplication pull2 = this.createPullReplication();
+
+        Assert.assertEquals(pull1.createReplicationStrategy().getReplicationId(),
+                pull2.createReplicationStrategy().getReplicationId());
+    }
+
+    // two push reps identical
+    @Test
+    public void pushesEqual() throws URISyntaxException {
+        PushReplication push1 = this.createPushReplication();
+        PushReplication push2 = this.createPushReplication();
+        Assert.assertEquals(push1.createReplicationStrategy().getReplicationId(),
+                push2.createReplicationStrategy().getReplicationId());
+    }
+
+    // two push reps with differing target not equal
+    @Test
+    public void pushesDifferingTargetNotEqual() throws URISyntaxException {
+        PushReplication push1 = this.createPushReplication();
+        PushReplication push2 = this.createPushReplication();
+        push1.target = new URI("http://a-host/a-database");
+        push2.target = new URI("http://another-host/another-database");
+
+        Assert.assertNotEquals(push1.createReplicationStrategy().getReplicationId(),
+                push2.createReplicationStrategy().getReplicationId());
+    }
+
+    // two pull reps with differing source not equal
+    @Test
+    public void pullsDifferingSourceNotEqual() throws URISyntaxException {
+        PullReplication pull1 = this.createPullReplication();
+        PullReplication pull2 = this.createPullReplication();
+        pull1.source = new URI("http://a-host/a-database");
+        pull2.source = new URI("http://another-host/another-database");
+
+        Assert.assertNotEquals(pull1.createReplicationStrategy().getReplicationId(),
+                pull2.createReplicationStrategy().getReplicationId());
+    }
+
+    // two pull reps, one with filter, one without, not equal
+    @Test
+    public void pullWithFilterNotEqual() throws URISyntaxException {
+        PullReplication pull1 = this.createPullReplication();
+        PullReplication pull2 = this.createPullReplication();
+        pull2.filter = new Replication.Filter("animal/by_class",
+                ImmutableMap.of("class", "mammal"));
+
+        Assert.assertNotEquals(pull1.createReplicationStrategy().getReplicationId(),
+                pull2.createReplicationStrategy().getReplicationId());
+    }
+
+    // two pull reps, both with different filters, not equal
+    @Test
+    public void pullWithDifferentFiltersNotEqual() throws URISyntaxException {
+        PullReplication pull1 = this.createPullReplication();
+        PullReplication pull2 = this.createPullReplication();
+        pull1.filter = new Replication.Filter("animal/by_class",
+                ImmutableMap.of("class", "mammal"));
+        pull2.filter = new Replication.Filter("animal/by_class",
+                ImmutableMap.of("class", "bird"));
+
+        Assert.assertNotEquals(pull1.createReplicationStrategy().getReplicationId(),
+                pull2.createReplicationStrategy().getReplicationId());
+    }
+}


### PR DESCRIPTION
- Source and Destination are inputs to the hash
- Filter and Query string are inputs to the hash for pull
  replications, if set

This implementation of replicator IDs is closer in spirit to the CDTDatastore one. Note that we don't need to include the 'push' flag as the input to the hash because source and destination are given, with their own keys.
