### PR TITLE
Add simple AND query find functionality

### DIFF
--- a/sync-core/src/main/java/com/cloudant/sync/query/AndQueryNode.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/AndQueryNode.java
@@ -12,23 +12,12 @@
 
 package com.cloudant.sync.query;
 
-import org.junit.Assert;
-import org.junit.Test;
+/**
+ *  An AndQueryNode object is used to specify that document IDs passed up the tree from child
+ *  nodes need to be intersected before being passed to the parent node.
+ */
+class AndQueryNode extends ChildrenQueryNode {
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+    // This class is used to define a ChildrenQueryNode as a specific type of QueryNode
 
-public class IndexManagerTest extends AbstractIndexTestBase {
-
-    @Test
-    public void unimplementedEnsureIndexed() {
-        List<Object> fieldNames = Arrays.<Object>asList("name");
-        Assert.assertNull(im.ensureIndexed(fieldNames));
-    }
-
-    @Test
-    public void unimplementedDeleteIndexNamed() {
-        Assert.assertFalse(im.deleteIndexNamed("basic"));
-    }
 }

--- a/sync-core/src/main/java/com/cloudant/sync/query/ChildrenQueryNode.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/ChildrenQueryNode.java
@@ -12,23 +12,19 @@
 
 package com.cloudant.sync.query;
 
-import org.junit.Assert;
-import org.junit.Test;
-
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
-public class IndexManagerTest extends AbstractIndexTestBase {
+/**
+ *  A ChildrenQueryNode object represents a tree node that is not a leaf,
+ *  specialized further in subclasses.
+ */
+class ChildrenQueryNode implements QueryNode {
 
-    @Test
-    public void unimplementedEnsureIndexed() {
-        List<Object> fieldNames = Arrays.<Object>asList("name");
-        Assert.assertNull(im.ensureIndexed(fieldNames));
+    public List<QueryNode> children;
+
+    ChildrenQueryNode() {
+        children = new ArrayList<QueryNode>();
     }
 
-    @Test
-    public void unimplementedDeleteIndexNamed() {
-        Assert.assertFalse(im.deleteIndexNamed("basic"));
-    }
 }

--- a/sync-core/src/main/java/com/cloudant/sync/query/IndexCreator.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/IndexCreator.java
@@ -30,6 +30,9 @@ import java.util.concurrent.Future;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+/**
+ *  Handles creating indexes for a given datastore.
+ */
 class IndexCreator {
 
     private final SQLDatabase database;
@@ -45,7 +48,7 @@ class IndexCreator {
         this.queue = queue;
     }
 
-    protected static String ensureIndexed(ArrayList<Object> fieldNames,
+    protected static String ensureIndexed(List<Object> fieldNames,
                                           String indexName,
                                           String indexType,
                                           SQLDatabase database,
@@ -66,7 +69,7 @@ class IndexCreator {
      *  @param indexType "json" is the only supported type for now
      *  @return name of created index
      */
-    private String ensureIndexed(ArrayList<Object> fieldNames,
+    private String ensureIndexed(List<Object> fieldNames,
                                  final String indexName,
                                  final String indexType) {
         if (fieldNames == null || fieldNames.isEmpty()) {
@@ -79,7 +82,7 @@ class IndexCreator {
             return null;
         }
 
-        final ArrayList<String> fieldNamesList = removeDirectionsFromFields(fieldNames);
+        final List<String> fieldNamesList = removeDirectionsFromFields(fieldNames);
 
         for (String fieldName: fieldNamesList) {
             if (!validFieldName(fieldName)) {
@@ -229,8 +232,8 @@ class IndexCreator {
      *  We don't support directions on field names, but they are an optimisation so
      *  we can discard them safely.
      */
-    protected static ArrayList<String> removeDirectionsFromFields(ArrayList<Object> fieldNames) {
-        ArrayList<String> result = new ArrayList<String>();
+    protected static List<String> removeDirectionsFromFields(List<Object> fieldNames) {
+        List<String> result = new ArrayList<String>();
 
         for (Object field: fieldNames) {
             if (field instanceof Map) {
@@ -262,7 +265,7 @@ class IndexCreator {
     }
 
     private String createIndexTableStatementForIndexName(String indexName, List<String> columns) {
-        String tableName = IndexManager.INDEX_TABLE_PREFIX.concat(indexName);
+        String tableName = IndexManager.tableNameForIndex(indexName);
         Joiner joiner = Joiner.on(" NONE,").skipNulls();
         String cols = joiner.join(columns);
 
@@ -270,7 +273,7 @@ class IndexCreator {
     }
 
     private String createIndexIndexStatementForIndexName(String indexName, List<String> columns) {
-        String tableName = IndexManager.INDEX_TABLE_PREFIX.concat(indexName);
+        String tableName = IndexManager.tableNameForIndex(indexName);
         String sqlIndexName = tableName.concat("_index");
         Joiner joiner = Joiner.on(",").skipNulls();
         String cols = joiner.join(columns);

--- a/sync-core/src/main/java/com/cloudant/sync/query/IndexManager.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/IndexManager.java
@@ -67,7 +67,7 @@ import java.util.regex.Pattern;
  */
 public class IndexManager {
 
-    public static final String INDEX_TABLE_PREFIX = "_t_cloudant_sync_query_index_";
+    private static final String INDEX_TABLE_PREFIX = "_t_cloudant_sync_query_index_";
     public static final String INDEX_METADATA_TABLE_NAME = "_t_cloudant_sync_query_metadata";
 
     private static final String EXTENSION_NAME = "com.cloudant.sync.query";
@@ -169,7 +169,7 @@ public class IndexManager {
      *  @param fieldNames List of field names in the sort format
      *  @return name of created index
      */
-    public String ensureIndexed(ArrayList<Object> fieldNames) {
+    public String ensureIndexed(List<Object> fieldNames) {
         logger.log(Level.SEVERE, "ensureIndexed(fieldNames) not implemented.");
 
         return null;
@@ -184,7 +184,7 @@ public class IndexManager {
      *  @param indexName Name of index to create
      *  @return name of created index
      */
-    public String ensureIndexed(ArrayList<Object> fieldNames, String indexName) {
+    public String ensureIndexed(List<Object> fieldNames, String indexName) {
         return ensureIndexed(fieldNames, indexName, "json");
     }
 
@@ -198,7 +198,7 @@ public class IndexManager {
      *  @param indexType "json" is the only supported type for now
      *  @return name of created index
      */
-    public String ensureIndexed(ArrayList<Object> fieldNames, String indexName, String indexType) {
+    public String ensureIndexed(List<Object> fieldNames, String indexName, String indexType) {
         if (fieldNames == null || fieldNames.isEmpty()) {
             return null;
         }
@@ -248,13 +248,28 @@ public class IndexManager {
         return IndexUpdater.updateAllIndexes(indexes, database, datastore, queue);
     }
 
-    public QueryResultSet find(Map<String, Object> query) {
+    public QueryResult find(Map<String, Object> query) {
+        return find(query, 0, 0, null, null);
+    }
 
-        // TODO - implement method
+    public QueryResult find(Map<String, Object> query,
+                            long skip,
+                            long limit,
+                            List<String> fields,
+                            List<Map<String, String>> sortDocument) {
+        if (query == null) {
+            logger.log(Level.SEVERE, "-find called with null selector; bailing.");
+            return null;
+        }
 
-        logger.log(Level.SEVERE, "find(query) not implemented.");
+        if (!updateAllIndexes()) {
+            return null;
+        }
 
-        return null;
+        QueryExecutor queryExecutor = new QueryExecutor(database, datastore, queue);
+        Map<String, Object> indexes = listIndexes();
+
+        return queryExecutor.find(query, indexes, skip, limit, fields, sortDocument);
     }
 
     protected static String tableNameForIndex(String indexName) {

--- a/sync-core/src/main/java/com/cloudant/sync/query/IndexUpdater.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/IndexUpdater.java
@@ -86,7 +86,7 @@ class IndexUpdater {
      *  @return index update success status (true/false)
      */
     public static boolean updateIndex(String indexName,
-                                      ArrayList<String> fieldNames,
+                                      List<String> fieldNames,
                                       SQLDatabase database,
                                       Datastore datastore,
                                       ExecutorService queue) {
@@ -101,7 +101,7 @@ class IndexUpdater {
 
         for (String indexName: indexes.keySet()) {
             Map<String, Object> index = (Map<String, Object>) indexes.get(indexName);
-            ArrayList<String> fields = (ArrayList<String>) index.get("fields");
+            List<String> fields = (ArrayList<String>) index.get("fields");
             success = updateIndex(indexName, fields);
             if (!success) {
                 break;
@@ -111,7 +111,7 @@ class IndexUpdater {
         return success;
     }
 
-    private boolean updateIndex(String indexName, ArrayList<String> fieldNames) {
+    private boolean updateIndex(String indexName, List<String> fieldNames) {
         boolean success;
         Changes changes;
         long lastSequence = sequenceNumberForIndex(indexName);
@@ -131,7 +131,7 @@ class IndexUpdater {
     }
 
     private boolean updateIndex(final String indexName,
-                                final ArrayList<String> fieldNames,
+                                final List<String> fieldNames,
                                 final Changes changes,
                                 long lastSequence) {
         if (indexName == null || indexName.isEmpty()) {
@@ -215,7 +215,7 @@ class IndexUpdater {
     @SuppressWarnings("unchecked")
     private List<DBParameter> parametersToIndexRevision (BasicDocumentRevision rev,
                                                          String indexName,
-                                                         ArrayList<String> fieldNames) {
+                                                         List<String> fieldNames) {
         if (rev == null) {
             return null;
         }
@@ -253,10 +253,10 @@ class IndexUpdater {
             // in the index. _id and _rev are special fields in that they don't appear in the
             // body, so they need special-casing to get the values.
 
-            ArrayList<String> initialIncludedFields = new ArrayList<String>();
+            List<String> initialIncludedFields = new ArrayList<String>();
             initialIncludedFields.add("_id");
             initialIncludedFields.add("_rev");
-            ArrayList<Object> initialArgs = new ArrayList<Object>();
+            List<Object> initialArgs = new ArrayList<Object>();
             initialArgs.add(rev.getId());
             initialArgs.add(rev.getRevision());
             DBParameter parameter = populateDBParameter(fieldNames,
@@ -270,15 +270,15 @@ class IndexUpdater {
             parameters.add(parameter);
         } else if (arrayFieldName != null) {
             // We know the value is an array, we found this out in the check above
-            ArrayList<Object> arrayFieldValues;
+            List<Object> arrayFieldValues;
             arrayFieldValues = (ArrayList) ValueExtractor.extractValueForFieldName(arrayFieldName,
                                                                                    rev.getBody());
             for (Object value: arrayFieldValues) {
-                ArrayList<String> initialIncludedFields = new ArrayList<String>();
+                List<String> initialIncludedFields = new ArrayList<String>();
                 initialIncludedFields.add("_id");
                 initialIncludedFields.add("_rev");
                 initialIncludedFields.add(arrayFieldName);
-                ArrayList<Object> initialArgs = new ArrayList<Object>();
+                List<Object> initialArgs = new ArrayList<Object>();
                 initialArgs.add(rev.getId());
                 initialArgs.add(rev.getRevision());
                 initialArgs.add(value);
@@ -298,9 +298,9 @@ class IndexUpdater {
         return parameters;
     }
 
-    private DBParameter populateDBParameter(ArrayList<String> fieldNames,
-                                            ArrayList<String> initialIncludedFields,
-                                            ArrayList<Object> initialArgs,
+    private DBParameter populateDBParameter(List<String> fieldNames,
+                                            List<String> initialIncludedFields,
+                                            List<Object> initialArgs,
                                             String indexName,
                                             BasicDocumentRevision rev) {
         List<String> includeFieldNames = new ArrayList<String>();

--- a/sync-core/src/main/java/com/cloudant/sync/query/OrQueryNode.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/OrQueryNode.java
@@ -12,23 +12,10 @@
 
 package com.cloudant.sync.query;
 
-import org.junit.Assert;
-import org.junit.Test;
+/**
+ *  An OrQueryNode object is used to specify that document IDs passed up the tree from child
+ *  nodes need to be unioned before being passed to the parent node.
+ */
+class OrQueryNode extends ChildrenQueryNode {
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
-public class IndexManagerTest extends AbstractIndexTestBase {
-
-    @Test
-    public void unimplementedEnsureIndexed() {
-        List<Object> fieldNames = Arrays.<Object>asList("name");
-        Assert.assertNull(im.ensureIndexed(fieldNames));
-    }
-
-    @Test
-    public void unimplementedDeleteIndexNamed() {
-        Assert.assertFalse(im.deleteIndexNamed("basic"));
-    }
 }

--- a/sync-core/src/main/java/com/cloudant/sync/query/QueryExecutor.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/QueryExecutor.java
@@ -1,0 +1,284 @@
+//  Copyright (c) 2014 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+package com.cloudant.sync.query;
+
+import com.cloudant.sync.datastore.Datastore;
+import com.cloudant.sync.sqlite.Cursor;
+import com.cloudant.sync.sqlite.SQLDatabase;
+import com.cloudant.sync.util.DatabaseUtils;
+import com.google.common.collect.Sets;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ *  Handles querying indexes for a given datastore.
+ */
+class QueryExecutor {
+
+    private final SQLDatabase database;
+    private final Datastore datastore;
+    private final ExecutorService queue;
+
+    private static final Logger logger = Logger.getLogger(QueryExecutor.class.getName());
+
+    /**
+     *  Constructs a new CDTQQueryExecutor using the indexes in 'database' to find documents from
+     *  'datastore'.
+     */
+    QueryExecutor(SQLDatabase database, Datastore datastore, ExecutorService queue) {
+        this.database = database;
+        this.datastore = datastore;
+        this.queue = queue;
+    }
+
+    /**
+     *  Execute the query passed using the selection of index definition provided.
+     *
+     *  The index definitions are presumed to already exist and be up to date for the
+     *  datastore and database passed to the constructor.
+     *
+     *  @param query query to execute.
+     *  @param indexes indexes to use (this method will select the most appropriate).
+     *  @param skip how many results to skip before returning results to caller
+     *  @param limit number of documents the result should be limited to
+     *  @param fields fields to project from the result documents
+     *  @param sortDocument document specifying the order to return results, null to have no sorting
+     *  @return the query result
+     */
+    public QueryResult find(Map<String, Object> query,
+                            final Map<String, Object> indexes,
+                            long skip,
+                            long limit,
+                            List<String> fields,
+                            final List<Map<String, String>> sortDocument) {
+        //
+        // Validate inputs
+        //
+
+        if (!validateSortDocument(sortDocument)) {
+            return null;  // validate logs the error if doc is invalid
+        }
+
+        fields = normaliseFields(fields);
+
+        if (!validateFields(fields)) {
+            return null;  // validate logs error message
+        }
+
+        // normalise and validate query by passing into the executors
+
+        query = QueryValidator.normaliseAndValidateQuery(query);
+
+        if (query == null) {
+            return null;
+        }
+
+        //
+        // Execute the query
+        //
+
+        Boolean[] indexesCoverQuery = new Boolean[]{ false };
+        final ChildrenQueryNode root = translateQuery(query, indexes, indexesCoverQuery);
+
+        if (root == null) {
+            return null;
+        }
+
+        Future<List<String>> result = queue.submit(new Callable<List<String>>() {
+            @Override
+            public List<String> call() throws Exception {
+                Set<String> docIdSet = executeQueryTree(root, database);
+                List<String> docIdList;
+
+                // sorting
+                if (sortDocument != null && !sortDocument.isEmpty()) {
+                    docIdList = sortIds(docIdSet, sortDocument, indexes, database);
+                } else {
+                    docIdList = docIdSet != null ? new ArrayList<String>(docIdSet) : null;
+                }
+
+                return docIdList;
+            }
+        });
+
+        List<String> docIds;
+        try {
+            docIds = result.get();
+        } catch (ExecutionException e) {
+            logger.log(Level.SEVERE, "Execution error encountered:", e);
+            return null;
+        } catch (InterruptedException e) {
+            logger.log(Level.SEVERE, "Execution interrupted error encountered:", e);
+            return null;
+        }
+
+        if (docIds == null) {
+            return null;
+        }
+
+        UnindexedMatcher matcher = matcherForIndexCoverage(indexesCoverQuery, query);
+
+        if (matcher != null) {
+            String msg = "Query could not be executed using indexes alone; falling back to ";
+            msg += "filtering documents themselves. This will be VERY SLOW as each candidate ";
+            msg += "document is loaded from the datastore and matched against the query selector.";
+            logger.log(Level.WARNING, msg);
+        }
+
+        return new QueryResult(docIds, datastore, fields, skip, limit, matcher);
+    }
+
+    protected ChildrenQueryNode translateQuery(Map<String, Object> query,
+                                               Map<String, Object> indexes,
+                                               Boolean[] indexesCoverQuery) {
+        return (ChildrenQueryNode) QuerySqlTranslator.translateQuery(query,
+                                                                     indexes,
+                                                                     indexesCoverQuery);
+    }
+
+    protected UnindexedMatcher matcherForIndexCoverage(Boolean[] indexesCoverQuery,
+                                                       Map<String, Object> selector) {
+        return indexesCoverQuery[0] ? null : UnindexedMatcher.matcherWithSelector(selector);
+    }
+
+    private boolean validateSortDocument(List<Map<String, String>> sortDocument) {
+        if (sortDocument == null || sortDocument.isEmpty()) {
+            return true; // empty or null sort docs just mean "don't sort", so are valid
+        }
+
+        for (Map<String, String> clause: sortDocument) {
+            if (clause.size() > 1) {
+                logger.log(Level.SEVERE, "Each order clause can only be a single field");
+                return false;
+            }
+            String fieldName = (String) clause.keySet().toArray()[0];
+            String direction = clause.get(fieldName);
+            if (!direction.equalsIgnoreCase("ASC") && !direction.equalsIgnoreCase("DESC")) {
+                String msg = String.format("Order direction %s not valid, use `asc` or `desc`",
+                                           direction);
+                logger.log(Level.SEVERE, msg);
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private List<String> normaliseFields(List<String> fields) {
+        if (fields == null || fields.isEmpty()) {
+            String msg = "Projection fields array is empty, disabling project for this query";
+            logger.log(Level.WARNING, msg);
+            return null;
+        }
+
+        return fields;
+    }
+
+    private Set<String> executeQueryTree(QueryNode node, SQLDatabase db) {
+        if (node instanceof AndQueryNode) {
+            Set<String> accumulator = null;
+
+            AndQueryNode andNode = (AndQueryNode) node;
+            for (QueryNode qNode: andNode.children) {
+                Set<String> childIds = executeQueryTree(qNode, db);
+                if (accumulator == null) {
+                    accumulator = new HashSet<String>(childIds);
+                } else {
+                    accumulator = Sets.intersection(accumulator, childIds);
+                }
+
+                // TODO optimisation is to bail here if accumulator is empty
+            }
+
+            return accumulator;
+        }
+        if (node instanceof OrQueryNode) {
+            Set<String> accumulator = null;
+            // TODO - OR execute query tree logic...
+            return accumulator;
+        } else if (node instanceof SqlQueryNode) {
+            SqlQueryNode sqlNode = (SqlQueryNode) node;
+            SqlParts sqlParts = sqlNode.sql;
+
+            List<String> docIds = new ArrayList<String>();
+
+            Cursor cursor = null;
+            try {
+                cursor = db.rawQuery(sqlParts.sqlWithPlaceHolders, sqlParts.placeHolderValues);
+                while (cursor.moveToNext()) {
+                    String docId = cursor.getString(0);
+                    docIds.add(docId);
+                }
+            } catch (SQLException e) {
+                logger.log(Level.SEVERE, "Failed to get a list of doc ids.", e);
+            } finally {
+                DatabaseUtils.closeCursorQuietly(cursor);
+            }
+
+            return new HashSet<String>(docIds);
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     *  Return ordered list of document IDs using provided indexes.
+     *
+     *  Method assumes 'sortDocument' is valid.
+     *
+     *  @param docIdSet Set of current results which are sorted
+     *  @param sortDocument Array of ordering definitions
+     *                      '[ {"fieldName": "asc"}, {"fieldName2", "desc"} ]'
+     *  @param indexes dictionary of indexes
+     *  @param db database containing 'indexes' to use when sorting documents
+     *  @return an ordered list of document IDs using provided indexes.
+     */
+    private List<String> sortIds(Set<String> docIdSet,
+                                 List<Map<String, String>> sortDocument,
+                                 Map<String, Object> indexes,
+                                 SQLDatabase db) {
+        // TODO - sort logic...
+        return null;
+    }
+
+    /**
+     *  Checks if the fields are valid.
+     */
+    private boolean validateFields(List<String> fields) {
+        if (fields == null) {
+            return true;
+        }
+        for (String field: fields) {
+            if (field.contains("\\.")) {
+                String msg = String.format("Projection field cannot use dotted notation: %s",
+                                           field);
+                logger.log(Level.SEVERE, msg);
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+}

--- a/sync-core/src/main/java/com/cloudant/sync/query/QueryNode.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/QueryNode.java
@@ -12,23 +12,10 @@
 
 package com.cloudant.sync.query;
 
-import org.junit.Assert;
-import org.junit.Test;
+/**
+ *  The QueryNode interface provides a general categorization in the trees generated.  When parsing
+ *  selectors into trees we can easily walk to process a query.
+ */
+interface QueryNode {
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
-public class IndexManagerTest extends AbstractIndexTestBase {
-
-    @Test
-    public void unimplementedEnsureIndexed() {
-        List<Object> fieldNames = Arrays.<Object>asList("name");
-        Assert.assertNull(im.ensureIndexed(fieldNames));
-    }
-
-    @Test
-    public void unimplementedDeleteIndexNamed() {
-        Assert.assertFalse(im.deleteIndexNamed("basic"));
-    }
 }

--- a/sync-core/src/main/java/com/cloudant/sync/query/QueryResult.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/QueryResult.java
@@ -1,0 +1,163 @@
+//  Copyright (c) 2014 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+package com.cloudant.sync.query;
+
+import com.cloudant.sync.datastore.BasicDocumentRevision;
+import com.cloudant.sync.datastore.Datastore;
+import com.google.common.collect.Lists;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ *  Iterable result of a query executed with {@link com.cloudant.sync.query.IndexManager}.
+ *
+ *  @see com.cloudant.sync.query.IndexManager
+ */
+class QueryResult implements Iterable<BasicDocumentRevision> {
+
+    private final static int DEFAULT_BATCH_SIZE = 50;
+
+    private final List<String> docIds;
+    private final Datastore datastore;
+    private final List<String> fields;
+    private final long skip;
+    private final long limit;
+    private final UnindexedMatcher matcher;
+
+    public QueryResult(List<String> docIds,
+                       Datastore datastore,
+                       List<String> fields,
+                       long skip,
+                       long limit,
+                       UnindexedMatcher matcher) {
+        this.docIds = docIds;
+        this.datastore = datastore;
+        this.fields = fields;
+        this.skip = skip;
+        this.limit = limit;
+        this.matcher = matcher;
+    }
+
+    /**
+     *  Returns the number of documents in this query result.
+     *
+     *  @return the number of the {@code DocumentRevision} in this query result
+     */
+    public long size() {
+        // TODO - skip, limit w.r.t. size
+
+        return docIds.size();
+    }
+
+    /**
+     *  Returns a list of the document ids in this query result.
+     *
+     *  @return list of the document ids
+     */
+    public List<String> documentIds() {
+        // TODO - skip, limit w.r.t. document id list
+
+        return docIds;
+    }
+
+    @Override
+    public Iterator<BasicDocumentRevision> iterator() {
+
+        /**
+         * Partitions a set of document IDs into batches of DocumentRevision
+         * objects, and provides an iterator over the whole, un-partitioned set
+         * of revision objects (as if they were not batched).
+         */
+        return new Iterator<BasicDocumentRevision>() {
+
+            // TODO - skip, limit, field projection, apply post-hoc matcher
+
+            /** List containing lists of partitions document IDs */
+            private final List<List<String>> subLists = this.partition(docIds, DEFAULT_BATCH_SIZE);
+            /** The current partition's iterator of document objects */
+            private Iterator<BasicDocumentRevision> subIterator = null;
+
+            @Override
+            public boolean hasNext() {
+                if(subIterator == null) {
+                    return subLists.size() > 0;
+                } else {
+                    return this.subIterator.hasNext() || subLists.size() > 0;
+                }
+            }
+
+            @Override
+            public BasicDocumentRevision next() {
+                if(subIterator == null || !subIterator.hasNext()) {
+                    List<String> ids = subLists.remove(0);
+                    subIterator = this.nextSubIterator(ids);
+                }
+                
+                return subIterator.next();
+            }
+
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
+            }
+
+            /**
+             * Partition a list of document IDs into batches of batchSize.
+             *
+             * Return a mutable list of consecutive sublists.
+             * Same as Guava's "Lists.partition" except the result list is mutable.
+             * It is needed because this iterator removes sublist from the partitions
+             * as it goes.
+             *
+             * @see <a href="http://docs.guava-libraries.googlecode.com/git/javadoc/com/google/
+             * common/collect/Lists.html#partition(java.util.List, int)">Lists.partition</a>
+             */
+            private List<List<String>> partition(List<String> documentIds, int batchSize) {
+                List<List<String>> partitions = Lists.partition(documentIds, batchSize);
+                List<List<String>> res = new LinkedList<List<String>>();
+                for(List<String> p : partitions) {
+                    res.add(p);
+                }
+                return res;
+            }
+
+            /**
+             * Load the next partition of DocumentRevision objects for the
+             * iterator.
+             *
+             * @param ids the IDs of the revisions to load.
+             * @return an iterator over the DocumentRevision objects for `ids`.
+             */
+            private Iterator<BasicDocumentRevision> nextSubIterator(List<String> ids) {
+                HashMap<String, BasicDocumentRevision> map = new HashMap<String, BasicDocumentRevision>();
+                for(BasicDocumentRevision revision : datastore.getDocumentsWithIds(ids)) {
+                    map.put(revision.getId(), revision);
+                }
+                List<BasicDocumentRevision> revisions = new ArrayList<BasicDocumentRevision>(ids.size());
+                // return list of DocumentRevision that in the same order as input "ids"
+                for(String id : ids) {
+                    BasicDocumentRevision revision = map.get(id);
+                    if(revision != null ) {
+                        revisions.add(revision);
+                    }
+                }
+                return revisions.iterator();
+            }
+        };
+    }
+
+}

--- a/sync-core/src/main/java/com/cloudant/sync/query/QuerySqlTranslator.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/QuerySqlTranslator.java
@@ -1,0 +1,393 @@
+//  Copyright (c) 2014 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+package com.cloudant.sync.query;
+
+import com.google.common.base.Joiner;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ *  This class translates Cloudant Query selectors into the SQL we need to use
+ *  to query our indexes.
+ *
+ *  It creates a tree structure which contains AND/OR nodes, along with the SQL which
+ *  needs to be used to get a list of document IDs for each level. This tree structure
+ *  is passed back out of the translation process for execution by an interpreter which
+ *  can perform the needed AND and OR operations between the document ID sets returned
+ *  by the SQL queries.
+ *
+ *  This merging of results in code allows us to make more intelligent use of indexes
+ *  within the SQLite database. As SQLite allows us to use just a single index per query,
+ *  performing several queries over indexes and then using set operations works out
+ *  more flexible and likely more efficient.
+ *
+ *  The SQL must be executed separately so we can do it in a transaction so we're doing
+ *  it over a consistent view of the index.
+ *
+ *  The translator is a simple depth-first, recursive decent parser over the selector
+ *  map(dictionary).
+ *
+ *  Some examples:
+ *
+ *  AND : [ { x: X }, { y: Y } ]
+ *
+ *  This can be represented by a single SQL query and AND tree node:
+ *
+ *  AND
+ *   |
+ *  sql
+ *
+ *
+ *  OR : [ { x: X }, { y: Y } ]
+ *
+ *  This is a single OR node and two SQL queries:
+ *
+ *     OR
+ *     /\
+ *  sql sql
+ *
+ *  The interpreter then unions the results.
+ *
+ *
+ *  OR : [ { AND : [ { x: X }, { y: Y } ] }, { y: Y } ]
+ *
+ *  This requires a more complex tree:
+ *
+ *      OR
+ *     / \
+ *  AND  sql
+ *   |
+ *  sql
+ *
+ *  We could collapse out the extra AND node.
+ *
+ *
+ *  AND : [ { OR : [ { x: X }, { y: Y } ] }, { y: Y } ]
+ *
+ *  This is really the most complex situation:
+ *
+ *       AND
+ *       / \
+ *     OR  sql
+ *     /\
+ *  sql sql
+ *
+ *  These basic patterns can be composed into more complicate structures.
+ */
+class QuerySqlTranslator {
+
+    private static final String AND = "$and";
+    private static final String OR = "$or";
+    private static final String EQ = "$eq";
+    private static final String NOT = "$not";
+    private static final String EXISTS = "$exists";
+
+    private static final Logger logger = Logger.getLogger(QuerySqlTranslator.class.getName());
+
+    public static QueryNode translateQuery(Map<String, Object> query,
+                                           Map<String, Object> indexes,
+                                           Boolean[] indexesCoverQuery) {
+        TranslatorState state = new TranslatorState();
+        QueryNode node = translateQuery(query, indexes, state);
+
+        // If we haven't used a single index, we need to return a query
+        // which returns every document, so the posthoc matcher can
+        // run over every document to manually carry out the query.
+        if (!state.atLeastOneIndexUsed) {
+            // TODO
+            return null;
+        } else {
+            indexesCoverQuery[0] = !state.atLeastOneIndexMissing;
+            return node;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static QueryNode translateQuery(Map<String, Object> query,
+                                           Map<String, Object> indexes,
+                                           TranslatorState state) {
+        // At this point we will have a root compound predicate, AND or OR, and
+        // the query will be reduced to a single entry:
+        // { "$and": [ ... predicates (possibly compound) ... ] }
+        // { "$or": [ ... predicates (possibly compound) ... ] }
+
+        ChildrenQueryNode root = null;
+        List<Object> clauses = new ArrayList<Object>();
+
+        if (query.get(AND) != null) {
+            clauses = (ArrayList<Object>) query.get(AND);
+            root = new AndQueryNode();
+        } else if (query.get(OR) != null) {
+            clauses = (ArrayList<Object>) query.get(OR);
+            root = new OrQueryNode();
+        }
+
+        //
+        // First handle the simple "field": { "$operator": "value" } clauses. These are
+        // handled differently for AND and OR parents, so we need to have the conditional
+        // logic below.
+        //
+
+        List<Object> basicClauses = new ArrayList<Object>();
+
+        for (Object rawClause: clauses) {
+            Map<String, Object> clause = (Map<String, Object>) rawClause;
+            String field = (String) clause.keySet().toArray()[0];
+            if (!field.startsWith("$")) {
+                basicClauses.add(rawClause);
+            }
+        }
+
+        if (query.get(AND) != null) {
+            // For an AND query, we require a single compound index and we generate a
+            // single SQL statement to use that index to satisfy the clauses.
+
+            String chosenIndex = chooseIndexForAndClause(basicClauses, indexes);
+            if (chosenIndex == null || chosenIndex.isEmpty()) {
+                state.atLeastOneIndexMissing = true;
+                String msg = String.format("No single index contains all of %s; %s",
+                                           basicClauses.toString(),
+                                           "add index for these fields to query efficiently.");
+                logger.log(Level.WARNING, msg);
+            } else {
+                state.atLeastOneIndexUsed = true;
+
+                // Execute SQL on that index with appropriate values
+                SqlParts select = selectStatementForAndClause(basicClauses, chosenIndex);
+                if (select == null) {
+                    String msg = String.format("Error generating SELECT clause for %s",
+                                               basicClauses);
+                    logger.log(Level.SEVERE, msg);
+                    return null;
+                }
+
+                SqlQueryNode sqlNode = new SqlQueryNode();
+                sqlNode.sql = select;
+
+                if (root != null) {
+                    root.children.add(sqlNode);
+                }
+            }
+        } else if (query.get(OR) != null) {
+            // OR nodes require a query for each clause.
+            //
+            // We want to allow OR clauses to use separate indexes, unlike for AND, to allow
+            // users to query over multiple indexes during a single query. This prevents users
+            // having to create a single huge index just because one query in their application
+            // requires it, slowing execution of all the other queries down.
+            //
+            // We could optimise for OR parts where we have an appropriate compound index,
+            // but we don't for now.
+
+            // TODO - implement OR logic...
+        }
+
+        //
+        // AND and OR subclauses are handled identically whatever the parent is.
+        // We go through the query twice to order the OR clauses before the AND
+        // clauses, for predictability.
+        //
+
+        // Add subclauses that are OR
+        // TODO
+
+        // Add subclauses that are AND
+        // TODO
+
+        return root;
+    }
+
+    private static List<String> fieldsForAndClause(List<Object> clause) {
+        if (clause == null) {
+            return null;
+        }
+        List<String> fieldNames = new ArrayList<String>();
+        for (Object rawTerm: clause) {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> term = (Map<String, Object>) rawTerm;
+            if (term.size() == 1) {
+                fieldNames.add((String) term.keySet().toArray()[0]);
+            }
+        }
+
+        return fieldNames;
+    }
+
+    protected static String chooseIndexForAndClause(List<Object> clause,
+                                                    Map<String, Object> indexes) {
+        if (clause == null || clause.isEmpty()) {
+            return null;
+        }
+
+        if (indexes == null || indexes.isEmpty()) {
+            return null;
+        }
+
+        List<String> fieldList = fieldsForAndClause(clause);
+        Set<String> neededFields = new HashSet<String>(fieldList);
+
+        if (neededFields.isEmpty()) {
+            String msg = String.format("Invalid clauses in $and clause %s.", clause.toString());
+            logger.log(Level.SEVERE, msg);
+            return null;
+        }
+
+        return chooseIndexForFields(neededFields, indexes);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static String chooseIndexForFields(Set<String> neededFields,
+                                               Map<String, Object> indexes) {
+        String chosenIndex = null;
+        for (String indexName: indexes.keySet()) {
+            Map<String, Object> indexDefinition = (Map<String, Object>) indexes.get(indexName);
+            List<String> fieldList = (List<String>) indexDefinition.get("fields");
+            Set<String> providedFields = new HashSet<String>(fieldList);
+            if (providedFields.containsAll(neededFields)) {
+                chosenIndex = indexName;
+                break;
+            }
+        }
+
+        return chosenIndex;
+    }
+
+    protected static SqlParts selectStatementForAndClause(List<Object> clause,
+                                                          String indexName) {
+        if (clause == null || clause.isEmpty()) {
+            return null;  // no query here
+        }
+
+        if (indexName == null || indexName.isEmpty()) {
+            return null;
+        }
+
+        SqlParts where = whereSqlForAndClause(clause);
+
+        if (where == null) {
+            return null;
+        }
+
+        String tableName = IndexManager.tableNameForIndex(indexName);
+
+        String sql = String.format("SELECT _id FROM %s WHERE %s",
+                                   tableName,
+                                   where.sqlWithPlaceHolders);
+        return SqlParts.partsForSql(sql, where.placeHolderValues);
+    }
+
+    @SuppressWarnings("unchecked")
+    protected static SqlParts whereSqlForAndClause(List<Object> clause) {
+        if (clause == null || clause.isEmpty()) {
+            return null;  //  no point in querying empty set of fields
+        }
+
+        // [ { "fieldName":  "mike"}, ...]
+
+        List<String> whereClauses = new ArrayList<String>();
+        List<Object> sqlParameters = new ArrayList<Object>();
+
+        Map<String, String> operatorMap = new HashMap<String, String>();
+        operatorMap.put("$eq", "=");
+        operatorMap.put("$gt", ">");
+        operatorMap.put("$gte", ">=");
+        operatorMap.put("$lt", "<");
+        operatorMap.put("$lte", "<=");
+        operatorMap.put("$ne", "!=");
+
+        // We apply these if the clause is negated, along with the NULL clause
+        Map<String, String> notOperatorMap = new HashMap<String, String>();
+        notOperatorMap.put("$eq", "!=");
+        notOperatorMap.put("$gt", "<=");
+        notOperatorMap.put("$gte", "<");
+        notOperatorMap.put("$lt", ">=");
+        notOperatorMap.put("$lte", ">");
+        notOperatorMap.put("$ne", "=");
+
+        for (Object rawComponent: clause) {
+            Map<String, Object> component = (Map<String, Object>) rawComponent;
+            if (component.size() != 1) {
+                String msg = String.format("Expected single predicate per clause map, got %s",
+                                           component.toString());
+                logger.log(Level.SEVERE, msg);
+                return null;
+            }
+
+            String fieldName = (String) component.keySet().toArray()[0];
+            Map<String, Object> predicate = (Map<String, Object>) component.get(fieldName);
+
+            if (predicate.size() != 1) {
+                String msg = String.format("Expected single operator per predicate map, got %s",
+                                           predicate.toString());
+                logger.log(Level.SEVERE, msg);
+                return null;
+            }
+
+            String operator = (String) predicate.keySet().toArray()[0];
+
+            // $not specifies the opposite operator OR NULL documents be returned
+            if (operator.equals(NOT)) {
+                // TODO - implement NOT logic...
+            } else {
+                if (operator.equals(EXISTS)) {
+                    // TODO - implement EXISTS logic...
+                } else {
+                    String sqlOperator = operatorMap.get(operator);
+                    if (sqlOperator == null || sqlOperator.isEmpty()) {
+                        String msg = String.format("Unsupported comparison operator %s", operator);
+                        logger.log(Level.SEVERE, msg);
+                        return null;
+                    }
+
+                    String whereClause = String.format("\"%s\" %s ?", fieldName, sqlOperator);
+                    whereClauses.add(whereClause);
+                    Object predicateValue = predicate.get(operator);
+                    if (validatePredicateValue(predicateValue)) {
+                        sqlParameters.add(String.valueOf(predicateValue));
+                    } else {
+                        logger.log(Level.SEVERE, "Unsupported predicate type");
+                        return null;
+                    }
+                }
+            }
+        }
+        Joiner joiner = Joiner.on(" AND ").skipNulls();
+        String where = joiner.join(whereClauses);
+        String[] parameterArray = new String[sqlParameters.size()];
+        int idx = 0;
+        for (Object parameter: sqlParameters) {
+            parameterArray[idx] = String.valueOf(parameter);
+            idx++;
+        }
+
+        return SqlParts.partsForSql(where, parameterArray);
+    }
+
+    private static boolean validatePredicateValue(Object predicateValue) {
+        return (predicateValue instanceof String ||
+                predicateValue instanceof Byte ||
+                predicateValue instanceof Integer ||
+                predicateValue instanceof Long ||
+                predicateValue instanceof Short ||
+                predicateValue instanceof Double ||
+                predicateValue instanceof Float);
+    }
+
+}

--- a/sync-core/src/main/java/com/cloudant/sync/query/QueryValidator.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/QueryValidator.java
@@ -1,0 +1,162 @@
+//  Copyright (c) 2014 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+package com.cloudant.sync.query;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ *  This class contains common validation options for the
+ *  two different implementations of query.
+ */
+class QueryValidator {
+
+    public static final String AND = "$and";
+    public static final String OR = "$or";
+    public static final String EQ = "$eq";
+
+    /**
+     *  Expand implicit operators in a query, and validate
+     */
+    @SuppressWarnings("unchecked")
+    public static Map<String, Object> normaliseAndValidateQuery(Map<String, Object> query) {
+        boolean isWildCard = false;
+        if (query.isEmpty()) {
+            isWildCard = true;
+        }
+
+        // First expand the query to include a leading compound predicate
+        // if there isn't one already.
+        query = addImplicitAnd(query);
+
+        // At this point we will have a single entry map, key AND or OR,
+        // forming the compound predicate.
+        // Next make sure all the predicates have an operator -- the EQ
+        // operator is implicit and we need to add it if there isn't one.
+        // Take
+        //     [ {"field1": @"mike"}, ... ]
+        // and make
+        //     [ {"field1": { "$eq": "mike"} }, ... } ]
+        String compoundOperator = (String) query.keySet().toArray()[0];
+        List<Object> predicates = new ArrayList<Object>();
+        if (query.get(compoundOperator) instanceof List) {
+            predicates = addImplicitEq((List<Object>) query.get(compoundOperator));
+        }
+
+        Map<String, Object> selector = new HashMap<String, Object>();
+        selector.put(compoundOperator, predicates);
+        if (isWildCard || validateSelector(selector)) {
+            return selector;
+        }
+
+        return null;
+    }
+
+    private static Map<String, Object> addImplicitAnd(Map<String, Object> query) {
+        // query is:
+        //  either { "field1": "value1", ... } -- we need to add $and
+        //  or     { "$and": [ ... ] } -- we don't
+        //  or     { "$or": [ ... ] } -- we don't
+
+        if (query.size() == 1 && (query.get(AND) != null || query.get(OR) != null)) {
+            return query;
+        } else {
+            // Take
+            //     {"field1": "mike", ...}
+            //     {"field1": [ "mike", "bob" ], ...}
+            // and make
+            //     [ {"field1": "mike"}, ... ]
+            //     [ {"field1": [ "mike", "bob" ]}, ... ]
+            List<Object> andClause = new ArrayList<Object>();
+            for (String k: query.keySet()) {
+                Object predicate = query.get(k);
+                Map<String, Object> element = new HashMap<String, Object>();
+                element.put(k, predicate);
+                andClause.add(element);
+            }
+            query.clear();
+            query.put(AND, andClause);
+            return query;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<Object> addImplicitEq(List<Object> clause) {
+        List<Object> accumulator = new ArrayList<Object>();
+
+        for (Object fieldClause: clause) {
+            // fieldClause is:
+            //  either { "field1": "mike"} -- we need to add the $eq operator
+            //  or     { "field1": { "$operator": "value" } -- we don't
+            //  or     { "$and": [ ... ] } -- we don't
+            //  or     { "$or": [ ... ] } -- we don't
+            Object predicate;
+            String fieldName;
+            // if fieldClause isn't a dictionary, we don't know what to do so pass it back
+            if (fieldClause instanceof Map && !((Map) fieldClause).isEmpty()) {
+                Map<String, Object> fieldClauseMap = (Map<String, Object>) fieldClause;
+                fieldName = (String) fieldClauseMap.keySet().toArray()[0];
+                predicate = fieldClauseMap.get(fieldName);
+            } else {
+                accumulator.add(fieldClause);
+                continue;
+            }
+
+            // If the clause isn't a special clause (the field name starts with
+            // $, e.g., $and), we need to check whether the clause already
+            // has an operator. If not, we need to add the implicit $eq.
+            if (!fieldName.startsWith("$")) {
+                if (!(predicate instanceof Map)) {
+                    Map<String, Object> eqPredicate = new HashMap<String, Object>();
+                    eqPredicate.put(EQ, predicate);
+                    predicate = eqPredicate;
+                }
+            } else if (predicate instanceof List) {
+                predicate = addImplicitEq((List<Object>) predicate);
+            }
+
+            Map<String, Object> element = new HashMap<String, Object>();
+            element.put(fieldName, predicate);
+            accumulator.add(element);  // can't put null into accumulator
+        }
+
+        return accumulator;
+    }
+
+    /**
+     *  we are going to need to walk the query tree to validate it before executing it
+     */
+    @SuppressWarnings("unchecked")
+    private static boolean validateSelector(Map<String, Object> selector) {
+        String topLevelOp = (String) selector.keySet().toArray()[0];
+
+        // top level op can only be $and or $or after normalisation
+        if (topLevelOp.equals(AND) || topLevelOp.equals(OR)) {
+            Object topLevelArg = selector.get(topLevelOp);
+            if (topLevelArg instanceof List) {
+                // safe we know its a List
+                return validateCompoundOperatorClauses((List<Object>) topLevelArg);
+            }
+        }
+
+        return false;
+    }
+
+    private static boolean validateCompoundOperatorClauses(List<Object> clauses) {
+        // TODO - implement logic...
+        return true;
+    }
+
+}

--- a/sync-core/src/main/java/com/cloudant/sync/query/SqlParts.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/SqlParts.java
@@ -12,23 +12,17 @@
 
 package com.cloudant.sync.query;
 
-import org.junit.Assert;
-import org.junit.Test;
+class SqlParts {
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+    public String sqlWithPlaceHolders;
+    public String[] placeHolderValues;
 
-public class IndexManagerTest extends AbstractIndexTestBase {
+    public static SqlParts partsForSql(String sql, String[] parameters) {
+        SqlParts parts = new SqlParts();
+        parts.sqlWithPlaceHolders = sql;
+        parts.placeHolderValues = parameters;
 
-    @Test
-    public void unimplementedEnsureIndexed() {
-        List<Object> fieldNames = Arrays.<Object>asList("name");
-        Assert.assertNull(im.ensureIndexed(fieldNames));
+        return parts;
     }
 
-    @Test
-    public void unimplementedDeleteIndexNamed() {
-        Assert.assertFalse(im.deleteIndexNamed("basic"));
-    }
 }

--- a/sync-core/src/main/java/com/cloudant/sync/query/SqlQueryNode.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/SqlQueryNode.java
@@ -2,15 +2,24 @@
 //
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
 //  except in compliance with the License. You may obtain a copy of the License at
+//
 //    http://www.apache.org/licenses/LICENSE-2.0
+//
 //  Unless required by applicable law or agreed to in writing, software distributed under the
 //  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
 //  either express or implied. See the License for the specific language governing permissions
 //  and limitations under the License.
 
-
 package com.cloudant.sync.query;
 
-public class QueryResultSet {
-    // TODO - implement class
+/**
+ *  The SqlQueryNode class is a base level class of
+ *  the {@link com.cloudant.sync.query.QueryNode}.
+ *
+ *  @see com.cloudant.sync.query.QueryNode
+ */
+class SqlQueryNode implements QueryNode {
+
+    public SqlParts sql;
+
 }

--- a/sync-core/src/main/java/com/cloudant/sync/query/TranslatorState.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/TranslatorState.java
@@ -1,0 +1,35 @@
+//  Copyright (c) 2014 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+package com.cloudant.sync.query;
+
+/**
+ *  The purpose of a TranslatorState object is to track the state of a query translation operation
+ *  performed by method calls in the {@link com.cloudant.sync.query.QuerySqlTranslator}.  Since
+ *  all methods within the {@link com.cloudant.sync.query.QuerySqlTranslator} class that
+ *  utilize a TranslatorState object are static in nature, the TranslatorState class cannot be
+ *  implemented as an inner class to {@link com.cloudant.sync.query.QuerySqlTranslator} and must be
+ *  implemented this way instead.
+ *
+ *  @see com.cloudant.sync.query.QuerySqlTranslator
+ */
+class TranslatorState {
+
+    public boolean atLeastOneIndexUsed;
+    public boolean atLeastOneIndexMissing;
+
+    TranslatorState() {
+        atLeastOneIndexUsed = false;
+        atLeastOneIndexMissing = false;
+    }
+
+}

--- a/sync-core/src/main/java/com/cloudant/sync/query/UnindexedMatcher.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/UnindexedMatcher.java
@@ -1,0 +1,111 @@
+//  Copyright (c) 2014 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+package com.cloudant.sync.query;
+
+import java.util.Map;
+
+/**
+ *  Determine whether a document matches a selector.
+ *
+ *  This class is used when a selector cannot be satisfied using
+ *  indexes alone. It takes a selector, compiles it into an internal
+ *  representation and is able to then determine whether a document
+ *  matches that selector.
+ *
+ *  The matcher works by first creating a simple tree, which is then
+ *  executed against each document it's asked to match.
+ *
+ *
+ *  Some examples:
+ *
+ *  AND : [ { x: X }, { y: Y } ]
+ *
+ *  This can be represented by a two operator expressions and AND tree node:
+ *
+ *          AND
+ *         /   \
+ *  { x: X }  { y: Y }
+ *
+ *
+ *  OR : [ { x: X }, { y: Y } ]
+ *
+ *  This is a single OR node and two operator expressions:
+ *
+ *          OR
+ *         /  \
+ *  { x: X }  { y: Y }
+ *
+ *  The interpreter then unions the results.
+ *
+ *
+ *  OR : [ { AND : [ { x: X }, { y: Y } ] }, { y: Y } ]
+ *
+ *  This requires a more complex tree:
+ *
+ *              OR
+ *             /  \
+ *          AND   { y: Y }
+ *         /   \
+ *  { x: X }  { y: Y }
+ *
+ *
+ *  AND : [ { OR : [ { x: X }, { y: Y } ] }, { y: Y } ]
+ *
+ *  This is really the most complex situation:
+ *
+ *              AND
+ *             /   \
+ *           OR   { y: Y }
+ *         /    \
+ *  { x: X }  { y: Y }
+ *
+ *  These basic patterns can be composed into more complicate structures.
+ */
+public class UnindexedMatcher {
+
+    private ChildrenQueryNode root;
+
+    private static final String AND = "$and";
+    private static final String OR = "$or";
+    private static final String NOT = "$not";
+
+    /**
+     *  Return a new initialised matcher.
+     *
+     *  Assumes selector is valid as we're calling this late in
+     *  the query processing.
+     */
+    public static UnindexedMatcher matcherWithSelector(Map<String, Object> selector) {
+        ChildrenQueryNode root = buildExecutionTreeForSelector(selector);
+
+        if (root == null) {
+            return null;
+        }
+
+        UnindexedMatcher matcher = new UnindexedMatcher();
+        matcher.root = root;
+
+        return matcher;
+    }
+
+    private static ChildrenQueryNode buildExecutionTreeForSelector(Map<String, Object> selector) {
+        // At this point we will have a root compound predicate, AND or OR, and
+        // the query will be reduced to a single entry:
+        // { "$and": [ ... predicates (possibly compound) ... ] }
+        // { "$or": [ ... predicates (possibly compound) ... ] }
+
+        // TODO - build execution tree for selector
+        return null;
+    }
+
+}

--- a/sync-core/src/test/java/com/cloudant/sync/query/IndexCreatorTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/IndexCreatorTest.java
@@ -16,6 +16,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -36,12 +37,12 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
         Assert.assertNull(name);
 
         // doesn't create an index on no fields
-        ArrayList<Object> fieldNames = new ArrayList<Object>();
+        List<Object> fieldNames = new ArrayList<Object>();
         name = im.ensureIndexed(fieldNames, "basic");
         Assert.assertNull(name);
 
         // doesn't create an index on null name
-        fieldNames.add("name");
+        fieldNames = Arrays.<Object>asList("name");
         name = im.ensureIndexed(fieldNames, null);
         Assert.assertNull(name);
 
@@ -54,18 +55,14 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
         Assert.assertNull(name);
 
         // doesn't create an index if duplicate fields
-        fieldNames.clear();
-        fieldNames.add("age");
-        fieldNames.add("pet");
-        fieldNames.add("age");
+        fieldNames = Arrays.<Object>asList("age", "pet", "age");
         name = im.ensureIndexed(fieldNames, "basic");
         Assert.assertNull(name);
     }
 
     @Test
     public void createIndexOverOneField() {
-        ArrayList<Object> fieldNames = new ArrayList<Object>();
-        fieldNames.add("name");
+        List<Object> fieldNames = Arrays.<Object>asList("name");
         String name = im.ensureIndexed(fieldNames, "basic");
         Assert.assertTrue(name.equals("basic"));
 
@@ -85,9 +82,7 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
 
     @Test
     public void createIndexOverTwoFields() {
-        ArrayList<Object> fieldNames = new ArrayList<Object>();
-        fieldNames.add("name");
-        fieldNames.add("age");
+        List<Object> fieldNames = Arrays.<Object>asList("name", "age");
         String name = im.ensureIndexed(fieldNames, "basic");
         Assert.assertTrue(name.equals("basic"));
 
@@ -108,9 +103,7 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
 
     @Test
     public void createIndexUsingDottedNotation() {
-        ArrayList<Object> fieldNames = new ArrayList<Object>();
-        fieldNames.add("name.first");
-        fieldNames.add("age.years");
+        List<Object> fieldNames = Arrays.<Object>asList("name.first", "age.years");
         String name = im.ensureIndexed(fieldNames, "basic");
         Assert.assertTrue(name.equals("basic"));
 
@@ -131,13 +124,10 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
 
     @Test
     public void createMultipleIndexes() {
-        ArrayList<Object> fieldNames = new ArrayList<Object>();
-        fieldNames.add("name");
-        fieldNames.add("age");
+        List<Object> fieldNames = Arrays.<Object>asList("name", "age");
         im.ensureIndexed(fieldNames, "basic");
         im.ensureIndexed(fieldNames, "another");
-        fieldNames.clear();
-        fieldNames.add("cat");
+        fieldNames = Arrays.<Object>asList("cat");
         im.ensureIndexed(fieldNames, "petname");
 
         Map<String, Object> indexes = im.listIndexes();
@@ -178,13 +168,11 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
 
     @Test
     public void createIndexSpecifiedWithAscOrDesc() {
-        ArrayList<Object> fieldNames = new ArrayList<Object>();
         HashMap<String, String> nameField = new HashMap<String, String>();
         nameField.put("name", "asc");
         HashMap<String, String> ageField = new HashMap<String, String>();
         ageField.put("age", "desc");
-        fieldNames.add(nameField);
-        fieldNames.add(ageField);
+        List<Object> fieldNames = Arrays.<Object>asList(nameField, ageField);
         String name = im.ensureIndexed(fieldNames, "basic");
         Assert.assertTrue(name.equals("basic"));
 
@@ -205,13 +193,11 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
 
     @Test
     public void createIndexWhenIndexNameExistsIdxDefinitionSame() {
-        ArrayList<Object> fieldNames = new ArrayList<Object>();
         HashMap<String, String> nameField = new HashMap<String, String>();
         nameField.put("name", "asc");
         HashMap<String, String> ageField = new HashMap<String, String>();
         ageField.put("age", "desc");
-        fieldNames.add(nameField);
-        fieldNames.add(ageField);
+        List<Object> fieldNames = Arrays.<Object>asList(nameField, ageField);
         String name = im.ensureIndexed(fieldNames, "basic");
         Assert.assertTrue(name.equals("basic"));
 
@@ -222,34 +208,30 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
 
     @Test
     public void createIndexWhenIndexNameExistsIdxDefinitionDifferent() {
-        ArrayList<Object> fieldNames = new ArrayList<Object>();
         HashMap<String, String> nameField = new HashMap<String, String>();
         nameField.put("name", "asc");
         HashMap<String, String> ageField = new HashMap<String, String>();
         ageField.put("age", "desc");
-        fieldNames.add(nameField);
-        fieldNames.add(ageField);
+        List<Object> fieldNames = Arrays.<Object>asList(nameField, ageField);
         String name = im.ensureIndexed(fieldNames, "basic");
         Assert.assertTrue(name.equals("basic"));
 
         // fails when the index definition is different
-        fieldNames.remove(1);
+        fieldNames = Arrays.<Object>asList(nameField);
         HashMap<String, String> petField = new HashMap<String, String>();
         petField.put("pet", "desc");
-        fieldNames.add(petField);
+        Arrays.<Object>asList(nameField, petField);
         name = im.ensureIndexed(fieldNames, "basic");
         Assert.assertNull(name);
     }
 
     @Test
     public void createIndexWithJsonType() {
-        ArrayList<Object> fieldNames = new ArrayList<Object>();
         HashMap<String, String> nameField = new HashMap<String, String>();
         nameField.put("name", "asc");
         HashMap<String, String> ageField = new HashMap<String, String>();
         ageField.put("age", "desc");
-        fieldNames.add(nameField);
-        fieldNames.add(ageField);
+        List<Object> fieldNames = Arrays.<Object>asList(nameField, ageField);
 
         // supports using the json type
         String name = im.ensureIndexed(fieldNames, "basic", "json");
@@ -258,13 +240,11 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
 
     @Test
     public void createIndexWithTextType() {
-        ArrayList<Object> fieldNames = new ArrayList<Object>();
         HashMap<String, String> nameField = new HashMap<String, String>();
         nameField.put("name", "asc");
         HashMap<String, String> ageField = new HashMap<String, String>();
         ageField.put("age", "desc");
-        fieldNames.add(nameField);
-        fieldNames.add(ageField);
+        List<Object> fieldNames = Arrays.<Object>asList(nameField, ageField);
 
         // doesn't support using the text type
         String name = im.ensureIndexed(fieldNames, "basic", "text");
@@ -273,13 +253,11 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
 
     @Test
     public void createIndexWithGeoType() {
-        ArrayList<Object> fieldNames = new ArrayList<Object>();
         HashMap<String, String> nameField = new HashMap<String, String>();
         nameField.put("name", "asc");
         HashMap<String, String> ageField = new HashMap<String, String>();
         ageField.put("age", "desc");
-        fieldNames.add(nameField);
-        fieldNames.add(ageField);
+        List<Object> fieldNames = Arrays.<Object>asList(nameField, ageField);
 
         // doesn't support using the geo type
         String name = im.ensureIndexed(fieldNames, "basic", "geo");
@@ -288,13 +266,11 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
 
     @Test
     public void createIndexWithUnplannedType() {
-        ArrayList<Object> fieldNames = new ArrayList<Object>();
         HashMap<String, String> nameField = new HashMap<String, String>();
         nameField.put("name", "asc");
         HashMap<String, String> ageField = new HashMap<String, String>();
         ageField.put("age", "desc");
-        fieldNames.add(nameField);
-        fieldNames.add(ageField);
+        List<Object> fieldNames = Arrays.<Object>asList(nameField, ageField);
 
         // doesn't support using the unplanned type
         String name = im.ensureIndexed(fieldNames, "basic", "frog");
@@ -303,10 +279,7 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
 
     @Test
     public void createIndexUsingNonAsciiText() {
-        ArrayList<Object> fieldNames = new ArrayList<Object>();
-        fieldNames.add("اسم");
-        fieldNames.add("datatype");
-        fieldNames.add("ages");
+        List<Object> fieldNames = Arrays.<Object>asList("اسم", "datatype", "ages");
 
         // can create indexes successfully
         String name = im.ensureIndexed(fieldNames, "nonascii");
@@ -315,17 +288,14 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
 
     @Test
     public void normalizeIndexFields() {
-        ArrayList<Object> fieldNames = new ArrayList<Object>();
         HashMap<String, String> nameField = new HashMap<String, String>();
         nameField.put("name", "asc");
         HashMap<String, String> petField = new HashMap<String, String>();
         petField.put("pet", "desc");
-        fieldNames.add(nameField);
-        fieldNames.add(petField);
-        fieldNames.add("age");
+        List<Object> fieldNames = Arrays.<Object>asList(nameField, petField, "age");
 
         // removes directions from the field specifiers
-        ArrayList<String> fields = IndexCreator.removeDirectionsFromFields(fieldNames);
+        List<String> fields = IndexCreator.removeDirectionsFromFields(fieldNames);
         Assert.assertEquals(3, fields.size());
         Assert.assertTrue(fields.contains("name"));
         Assert.assertTrue(fields.contains("pet"));
@@ -334,17 +304,13 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
 
     @Test
     public void createIndexWhereFieldNameContainsDollarSign() {
-        ArrayList<Object> fieldNames = new ArrayList<Object>();
-        fieldNames.add("$name");
-        fieldNames.add("datatype");
+        List<Object> fieldNames = Arrays.<Object>asList("$name", "datatype");
 
         // rejects indexes with $ at start
         String name = im.ensureIndexed(fieldNames, "basic");
         Assert.assertNull(name);
 
-        fieldNames.clear();
-        fieldNames.add("na$me");
-        fieldNames.add("datatype$");
+        fieldNames = Arrays.<Object>asList("na$me", "datatype$");
 
         // creates indexes with $ not at start
         name = im.ensureIndexed(fieldNames, "basic");

--- a/sync-core/src/test/java/com/cloudant/sync/query/IndexUpdaterTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/IndexUpdaterTest.java
@@ -24,13 +24,14 @@ import org.junit.Test;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 public class IndexUpdaterTest extends AbstractIndexTestBase {
 
-    ArrayList<String> fields;
+    List<String> fields;
 
     @Override
     public void tearDown() {
@@ -40,8 +41,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
 
     @Test
     public void updateIndexNoIndexName() {
-        ArrayList<Object> fieldNames = new ArrayList<Object>();
-        fieldNames.add("name");
+        List<Object> fieldNames = Arrays.<Object>asList("name");
         createIndex("basic", fieldNames);
 
         Assert.assertFalse(IndexUpdater.updateIndex(null, fields, db, ds, im.getQueue()));
@@ -49,13 +49,12 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
 
     @Test
     public void updateOneFieldIndex() {
-        ArrayList<Object> fieldNames = new ArrayList<Object>();
-        fieldNames.add("name");
+        List<Object> fieldNames = Arrays.<Object>asList("name");
         createIndex("basic", fieldNames);
 
         Assert.assertEquals(0, getIndexSequenceNumber("basic"));
 
-        String table = IndexManager.INDEX_TABLE_PREFIX.concat("basic");
+        String table = IndexManager.tableNameForIndex("basic");
         String sql = String.format("SELECT * FROM %s", table);
         Cursor cursor = null;
         try {
@@ -105,14 +104,12 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
 
     @Test
     public void updateTwoFieldIndex() {
-        ArrayList<Object> fieldNames = new ArrayList<Object>();
-        fieldNames.add("name");
-        fieldNames.add("age");
+        List<Object> fieldNames = Arrays.<Object>asList("name", "age");
         createIndex("basic", fieldNames);
 
         Assert.assertEquals(0, getIndexSequenceNumber("basic"));
 
-        String table = IndexManager.INDEX_TABLE_PREFIX.concat("basic");
+        String table = IndexManager.tableNameForIndex("basic");
         String sql = String.format("SELECT * FROM %s", table);
         Cursor cursor = null;
         try {
@@ -165,16 +162,12 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
 
     @Test
     public void updateMultiFieldIndex() {
-        ArrayList<Object> fieldNames = new ArrayList<Object>();
-        fieldNames.add("name");
-        fieldNames.add("age");
-        fieldNames.add("pet");
-        fieldNames.add("car");
+        List<Object> fieldNames = Arrays.<Object>asList("name", "age", "pet", "car");
         createIndex("basic", fieldNames);
 
         Assert.assertEquals(0, getIndexSequenceNumber("basic"));
 
-        String table = IndexManager.INDEX_TABLE_PREFIX.concat("basic");
+        String table = IndexManager.tableNameForIndex("basic");
         String sql = String.format("SELECT * FROM %s", table);
         Cursor cursor = null;
         try {
@@ -238,16 +231,12 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
 
     @Test
     public void updateMultiFieldIndexMissingFields() {
-        ArrayList<Object> fieldNames = new ArrayList<Object>();
-        fieldNames.add("name");
-        fieldNames.add("age");
-        fieldNames.add("pet");
-        fieldNames.add("car");
+        List<Object> fieldNames = Arrays.<Object>asList("name", "age", "pet", "car");
         createIndex("basic", fieldNames);
 
         Assert.assertEquals(0, getIndexSequenceNumber("basic"));
 
-        String table = IndexManager.INDEX_TABLE_PREFIX.concat("basic");
+        String table = IndexManager.tableNameForIndex("basic");
         String sql = String.format("SELECT * FROM %s", table);
         Cursor cursor = null;
         try {
@@ -306,14 +295,12 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
 
     @Test
     public void updateMultiFieldIndexWithBlankRow() {
-        ArrayList<Object> fieldNames = new ArrayList<Object>();
-        fieldNames.add("car");
-        fieldNames.add("van");
+        List<Object> fieldNames = Arrays.<Object>asList("car", "van");
         createIndex("basic", fieldNames);
 
         Assert.assertEquals(0, getIndexSequenceNumber("basic"));
 
-        String table = IndexManager.INDEX_TABLE_PREFIX.concat("basic");
+        String table = IndexManager.tableNameForIndex("basic");
         String sql = String.format("SELECT * FROM %s", table);
         Cursor cursor = null;
         try {
@@ -368,14 +355,12 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
 
     @Test
     public void indexSingleArrayFieldWhenIndexingArrays() {
-        ArrayList<Object> fieldNames = new ArrayList<Object>();
-        fieldNames.add("name");
-        fieldNames.add("pet");
+        List<Object> fieldNames = Arrays.<Object>asList("name", "pet");
         createIndex("basic", fieldNames);
 
         Assert.assertEquals(0, getIndexSequenceNumber("basic"));
 
-        String table = IndexManager.INDEX_TABLE_PREFIX.concat("basic");
+        String table = IndexManager.tableNameForIndex("basic");
         String sql = String.format("SELECT * FROM %s", table);
         Cursor cursor = null;
         try {
@@ -392,10 +377,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         // body content: { "name" : "mike",  "pet" : [ "cat", "dog", "parrot" ] }
         Map<String, Object> bodyMap = new HashMap<String, Object>();
         bodyMap.put("name", "mike");
-        ArrayList<String> pets = new ArrayList<String>();
-        pets.add("cat");
-        pets.add("dog");
-        pets.add("parrot");
+        List<String> pets = Arrays.asList("cat", "dog", "parrot");
         bodyMap.put("pet", pets);
         rev.body = DocumentBodyFactory.create(bodyMap);
         BasicDocumentRevision saved = null;
@@ -437,14 +419,12 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
 
     @Test
     public void indexSingleArrayFieldWhenIndexingArraysInSubDoc() {
-        ArrayList<Object> fieldNames = new ArrayList<Object>();
-        fieldNames.add("name");
-        fieldNames.add("pet.species");
+        List<Object> fieldNames = Arrays.<Object>asList("name", "pet.species");
         createIndex("basic", fieldNames);
 
         Assert.assertEquals(0, getIndexSequenceNumber("basic"));
 
-        String table = IndexManager.INDEX_TABLE_PREFIX.concat("basic");
+        String table = IndexManager.tableNameForIndex("basic");
         String sql = String.format("SELECT * FROM %s", table);
         Cursor cursor = null;
         try {
@@ -461,9 +441,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         // body content: { "name" : "mike",  "pet" : { "species" : [ "cat", "dog" ] } }
         Map<String, Object> bodyMap = new HashMap<String, Object>();
         bodyMap.put("name", "mike");
-        ArrayList<String> species = new ArrayList<String>();
-        species.add("cat");
-        species.add("dog");
+        List<String> species = Arrays.asList("cat", "dog");
         Map<String, Object> pets = new HashMap<String, Object>();
         pets.put("species", species);
         bodyMap.put("pet", pets);
@@ -506,15 +484,12 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
 
     @Test
     public void rejectsDocsWithMultipleArrays() {
-        ArrayList<Object> fieldNames = new ArrayList<Object>();
-        fieldNames.add("name");
-        fieldNames.add("pet");
-        fieldNames.add("pet2");
+        List<Object> fieldNames = Arrays.<Object>asList("name", "pet", "pet2");
         createIndex("basic", fieldNames);
 
         Assert.assertEquals(0, getIndexSequenceNumber("basic"));
 
-        String table = IndexManager.INDEX_TABLE_PREFIX.concat("basic");
+        String table = IndexManager.tableNameForIndex("basic");
         String sql = String.format("SELECT * FROM %s", table);
         Cursor cursor = null;
         try {
@@ -531,10 +506,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         // body content: { "name" : "mike", "pet" : [ "cat", "dog", "parrot" ] }
         Map<String, Object> goodBodyMap = new HashMap<String, Object>();
         goodBodyMap.put("name", "mike");
-        ArrayList<String> pets = new ArrayList<String>();
-        pets.add("cat");
-        pets.add("dog");
-        pets.add("parrot");
+        List<String> pets = Arrays.asList("cat", "dog", "parrot");
         goodBodyMap.put("pet", pets);
         goodRev.body = DocumentBodyFactory.create(goodBodyMap);
         BasicDocumentRevision saved = null;
@@ -674,14 +646,10 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
             Assert.fail(String.format("IOException occurred creating document revision: %s", e));
         }
 
-        ArrayList<Object> fieldNames = new ArrayList<Object>();
-        fieldNames.add("age");
-        fieldNames.add("pet");
-        fieldNames.add("name");
+        List<Object> fieldNames = Arrays.<Object>asList("age", "pet", "name");
         createIndex("basic", fieldNames);
 
-        fieldNames.remove("age");
-        fieldNames.remove("pet");
+        fieldNames = Arrays.<Object>asList("name");
         createIndex("basicName", fieldNames);
 
         im.updateAllIndexes();
@@ -689,8 +657,8 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         Assert.assertEquals(6, getIndexSequenceNumber("basic"));
         Assert.assertEquals(6, getIndexSequenceNumber("basicName"));
 
-        String basicTable = IndexManager.INDEX_TABLE_PREFIX.concat("basic");
-        String basicNameTable = IndexManager.INDEX_TABLE_PREFIX.concat("basicName");
+        String basicTable = IndexManager.tableNameForIndex("basic");
+        String basicNameTable = IndexManager.tableNameForIndex("basicName");
         String sqlBasic = String.format("SELECT * FROM %s", basicTable);
         String sqlBasicName = String.format("SELECT * FROM %s", basicNameTable);
         Cursor cursor = null;
@@ -793,7 +761,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
     }
 
     @SuppressWarnings("unchecked")
-    private void createIndex(String indexName, ArrayList<Object> fieldNames) {
+    private void createIndex(String indexName, List<Object> fieldNames) {
         String name = im.ensureIndexed(fieldNames, indexName);
         Assert.assertTrue(name.equals(indexName));
 
@@ -801,7 +769,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         Assert.assertTrue(indexes.containsKey(indexName));
 
         Map<String, Object> index = (Map<String, Object>) indexes.get(indexName);
-        fields = (ArrayList<String>) index.get("fields");
+        fields = (List<String>) index.get("fields");
         Assert.assertEquals(fieldNames.size() + 2, fields.size());
         for (Object fieldName: fieldNames) {
             String field = (String) fieldName;

--- a/sync-core/src/test/java/com/cloudant/sync/query/QueryExecutorTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/QueryExecutorTest.java
@@ -1,0 +1,283 @@
+//  Copyright (c) 2014 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+package com.cloudant.sync.query;
+
+import com.cloudant.sync.datastore.DocumentBodyFactory;
+import com.cloudant.sync.datastore.DocumentRevision;
+import com.cloudant.sync.datastore.MutableDocumentRevision;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class QueryExecutorTest extends AbstractIndexTestBase {
+
+    @Override
+    public void setUp() throws SQLException {
+        super.setUp();
+
+        MutableDocumentRevision rev = new MutableDocumentRevision();
+        rev.docId = "mike12";
+        Map<String, Object> bodyMap = new HashMap<String, Object>();
+        bodyMap.put("name", "mike");
+        bodyMap.put("age", 12);
+        bodyMap.put("pet", "cat");
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        try {
+            ds.createDocumentFromRevision(rev);
+        } catch (IOException e) {
+            e.printStackTrace();
+            Assert.fail("Failed to create document revision");
+        }
+
+        rev.docId = "mike34";
+        bodyMap.clear();
+        bodyMap.put("name", "mike");
+        bodyMap.put("age", 34);
+        bodyMap.put("pet", "dog");
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        try {
+            ds.createDocumentFromRevision(rev);
+        } catch (IOException e) {
+            e.printStackTrace();
+            Assert.fail("Failed to create document revision");
+        }
+
+        rev.docId = "mike72";
+        bodyMap.clear();
+        bodyMap.put("name", "mike");
+        bodyMap.put("age", 72);
+        bodyMap.put("pet", "cat");
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        try {
+            ds.createDocumentFromRevision(rev);
+        } catch (IOException e) {
+            e.printStackTrace();
+            Assert.fail("Failed to create document revision");
+        }
+
+        rev.docId = "fred34";
+        bodyMap.clear();
+        bodyMap.put("name", "fred");
+        bodyMap.put("age", 34);
+        bodyMap.put("pet", "cat");
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        try {
+            ds.createDocumentFromRevision(rev);
+        } catch (IOException e) {
+            e.printStackTrace();
+            Assert.fail("Failed to create document revision");
+        }
+
+        rev.docId = "fred12";
+        bodyMap.clear();
+        bodyMap.put("name", "fred");
+        bodyMap.put("age", 12);
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        try {
+            ds.createDocumentFromRevision(rev);
+        } catch (IOException e) {
+            e.printStackTrace();
+            Assert.fail("Failed to create document revision");
+        }
+
+        List<Object> fieldNames = Arrays.<Object>asList("name", "age");
+        Assert.assertEquals("basic", im.ensureIndexed(fieldNames, "basic"));
+
+        fieldNames = Arrays.<Object>asList("name", "pet");
+        Assert.assertEquals("pet", im.ensureIndexed(fieldNames, "pet"));
+    }
+
+    @Test
+    public void returnsNullForNoQuery() {
+        Assert.assertNull(im.find(null));
+    }
+
+    @Test
+    public void canQueryOverOneStringField() {
+        // query - { "name" : "mike" }
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("name", "mike");
+        QueryResult queryResult = im.find(query);
+        Assert.assertNotNull(queryResult);
+        Assert.assertEquals(3, queryResult.size());
+        List<String> checkList = Arrays.asList("mike12", "mike34", "mike72");
+        Assert.assertEquals(3, queryResult.documentIds().size());
+        Assert.assertTrue(queryResult.documentIds().containsAll(checkList));
+    }
+
+    @Test
+    public void canQueryOverOneStringFieldNormalized() {
+        // query - { "name" : { "eq" : "mike" } }
+        Map<String, Object> operator = new HashMap<String, Object>();
+        operator.put("$eq", "mike");
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("name", operator);
+        QueryResult queryResult = im.find(query);
+        Assert.assertNotNull(queryResult);
+        Assert.assertEquals(3, queryResult.size());
+        List<String> checkList = Arrays.asList("mike12", "mike34", "mike72");
+        Assert.assertEquals(3, queryResult.documentIds().size());
+        Assert.assertTrue(queryResult.documentIds().containsAll(checkList));
+    }
+
+    @Test
+    public void canQueryOverOneNumberField() {
+        // query - { "age" : 12 }
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("age", 12);
+        QueryResult queryResult = im.find(query);
+        Assert.assertNotNull(queryResult);
+        Assert.assertEquals(2, queryResult.size());
+        List<String> checkList = Arrays.asList("mike12", "fred12");
+        Assert.assertEquals(2, queryResult.documentIds().size());
+        Assert.assertTrue(queryResult.documentIds().containsAll(checkList));
+    }
+
+    @Test
+    public void canQueryOverOneNumberFieldNormalized() {
+        // query - { "age" : { "eq" : 12 } }
+        Map<String, Object> operator = new HashMap<String, Object>();
+        operator.put("$eq", 12);
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("age", operator);
+        QueryResult queryResult = im.find(query);
+        Assert.assertNotNull(queryResult);
+        Assert.assertEquals(2, queryResult.size());
+        List<String> checkList = Arrays.asList("mike12", "fred12");
+        Assert.assertEquals(2, queryResult.documentIds().size());
+        Assert.assertTrue(queryResult.documentIds().containsAll(checkList));
+    }
+
+    @Test
+    public void canQueryOverTwoStringFields() {
+        // query - { "name" : "mike", "pet" : "cat" }
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("name", "mike");
+        query.put("pet", "cat");
+        QueryResult queryResult = im.find(query);
+        Assert.assertNotNull(queryResult);
+        Assert.assertEquals(2, queryResult.size());
+        List<String> checkList = Arrays.asList("mike12", "mike72");
+        Assert.assertEquals(2, queryResult.documentIds().size());
+        Assert.assertTrue(queryResult.documentIds().containsAll(checkList));
+    }
+
+    @Test
+    public void canQueryOverTwoStringFieldsNormalized() {
+        // query - { "name" : { "eq" : "mike" }, "pet" : { "$eq" : "cat" } }
+        Map<String, Object> nameOperator = new HashMap<String, Object>();
+        nameOperator.put("$eq", "mike");
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("name", nameOperator);
+        Map<String, Object> petOperator = new HashMap<String, Object>();
+        petOperator.put("$eq", "cat");
+        query.put("pet", petOperator);
+        QueryResult queryResult = im.find(query);
+        Assert.assertNotNull(queryResult);
+        Assert.assertEquals(2, queryResult.size());
+        List<String> checkList = Arrays.asList("mike12", "mike72");
+        Assert.assertEquals(2, queryResult.documentIds().size());
+        Assert.assertTrue(queryResult.documentIds().containsAll(checkList));
+    }
+
+    @Test
+    public void canQueryOverTwoMixedFields() {
+        // query - { "name" : "mike", "age" : "12" }
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("name", "mike");
+        query.put("age", 12);
+        QueryResult queryResult = im.find(query);
+        Assert.assertNotNull(queryResult);
+        Assert.assertEquals(1, queryResult.size());
+        List<String> checkList = Arrays.asList("mike12");
+        Assert.assertEquals(1, queryResult.documentIds().size());
+        Assert.assertTrue(queryResult.documentIds().containsAll(checkList));
+    }
+
+    @Test
+    public void canQueryOverTwoMixedFieldsNormalized() {
+        // query - { "name" : { "eq" : "mike" }, "age" : { "$eq" : 12 } }
+        Map<String, Object> nameOperator = new HashMap<String, Object>();
+        nameOperator.put("$eq", "mike");
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("name", nameOperator);
+        Map<String, Object> ageOperator = new HashMap<String, Object>();
+        ageOperator.put("$eq", 12);
+        query.put("age", ageOperator);
+        QueryResult queryResult = im.find(query);
+        Assert.assertNotNull(queryResult);
+        Assert.assertEquals(1, queryResult.size());
+        List<String> checkList = Arrays.asList("mike12");
+        Assert.assertEquals(1, queryResult.documentIds().size());
+        Assert.assertTrue(queryResult.documentIds().containsAll(checkList));
+    }
+
+    @Test
+    public void noResultsWhenQueryOverOneFieldIsMismatched() {
+        // query - { "name" : "bill" }
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("name", "bill");
+        QueryResult queryResult = im.find(query);
+        Assert.assertNotNull(queryResult);
+        Assert.assertEquals(0, queryResult.size());
+    }
+
+    @Test
+    public void noResultsWhenQueryOverTwoFieldsOneIsMismatched() {
+        // query - { "name" : "bill", "age" : 12 }
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("name", "bill");
+        query.put("age", 12);
+        QueryResult queryResult = im.find(query);
+        Assert.assertNotNull(queryResult);
+        Assert.assertEquals(0, queryResult.size());
+    }
+
+    @Test
+    public void noResultsWhenQueryOverTwoFieldsBothAreMismatched() {
+        // query - { "name" : "bill", "age" : 17 }
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("name", "bill");
+        query.put("age", 17);
+        QueryResult queryResult = im.find(query);
+        Assert.assertNotNull(queryResult);
+        Assert.assertEquals(0, queryResult.size());
+    }
+
+    @Test
+    public void validateIteratorContentWithDocumentIdsList() {
+        // query - { "name" : "mike" }
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("name", "mike");
+        QueryResult queryResult = im.find(query);
+        Assert.assertNotNull(queryResult);
+        Assert.assertTrue(queryResult.size() == queryResult.documentIds().size());
+        List<String> docCheckList = new ArrayList<String>();
+        for (DocumentRevision rev: queryResult) {
+            Assert.assertNotNull(rev.getId());
+            Assert.assertNotNull(rev.getBody());
+            docCheckList.add(rev.getId());
+        }
+        Assert.assertTrue(queryResult.size() == docCheckList.size());
+        Assert.assertTrue(docCheckList.containsAll(queryResult.documentIds()));
+    }
+
+}

--- a/sync-core/src/test/java/com/cloudant/sync/query/QuerySqlTranslatorTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/QuerySqlTranslatorTest.java
@@ -1,0 +1,402 @@
+//  Copyright (c) 2014 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+package com.cloudant.sync.query;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
+
+    Map<String, Object> indexes;
+    Boolean[] indexesCoverQuery;
+
+    @Override
+    public void setUp() throws SQLException {
+        super.setUp();
+        List<Object> fieldNames = Arrays.<Object>asList("name", "age", "pet");
+        Assert.assertEquals("basic", im.ensureIndexed(fieldNames, "basic"));
+        indexes = im.listIndexes();
+        Assert.assertNotNull(indexes);
+        indexesCoverQuery = new Boolean[]{ false };
+    }
+
+    // When creating a tree
+
+    @Test
+    public void copesWithSingleFieldQuery() {
+        // query - { "name" : "mike" }
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("name", "mike");
+        query = QueryValidator.normaliseAndValidateQuery(query);
+        QueryNode node = QuerySqlTranslator.translateQuery(query, indexes, indexesCoverQuery);
+        Assert.assertNotNull(node);
+        Assert.assertTrue(node instanceof AndQueryNode);
+        Assert.assertTrue(indexesCoverQuery[0]);
+        AndQueryNode andNode = (AndQueryNode) node;
+        Assert.assertEquals(1, andNode.children.size());
+        Assert.assertTrue(andNode.children.get(0) instanceof SqlQueryNode);
+        SqlQueryNode sqlNode = (SqlQueryNode) andNode.children.get(0);
+        String sql = sqlNode.sql.sqlWithPlaceHolders;
+        String[] valuesArray = sqlNode.sql.placeHolderValues;
+        Assert.assertTrue(sql.equals("SELECT _id FROM _t_cloudant_sync_query_index_basic " +
+                                     "WHERE \"name\" = ?"));
+        List<String> placeHolderValues = Arrays.asList("mike");
+        Assert.assertTrue(placeHolderValues.containsAll(Arrays.asList(valuesArray)));
+    }
+
+    @Test
+    public void copesWithSingleLevelANDedQuery() {
+        // query - { "name" : "mike", "pet" : "cat" }
+        Map<String, Object> query = new LinkedHashMap<String, Object>();
+        query.put("name", "mike");
+        query.put("pet", "cat");
+        query = QueryValidator.normaliseAndValidateQuery(query);
+        QueryNode node = QuerySqlTranslator.translateQuery(query, indexes, indexesCoverQuery);
+        Assert.assertNotNull(node);
+        Assert.assertTrue(node instanceof AndQueryNode);
+        Assert.assertTrue(indexesCoverQuery[0]);
+        AndQueryNode andNode = (AndQueryNode) node;
+        Assert.assertEquals(1, andNode.children.size());
+        Assert.assertTrue(andNode.children.get(0) instanceof SqlQueryNode);
+        SqlQueryNode sqlNode = (SqlQueryNode) andNode.children.get(0);
+        String sql = sqlNode.sql.sqlWithPlaceHolders;
+        String[] valuesArray = sqlNode.sql.placeHolderValues;
+        Assert.assertTrue(sql.equals("SELECT _id FROM _t_cloudant_sync_query_index_basic " +
+                                     "WHERE \"name\" = ? AND \"pet\" = ?"));
+        List<String> placeHolderValues = Arrays.asList("mike", "cat");
+        Assert.assertTrue(placeHolderValues.containsAll(Arrays.asList(valuesArray)));
+    }
+
+    @Test
+    public void copesWithLongHandSingleLevelANDedQuery() {
+        // query - { "and" : [ { "name" : "mike" }, { "pet" : "cat" } ] }
+        Map<String, Object> nameMap = new HashMap<String, Object>();
+        nameMap.put("name", "mike");
+        Map<String, Object> petMap = new HashMap<String, Object>();
+        petMap.put("pet", "cat");
+        List<Object> fields = Arrays.<Object>asList(nameMap, petMap);
+        Map<String, Object> query = new LinkedHashMap<String, Object>();
+        query.put("$and", fields);
+        query = QueryValidator.normaliseAndValidateQuery(query);
+        QueryNode node = QuerySqlTranslator.translateQuery(query, indexes, indexesCoverQuery);
+        Assert.assertNotNull(node);
+        Assert.assertTrue(node instanceof AndQueryNode);
+        Assert.assertTrue(indexesCoverQuery[0]);
+        AndQueryNode andNode = (AndQueryNode) node;
+        Assert.assertEquals(1, andNode.children.size());
+        Assert.assertTrue(andNode.children.get(0) instanceof SqlQueryNode);
+        SqlQueryNode sqlNode = (SqlQueryNode) andNode.children.get(0);
+        String sql = sqlNode.sql.sqlWithPlaceHolders;
+        String[] valuesArray = sqlNode.sql.placeHolderValues;
+        Assert.assertTrue(sql.equals("SELECT _id FROM _t_cloudant_sync_query_index_basic " +
+                                     "WHERE \"name\" = ? AND \"pet\" = ?"));
+        List<String> placeHolderValues = Arrays.asList("mike", "cat");
+        Assert.assertTrue(placeHolderValues.containsAll(Arrays.asList(valuesArray)));
+    }
+
+    // When selecting an index to use
+
+    @Test
+    public void indexSelectionFailsWhenNoIndexes() {
+        Map<String, Object> eq = new HashMap<String, Object>();
+        eq.put("$eq", "mike");
+        Map<String, Object> name = new HashMap<String, Object>();
+        name.put("name", eq);
+        List<Object> clause = Arrays.<Object>asList(name);
+        Assert.assertNull(QuerySqlTranslator.chooseIndexForAndClause(clause, null));
+    }
+
+    @Test
+    public void indexSelectionFailsWhenNoQueryKeys() {
+        Map<String, Object> indexes = new HashMap<String, Object>();
+        List<Object> fields = Arrays.<Object>asList("name", "age", "pet");
+        indexes.put("named", fields);
+        Assert.assertNull(QuerySqlTranslator.chooseIndexForAndClause(null, indexes));
+        Assert.assertNull(QuerySqlTranslator.chooseIndexForAndClause(new ArrayList<Object>(),
+                                                                     indexes));
+    }
+
+    @Test
+    public void selectsIndexForSingleFieldQuery() {
+        Map<String, Object> indexes = new HashMap<String, Object>();
+        Map<String, Object> index = new HashMap<String, Object>();
+        index.put("name", "named");
+        index.put("type", "json");
+        List<Object> fields = Arrays.<Object>asList("name");
+        index.put("fields", fields);
+        indexes.put("named", index);
+
+        Map<String, Object> eq = new HashMap<String, Object>();
+        eq.put("$eq", "mike");
+        Map<String, Object> name = new HashMap<String, Object>();
+        name.put("name", eq);
+        List<Object> clause = Arrays.<Object>asList(name);
+
+        String idx = QuerySqlTranslator.chooseIndexForAndClause(clause, indexes);
+        Assert.assertTrue(idx.equals("named"));
+    }
+
+    @Test
+    public void selectsIndexForMultiFieldQuery() {
+        Map<String, Object> indexes = new HashMap<String, Object>();
+        Map<String, Object> index = new HashMap<String, Object>();
+        index.put("name", "named");
+        index.put("type", "json");
+        List<Object> fields = Arrays.<Object>asList("name", "age", "pet");
+        index.put("fields", fields);
+        indexes.put("named", index);
+
+        Map<String, Object> name = new HashMap<String, Object>();
+        name.put("name", "mike");
+        Map<String, Object> pet = new HashMap<String, Object>();
+        pet.put("pet", "cat");
+        List<Object> clause = Arrays.<Object>asList(name, pet);
+
+        String idx = QuerySqlTranslator.chooseIndexForAndClause(clause, indexes);
+        Assert.assertTrue(idx.equals("named"));
+    }
+
+    @Test
+    public void selectsIndexFromMultipleIndexesForMultiFieldQuery() {
+        Map<String, Object> indexes = new HashMap<String, Object>();
+
+        Map<String, Object> named = new HashMap<String, Object>();
+        named.put("name", "named");
+        named.put("type", "json");
+        List<Object> namedFields = Arrays.<Object>asList("name", "age", "pet");
+        named.put("fields", namedFields);
+
+        Map<String, Object> bopped = new HashMap<String, Object>();
+        bopped.put("name", "bopped");
+        bopped.put("type", "json");
+        List<Object> boppedFields = Arrays.<Object>asList("house_number", "pet");
+        bopped.put("fields", boppedFields);
+
+        Map<String, Object> unsuitable = new HashMap<String, Object>();
+        unsuitable.put("name", "unsuitable");
+        unsuitable.put("type", "json");
+        List<Object> unsuitableFields = Arrays.<Object>asList("name");
+        unsuitable.put("fields", unsuitableFields);
+
+        indexes.put("named", named);
+        indexes.put("bopped", bopped);
+        indexes.put("unsuitable", unsuitable);
+
+        Map<String, Object> name = new HashMap<String, Object>();
+        name.put("name", "mike");
+        Map<String, Object> pet = new HashMap<String, Object>();
+        pet.put("pet", "cat");
+        List<Object> clause = Arrays.<Object>asList(name, pet);
+
+        String idx = QuerySqlTranslator.chooseIndexForAndClause(clause, indexes);
+        Assert.assertTrue(idx.equals("named"));
+    }
+
+    @Test
+    public void selectsCorrectIndexWhenSeveralMatch() {
+        Map<String, Object> indexes = new HashMap<String, Object>();
+
+        Map<String, Object> named = new HashMap<String, Object>();
+        named.put("name", "named");
+        named.put("type", "json");
+        List<Object> namedFields = Arrays.<Object>asList("name", "age", "pet");
+        named.put("fields", namedFields);
+
+        Map<String, Object> bopped = new HashMap<String, Object>();
+        bopped.put("name", "bopped");
+        bopped.put("type", "json");
+        List<Object> boppedFields = Arrays.<Object>asList("name", "age", "pet");
+        bopped.put("fields", boppedFields);
+
+        Map<String, Object> manyField = new HashMap<String, Object>();
+        manyField.put("name", "manyField");
+        manyField.put("type", "json");
+        List<Object> manyFieldFields = Arrays.<Object>asList("name", "age", "pet");
+        manyField.put("fields", manyFieldFields);
+
+        Map<String, Object> unsuitable = new HashMap<String, Object>();
+        unsuitable.put("name", "unsuitable");
+        unsuitable.put("type", "json");
+        List<Object> unsuitableFields = Arrays.<Object>asList("name");
+        unsuitable.put("fields", unsuitableFields);
+
+        indexes.put("named", named);
+        indexes.put("bopped", bopped);
+        indexes.put("manyField", manyField);
+        indexes.put("unsuitable", unsuitable);
+
+        Map<String, Object> name = new HashMap<String, Object>();
+        name.put("name", "mike");
+        Map<String, Object> pet = new HashMap<String, Object>();
+        pet.put("pet", "cat");
+        List<Object> clause = Arrays.<Object>asList(name, pet);
+
+        String idx = QuerySqlTranslator.chooseIndexForAndClause(clause, indexes);
+        Assert.assertTrue(idx.equals("named") || idx.equals("bopped"));
+    }
+
+    @Test
+    public void nullWhenNoSuitableIndexAvailable() {
+        Map<String, Object> indexes = new HashMap<String, Object>();
+
+        Map<String, Object> named = new HashMap<String, Object>();
+        named.put("name", "named");
+        named.put("type", "json");
+        List<Object> namedFields = Arrays.<Object>asList("name", "age");
+        named.put("fields", namedFields);
+
+        Map<String, Object> unsuitable = new HashMap<String, Object>();
+        unsuitable.put("name", "unsuitable");
+        unsuitable.put("type", "json");
+        List<Object> unsuitableFields = Arrays.<Object>asList("name");
+        unsuitable.put("fields", unsuitableFields);
+
+        indexes.put("named", named);
+        indexes.put("unsuitable", unsuitable);
+
+        Map<String, Object> pet = new HashMap<String, Object>();
+        pet.put("pet", "cat");
+        List<Object> clause = Arrays.<Object>asList(pet);
+
+        Assert.assertNull(QuerySqlTranslator.chooseIndexForAndClause(clause, indexes));
+    }
+
+    // When generating query WHERE clauses
+
+    @Test
+    public void nullWhereClauseWhenQueryEmpty() {
+        Assert.assertNull(QuerySqlTranslator.whereSqlForAndClause(null));
+        Assert.assertNull(QuerySqlTranslator.whereSqlForAndClause(new ArrayList<Object>()));
+    }
+
+    @Test
+    public void validWhereClauseForSingleTermEQ() {
+        Map<String, Object> eq = new HashMap<String, Object>();
+        eq.put("$eq", "mike");
+        Map<String, Object> name = new HashMap<String, Object>();
+        name.put("name", eq);
+        List<Object> clause = Arrays.<Object>asList(name);
+        SqlParts where = QuerySqlTranslator.whereSqlForAndClause(clause);
+        Assert.assertNotNull(where);
+        Assert.assertTrue(where.sqlWithPlaceHolders.equals("\"name\" = ?"));
+        List<String> placeHolderValues = Arrays.asList("mike");
+        Assert.assertTrue(placeHolderValues.containsAll(Arrays.asList(where.placeHolderValues)));
+    }
+
+    @Test
+    public void validWhereClauseForMultiTermEQ() {
+        Map<String, Object> nameEq = new HashMap<String, Object>();
+        nameEq.put("$eq", "mike");
+        Map<String, Object> name = new HashMap<String, Object>();
+        name.put("name", nameEq);
+
+        Map<String, Object> ageEq = new HashMap<String, Object>();
+        ageEq.put("$eq", 12);
+        Map<String, Object> age = new HashMap<String, Object>();
+        age.put("age", ageEq);
+
+        Map<String, Object> petEq = new HashMap<String, Object>();
+        petEq.put("$eq", "cat");
+        Map<String, Object> pet = new HashMap<String, Object>();
+        pet.put("pet", petEq);
+
+        List<Object> clause = Arrays.<Object>asList(name, age, pet);
+        SqlParts where = QuerySqlTranslator.whereSqlForAndClause(clause);
+        Assert.assertNotNull(where);
+        String expected = "\"name\" = ? AND \"age\" = ? AND \"pet\" = ?";
+        Assert.assertTrue(where.sqlWithPlaceHolders.equals(expected));
+        List<String> placeHolderValues = Arrays.asList("mike", "12", "cat");
+        Assert.assertTrue(placeHolderValues.containsAll(Arrays.asList(where.placeHolderValues)));
+    }
+
+    @Test
+    public void nullWhereClauseForUnsupportedOperator() {
+        Map<String, Object> eq = new HashMap<String, Object>();
+        eq.put("$blah", "mike");
+        Map<String, Object> name = new HashMap<String, Object>();
+        name.put("name", eq);
+        List<Object> clause = Arrays.<Object>asList(name);
+        Assert.assertNull(QuerySqlTranslator.whereSqlForAndClause(clause));
+    }
+
+    // When generating query SELECT clauses
+
+    @Test
+    public void nullSelectClauseWhenQueryEmpty() {
+        Assert.assertNull(QuerySqlTranslator.selectStatementForAndClause(null, "named"));
+        Assert.assertNull(QuerySqlTranslator.selectStatementForAndClause(new ArrayList<Object>(),
+                                                                         "named"));
+    }
+
+    @Test
+    public void nullSelectClauseWhenIndexEmpty() {
+        Map<String, Object> eq = new HashMap<String, Object>();
+        eq.put("$eq", "mike");
+        Map<String, Object> name = new HashMap<String, Object>();
+        name.put("name", eq);
+        List<Object> clause = Arrays.<Object>asList(name);
+        Assert.assertNull(QuerySqlTranslator.selectStatementForAndClause(clause, null));
+        Assert.assertNull(QuerySqlTranslator.selectStatementForAndClause(clause, ""));
+    }
+
+    @Test
+    public void validSelectClauseForSingleTermEQ() {
+        Map<String, Object> eq = new HashMap<String, Object>();
+        eq.put("$eq", "mike");
+        Map<String, Object> name = new HashMap<String, Object>();
+        name.put("name", eq);
+        List<Object> clause = Arrays.<Object>asList(name);
+        SqlParts sql = QuerySqlTranslator.selectStatementForAndClause(clause, "anIndex");
+        Assert.assertNotNull(sql);
+        String expected = "SELECT _id FROM _t_cloudant_sync_query_index_anIndex WHERE \"name\" = ?";
+        Assert.assertTrue(sql.sqlWithPlaceHolders.equals(expected));
+        List<String> placeHolderValues = Arrays.asList("mike");
+        Assert.assertTrue(placeHolderValues.containsAll(Arrays.asList(sql.placeHolderValues)));
+    }
+
+    @Test
+    public void validSelectClauseForMultiTermEQ() {
+        Map<String, Object> nameEq = new HashMap<String, Object>();
+        nameEq.put("$eq", "mike");
+        Map<String, Object> name = new HashMap<String, Object>();
+        name.put("name", nameEq);
+
+        Map<String, Object> ageEq = new HashMap<String, Object>();
+        ageEq.put("$eq", 12);
+        Map<String, Object> age = new HashMap<String, Object>();
+        age.put("age", ageEq);
+
+        Map<String, Object> petEq = new HashMap<String, Object>();
+        petEq.put("$eq", "cat");
+        Map<String, Object> pet = new HashMap<String, Object>();
+        pet.put("pet", petEq);
+
+        List<Object> clause = Arrays.<Object>asList(name, age, pet);
+        SqlParts sql = QuerySqlTranslator.selectStatementForAndClause(clause, "anIndex");
+        Assert.assertNotNull(sql);
+        String expected = "SELECT _id FROM _t_cloudant_sync_query_index_anIndex WHERE \"name\" = " +
+                          "? AND \"age\" = ? AND \"pet\" = ?";
+        Assert.assertTrue(sql.sqlWithPlaceHolders.equals(expected));
+        List<String> placeHolderValues = Arrays.asList("mike", "12", "cat");
+        Assert.assertTrue(placeHolderValues.containsAll(Arrays.asList(sql.placeHolderValues)));
+    }
+
+}

--- a/sync-core/src/test/java/com/cloudant/sync/query/QueryValidatorTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/QueryValidatorTest.java
@@ -1,0 +1,90 @@
+//  Copyright (c) 2014 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+package com.cloudant.sync.query;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class QueryValidatorTest {
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void normalizeSingleFieldQuery() {
+        Map<String, Object> query = new HashMap<String, Object>();
+        // query - { "name" : "mike" }
+        query.put("name", "mike");
+        Map<String, Object> normalizedQuery = QueryValidator.normaliseAndValidateQuery(query);
+
+        // normalized query - { "$and" : [ { "name" : { "$eq" : "mike" } } ]
+        Assert.assertNotNull(normalizedQuery);
+        Assert.assertEquals(1, normalizedQuery.size());
+        Assert.assertTrue(normalizedQuery.keySet().toArray()[0].equals("$and"));
+        Assert.assertTrue(normalizedQuery.get("$and") instanceof List);
+        List<Object> fields = (ArrayList) normalizedQuery.get("$and");
+        Assert.assertEquals(1, fields.size());
+        Assert.assertTrue(fields.get(0) instanceof Map);
+        Map<String, Object> fieldMap = (Map) fields.get(0);
+        Assert.assertEquals(1, fieldMap.size());
+        Assert.assertTrue(fieldMap.keySet().toArray()[0].equals("name"));
+        Map<String, Object> predicate = (Map) fieldMap.get("name");
+        Assert.assertEquals(1, predicate.size());
+        Assert.assertTrue(predicate.keySet().toArray()[0].equals("$eq"));
+        Assert.assertTrue(predicate.get("$eq").equals("mike"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void normalizeMultiFieldQuery() {
+        Map<String, Object> query = new LinkedHashMap<String, Object>();
+        // query - { "name" : "mike", "age", 12 }
+        query.put("name", "mike");
+        query.put("age", 12);
+        Map<String, Object> normalizedQuery = QueryValidator.normaliseAndValidateQuery(query);
+
+        // normalized query - { "$and" : [ { "name" : { "$eq" : "mike" } },
+        //                                 { "age" : { "$eq" : "12" } } ]
+        Assert.assertNotNull(normalizedQuery);
+        Assert.assertEquals(1, normalizedQuery.size());
+        Assert.assertTrue(normalizedQuery.keySet().toArray()[0].equals("$and"));
+        Assert.assertTrue(normalizedQuery.get("$and") instanceof List);
+        List<Object> fields = (ArrayList) normalizedQuery.get("$and");
+        Assert.assertEquals(2, fields.size());
+        for (Object field: fields) {
+            Assert.assertTrue(field instanceof Map);
+        }
+        Map<String, Object> fieldMap = (Map) fields.get(0);
+        Assert.assertEquals(1, fieldMap.size());
+        Assert.assertTrue(fieldMap.keySet().toArray()[0].equals("name"));
+        Map<String, Object> predicate = (Map) fieldMap.get("name");
+        Assert.assertEquals(1, predicate.size());
+        Assert.assertTrue(predicate.keySet().toArray()[0].equals("$eq"));
+        Assert.assertTrue(predicate.get("$eq").equals("mike"));
+
+        fieldMap.clear();
+        fieldMap = (Map) fields.get(1);
+        Assert.assertEquals(1, fieldMap.size());
+        Assert.assertTrue(fieldMap.keySet().toArray()[0].equals("age"));
+        predicate.clear();
+        predicate = (Map) fieldMap.get("age");
+        Assert.assertEquals(1, predicate.size());
+        Assert.assertTrue(predicate.keySet().toArray()[0].equals("$eq"));
+        Assert.assertEquals(12, predicate.get("$eq"));
+    }
+
+}


### PR DESCRIPTION
This pull request replaces PR #74. The single valid commit from that PR was cherry picked from the 42942-query-simple-AND-query branch and placed into this new branch 42942-query-find-simple-AND.  That commit was commented on by @mikerhodes and the subsequent commit 1c1ba14 to this branch addressed all issues raised with the exception of the naming and content of the TranslatorState class.  See https://github.com/cloudant/sync-android/commit/38f37b43ec52273943c9a0b8301cdcc21e83f0f6#commitcomment-9185831.