### PR TITLE
26049 run on api 14 android

### DIFF
--- a/AndroidTest/app/build.gradle
+++ b/AndroidTest/app/build.gradle
@@ -13,7 +13,7 @@ android {
 
     defaultConfig {
         applicationId "cloudant.com.androidtest"
-        minSdkVersion 15
+        minSdkVersion 14
         targetSdkVersion 20
         versionCode 1
         versionName "1.0"
@@ -88,6 +88,8 @@ dependencies {
         // the current version of objenesis which mockito depends on is buggy on android, so force a newer version
         force true
     }
+
+    compile 'com.google.code.findbugs:jsr305:3.0.0' //this is needed for some versions of android
 
 }
 

--- a/sync-core/src/test/java/com/cloudant/mazha/CouchClientTestBase.java
+++ b/sync-core/src/test/java/com/cloudant/mazha/CouchClientTestBase.java
@@ -23,7 +23,7 @@ import org.junit.Before;
 
 public abstract class CouchClientTestBase {
 
-    static final String TEST_DB = "mazha-test";
+    String TEST_DB = "mazha-test"+System.currentTimeMillis();
 
     public static final Boolean TEST_WITH_CLOUDANT = Boolean.valueOf(
             System.getProperty("test.with.cloudant",Boolean.FALSE.toString()));

--- a/sync-core/src/test/java/com/cloudant/sync/replication/CompactedDBReplicationTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/replication/CompactedDBReplicationTest.java
@@ -81,7 +81,7 @@ public class CompactedDBReplicationTest extends ReplicationTestBase {
         CouchDbInfo info = couchClient.getDbInfo(getDbName());
 
         while(info.isCompactRunning()) {
-            Thread.sleep(10);
+            Thread.sleep(1000);
             info = couchClient.getDbInfo(getDbName());
         };
 

--- a/sync-core/src/test/java/com/cloudant/sync/replication/ReplicationTestBase.java
+++ b/sync-core/src/test/java/com/cloudant/sync/replication/ReplicationTestBase.java
@@ -37,6 +37,8 @@ public abstract class ReplicationTestBase extends CouchTestBase {
     protected CouchClientWrapper remoteDb = null;
     protected CouchClient couchClient = null;
 
+    private long dbSuffix = System.currentTimeMillis();
+
     @Before
     public void setUp() throws Exception {
         this.createDatastore();
@@ -72,7 +74,7 @@ public abstract class ReplicationTestBase extends CouchTestBase {
     }
 
     String getDbName() {
-        String dbName = getClass().getSimpleName();
+        String dbName = getClass().getSimpleName()+ dbSuffix;
         String regex = "([a-z])([A-Z])";
         String replacement = "$1_$2";
         return dbName.replaceAll(regex, replacement).toLowerCase();


### PR DESCRIPTION
Code changes to ensure tests can run against all android platform's we support.

These are:

Lower the minimum API level to 14 for the AndroidTest app
Add the system time in mills as a suffix for remote db names to avoid collisions