### PR TITLE
Remove methods which expose internal ID

### DIFF
--- a/sync-core/src/main/java/com/cloudant/sync/datastore/BasicDocumentRevision.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/BasicDocumentRevision.java
@@ -161,7 +161,7 @@ public class BasicDocumentRevision implements DocumentRevision, Comparable<Basic
      *
      * @return  the internal numeric ID of this document revision.
      */
-    public long getInternalNumericId(){
+    long getInternalNumericId(){
         return internalNumericId;
     }
 

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/DatastoreExtended.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/DatastoreExtended.java
@@ -211,18 +211,6 @@ public interface DatastoreExtended extends Datastore {
     public int getDocumentCount();
 
     /**
-     * <p>Returns the SQLite primary key of a document.</p>
-     *
-     * <p>Internally, each document has a row in a SQLite database table.
-     * This method gets the primary key of that row. It's meaningless
-     * outside of the local datastore, and dependent on the insertion
-     * order of documents.</p>
-     *
-     * @param documentId id of the specified document
-     * @return internal id of the given document
-     */
-    public long getDocNumericId(String documentId);
-    /**
      * Returns the subset of given the documentId/revisions that are not stored in the database.
      *
      * The input revisions is a map, whose key is document id, and value is a list of revisions.

--- a/sync-core/src/test/java/com/cloudant/sync/datastore/BasicDatastoreCRUDTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/datastore/BasicDatastoreCRUDTest.java
@@ -412,28 +412,6 @@ public class BasicDatastoreCRUDTest extends BasicDatastoreTestBase {
     }
 
     @Test
-    public void getDocNumericId() throws IOException {
-        MutableDocumentRevision rev_1Mut = new MutableDocumentRevision();
-        rev_1Mut.body = bodyOne;
-        BasicDocumentRevision rev_1 = datastore.createDocumentFromRevision(rev_1Mut);
-        MutableDocumentRevision rev_2Mut = new MutableDocumentRevision();
-        rev_2Mut.body = bodyTwo;
-        BasicDocumentRevision rev_2 = datastore.createDocumentFromRevision(rev_2Mut);
-        Assert.assertTrue(datastore.getDocNumericId(rev_1.getId()) == 1L);
-        Assert.assertTrue(datastore.getDocNumericId(rev_2.getId()) == 2L);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void getDocNumericId_null_exception() {
-        datastore.getDocNumericId(null);
-    }
-
-    @Test
-    public void getDocNumericId_idNotExist_minusOne() {
-        Assert.assertEquals(-1, datastore.getDocNumericId("invalidDocId"));
-    }
-
-    @Test
     public void getDocumentsWithIds_NA_allSpecifiedDocumentsShouldBeReturnedInCorrectOrder() throws ConflictException, IOException {
         MutableDocumentRevision rev_1Mut = new MutableDocumentRevision();
         rev_1Mut.body = bodyOne;

--- a/sync-core/src/test/java/com/cloudant/sync/datastore/DocumentRevisionTreeTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/datastore/DocumentRevisionTreeTest.java
@@ -29,8 +29,8 @@ import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 public class DocumentRevisionTreeTest {
 
     DocumentBody b;
-    BasicDocumentRevision d1, d2, d3, d4, d5;
-    BasicDocumentRevision c3, c4;
+    BasicDocumentRevision c1, c2, c3, c4, c5;
+    BasicDocumentRevision d3, d4;
     BasicDocumentRevision e1, e2, e3;
     BasicDocumentRevision f3, f4;
 
@@ -42,9 +42,9 @@ public class DocumentRevisionTreeTest {
         b = new BasicDocumentBody("{\"a\": \"haha\"}".getBytes());
 
         /**
-         * d1 -> d2 -> d3 -> d4 -> d5
+         * c1 -> c2 -> c3 -> c4 -> c5
          *        |
-         *        -> c3 -> c4
+         *        -> d3 -> d4
          *
          * e1 -> e2 -> e3
          *        |
@@ -56,54 +56,62 @@ public class DocumentRevisionTreeTest {
 
         opts.sequence = 1l;
         opts.parent = -1l;
-        d1 = new BasicDocumentRevision( "id1", "1-rev", b, opts);
+        opts.current = false;
+        c1 = new BasicDocumentRevision( "id1", "1-rev", b, opts);
 
         opts.sequence = 2l;
         opts.parent = 1l;
-        d2 = new BasicDocumentRevision( "id1", "2-rev", b, opts);
+        opts.current = false;
+        c2 = new BasicDocumentRevision( "id1", "2-rev", b, opts);
 
         opts.sequence = 3l;
         opts.parent = 2l;
-        d3 = new BasicDocumentRevision( "id1", "3-rev", b, opts);
+        opts.current = false;
+        c3 = new BasicDocumentRevision( "id1", "3-rev", b, opts);
 
         opts.sequence = 4l;
         opts.parent = 3l;
-        d4 = new BasicDocumentRevision( "id1", "4-rev", b, opts);
+        opts.current = false;
+        c4 = new BasicDocumentRevision( "id1", "4-rev", b, opts);
 
         opts.sequence = 5l;
         opts.parent = 4l;
         opts.current = true;
-        d5 = new BasicDocumentRevision( "id1", "5-rev", b, opts);
+        c5 = new BasicDocumentRevision( "id1", "5-rev", b, opts);
 
-        opts = new BasicDocumentRevision.BasicDocumentRevisionOptions();
         opts.sequence = 6l;
         opts.parent = 2l;
+        opts.current = false;
+        d3 = new BasicDocumentRevision( "id1", "3-rev2", b, opts);
 
-        c3 = new BasicDocumentRevision( "id1", "3-rev2", b, opts);
         opts.sequence = 7l;
         opts.parent = 6l;
         opts.current = true;
-        c4 = new BasicDocumentRevision( "id1", "4-rev2", b, opts);
+        d4 = new BasicDocumentRevision( "id1", "4-rev2", b, opts);
 
-        opts = new BasicDocumentRevision.BasicDocumentRevisionOptions();
         opts.sequence = 8l;
         opts.parent = -1l;
+        opts.current = false;
         e1 = new BasicDocumentRevision( "id1", "1-rev-star", b, opts);
 
         opts.sequence = 9l;
         opts.parent = 8l;
+        opts.current = false;
         e2 = new BasicDocumentRevision( "id1", "2-rev-star", b, opts);
 
         opts.sequence = 10l;
         opts.parent = 9l;
+        opts.current = false;
         e3 = new BasicDocumentRevision( "id1", "3-rev-star", b, opts);
 
         opts.sequence = 11l;
         opts.parent = 9l;
+        opts.current = false;
         f3 = new BasicDocumentRevision( "id1", "3-rev-star-star", b, opts);
 
         opts.sequence = 12l;
         opts.parent = 11l;
+        opts.current = false;
         f4 = new BasicDocumentRevision( "id1", "4-rev-star-star", b, opts);
 
         /**
@@ -114,17 +122,19 @@ public class DocumentRevisionTreeTest {
 
         opts = new BasicDocumentRevision.BasicDocumentRevisionOptions();
         opts.docInternalId = 2l;
-
         opts.sequence = 12l;
         opts.parent = -1l;
+        opts.current = false;
         x2 = new BasicDocumentRevision( "id2", "2-x", b, opts);
 
         opts.sequence = 13l;
         opts.parent = 12l;
+        opts.current = true;
         x3 = new BasicDocumentRevision( "id2", "3-x", b, opts);
 
         opts.sequence = 14l;
         opts.parent = 12l;
+        opts.current = false;
         y3 = new BasicDocumentRevision( "id2", "3-y", b, opts);
     }
 
@@ -132,88 +142,88 @@ public class DocumentRevisionTreeTest {
     public void constructor_nullRoot() {
         DocumentRevisionTree t = new DocumentRevisionTree();
         Assert.assertEquals(0, t.roots().size());
-        t.add(d1);
+        t.add(c1);
 
         checkTreeWithOnlyRootNode(t);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void constructor_invalidRootNode() {
-        DocumentRevisionTree t = new DocumentRevisionTree(d2);
+        DocumentRevisionTree t = new DocumentRevisionTree(c2);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void constructor_invalidRootNode2() {
         DocumentRevisionTree t = new DocumentRevisionTree();
-        t.add(d2);
+        t.add(c2);
     }
 
     @Test
     public void constructor() {
-        DocumentRevisionTree t = new DocumentRevisionTree(d1);
+        DocumentRevisionTree t = new DocumentRevisionTree(c1);
 
         checkTreeWithOnlyRootNode(t);
     }
 
     private void checkTreeWithOnlyRootNode(DocumentRevisionTree t) {
-        Assert.assertTrue(d1 == t.root(d1.getSequence()).getData());
+        Assert.assertTrue(c1 == t.root(c1.getSequence()).getData());
         List<DocumentRevisionTree.DocumentRevisionNode> l = t.leafs();
         Assert.assertEquals(1, l.size());
-        Assert.assertTrue(d1 == l.get(0).getData());
+        Assert.assertTrue(c1 == l.get(0).getData());
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void add_wrongOrder_exception () {
-        DocumentRevisionTree t = new DocumentRevisionTree(d1);
-        t.add(d3);
+        DocumentRevisionTree t = new DocumentRevisionTree(c1);
+        t.add(c3);
     }
 
     @Test(expected =  IllegalArgumentException.class)
     public void add_sameNodeAddedTwice_exception () {
-        DocumentRevisionTree t = new DocumentRevisionTree(d1);
-        t.add(d1);
+        DocumentRevisionTree t = new DocumentRevisionTree(c1);
+        t.add(c1);
     }
 
     @Test
     public void add_oneTreeInOrderOfSequence() {
-        DocumentRevisionTree t = new DocumentRevisionTree(d1);
+        DocumentRevisionTree t = new DocumentRevisionTree(c1);
 
         addOneTreeInOrderOfSequence(t);
     }
 
     private void addOneTreeInOrderOfSequence(DocumentRevisionTree t) {
-        t.add(d2).add(d3).add(d4).add(d5);
-        Assert.assertTrue(d1 == t.root(d1.getSequence()).getData());
+        t.add(c2).add(c3).add(c4).add(c5);
+        Assert.assertTrue(c1 == t.root(c1.getSequence()).getData());
         Assert.assertFalse(t.hasConflicts());
         Assert.assertEquals(1, t.leafs().size());
-        Assert.assertTrue(t.leafs().contains(new DocumentRevisionTree.DocumentRevisionNode(d5)));
+        Assert.assertTrue(t.leafs().contains(new DocumentRevisionTree.DocumentRevisionNode(c5)));
 
-        t.add(c3).add(c4);
-        Assert.assertTrue(d1 == t.root(d1.getSequence()).getData());
+        t.add(d3).add(d4);
+        Assert.assertTrue(c1 == t.root(c1.getSequence()).getData());
         Assert.assertTrue(t.hasConflicts());
         Assert.assertEquals(2, t.leafs().size());
-        Assert.assertTrue(t.leafs().contains(new DocumentRevisionTree.DocumentRevisionNode(d5)));
-        Assert.assertTrue(t.leafs().contains(new DocumentRevisionTree.DocumentRevisionNode(c4)));
+        Assert.assertTrue(t.leafs().contains(new DocumentRevisionTree.DocumentRevisionNode(c5)));
+        Assert.assertTrue(t.leafs().contains(new DocumentRevisionTree.DocumentRevisionNode(d4)));
     }
 
     @Test
     public void lookupBySequence_oneTree() {
-        DocumentRevisionTree t = new DocumentRevisionTree(d1);
-        t.add(d2).add(d3).add(d4).add(d5);
-        t.add(c3).add(c4);
+        DocumentRevisionTree t = new DocumentRevisionTree(c1);
+        t.add(c2).add(c3).add(c4).add(c5);
+        t.add(d3).add(d4);
 
         Assert.assertNull(t.bySequence(-2l));
-        BasicDocumentRevision d = t.bySequence(d2.getSequence());
-        Assert.assertTrue(d.getSequence() == d2.getSequence());
+        BasicDocumentRevision d = t.bySequence(c2.getSequence());
+        Assert.assertTrue(d.getSequence() == c2.getSequence());
     }
 
     @Test
     public void lookup_oneTree() {
-        DocumentRevisionTree t = new DocumentRevisionTree(d1);
-        t.add(d2).add(d3).add(d4).add(d5);
-        t.add(c3).add(c4);
+        DocumentRevisionTree t = new DocumentRevisionTree(c1);
+        t.add(c2).add(c3).add(c4).add(c5);
+        t.add(d3).add(d4);
 
-        BasicDocumentRevision d = t.lookup(d3.getId(), d3.getRevision());
+        BasicDocumentRevision d = t.lookup(c3.getId(), c3.getRevision());
         Assert.assertNotNull(d);
 
         BasicDocumentRevision m = t.lookup("haha", "hehe");
@@ -222,29 +232,29 @@ public class DocumentRevisionTreeTest {
 
     @Test
     public void depth_oneTree() {
-        DocumentRevisionTree t = new DocumentRevisionTree(d1);
-        t.add(d2).add(d3).add(d4).add(d5);
-        t.add(c3).add(c4);
+        DocumentRevisionTree t = new DocumentRevisionTree(c1);
+        t.add(c2).add(c3).add(c4).add(c5);
+        t.add(d3).add(d4);
 
-        Assert.assertEquals(0, t.depth(d1.getSequence()));
-        Assert.assertEquals(4, t.depth(d5.getSequence()));
-        Assert.assertEquals(3, t.depth(c4.getSequence()));
+        Assert.assertEquals(0, t.depth(c1.getSequence()));
+        Assert.assertEquals(4, t.depth(c5.getSequence()));
+        Assert.assertEquals(3, t.depth(d4.getSequence()));
         Assert.assertEquals(-1, t.depth(100l));
     }
 
     @Test
     public void leafs_oneTree() {
-        DocumentRevisionTree t = new DocumentRevisionTree(d1);
-        t.add(d2).add(d3).add(d4).add(d5);
-        t.add(c3).add(c4);
+        DocumentRevisionTree t = new DocumentRevisionTree(c1);
+        t.add(c2).add(c3).add(c4).add(c5);
+        t.add(d3).add(d4);
 
         Assert.assertEquals(2, t.leafs().size());
         List<BasicDocumentRevision> l = new ArrayList<BasicDocumentRevision>();
         for(DocumentRevisionTree.DocumentRevisionNode n : t.leafs()) {
             l.add(n.getData());
         }
-        Assert.assertTrue(l.contains(d5));
-        Assert.assertTrue(l.contains(c4));
+        Assert.assertTrue(l.contains(c5));
+        Assert.assertTrue(l.contains(d4));
     }
 
     @Test
@@ -255,94 +265,98 @@ public class DocumentRevisionTreeTest {
 
     @Test
     public void leafRevisions_oneTree() {
-        DocumentRevisionTree t = new DocumentRevisionTree(d1);
-        t.add(d2).add(d3).add(d4).add(d5);
-        t.add(c3).add(c4);
+        DocumentRevisionTree t = new DocumentRevisionTree(c1);
+        t.add(c2).add(c3).add(c4).add(c5);
+        t.add(d3).add(d4);
 
         Assert.assertThat(t.leafRevisionIds(), hasSize(2));
-        Assert.assertThat(t.leafRevisionIds(), hasItems(d5.getRevision(), c4.getRevision()));
+        Assert.assertThat(t.leafRevisionIds(), hasItems(c5.getRevision(), d4.getRevision()));
     }
 
     @Test
     public void getPathForLeaf_oneTreeWithLeafNodes_correctPathShouldBeReturned() {
-        DocumentRevisionTree t = new DocumentRevisionTree(d1);
-        t.add(d2).add(d3).add(d4).add(d5);
-        t.add(c3).add(c4);
+        DocumentRevisionTree t = new DocumentRevisionTree(c1);
+        t.add(c2).add(c3).add(c4).add(c5);
+        t.add(d3).add(d4);
 
         {
-            List<BasicDocumentRevision> p = t.getPathForNode(d5.getSequence());
+            List<BasicDocumentRevision> p = t.getPathForNode(c5.getSequence());
             Assert.assertEquals(5, p.size());
-            Assert.assertEquals(p.get(4).getSequence(), d1.getSequence());
-            Assert.assertEquals(p.get(3).getSequence(), d2.getSequence());
-            Assert.assertEquals(p.get(2).getSequence(), d3.getSequence());
-            Assert.assertEquals(p.get(1).getSequence(), d4.getSequence());
-            Assert.assertEquals(p.get(0).getSequence(), d5.getSequence());
+            Assert.assertEquals(p.get(4).getSequence(), c1.getSequence());
+            Assert.assertEquals(p.get(3).getSequence(), c2.getSequence());
+            Assert.assertEquals(p.get(2).getSequence(), c3.getSequence());
+            Assert.assertEquals(p.get(1).getSequence(), c4.getSequence());
+            Assert.assertEquals(p.get(0).getSequence(), c5.getSequence());
         }
 
 
         {
-            List<BasicDocumentRevision> p2 = t.getPathForNode(c4.getSequence());
+            List<BasicDocumentRevision> p2 = t.getPathForNode(d4.getSequence());
             Assert.assertEquals(4, p2.size());
-            Assert.assertEquals(p2.get(3).getSequence(), d1.getSequence());
-            Assert.assertEquals(p2.get(2).getSequence(), d2.getSequence());
-            Assert.assertEquals(p2.get(1).getSequence(), c3.getSequence());
-            Assert.assertEquals(p2.get(0).getSequence(), c4.getSequence());
+            Assert.assertEquals(p2.get(3).getSequence(), c1.getSequence());
+            Assert.assertEquals(p2.get(2).getSequence(), c2.getSequence());
+            Assert.assertEquals(p2.get(1).getSequence(), d3.getSequence());
+            Assert.assertEquals(p2.get(0).getSequence(), d4.getSequence());
         }
     }
 
     @Test
     public void getPath_oneTreeWithLeafNodes_correctPathShouldBeReturned() {
-        DocumentRevisionTree t = new DocumentRevisionTree(d1);
-        t.add(d2).add(d3).add(d4).add(d5);
-        t.add(c3).add(c4);
+        DocumentRevisionTree t = new DocumentRevisionTree(c1);
+        t.add(c2).add(c3).add(c4).add(c5);
+        t.add(d3).add(d4);
 
         {
-            List<String> p = t.getPath(d5.getSequence());
+            List<String> p = t.getPath(c5.getSequence());
             Assert.assertEquals(5, p.size());
-            Assert.assertThat(p, equalTo(Arrays.asList(d5.getRevision(), d4.getRevision(), d3.getRevision(),
-                    d2.getRevision(), d1.getRevision())));
+            Assert.assertThat(p, equalTo(Arrays.asList(c5.getRevision(), c4.getRevision(),
+                    c3.getRevision(),
+                    c2.getRevision(), c1.getRevision())));
         }
 
 
         {
-            List<String> p2 = t.getPath(c4.getSequence());
+            List<String> p2 = t.getPath(d4.getSequence());
             Assert.assertEquals(4, p2.size());
-            Assert.assertThat(p2, equalTo(Arrays.asList(c4.getRevision(), c3.getRevision(), d2.getRevision(),
-                    d1.getRevision())));
+            Assert.assertThat(p2, equalTo(Arrays.asList(d4.getRevision(), d3.getRevision(),
+                    c2.getRevision(),
+                    c1.getRevision())));
         }
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void getPath_invalidSequence_exception() {
-        DocumentRevisionTree t = new DocumentRevisionTree(d1);
-        t.add(d2).add(d3).add(d4).add(d5);
-        t.add(c3).add(c4);
+        DocumentRevisionTree t = new DocumentRevisionTree(c1);
+        t.add(c2).add(c3).add(c4).add(c5);
+        t.add(d3).add(d4);
         t.getPath(1001L);
     }
 
     @Test
     public void getPath_treeWithOneRevision_correctTreeIsReturned() {
-        DocumentRevisionTree t = new DocumentRevisionTree(d1);
-        List<String> p = t.getPath(d1.getSequence());
+        DocumentRevisionTree t = new DocumentRevisionTree(c1);
+        List<String> p = t.getPath(c1.getSequence());
         Assert.assertThat(p, hasSize(1));
-        Assert.assertThat(p, equalTo(Arrays.asList(d1.getRevision())));
+        Assert.assertThat(p, equalTo(Arrays.asList(c1.getRevision())));
     }
 
     @Test
     public void add_twoTreesAndNodesInOrderOfSequence_treesShouldBeConstructedCorrectly() {
-        DocumentRevisionTree t = new DocumentRevisionTree(d1);
+        DocumentRevisionTree t = new DocumentRevisionTree(c1);
         addOneTreeInOrderOfSequence(t);
 
         t.add(e1).add(e2).add(e3);
         Assert.assertEquals(2, t.roots().size());
-        Assert.assertThat(t.roots().keySet(), hasItems(d1.getSequence(), e1.getSequence()));
+        Assert.assertThat(t.roots().keySet(), hasItems(c1.getSequence(), e1.getSequence()));
         Assert.assertEquals(3, t.leafs().size());
-        Assert.assertThat(leafSequences(t.leafs()), hasItems(d5.getSequence(), c4.getSequence(), e3.getSequence()));
+        Assert.assertThat(leafSequences(t.leafs()), hasItems(c5.getSequence(), d4.getSequence(),
+                e3.getSequence()));
 
         t.add(f3).add(f4);
         Assert.assertEquals(2, t.roots().size());
         Assert.assertEquals(4, t.leafs().size());
-        Assert.assertThat(leafSequences(t.leafs()), hasItems(d5.getSequence(), c4.getSequence(), e3.getSequence(),
+        Assert.assertThat(leafSequences(t.leafs()), hasItems(c5.getSequence(), d4.getSequence(),
+                e3.getSequence(),
                 f4.getSequence()));
 
     }


### PR DESCRIPTION
Remove the following methods with expose internal IDs
from public view
- DatastoreExtended#getDocNumericId() - Removed from public interface
- BasicDocumentRevision#getInternalNumericId() - Changed visibiity to protected

Only one question, should the getDocNumericId on BasicDatastore remain public or be made protected?
