### PR TITLE
Update Query unit tests to use Hamcrest matchers

### DIFF
--- a/sync-core/src/test/java/com/cloudant/sync/query/AbstractIndexTestBase.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/AbstractIndexTestBase.java
@@ -12,6 +12,10 @@
 
 package com.cloudant.sync.query;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
 import com.cloudant.sync.datastore.DatastoreExtended;
 import com.cloudant.sync.datastore.DatastoreManager;
 import com.cloudant.sync.sqlite.SQLDatabase;
@@ -19,7 +23,6 @@ import com.cloudant.sync.util.SQLDatabaseTestUtils;
 import com.cloudant.sync.util.TestUtils;
 
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 
 import java.sql.SQLException;
@@ -35,16 +38,16 @@ public class AbstractIndexTestBase {
     @Before
     public void setUp() throws SQLException {
         factoryPath = TestUtils.createTempTestingDir(AbstractIndexTestBase.class.getName());
-        Assert.assertNotNull(factoryPath);
+        assertThat(factoryPath, is(notNullValue()));
         factory = new DatastoreManager(factoryPath);
-        Assert.assertNotNull(factory);
+        assertThat(factory, is(notNullValue()));
         ds = (DatastoreExtended) factory.openDatastore(AbstractIndexTestBase.class.getSimpleName());
-        Assert.assertNotNull(ds);
+        assertThat(ds, is(notNullValue()));
         im = new IndexManager(ds);
-        Assert.assertNotNull(im);
+        assertThat(im, is(notNullValue()));
         db = im.getDatabase();
-        Assert.assertNotNull(db);
-        Assert.assertNotNull(im.getQueue());
+        assertThat(db, is(notNullValue()));
+        assertThat(im.getQueue(), is(notNullValue()));
         String[] metadataTableList = new String[] { IndexManager.INDEX_METADATA_TABLE_NAME };
         SQLDatabaseTestUtils.assertTablesExist(db, metadataTableList);
     }
@@ -52,7 +55,7 @@ public class AbstractIndexTestBase {
     @After
     public void tearDown() {
         im.close();
-        Assert.assertTrue(im.getQueue().isShutdown());
+        assertThat(im.getQueue().isShutdown(), is(true));
         ds.close();
         TestUtils.deleteDatabaseQuietly(db);
         TestUtils.deleteTempTestingDir(factoryPath);

--- a/sync-core/src/test/java/com/cloudant/sync/query/IndexManagerTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/IndexManagerTest.java
@@ -12,23 +12,23 @@
 
 package com.cloudant.sync.query;
 
-import org.junit.Assert;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 
 public class IndexManagerTest extends AbstractIndexTestBase {
 
     @Test
     public void unimplementedEnsureIndexed() {
-        List<Object> fieldNames = Arrays.<Object>asList("name");
-        Assert.assertNull(im.ensureIndexed(fieldNames));
+        assertThat(im.ensureIndexed(Arrays.<Object>asList("name")), is(nullValue()));
     }
 
     @Test
     public void unimplementedDeleteIndexNamed() {
-        Assert.assertFalse(im.deleteIndexNamed("basic"));
+        assertThat(im.deleteIndexNamed("basic"), is(false));
     }
 }

--- a/sync-core/src/test/java/com/cloudant/sync/query/IndexUpdaterTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/IndexUpdaterTest.java
@@ -12,6 +12,14 @@
 
 package com.cloudant.sync.query;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
 import com.cloudant.sync.datastore.BasicDocumentRevision;
 import com.cloudant.sync.datastore.DocumentBodyFactory;
 import com.cloudant.sync.datastore.MutableDocumentRevision;
@@ -41,25 +49,22 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
 
     @Test
     public void updateIndexNoIndexName() {
-        List<Object> fieldNames = Arrays.<Object>asList("name");
-        createIndex("basic", fieldNames);
-
-        Assert.assertFalse(IndexUpdater.updateIndex(null, fields, db, ds, im.getQueue()));
+        createIndex("basic", Arrays.<Object>asList("name"));
+        assertThat(IndexUpdater.updateIndex(null, fields, db, ds, im.getQueue()), is(false));
     }
 
     @Test
     public void updateOneFieldIndex() {
-        List<Object> fieldNames = Arrays.<Object>asList("name");
-        createIndex("basic", fieldNames);
+        createIndex("basic", Arrays.<Object>asList("name"));
 
-        Assert.assertEquals(0, getIndexSequenceNumber("basic"));
+        assertThat(getIndexSequenceNumber("basic"), is(0l));
 
         String table = IndexManager.tableNameForIndex("basic");
         String sql = String.format("SELECT * FROM %s", table);
         Cursor cursor = null;
         try {
             cursor = db.rawQuery(sql, new String[]{});
-            Assert.assertEquals(0, cursor.getCount());
+            assertThat(cursor.getCount(), is(0));
         } catch (SQLException e) {
             Assert.fail(String.format("SQLException occurred executing %s: %s", sql, e));
         } finally {
@@ -79,21 +84,21 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
             Assert.fail(String.format("IOException occurred creating document revision: %s", e));
         }
 
-        Assert.assertTrue(IndexUpdater.updateIndex("basic", fields, db, ds, im.getQueue()));
-        Assert.assertEquals(1, getIndexSequenceNumber("basic"));
+        assertThat(IndexUpdater.updateIndex("basic", fields, db, ds, im.getQueue()), is(true));
+        assertThat(getIndexSequenceNumber("basic"), is(1l));
 
         cursor = null;
         try {
             cursor = db.rawQuery(sql, new String[]{});
-            Assert.assertEquals(1, cursor.getCount());
-            Assert.assertEquals(3, cursor.getColumnCount());
+            assertThat(cursor.getCount(), is(1));
+            assertThat(cursor.getColumnCount(), is(3));
             while (cursor.moveToNext()) {
-                Assert.assertTrue(cursor.columnName(0).equals("_id"));
-                Assert.assertTrue(cursor.getString(0).equals("id123"));
-                Assert.assertTrue(cursor.columnName(1).equals("_rev"));
-                Assert.assertTrue(cursor.getString(1).equals(saved.getRevision()));
-                Assert.assertTrue(cursor.columnName(2).equals("name"));
-                Assert.assertTrue(cursor.getString(2).equals("mike"));
+                assertThat(cursor.columnName(0), is("_id"));
+                assertThat(cursor.getString(0), is("id123"));
+                assertThat(cursor.columnName(1), is("_rev"));
+                assertThat(cursor.getString(1), is(saved.getRevision()));
+                assertThat(cursor.columnName(2), is("name"));
+                assertThat(cursor.getString(2), is("mike"));
             }
         }catch (SQLException e) {
             Assert.fail(String.format("SQLException occurred executing %s: %s", sql, e));
@@ -104,17 +109,16 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
 
     @Test
     public void updateTwoFieldIndex() {
-        List<Object> fieldNames = Arrays.<Object>asList("name", "age");
-        createIndex("basic", fieldNames);
+        createIndex("basic", Arrays.<Object>asList("name", "age"));
 
-        Assert.assertEquals(0, getIndexSequenceNumber("basic"));
+        assertThat(getIndexSequenceNumber("basic"), is(0l));
 
         String table = IndexManager.tableNameForIndex("basic");
         String sql = String.format("SELECT * FROM %s", table);
         Cursor cursor = null;
         try {
             cursor = db.rawQuery(sql, new String[]{});
-            Assert.assertEquals(0, cursor.getCount());
+            assertThat(cursor.getCount(), is(0));
         } catch (SQLException e) {
             Assert.fail(String.format("SQLException occurred executing %s: %s", sql, e));
         } finally {
@@ -135,23 +139,23 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
             Assert.fail(String.format("IOException occurred creating document revision: %s", e));
         }
 
-        Assert.assertTrue(IndexUpdater.updateIndex("basic", fields, db, ds, im.getQueue()));
-        Assert.assertEquals(1, getIndexSequenceNumber("basic"));
+        assertThat(IndexUpdater.updateIndex("basic", fields, db, ds, im.getQueue()), is(true));
+        assertThat(getIndexSequenceNumber("basic"), is(1l));
 
         cursor = null;
         try {
             cursor = db.rawQuery(sql, new String[]{});
-            Assert.assertEquals(1, cursor.getCount());
-            Assert.assertEquals(4, cursor.getColumnCount());
+            assertThat(cursor.getCount(), is(1));
+            assertThat(cursor.getColumnCount(), is(4));
             while (cursor.moveToNext()) {
-                Assert.assertTrue(cursor.columnName(0).equals("_id"));
-                Assert.assertTrue(cursor.getString(0).equals("id123"));
-                Assert.assertTrue(cursor.columnName(1).equals("_rev"));
-                Assert.assertTrue(cursor.getString(1).equals(saved.getRevision()));
-                Assert.assertTrue(cursor.columnName(2).equals("name"));
-                Assert.assertTrue(cursor.getString(2).equals("mike"));
-                Assert.assertTrue(cursor.columnName(3).equals("age"));
-                Assert.assertEquals(12, cursor.getInt(3));
+                assertThat(cursor.columnName(0), is("_id"));
+                assertThat(cursor.getString(0), is("id123"));
+                assertThat(cursor.columnName(1), is("_rev"));
+                assertThat(cursor.getString(1), is(saved.getRevision()));
+                assertThat(cursor.columnName(2), is("name"));
+                assertThat(cursor.getString(2), is("mike"));
+                assertThat(cursor.columnName(3), is("age"));
+                assertThat(cursor.getInt(3), is(12));
             }
         }catch (SQLException e) {
             Assert.fail(String.format("SQLException occurred executing %s: %s", sql, e));
@@ -162,17 +166,16 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
 
     @Test
     public void updateMultiFieldIndex() {
-        List<Object> fieldNames = Arrays.<Object>asList("name", "age", "pet", "car");
-        createIndex("basic", fieldNames);
+        createIndex("basic", Arrays.<Object>asList("name", "age", "pet", "car"));
 
-        Assert.assertEquals(0, getIndexSequenceNumber("basic"));
+        assertThat(getIndexSequenceNumber("basic"), is(0l));
 
         String table = IndexManager.tableNameForIndex("basic");
         String sql = String.format("SELECT * FROM %s", table);
         Cursor cursor = null;
         try {
             cursor = db.rawQuery(sql, new String[]{});
-            Assert.assertEquals(0, cursor.getCount());
+            assertThat(cursor.getCount(), is(0));
         } catch (SQLException e) {
             Assert.fail(String.format("SQLException occurred executing %s: %s", sql, e));
         } finally {
@@ -200,27 +203,27 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
             Assert.fail(String.format("IOException occurred creating document revision: %s", e));
         }
 
-        Assert.assertTrue(IndexUpdater.updateIndex("basic", fields, db, ds, im.getQueue()));
-        Assert.assertEquals(1, getIndexSequenceNumber("basic"));
+        assertThat(IndexUpdater.updateIndex("basic", fields, db, ds, im.getQueue()), is(true));
+        assertThat(getIndexSequenceNumber("basic"), is(1l));
 
         cursor = null;
         try {
             cursor = db.rawQuery(sql, new String[]{});
-            Assert.assertEquals(1, cursor.getCount());
-            Assert.assertEquals(6, cursor.getColumnCount());
+            assertThat(cursor.getCount(), is(1));
+            assertThat(cursor.getColumnCount(), is(6));
             while (cursor.moveToNext()) {
-                Assert.assertTrue(cursor.columnName(0).equals("_id"));
-                Assert.assertTrue(cursor.getString(0).equals("id123"));
-                Assert.assertTrue(cursor.columnName(1).equals("_rev"));
-                Assert.assertTrue(cursor.getString(1).equals(saved.getRevision()));
-                Assert.assertTrue(cursor.columnName(2).equals("name"));
-                Assert.assertTrue(cursor.getString(2).equals("mike"));
-                Assert.assertTrue(cursor.columnName(3).equals("age"));
-                Assert.assertEquals(12, cursor.getInt(3));
-                Assert.assertTrue(cursor.columnName(4).equals("pet"));
-                Assert.assertTrue(cursor.getString(4).equals("cat"));
-                Assert.assertTrue(cursor.columnName(5).equals("car"));
-                Assert.assertTrue(cursor.getString(5).equals("mini"));
+                assertThat(cursor.columnName(0), is("_id"));
+                assertThat(cursor.getString(0), is("id123"));
+                assertThat(cursor.columnName(1), is("_rev"));
+                assertThat(cursor.getString(1), is(saved.getRevision()));
+                assertThat(cursor.columnName(2), is("name"));
+                assertThat(cursor.getString(2), is("mike"));
+                assertThat(cursor.columnName(3), is("age"));
+                assertThat(cursor.getInt(3), is(12));
+                assertThat(cursor.columnName(4), is("pet"));
+                assertThat(cursor.getString(4), is("cat"));
+                assertThat(cursor.columnName(5), is("car"));
+                assertThat(cursor.getString(5), is("mini"));
             }
         }catch (SQLException e) {
             Assert.fail(String.format("SQLException occurred executing %s: %s", sql, e));
@@ -231,17 +234,16 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
 
     @Test
     public void updateMultiFieldIndexMissingFields() {
-        List<Object> fieldNames = Arrays.<Object>asList("name", "age", "pet", "car");
-        createIndex("basic", fieldNames);
+        createIndex("basic", Arrays.<Object>asList("name", "age", "pet", "car"));
 
-        Assert.assertEquals(0, getIndexSequenceNumber("basic"));
+        assertThat(getIndexSequenceNumber("basic"), is(0l));
 
         String table = IndexManager.tableNameForIndex("basic");
         String sql = String.format("SELECT * FROM %s", table);
         Cursor cursor = null;
         try {
             cursor = db.rawQuery(sql, new String[]{});
-            Assert.assertEquals(0, cursor.getCount());
+            assertThat(cursor.getCount(), is(0));
         } catch (SQLException e) {
             Assert.fail(String.format("SQLException occurred executing %s: %s", sql, e));
         } finally {
@@ -264,8 +266,8 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
             Assert.fail(String.format("IOException occurred creating document revision: %s", e));
         }
 
-        Assert.assertTrue(IndexUpdater.updateIndex("basic", fields, db, ds, im.getQueue()));
-        Assert.assertEquals(1, getIndexSequenceNumber("basic"));
+        assertThat(IndexUpdater.updateIndex("basic", fields, db, ds, im.getQueue()), is(true));
+        assertThat(getIndexSequenceNumber("basic"), is(1l));
 
         cursor = null;
         try {
@@ -273,18 +275,18 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
             Assert.assertEquals(1, cursor.getCount());
             Assert.assertEquals(6, cursor.getColumnCount());
             while (cursor.moveToNext()) {
-                Assert.assertTrue(cursor.columnName(0).equals("_id"));
-                Assert.assertTrue(cursor.getString(0).equals("id123"));
-                Assert.assertTrue(cursor.columnName(1).equals("_rev"));
-                Assert.assertTrue(cursor.getString(1).equals(saved.getRevision()));
-                Assert.assertTrue(cursor.columnName(2).equals("name"));
-                Assert.assertTrue(cursor.getString(2).equals("mike"));
-                Assert.assertTrue(cursor.columnName(3).equals("age"));
-                Assert.assertEquals(12, cursor.getLong(3));
-                Assert.assertTrue(cursor.columnName(4).equals("pet"));
-                Assert.assertTrue(cursor.getString(4).equals("cat"));
-                Assert.assertTrue(cursor.columnName(5).equals("car"));
-                Assert.assertNull(cursor.getString(5));
+                assertThat(cursor.columnName(0), is("_id"));
+                assertThat(cursor.getString(0), is("id123"));
+                assertThat(cursor.columnName(1), is("_rev"));
+                assertThat(cursor.getString(1), is(saved.getRevision()));
+                assertThat(cursor.columnName(2), is("name"));
+                assertThat(cursor.getString(2), is("mike"));
+                assertThat(cursor.columnName(3), is("age"));
+                assertThat(cursor.getInt(3), is(12));
+                assertThat(cursor.columnName(4), is("pet"));
+                assertThat(cursor.getString(4), is("cat"));
+                assertThat(cursor.columnName(5), is("car"));
+                assertThat(cursor.getString(5), is(nullValue()));
             }
         }catch (SQLException e) {
             Assert.fail(String.format("SQLException occurred executing %s: %s", sql, e));
@@ -295,17 +297,16 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
 
     @Test
     public void updateMultiFieldIndexWithBlankRow() {
-        List<Object> fieldNames = Arrays.<Object>asList("car", "van");
-        createIndex("basic", fieldNames);
+        createIndex("basic", Arrays.<Object>asList("car", "van"));
 
-        Assert.assertEquals(0, getIndexSequenceNumber("basic"));
+        assertThat(getIndexSequenceNumber("basic"), is(0l));
 
         String table = IndexManager.tableNameForIndex("basic");
         String sql = String.format("SELECT * FROM %s", table);
         Cursor cursor = null;
         try {
             cursor = db.rawQuery(sql, new String[]{});
-            Assert.assertEquals(0, cursor.getCount());
+            assertThat(cursor.getCount(), is(0));
         } catch (SQLException e) {
             Assert.fail(String.format("SQLException occurred executing %s: %s", sql, e));
         } finally {
@@ -328,23 +329,23 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
             Assert.fail(String.format("IOException occurred creating document revision: %s", e));
         }
 
-        Assert.assertTrue(IndexUpdater.updateIndex("basic", fields, db, ds, im.getQueue()));
-        Assert.assertEquals(1, getIndexSequenceNumber("basic"));
+        assertThat(IndexUpdater.updateIndex("basic", fields, db, ds, im.getQueue()), is(true));
+        assertThat(getIndexSequenceNumber("basic"), is(1l));
 
         cursor = null;
         try {
             cursor = db.rawQuery(sql, new String[]{});
-            Assert.assertEquals(1, cursor.getCount());
-            Assert.assertEquals(4, cursor.getColumnCount());
+            assertThat(cursor.getCount(), is(1));
+            assertThat(cursor.getColumnCount(), is(4));
             while (cursor.moveToNext()) {
-                Assert.assertTrue(cursor.columnName(0).equals("_id"));
-                Assert.assertTrue(cursor.getString(0).equals("id123"));
-                Assert.assertTrue(cursor.columnName(1).equals("_rev"));
-                Assert.assertTrue(cursor.getString(1).equals(saved.getRevision()));
-                Assert.assertTrue(cursor.columnName(2).equals("car"));
-                Assert.assertNull(cursor.getString(2));
-                Assert.assertTrue(cursor.columnName(3).equals("van"));
-                Assert.assertNull(cursor.getString(3));
+                assertThat(cursor.columnName(0), is("_id"));
+                assertThat(cursor.getString(0), is("id123"));
+                assertThat(cursor.columnName(1), is("_rev"));
+                assertThat(cursor.getString(1), is(saved.getRevision()));
+                assertThat(cursor.columnName(2), is("car"));
+                assertThat(cursor.getString(2), is(nullValue()));
+                assertThat(cursor.columnName(3), is("van"));
+                assertThat(cursor.getString(3), is(nullValue()));
             }
         }catch (SQLException e) {
             Assert.fail(String.format("SQLException occurred executing %s: %s", sql, e));
@@ -355,8 +356,9 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
 
     @Test
     public void indexSingleArrayFieldWhenIndexingArrays() {
-        List<Object> fieldNames = Arrays.<Object>asList("name", "pet");
-        createIndex("basic", fieldNames);
+        createIndex("basic", Arrays.<Object>asList("name", "pet"));
+
+        assertThat(getIndexSequenceNumber("basic"), is(0l));
 
         Assert.assertEquals(0, getIndexSequenceNumber("basic"));
 
@@ -365,7 +367,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         Cursor cursor = null;
         try {
             cursor = db.rawQuery(sql, new String[]{});
-            Assert.assertEquals(0, cursor.getCount());
+            assertThat(cursor.getCount(), is(0));
         } catch (SQLException e) {
             Assert.fail(String.format("SQLException occurred executing %s: %s", sql, e));
         } finally {
@@ -387,29 +389,27 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
             Assert.fail(String.format("IOException occurred creating document revision: %s", e));
         }
 
-        Assert.assertTrue(IndexUpdater.updateIndex("basic", fields, db, ds, im.getQueue()));
-        Assert.assertEquals(1, getIndexSequenceNumber("basic"));
+        assertThat(IndexUpdater.updateIndex("basic", fields, db, ds, im.getQueue()), is(true));
+        assertThat(getIndexSequenceNumber("basic"), is(1l));
 
         cursor = null;
         try {
             cursor = db.rawQuery(sql, new String[]{});
-            Assert.assertEquals(3, cursor.getCount());
-            Assert.assertEquals(4, cursor.getColumnCount());
+            assertThat(cursor.getCount(), is(3));
+            assertThat(cursor.getColumnCount(), is(4));
             List<String> petList = new ArrayList<String>();
             while (cursor.moveToNext()) {
-                Assert.assertTrue(cursor.columnName(0).equals("_id"));
-                Assert.assertTrue(cursor.getString(0).equals("id123"));
-                Assert.assertTrue(cursor.columnName(1).equals("_rev"));
-                Assert.assertTrue(cursor.getString(1).equals(saved.getRevision()));
-                Assert.assertTrue(cursor.columnName(2).equals("name"));
-                Assert.assertTrue(cursor.getString(2).equals("mike"));
-                Assert.assertTrue(cursor.columnName(3).equals("pet"));
+                assertThat(cursor.columnName(0), is("_id"));
+                assertThat(cursor.getString(0), is("id123"));
+                assertThat(cursor.columnName(1), is("_rev"));
+                assertThat(cursor.getString(1), is(saved.getRevision()));
+                assertThat(cursor.columnName(2), is("name"));
+                assertThat(cursor.getString(2), is("mike"));
+                assertThat(cursor.columnName(3), is("pet"));
+                assertThat(cursor.getString(3), is(notNullValue()));
                 petList.add(cursor.getString(3));
             }
-            Assert.assertEquals(3, petList.size());
-            Assert.assertTrue(petList.contains("cat"));
-            Assert.assertTrue(petList.contains("dog"));
-            Assert.assertTrue(petList.contains("parrot"));
+            assertThat(petList, containsInAnyOrder("cat", "dog", "parrot"));
         }catch (SQLException e) {
             Assert.fail(String.format("SQLException occurred executing %s: %s", sql, e));
         } finally {
@@ -419,17 +419,16 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
 
     @Test
     public void indexSingleArrayFieldWhenIndexingArraysInSubDoc() {
-        List<Object> fieldNames = Arrays.<Object>asList("name", "pet.species");
-        createIndex("basic", fieldNames);
+        createIndex("basic", Arrays.<Object>asList("name", "pet.species"));
 
-        Assert.assertEquals(0, getIndexSequenceNumber("basic"));
+        assertThat(getIndexSequenceNumber("basic"), is(0l));
 
         String table = IndexManager.tableNameForIndex("basic");
         String sql = String.format("SELECT * FROM %s", table);
         Cursor cursor = null;
         try {
             cursor = db.rawQuery(sql, new String[]{});
-            Assert.assertEquals(0, cursor.getCount());
+            assertThat(cursor.getCount(), is(0));
         } catch (SQLException e) {
             Assert.fail(String.format("SQLException occurred executing %s: %s", sql, e));
         } finally {
@@ -453,28 +452,27 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
             Assert.fail(String.format("IOException occurred creating document revision: %s", e));
         }
 
-        Assert.assertTrue(IndexUpdater.updateIndex("basic", fields, db, ds, im.getQueue()));
-        Assert.assertEquals(1, getIndexSequenceNumber("basic"));
+        assertThat(IndexUpdater.updateIndex("basic", fields, db, ds, im.getQueue()), is(true));
+        assertThat(getIndexSequenceNumber("basic"), is(1l));
 
         cursor = null;
         try {
             cursor = db.rawQuery(sql, new String[]{});
-            Assert.assertEquals(2, cursor.getCount());
-            Assert.assertEquals(4, cursor.getColumnCount());
+            assertThat(cursor.getCount(), is(2));
+            assertThat(cursor.getColumnCount(), is(4));
             List<String> petList = new ArrayList<String>();
             while (cursor.moveToNext()) {
-                Assert.assertTrue(cursor.columnName(0).equals("_id"));
-                Assert.assertTrue(cursor.getString(0).equals("id123"));
-                Assert.assertTrue(cursor.columnName(1).equals("_rev"));
-                Assert.assertTrue(cursor.getString(1).equals(saved.getRevision()));
-                Assert.assertTrue(cursor.columnName(2).equals("name"));
-                Assert.assertTrue(cursor.getString(2).equals("mike"));
-                Assert.assertTrue(cursor.columnName(3).equals("pet.species"));
+                assertThat(cursor.columnName(0), is("_id"));
+                assertThat(cursor.getString(0), is("id123"));
+                assertThat(cursor.columnName(1), is("_rev"));
+                assertThat(cursor.getString(1), is(saved.getRevision()));
+                assertThat(cursor.columnName(2), is("name"));
+                assertThat(cursor.getString(2), is("mike"));
+                assertThat(cursor.columnName(3), is("pet.species"));
+                assertThat(cursor.getString(3), is(notNullValue()));
                 petList.add(cursor.getString(3));
             }
-            Assert.assertEquals(2, petList.size());
-            Assert.assertTrue(petList.contains("cat"));
-            Assert.assertTrue(petList.contains("dog"));
+            assertThat(petList, containsInAnyOrder("cat", "dog"));
         }catch (SQLException e) {
             Assert.fail(String.format("SQLException occurred executing %s: %s", sql, e));
         } finally {
@@ -484,17 +482,16 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
 
     @Test
     public void rejectsDocsWithMultipleArrays() {
-        List<Object> fieldNames = Arrays.<Object>asList("name", "pet", "pet2");
-        createIndex("basic", fieldNames);
+        createIndex("basic", Arrays.<Object>asList("name", "pet", "pet2"));
 
-        Assert.assertEquals(0, getIndexSequenceNumber("basic"));
+        assertThat(getIndexSequenceNumber("basic"), is(0l));
 
         String table = IndexManager.tableNameForIndex("basic");
         String sql = String.format("SELECT * FROM %s", table);
         Cursor cursor = null;
         try {
             cursor = db.rawQuery(sql, new String[]{});
-            Assert.assertEquals(0, cursor.getCount());
+            assertThat(cursor.getCount(), is(0));
         } catch (SQLException e) {
             Assert.fail(String.format("SQLException occurred executing %s: %s", sql, e));
         } finally {
@@ -528,37 +525,31 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
             Assert.fail(String.format("IOException occurred creating document revision: %s", e));
         }
 
-        Assert.assertTrue(IndexUpdater.updateIndex("basic",
-                                                    fields,
-                                                    db,
-                                                    ds,
-                                                    im.getQueue()));
-        Assert.assertEquals(2, getIndexSequenceNumber("basic"));
+        assertThat(IndexUpdater.updateIndex("basic", fields, db, ds, im.getQueue()), is(true));
+        assertThat(getIndexSequenceNumber("basic"), is(2l));
 
         // Document id123 is successfully indexed. 
         // Document id456 is rejected due to multiple arrays.
         cursor = null;
         try {
             cursor = db.rawQuery(sql, new String[]{});
-            Assert.assertEquals(3, cursor.getCount());
-            Assert.assertEquals(5, cursor.getColumnCount());
+            assertThat(cursor.getCount(), is(3));
+            assertThat(cursor.getColumnCount(), is(5));
             List<String> petList = new ArrayList<String>();
             while (cursor.moveToNext()) {
-                Assert.assertTrue(cursor.columnName(0).equals("_id"));
-                Assert.assertTrue(cursor.getString(0).equals("id123"));
-                Assert.assertTrue(cursor.columnName(1).equals("_rev"));
-                Assert.assertTrue(cursor.getString(1).equals(saved.getRevision()));
-                Assert.assertTrue(cursor.columnName(2).equals("name"));
-                Assert.assertTrue(cursor.getString(2).equals("mike"));
-                Assert.assertTrue(cursor.columnName(3).equals("pet"));
+                assertThat(cursor.columnName(0), is("_id"));
+                assertThat(cursor.getString(0), is("id123"));
+                assertThat(cursor.columnName(1), is("_rev"));
+                assertThat(cursor.getString(1), is(saved.getRevision()));
+                assertThat(cursor.columnName(2), is("name"));
+                assertThat(cursor.getString(2), is("mike"));
+                assertThat(cursor.columnName(3), is("pet"));
+                assertThat(cursor.getString(3), is(notNullValue()));
                 petList.add(cursor.getString(3));
-                Assert.assertTrue(cursor.columnName(4).equals("pet2"));
-                Assert.assertNull(cursor.getString(4));
+                assertThat(cursor.columnName(4), is("pet2"));
+                assertThat(cursor.getString(4), is(nullValue()));
             }
-            Assert.assertEquals(3, petList.size());
-            Assert.assertTrue(petList.contains("cat"));
-            Assert.assertTrue(petList.contains("dog"));
-            Assert.assertTrue(petList.contains("parrot"));
+            assertThat(petList, containsInAnyOrder("cat", "dog", "parrot"));
         }catch (SQLException e) {
             Assert.fail(String.format("SQLException occurred executing %s: %s", sql, e));
         } finally {
@@ -646,16 +637,13 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
             Assert.fail(String.format("IOException occurred creating document revision: %s", e));
         }
 
-        List<Object> fieldNames = Arrays.<Object>asList("age", "pet", "name");
-        createIndex("basic", fieldNames);
-
-        fieldNames = Arrays.<Object>asList("name");
-        createIndex("basicName", fieldNames);
+        createIndex("basic", Arrays.<Object>asList("age", "pet", "name"));
+        createIndex("basicName", Arrays.<Object>asList("name"));
 
         im.updateAllIndexes();
 
-        Assert.assertEquals(6, getIndexSequenceNumber("basic"));
-        Assert.assertEquals(6, getIndexSequenceNumber("basicName"));
+        assertThat(getIndexSequenceNumber("basic"), is(6l));
+        assertThat(getIndexSequenceNumber("basicName"), is(6l));
 
         String basicTable = IndexManager.tableNameForIndex("basic");
         String basicNameTable = IndexManager.tableNameForIndex("basicName");
@@ -664,14 +652,14 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         Cursor cursor = null;
         try {
             cursor = db.rawQuery(sqlBasic, new String[]{});
-            Assert.assertEquals(6, cursor.getCount());
-            Assert.assertEquals(5, cursor.getColumnCount());
+            assertThat(cursor.getCount(), is(6));
+            assertThat(cursor.getColumnCount(), is(5));
             while (cursor.moveToNext()) {
-                Assert.assertTrue(cursor.columnName(0).equals("_id"));
-                Assert.assertTrue(cursor.columnName(1).equals("_rev"));
-                Assert.assertTrue(cursor.columnName(2).equals("age"));
-                Assert.assertTrue(cursor.columnName(3).equals("pet"));
-                Assert.assertTrue(cursor.columnName(4).equals("name"));
+                assertThat(cursor.columnName(0), is("_id"));
+                assertThat(cursor.columnName(1), is("_rev"));
+                assertThat(cursor.columnName(2), is("age"));
+                assertThat(cursor.columnName(3), is("pet"));
+                assertThat(cursor.columnName(4), is("name"));
             }
         }catch (SQLException e) {
             Assert.fail(String.format("SQLException occurred executing %s: %s", sqlBasic, e));
@@ -681,12 +669,12 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
 
         try {
             cursor = db.rawQuery(sqlBasicName, new String[]{});
-            Assert.assertEquals(6, cursor.getCount());
-            Assert.assertEquals(3, cursor.getColumnCount());
+            assertThat(cursor.getCount(), is(6));
+            assertThat(cursor.getColumnCount(), is(3));
             while (cursor.moveToNext()) {
-                Assert.assertTrue(cursor.columnName(0).equals("_id"));
-                Assert.assertTrue(cursor.columnName(1).equals("_rev"));
-                Assert.assertTrue(cursor.columnName(2).equals("name"));
+                assertThat(cursor.columnName(0), is("_id"));
+                assertThat(cursor.columnName(1), is("_rev"));
+                assertThat(cursor.columnName(2), is("name"));
             }
         }catch (SQLException e) {
             Assert.fail(String.format("SQLException occurred executing %s: %s", sqlBasicName, e));
@@ -703,19 +691,19 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
 
         im.updateAllIndexes();
 
-        Assert.assertEquals(7, getIndexSequenceNumber("basic"));
-        Assert.assertEquals(7, getIndexSequenceNumber("basicName"));
+        assertThat(getIndexSequenceNumber("basic"), is(7l));
+        assertThat(getIndexSequenceNumber("basicName"), is(7l));
 
         try {
             cursor = db.rawQuery(sqlBasic, new String[]{});
-            Assert.assertEquals(7, cursor.getCount());
-            Assert.assertEquals(5, cursor.getColumnCount());
+            assertThat(cursor.getCount(), is(7));
+            assertThat(cursor.getColumnCount(), is(5));
             while (cursor.moveToNext()) {
-                Assert.assertTrue(cursor.columnName(0).equals("_id"));
-                Assert.assertTrue(cursor.columnName(1).equals("_rev"));
-                Assert.assertTrue(cursor.columnName(2).equals("age"));
-                Assert.assertTrue(cursor.columnName(3).equals("pet"));
-                Assert.assertTrue(cursor.columnName(4).equals("name"));
+                assertThat(cursor.columnName(0), is("_id"));
+                assertThat(cursor.columnName(1), is("_rev"));
+                assertThat(cursor.columnName(2), is("age"));
+                assertThat(cursor.columnName(3), is("pet"));
+                assertThat(cursor.columnName(4), is("name"));
             }
         }catch (SQLException e) {
             Assert.fail(String.format("SQLException occurred executing %s: %s", sqlBasic, e));
@@ -725,12 +713,12 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
 
         try {
             cursor = db.rawQuery(sqlBasicName, new String[]{});
-            Assert.assertEquals(7, cursor.getCount());
-            Assert.assertEquals(3, cursor.getColumnCount());
+            assertThat(cursor.getCount(), is(7));
+            assertThat(cursor.getColumnCount(), is(3));
             while (cursor.moveToNext()) {
-                Assert.assertTrue(cursor.columnName(0).equals("_id"));
-                Assert.assertTrue(cursor.columnName(1).equals("_rev"));
-                Assert.assertTrue(cursor.columnName(2).equals("name"));
+                assertThat(cursor.columnName(0), is("_id"));
+                assertThat(cursor.columnName(1), is("_rev"));
+                assertThat(cursor.columnName(2), is("name"));
             }
         }catch (SQLException e) {
             Assert.fail(String.format("SQLException occurred executing %s: %s", sqlBasicName, e));
@@ -748,7 +736,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         Long lastSequence = 0l;
         try {
             cursor = db.rawQuery(sql, new String[]{});
-            Assert.assertEquals(1, cursor.getCount());
+            assertThat(cursor.getCount(), is(1));
             while (cursor.moveToNext()) {
                 lastSequence = cursor.getLong(0);
             }
@@ -762,19 +750,18 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
 
     @SuppressWarnings("unchecked")
     private void createIndex(String indexName, List<Object> fieldNames) {
-        String name = im.ensureIndexed(fieldNames, indexName);
-        Assert.assertTrue(name.equals(indexName));
+        assertThat(im.ensureIndexed(fieldNames, indexName), is(indexName));
 
         Map<String, Object> indexes = im.listIndexes();
-        Assert.assertTrue(indexes.containsKey(indexName));
+        assertThat(indexes, hasKey(indexName));
 
         Map<String, Object> index = (Map<String, Object>) indexes.get(indexName);
         fields = (List<String>) index.get("fields");
-        Assert.assertEquals(fieldNames.size() + 2, fields.size());
-        for (Object fieldName: fieldNames) {
-            String field = (String) fieldName;
-            Assert.assertTrue(fields.contains(field));
-        }
+        assertThat(fields.size(), is(fieldNames.size() +2));
+        assertThat(fields, hasItems(Arrays.copyOf(fieldNames.toArray(),
+                                                  fieldNames.size(),
+                                                  String[].class)));
+        assertThat(fields, hasItems("_id", "_rev"));
     }
 
 }

--- a/sync-core/src/test/java/com/cloudant/sync/query/QueryExecutorTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/QueryExecutorTest.java
@@ -12,6 +12,12 @@
 
 package com.cloudant.sync.query;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
 import com.cloudant.sync.datastore.DocumentBodyFactory;
 import com.cloudant.sync.datastore.DocumentRevision;
 import com.cloudant.sync.datastore.MutableDocumentRevision;
@@ -45,6 +51,7 @@ public class QueryExecutorTest extends AbstractIndexTestBase {
         } catch (IOException e) {
             e.printStackTrace();
             Assert.fail("Failed to create document revision");
+
         }
 
         rev.docId = "mike34";
@@ -98,11 +105,8 @@ public class QueryExecutorTest extends AbstractIndexTestBase {
             Assert.fail("Failed to create document revision");
         }
 
-        List<Object> fieldNames = Arrays.<Object>asList("name", "age");
-        Assert.assertEquals("basic", im.ensureIndexed(fieldNames, "basic"));
-
-        fieldNames = Arrays.<Object>asList("name", "pet");
-        Assert.assertEquals("pet", im.ensureIndexed(fieldNames, "pet"));
+        assertThat(im.ensureIndexed(Arrays.<Object>asList("name", "age"), "basic"), is("basic"));
+        assertThat(im.ensureIndexed(Arrays.<Object>asList("name", "pet"), "pet"), is("pet"));
     }
 
     @Test
@@ -116,11 +120,8 @@ public class QueryExecutorTest extends AbstractIndexTestBase {
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", "mike");
         QueryResult queryResult = im.find(query);
-        Assert.assertNotNull(queryResult);
-        Assert.assertEquals(3, queryResult.size());
-        List<String> checkList = Arrays.asList("mike12", "mike34", "mike72");
-        Assert.assertEquals(3, queryResult.documentIds().size());
-        Assert.assertTrue(queryResult.documentIds().containsAll(checkList));
+        assertThat(queryResult.size(), is(3l));
+        assertThat(queryResult.documentIds(), containsInAnyOrder("mike12", "mike34", "mike72"));
     }
 
     @Test
@@ -131,11 +132,8 @@ public class QueryExecutorTest extends AbstractIndexTestBase {
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", operator);
         QueryResult queryResult = im.find(query);
-        Assert.assertNotNull(queryResult);
-        Assert.assertEquals(3, queryResult.size());
-        List<String> checkList = Arrays.asList("mike12", "mike34", "mike72");
-        Assert.assertEquals(3, queryResult.documentIds().size());
-        Assert.assertTrue(queryResult.documentIds().containsAll(checkList));
+        assertThat(queryResult.size(), is(3l));
+        assertThat(queryResult.documentIds(), containsInAnyOrder("mike12", "mike34", "mike72"));
     }
 
     @Test
@@ -144,11 +142,8 @@ public class QueryExecutorTest extends AbstractIndexTestBase {
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("age", 12);
         QueryResult queryResult = im.find(query);
-        Assert.assertNotNull(queryResult);
-        Assert.assertEquals(2, queryResult.size());
-        List<String> checkList = Arrays.asList("mike12", "fred12");
-        Assert.assertEquals(2, queryResult.documentIds().size());
-        Assert.assertTrue(queryResult.documentIds().containsAll(checkList));
+        assertThat(queryResult.size(), is(2l));
+        assertThat(queryResult.documentIds(), containsInAnyOrder("mike12", "fred12"));
     }
 
     @Test
@@ -159,11 +154,8 @@ public class QueryExecutorTest extends AbstractIndexTestBase {
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("age", operator);
         QueryResult queryResult = im.find(query);
-        Assert.assertNotNull(queryResult);
-        Assert.assertEquals(2, queryResult.size());
-        List<String> checkList = Arrays.asList("mike12", "fred12");
-        Assert.assertEquals(2, queryResult.documentIds().size());
-        Assert.assertTrue(queryResult.documentIds().containsAll(checkList));
+        assertThat(queryResult.size(), is(2l));
+        assertThat(queryResult.documentIds(), containsInAnyOrder("mike12", "fred12"));
     }
 
     @Test
@@ -173,11 +165,8 @@ public class QueryExecutorTest extends AbstractIndexTestBase {
         query.put("name", "mike");
         query.put("pet", "cat");
         QueryResult queryResult = im.find(query);
-        Assert.assertNotNull(queryResult);
-        Assert.assertEquals(2, queryResult.size());
-        List<String> checkList = Arrays.asList("mike12", "mike72");
-        Assert.assertEquals(2, queryResult.documentIds().size());
-        Assert.assertTrue(queryResult.documentIds().containsAll(checkList));
+        assertThat(queryResult.size(), is(2l));
+        assertThat(queryResult.documentIds(), containsInAnyOrder("mike12", "mike72"));
     }
 
     @Test
@@ -191,11 +180,8 @@ public class QueryExecutorTest extends AbstractIndexTestBase {
         petOperator.put("$eq", "cat");
         query.put("pet", petOperator);
         QueryResult queryResult = im.find(query);
-        Assert.assertNotNull(queryResult);
-        Assert.assertEquals(2, queryResult.size());
-        List<String> checkList = Arrays.asList("mike12", "mike72");
-        Assert.assertEquals(2, queryResult.documentIds().size());
-        Assert.assertTrue(queryResult.documentIds().containsAll(checkList));
+        assertThat(queryResult.size(), is(2l));
+        assertThat(queryResult.documentIds(), containsInAnyOrder("mike12", "mike72"));
     }
 
     @Test
@@ -205,11 +191,8 @@ public class QueryExecutorTest extends AbstractIndexTestBase {
         query.put("name", "mike");
         query.put("age", 12);
         QueryResult queryResult = im.find(query);
-        Assert.assertNotNull(queryResult);
-        Assert.assertEquals(1, queryResult.size());
-        List<String> checkList = Arrays.asList("mike12");
-        Assert.assertEquals(1, queryResult.documentIds().size());
-        Assert.assertTrue(queryResult.documentIds().containsAll(checkList));
+        assertThat(queryResult.size(), is(1l));
+        assertThat(queryResult.documentIds(), contains("mike12"));
     }
 
     @Test
@@ -223,11 +206,8 @@ public class QueryExecutorTest extends AbstractIndexTestBase {
         ageOperator.put("$eq", 12);
         query.put("age", ageOperator);
         QueryResult queryResult = im.find(query);
-        Assert.assertNotNull(queryResult);
-        Assert.assertEquals(1, queryResult.size());
-        List<String> checkList = Arrays.asList("mike12");
-        Assert.assertEquals(1, queryResult.documentIds().size());
-        Assert.assertTrue(queryResult.documentIds().containsAll(checkList));
+        assertThat(queryResult.size(), is(1l));
+        assertThat(queryResult.documentIds(), contains("mike12"));
     }
 
     @Test
@@ -236,8 +216,7 @@ public class QueryExecutorTest extends AbstractIndexTestBase {
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", "bill");
         QueryResult queryResult = im.find(query);
-        Assert.assertNotNull(queryResult);
-        Assert.assertEquals(0, queryResult.size());
+        assertThat(queryResult.size(), is(0l));
     }
 
     @Test
@@ -247,8 +226,7 @@ public class QueryExecutorTest extends AbstractIndexTestBase {
         query.put("name", "bill");
         query.put("age", 12);
         QueryResult queryResult = im.find(query);
-        Assert.assertNotNull(queryResult);
-        Assert.assertEquals(0, queryResult.size());
+        assertThat(queryResult.size(), is(0l));
     }
 
     @Test
@@ -258,8 +236,7 @@ public class QueryExecutorTest extends AbstractIndexTestBase {
         query.put("name", "bill");
         query.put("age", 17);
         QueryResult queryResult = im.find(query);
-        Assert.assertNotNull(queryResult);
-        Assert.assertEquals(0, queryResult.size());
+        assertThat(queryResult.size(), is(0l));
     }
 
     @Test
@@ -268,16 +245,15 @@ public class QueryExecutorTest extends AbstractIndexTestBase {
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", "mike");
         QueryResult queryResult = im.find(query);
-        Assert.assertNotNull(queryResult);
-        Assert.assertTrue(queryResult.size() == queryResult.documentIds().size());
+        assertThat(queryResult.size(), is((long) queryResult.documentIds().size()));
         List<String> docCheckList = new ArrayList<String>();
         for (DocumentRevision rev: queryResult) {
-            Assert.assertNotNull(rev.getId());
-            Assert.assertNotNull(rev.getBody());
+            assertThat(rev.getId(), is(notNullValue()));
+            assertThat(rev.getBody(), is(notNullValue()));
             docCheckList.add(rev.getId());
         }
-        Assert.assertTrue(queryResult.size() == docCheckList.size());
-        Assert.assertTrue(docCheckList.containsAll(queryResult.documentIds()));
+        assertThat(queryResult.size(), is((long) docCheckList.size()));
+        assertThat(queryResult.documentIds(), containsInAnyOrder(docCheckList.toArray()));
     }
 
 }

--- a/sync-core/src/test/java/com/cloudant/sync/query/QuerySqlTranslatorTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/QuerySqlTranslatorTest.java
@@ -12,7 +12,15 @@
 
 package com.cloudant.sync.query;
 
-import org.junit.Assert;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
+import static org.hamcrest.Matchers.either;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
 import org.junit.Test;
 
 import java.sql.SQLException;
@@ -31,10 +39,10 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
     @Override
     public void setUp() throws SQLException {
         super.setUp();
-        List<Object> fieldNames = Arrays.<Object>asList("name", "age", "pet");
-        Assert.assertEquals("basic", im.ensureIndexed(fieldNames, "basic"));
+        String indexName = im.ensureIndexed(Arrays.<Object>asList("name", "age", "pet"), "basic");
+        assertThat(indexName, is("basic"));
         indexes = im.listIndexes();
-        Assert.assertNotNull(indexes);
+        assertThat(indexes, is(notNullValue()));
         indexesCoverQuery = new Boolean[]{ false };
     }
 
@@ -47,19 +55,18 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         query.put("name", "mike");
         query = QueryValidator.normaliseAndValidateQuery(query);
         QueryNode node = QuerySqlTranslator.translateQuery(query, indexes, indexesCoverQuery);
-        Assert.assertNotNull(node);
-        Assert.assertTrue(node instanceof AndQueryNode);
-        Assert.assertTrue(indexesCoverQuery[0]);
+        assertThat(node, is(instanceOf(AndQueryNode.class)));
         AndQueryNode andNode = (AndQueryNode) node;
-        Assert.assertEquals(1, andNode.children.size());
-        Assert.assertTrue(andNode.children.get(0) instanceof SqlQueryNode);
+        assertThat(indexesCoverQuery[0], is(true));
+        assertThat(andNode.children.size(), is(1));
+        assertThat(andNode.children.get(0), is(instanceOf(SqlQueryNode.class)));
         SqlQueryNode sqlNode = (SqlQueryNode) andNode.children.get(0);
         String sql = sqlNode.sql.sqlWithPlaceHolders;
-        String[] valuesArray = sqlNode.sql.placeHolderValues;
-        Assert.assertTrue(sql.equals("SELECT _id FROM _t_cloudant_sync_query_index_basic " +
-                                     "WHERE \"name\" = ?"));
-        List<String> placeHolderValues = Arrays.asList("mike");
-        Assert.assertTrue(placeHolderValues.containsAll(Arrays.asList(valuesArray)));
+        String[] placeHolderValues = sqlNode.sql.placeHolderValues;
+        String select = "SELECT _id FROM _t_cloudant_sync_query_index_basic";
+        String where = " WHERE \"name\" = ?";
+        assertThat(sql, is(String.format("%s%s", select, where)));
+        assertThat(placeHolderValues, is(arrayContaining("mike")));
     }
 
     @Test
@@ -70,19 +77,18 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         query.put("pet", "cat");
         query = QueryValidator.normaliseAndValidateQuery(query);
         QueryNode node = QuerySqlTranslator.translateQuery(query, indexes, indexesCoverQuery);
-        Assert.assertNotNull(node);
-        Assert.assertTrue(node instanceof AndQueryNode);
-        Assert.assertTrue(indexesCoverQuery[0]);
+        assertThat(node, is(instanceOf(AndQueryNode.class)));
         AndQueryNode andNode = (AndQueryNode) node;
-        Assert.assertEquals(1, andNode.children.size());
-        Assert.assertTrue(andNode.children.get(0) instanceof SqlQueryNode);
+        assertThat(indexesCoverQuery[0], is(true));
+        assertThat(andNode.children.size(), is(1));
+        assertThat(andNode.children.get(0), is(instanceOf(SqlQueryNode.class)));
         SqlQueryNode sqlNode = (SqlQueryNode) andNode.children.get(0);
         String sql = sqlNode.sql.sqlWithPlaceHolders;
-        String[] valuesArray = sqlNode.sql.placeHolderValues;
-        Assert.assertTrue(sql.equals("SELECT _id FROM _t_cloudant_sync_query_index_basic " +
-                                     "WHERE \"name\" = ? AND \"pet\" = ?"));
-        List<String> placeHolderValues = Arrays.asList("mike", "cat");
-        Assert.assertTrue(placeHolderValues.containsAll(Arrays.asList(valuesArray)));
+        String[] placeHolderValues = sqlNode.sql.placeHolderValues;
+        String select = "SELECT _id FROM _t_cloudant_sync_query_index_basic";
+        String where = " WHERE \"name\" = ? AND \"pet\" = ?";
+        assertThat(sql, is(String.format("%s%s", select, where)));
+        assertThat(placeHolderValues, is(arrayContainingInAnyOrder("mike", "cat")));
     }
 
     @Test
@@ -97,19 +103,18 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         query.put("$and", fields);
         query = QueryValidator.normaliseAndValidateQuery(query);
         QueryNode node = QuerySqlTranslator.translateQuery(query, indexes, indexesCoverQuery);
-        Assert.assertNotNull(node);
-        Assert.assertTrue(node instanceof AndQueryNode);
-        Assert.assertTrue(indexesCoverQuery[0]);
+        assertThat(node, is(instanceOf(AndQueryNode.class)));
         AndQueryNode andNode = (AndQueryNode) node;
-        Assert.assertEquals(1, andNode.children.size());
-        Assert.assertTrue(andNode.children.get(0) instanceof SqlQueryNode);
+        assertThat(indexesCoverQuery[0], is(true));
+        assertThat(andNode.children.size(), is(1));
+        assertThat(andNode.children.get(0), is(instanceOf(SqlQueryNode.class)));
         SqlQueryNode sqlNode = (SqlQueryNode) andNode.children.get(0);
         String sql = sqlNode.sql.sqlWithPlaceHolders;
-        String[] valuesArray = sqlNode.sql.placeHolderValues;
-        Assert.assertTrue(sql.equals("SELECT _id FROM _t_cloudant_sync_query_index_basic " +
-                                     "WHERE \"name\" = ? AND \"pet\" = ?"));
-        List<String> placeHolderValues = Arrays.asList("mike", "cat");
-        Assert.assertTrue(placeHolderValues.containsAll(Arrays.asList(valuesArray)));
+        String[] placeHolderValues = sqlNode.sql.placeHolderValues;
+        String select = "SELECT _id FROM _t_cloudant_sync_query_index_basic";
+        String where = " WHERE \"name\" = ? AND \"pet\" = ?";
+        assertThat(sql, is(String.format("%s%s", select, where)));
+        assertThat(placeHolderValues, is(arrayContainingInAnyOrder("mike", "cat")));
     }
 
     // When selecting an index to use
@@ -120,18 +125,17 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         eq.put("$eq", "mike");
         Map<String, Object> name = new HashMap<String, Object>();
         name.put("name", eq);
-        List<Object> clause = Arrays.<Object>asList(name);
-        Assert.assertNull(QuerySqlTranslator.chooseIndexForAndClause(clause, null));
+        assertThat(QuerySqlTranslator.chooseIndexForAndClause(Arrays.<Object>asList(name), null),
+                   is(nullValue()));
     }
 
     @Test
     public void indexSelectionFailsWhenNoQueryKeys() {
         Map<String, Object> indexes = new HashMap<String, Object>();
-        List<Object> fields = Arrays.<Object>asList("name", "age", "pet");
-        indexes.put("named", fields);
-        Assert.assertNull(QuerySqlTranslator.chooseIndexForAndClause(null, indexes));
-        Assert.assertNull(QuerySqlTranslator.chooseIndexForAndClause(new ArrayList<Object>(),
-                                                                     indexes));
+        indexes.put("named", Arrays.<Object>asList("name", "age", "pet"));
+        assertThat(QuerySqlTranslator.chooseIndexForAndClause(null, indexes), is(nullValue()));
+        assertThat(QuerySqlTranslator.chooseIndexForAndClause(new ArrayList<Object>(), null),
+                   is(nullValue()));
     }
 
     @Test
@@ -140,18 +144,17 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         Map<String, Object> index = new HashMap<String, Object>();
         index.put("name", "named");
         index.put("type", "json");
-        List<Object> fields = Arrays.<Object>asList("name");
-        index.put("fields", fields);
+        index.put("fields", Arrays.<Object>asList("name"));
         indexes.put("named", index);
 
         Map<String, Object> eq = new HashMap<String, Object>();
         eq.put("$eq", "mike");
         Map<String, Object> name = new HashMap<String, Object>();
         name.put("name", eq);
-        List<Object> clause = Arrays.<Object>asList(name);
 
-        String idx = QuerySqlTranslator.chooseIndexForAndClause(clause, indexes);
-        Assert.assertTrue(idx.equals("named"));
+        String idx = QuerySqlTranslator.chooseIndexForAndClause(Arrays.<Object>asList(name),
+                                                                indexes);
+        assertThat(idx, is("named"));
     }
 
     @Test
@@ -160,18 +163,17 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         Map<String, Object> index = new HashMap<String, Object>();
         index.put("name", "named");
         index.put("type", "json");
-        List<Object> fields = Arrays.<Object>asList("name", "age", "pet");
-        index.put("fields", fields);
+        index.put("fields", Arrays.<Object>asList("name", "age", "pet"));
         indexes.put("named", index);
 
         Map<String, Object> name = new HashMap<String, Object>();
         name.put("name", "mike");
         Map<String, Object> pet = new HashMap<String, Object>();
         pet.put("pet", "cat");
-        List<Object> clause = Arrays.<Object>asList(name, pet);
 
-        String idx = QuerySqlTranslator.chooseIndexForAndClause(clause, indexes);
-        Assert.assertTrue(idx.equals("named"));
+        String idx = QuerySqlTranslator.chooseIndexForAndClause(Arrays.<Object>asList(name, pet),
+                                                                indexes);
+        assertThat(idx, is("named"));
     }
 
     @Test
@@ -181,20 +183,17 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         Map<String, Object> named = new HashMap<String, Object>();
         named.put("name", "named");
         named.put("type", "json");
-        List<Object> namedFields = Arrays.<Object>asList("name", "age", "pet");
-        named.put("fields", namedFields);
+        named.put("fields", Arrays.<Object>asList("name", "age", "pet"));
 
         Map<String, Object> bopped = new HashMap<String, Object>();
         bopped.put("name", "bopped");
         bopped.put("type", "json");
-        List<Object> boppedFields = Arrays.<Object>asList("house_number", "pet");
-        bopped.put("fields", boppedFields);
+        bopped.put("fields", Arrays.<Object>asList("house_number", "pet"));
 
         Map<String, Object> unsuitable = new HashMap<String, Object>();
         unsuitable.put("name", "unsuitable");
         unsuitable.put("type", "json");
-        List<Object> unsuitableFields = Arrays.<Object>asList("name");
-        unsuitable.put("fields", unsuitableFields);
+        unsuitable.put("fields", Arrays.<Object>asList("name"));
 
         indexes.put("named", named);
         indexes.put("bopped", bopped);
@@ -204,10 +203,10 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         name.put("name", "mike");
         Map<String, Object> pet = new HashMap<String, Object>();
         pet.put("pet", "cat");
-        List<Object> clause = Arrays.<Object>asList(name, pet);
 
-        String idx = QuerySqlTranslator.chooseIndexForAndClause(clause, indexes);
-        Assert.assertTrue(idx.equals("named"));
+        String idx = QuerySqlTranslator.chooseIndexForAndClause(Arrays.<Object>asList(name, pet),
+                                                                indexes);
+        assertThat(idx, is("named"));
     }
 
     @Test
@@ -217,26 +216,22 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         Map<String, Object> named = new HashMap<String, Object>();
         named.put("name", "named");
         named.put("type", "json");
-        List<Object> namedFields = Arrays.<Object>asList("name", "age", "pet");
-        named.put("fields", namedFields);
+        named.put("fields", Arrays.<Object>asList("name", "age", "pet"));
 
         Map<String, Object> bopped = new HashMap<String, Object>();
         bopped.put("name", "bopped");
         bopped.put("type", "json");
-        List<Object> boppedFields = Arrays.<Object>asList("name", "age", "pet");
-        bopped.put("fields", boppedFields);
+        bopped.put("fields", Arrays.<Object>asList("name", "age", "pet"));
 
         Map<String, Object> manyField = new HashMap<String, Object>();
         manyField.put("name", "manyField");
         manyField.put("type", "json");
-        List<Object> manyFieldFields = Arrays.<Object>asList("name", "age", "pet");
-        manyField.put("fields", manyFieldFields);
+        manyField.put("fields", Arrays.<Object>asList("name", "age", "pet"));
 
         Map<String, Object> unsuitable = new HashMap<String, Object>();
         unsuitable.put("name", "unsuitable");
         unsuitable.put("type", "json");
-        List<Object> unsuitableFields = Arrays.<Object>asList("name");
-        unsuitable.put("fields", unsuitableFields);
+        unsuitable.put("fields", Arrays.<Object>asList("name"));
 
         indexes.put("named", named);
         indexes.put("bopped", bopped);
@@ -247,10 +242,10 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         name.put("name", "mike");
         Map<String, Object> pet = new HashMap<String, Object>();
         pet.put("pet", "cat");
-        List<Object> clause = Arrays.<Object>asList(name, pet);
 
-        String idx = QuerySqlTranslator.chooseIndexForAndClause(clause, indexes);
-        Assert.assertTrue(idx.equals("named") || idx.equals("bopped"));
+        String idx = QuerySqlTranslator.chooseIndexForAndClause(Arrays.<Object>asList(name, pet),
+                                                                indexes);
+        assertThat(idx, either(is("named")).or(is("bopped")));
     }
 
     @Test
@@ -260,31 +255,30 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         Map<String, Object> named = new HashMap<String, Object>();
         named.put("name", "named");
         named.put("type", "json");
-        List<Object> namedFields = Arrays.<Object>asList("name", "age");
-        named.put("fields", namedFields);
+        named.put("fields", Arrays.<Object>asList("name", "age"));
 
         Map<String, Object> unsuitable = new HashMap<String, Object>();
         unsuitable.put("name", "unsuitable");
         unsuitable.put("type", "json");
-        List<Object> unsuitableFields = Arrays.<Object>asList("name");
-        unsuitable.put("fields", unsuitableFields);
+        unsuitable.put("fields", Arrays.<Object>asList("name"));
 
         indexes.put("named", named);
         indexes.put("unsuitable", unsuitable);
 
         Map<String, Object> pet = new HashMap<String, Object>();
         pet.put("pet", "cat");
-        List<Object> clause = Arrays.<Object>asList(pet);
 
-        Assert.assertNull(QuerySqlTranslator.chooseIndexForAndClause(clause, indexes));
+        assertThat(QuerySqlTranslator.chooseIndexForAndClause(Arrays.<Object>asList(pet), indexes),
+                   is(nullValue()));
     }
 
     // When generating query WHERE clauses
 
     @Test
     public void nullWhereClauseWhenQueryEmpty() {
-        Assert.assertNull(QuerySqlTranslator.whereSqlForAndClause(null));
-        Assert.assertNull(QuerySqlTranslator.whereSqlForAndClause(new ArrayList<Object>()));
+        assertThat(QuerySqlTranslator.whereSqlForAndClause(null), is(nullValue()));
+        assertThat(QuerySqlTranslator.whereSqlForAndClause(new ArrayList<Object>()),
+                   is(nullValue()));
     }
 
     @Test
@@ -293,12 +287,9 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         eq.put("$eq", "mike");
         Map<String, Object> name = new HashMap<String, Object>();
         name.put("name", eq);
-        List<Object> clause = Arrays.<Object>asList(name);
-        SqlParts where = QuerySqlTranslator.whereSqlForAndClause(clause);
-        Assert.assertNotNull(where);
-        Assert.assertTrue(where.sqlWithPlaceHolders.equals("\"name\" = ?"));
-        List<String> placeHolderValues = Arrays.asList("mike");
-        Assert.assertTrue(placeHolderValues.containsAll(Arrays.asList(where.placeHolderValues)));
+        SqlParts where = QuerySqlTranslator.whereSqlForAndClause(Arrays.<Object>asList(name));
+        assertThat(where.sqlWithPlaceHolders, is("\"name\" = ?"));
+        assertThat(where.placeHolderValues, is(arrayContaining("mike")));
     }
 
     @Test
@@ -318,13 +309,12 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         Map<String, Object> pet = new HashMap<String, Object>();
         pet.put("pet", petEq);
 
-        List<Object> clause = Arrays.<Object>asList(name, age, pet);
-        SqlParts where = QuerySqlTranslator.whereSqlForAndClause(clause);
-        Assert.assertNotNull(where);
+        SqlParts where = QuerySqlTranslator.whereSqlForAndClause(Arrays.<Object>asList(name,
+                                                                                       age,
+                                                                                       pet));
         String expected = "\"name\" = ? AND \"age\" = ? AND \"pet\" = ?";
-        Assert.assertTrue(where.sqlWithPlaceHolders.equals(expected));
-        List<String> placeHolderValues = Arrays.asList("mike", "12", "cat");
-        Assert.assertTrue(placeHolderValues.containsAll(Arrays.asList(where.placeHolderValues)));
+        assertThat(where.sqlWithPlaceHolders, is(expected));
+        assertThat(where.placeHolderValues, is(arrayContainingInAnyOrder("mike", "12", "cat")));
     }
 
     @Test
@@ -333,17 +323,17 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         eq.put("$blah", "mike");
         Map<String, Object> name = new HashMap<String, Object>();
         name.put("name", eq);
-        List<Object> clause = Arrays.<Object>asList(name);
-        Assert.assertNull(QuerySqlTranslator.whereSqlForAndClause(clause));
+        assertThat(QuerySqlTranslator.whereSqlForAndClause(Arrays.<Object>asList(name)),
+                   is(nullValue()));
     }
 
     // When generating query SELECT clauses
 
     @Test
     public void nullSelectClauseWhenQueryEmpty() {
-        Assert.assertNull(QuerySqlTranslator.selectStatementForAndClause(null, "named"));
-        Assert.assertNull(QuerySqlTranslator.selectStatementForAndClause(new ArrayList<Object>(),
-                                                                         "named"));
+        assertThat(QuerySqlTranslator.selectStatementForAndClause(null, "named"), is(nullValue()));
+        assertThat(QuerySqlTranslator.selectStatementForAndClause(new ArrayList<Object>(), "named"),
+                   is(nullValue()));
     }
 
     @Test
@@ -353,8 +343,8 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         Map<String, Object> name = new HashMap<String, Object>();
         name.put("name", eq);
         List<Object> clause = Arrays.<Object>asList(name);
-        Assert.assertNull(QuerySqlTranslator.selectStatementForAndClause(clause, null));
-        Assert.assertNull(QuerySqlTranslator.selectStatementForAndClause(clause, ""));
+        assertThat(QuerySqlTranslator.selectStatementForAndClause(clause, null), is(nullValue()));
+        assertThat(QuerySqlTranslator.selectStatementForAndClause(clause, ""), is(nullValue()));
     }
 
     @Test
@@ -365,11 +355,9 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         name.put("name", eq);
         List<Object> clause = Arrays.<Object>asList(name);
         SqlParts sql = QuerySqlTranslator.selectStatementForAndClause(clause, "anIndex");
-        Assert.assertNotNull(sql);
         String expected = "SELECT _id FROM _t_cloudant_sync_query_index_anIndex WHERE \"name\" = ?";
-        Assert.assertTrue(sql.sqlWithPlaceHolders.equals(expected));
-        List<String> placeHolderValues = Arrays.asList("mike");
-        Assert.assertTrue(placeHolderValues.containsAll(Arrays.asList(sql.placeHolderValues)));
+        assertThat(sql.sqlWithPlaceHolders, is(expected));
+        assertThat(sql.placeHolderValues, is(arrayContaining("mike")));
     }
 
     @Test
@@ -391,12 +379,11 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
 
         List<Object> clause = Arrays.<Object>asList(name, age, pet);
         SqlParts sql = QuerySqlTranslator.selectStatementForAndClause(clause, "anIndex");
-        Assert.assertNotNull(sql);
-        String expected = "SELECT _id FROM _t_cloudant_sync_query_index_anIndex WHERE \"name\" = " +
-                          "? AND \"age\" = ? AND \"pet\" = ?";
-        Assert.assertTrue(sql.sqlWithPlaceHolders.equals(expected));
-        List<String> placeHolderValues = Arrays.asList("mike", "12", "cat");
-        Assert.assertTrue(placeHolderValues.containsAll(Arrays.asList(sql.placeHolderValues)));
+        String select = "SELECT _id FROM _t_cloudant_sync_query_index_anIndex";
+        String where = " WHERE \"name\" = ? AND \"age\" = ? AND \"pet\" = ?";
+        String expected = String.format("%s%s", select, where);
+        assertThat(sql.sqlWithPlaceHolders, is(expected));
+        assertThat(sql.placeHolderValues, is(arrayContainingInAnyOrder("mike", "12", "cat")));
     }
 
 }

--- a/sync-core/src/test/java/com/cloudant/sync/query/QueryValidatorTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/QueryValidatorTest.java
@@ -12,7 +12,11 @@
 
 package com.cloudant.sync.query;
 
-import org.junit.Assert;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -32,20 +36,17 @@ public class QueryValidatorTest {
         Map<String, Object> normalizedQuery = QueryValidator.normaliseAndValidateQuery(query);
 
         // normalized query - { "$and" : [ { "name" : { "$eq" : "mike" } } ]
-        Assert.assertNotNull(normalizedQuery);
-        Assert.assertEquals(1, normalizedQuery.size());
-        Assert.assertTrue(normalizedQuery.keySet().toArray()[0].equals("$and"));
-        Assert.assertTrue(normalizedQuery.get("$and") instanceof List);
+        assertThat(normalizedQuery.size(), is(1));
+        assertThat(normalizedQuery, hasKey("$and"));
         List<Object> fields = (ArrayList) normalizedQuery.get("$and");
-        Assert.assertEquals(1, fields.size());
-        Assert.assertTrue(fields.get(0) instanceof Map);
+        assertThat(fields.size(), is(1));
         Map<String, Object> fieldMap = (Map) fields.get(0);
-        Assert.assertEquals(1, fieldMap.size());
-        Assert.assertTrue(fieldMap.keySet().toArray()[0].equals("name"));
+        assertThat(fieldMap.size(), is(1));
+        assertThat(fieldMap, hasKey("name"));
         Map<String, Object> predicate = (Map) fieldMap.get("name");
-        Assert.assertEquals(1, predicate.size());
-        Assert.assertTrue(predicate.keySet().toArray()[0].equals("$eq"));
-        Assert.assertTrue(predicate.get("$eq").equals("mike"));
+        assertThat(predicate.size(), is(1));
+        assertThat(predicate, hasKey("$eq"));
+        assertThat((String) predicate.get("$eq"), is("mike"));
     }
 
     @Test
@@ -59,32 +60,28 @@ public class QueryValidatorTest {
 
         // normalized query - { "$and" : [ { "name" : { "$eq" : "mike" } },
         //                                 { "age" : { "$eq" : "12" } } ]
-        Assert.assertNotNull(normalizedQuery);
-        Assert.assertEquals(1, normalizedQuery.size());
-        Assert.assertTrue(normalizedQuery.keySet().toArray()[0].equals("$and"));
-        Assert.assertTrue(normalizedQuery.get("$and") instanceof List);
+        assertThat(normalizedQuery.size(), is(1));
+        assertThat(normalizedQuery, hasKey("$and"));
+
         List<Object> fields = (ArrayList) normalizedQuery.get("$and");
-        Assert.assertEquals(2, fields.size());
-        for (Object field: fields) {
-            Assert.assertTrue(field instanceof Map);
-        }
+        assertThat(fields.size(), is(2));
         Map<String, Object> fieldMap = (Map) fields.get(0);
-        Assert.assertEquals(1, fieldMap.size());
-        Assert.assertTrue(fieldMap.keySet().toArray()[0].equals("name"));
+        assertThat(fieldMap.size(), is(1));
+        assertThat(fieldMap, hasKey("name"));
         Map<String, Object> predicate = (Map) fieldMap.get("name");
-        Assert.assertEquals(1, predicate.size());
-        Assert.assertTrue(predicate.keySet().toArray()[0].equals("$eq"));
-        Assert.assertTrue(predicate.get("$eq").equals("mike"));
+        assertThat(predicate.size(), is(1));
+        assertThat(predicate, hasKey("$eq"));
+        assertThat((String) predicate.get("$eq"), is("mike"));
 
         fieldMap.clear();
         fieldMap = (Map) fields.get(1);
-        Assert.assertEquals(1, fieldMap.size());
-        Assert.assertTrue(fieldMap.keySet().toArray()[0].equals("age"));
+        assertThat(fieldMap.size(), is(1));
+        assertThat(fieldMap, hasKey("age"));
         predicate.clear();
         predicate = (Map) fieldMap.get("age");
-        Assert.assertEquals(1, predicate.size());
-        Assert.assertTrue(predicate.keySet().toArray()[0].equals("$eq"));
-        Assert.assertEquals(12, predicate.get("$eq"));
+        assertThat(predicate.size(), is(1));
+        assertThat(predicate, hasKey("$eq"));
+        assertThat((Integer) predicate.get("$eq"), is(12));
     }
 
 }

--- a/sync-core/src/test/java/com/cloudant/sync/query/ValueExtractorTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/ValueExtractorTest.java
@@ -12,12 +12,16 @@
 
 package com.cloudant.sync.query;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
 import com.cloudant.sync.datastore.DocumentBody;
 import com.cloudant.sync.datastore.DocumentBodyFactory;
 import com.cloudant.sync.datastore.DocumentRevision;
 import com.cloudant.sync.datastore.DocumentRevisionBuilder;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -45,33 +49,33 @@ public class ValueExtractorTest {
     @Test
     public void getDocIdFromRevision() {
         String value = (String) ValueExtractor.extractValueForFieldName("_id", revision);
-        Assert.assertTrue(value.equals("dsfsdfdfs"));
+        assertThat(value, is("dsfsdfdfs"));
     }
 
     @Test
     public void getRevIdFromRevision() {
         String value = (String) ValueExtractor.extractValueForFieldName("_rev", revision);
-        Assert.assertTrue(value.equals("1-qweqeqwewqe"));
+        assertThat(value, is("1-qweqeqwewqe"));
     }
 
     @Test
     public void getNameFromRevision() {
         String value = (String) ValueExtractor.extractValueForFieldName("name", revision);
-        Assert.assertTrue(value.equals("mike"));
+        assertThat(value, is("mike"));
     }
 
     @Test
     public void extractSingleFieldWhenEmptyFieldName() {
         // returns null for empty field name
         Object v = ValueExtractor.extractValueForFieldName("", body);
-        Assert.assertNull(v);
+        assertThat(v, is(nullValue()));
     }
 
     @Test
     public void extractSingleFieldForSingleDepth() {
         // returns value for single field depth
         String v = (String) ValueExtractor.extractValueForFieldName("name", body);
-        Assert.assertTrue(v.equals("mike"));
+        assertThat(v, is("mike"));
     }
 
     @Test
@@ -79,7 +83,7 @@ public class ValueExtractorTest {
         // returns value for two field depth
         String v = (String) ValueExtractor.extractValueForFieldName("name.first",
                                                                     getTwoLevelBody());
-        Assert.assertTrue(v.equals("mike"));
+        assertThat(v, is("mike"));
     }
 
     @Test
@@ -88,17 +92,17 @@ public class ValueExtractorTest {
         // returns value for three field depth
         String v = (String) ValueExtractor.extractValueForFieldName("aaa.bbb.ccc",
                                                                     getThreeLevelBody());
-        Assert.assertTrue(v.equals("mike"));
+        assertThat(v, is("mike"));
     }
 
     @Test
     public void extractSingleFieldWhenFieldNamePrefix() {
         // copes when a prefix of the field name exists
         Object v = ValueExtractor.extractValueForFieldName("name.first", body);
-        Assert.assertNull(v);
+        assertThat(v, is(nullValue()));
 
         v = ValueExtractor.extractValueForFieldName("name.first.mike", getThreeLevelBody());
-        Assert.assertNull(v);
+        assertThat(v, is(nullValue()));
     }
 
     @Test
@@ -107,10 +111,8 @@ public class ValueExtractorTest {
         @SuppressWarnings("unchecked")
         Map<String, String> v = (Map) ValueExtractor.extractValueForFieldName("aaa.bbb",
                                                                               getThreeLevelBody());
-        Assert.assertNotNull(v);
-        Assert.assertEquals(v.size(), 1);
-        Assert.assertTrue(v.containsKey("ccc"));
-        Assert.assertTrue(v.get("ccc").equals("mike"));
+        assertThat(v.size(), is(1));
+        assertThat(v, hasEntry("ccc", "mike"));
     }
 
     private DocumentBody getTwoLevelBody() {


### PR DESCRIPTION
The work included in this PR replaces Junit assert... statements with `assertThat` along with Hamcrest matchers in index/query unit tests where appropriate.  The use of the Hamcrest matchers provides clearer more readable code and in most cases is more concise.