### PR TITLE
Add unindexed matcher capability to query

### DIFF
--- a/sync-core/src/main/java/com/cloudant/sync/query/AndQueryNode.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/AndQueryNode.java
@@ -18,6 +18,4 @@ package com.cloudant.sync.query;
  */
 class AndQueryNode extends ChildrenQueryNode {
 
-    // This class is used to define a ChildrenQueryNode as a specific type of QueryNode
-
 }

--- a/sync-core/src/main/java/com/cloudant/sync/query/OperatorExpressionNode.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/OperatorExpressionNode.java
@@ -1,0 +1,31 @@
+//  Copyright (c) 2015 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+package com.cloudant.sync.query;
+
+import java.util.Map;
+
+/**
+ *  An OperatorExpressionNode object is used by the
+ *  {@link com.cloudant.sync.query.UnindexedMatcher}.  Since some methods within the
+ *  {@link com.cloudant.sync.query.UnindexedMatcher} class that utilize an OperatorExpressionNode
+ *  object are static in nature, the OperatorExpressionNode class cannot be implemented as an
+ *  inner class to {@link com.cloudant.sync.query.UnindexedMatcher} and must be
+ *  implemented this way instead.
+ *
+ *  @see com.cloudant.sync.query.UnindexedMatcher
+ */
+class OperatorExpressionNode implements QueryNode {
+
+    public Map<String, Object> expression;
+
+}

--- a/sync-core/src/main/java/com/cloudant/sync/query/QueryExecutor.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/QueryExecutor.java
@@ -43,7 +43,7 @@ class QueryExecutor {
     private static final Logger logger = Logger.getLogger(QueryExecutor.class.getName());
 
     /**
-     *  Constructs a new CDTQQueryExecutor using the indexes in 'database' to find documents from
+     *  Constructs a new QueryExecutor using the indexes in 'database' to find documents from
      *  'datastore'.
      */
     QueryExecutor(SQLDatabase database, Datastore datastore, ExecutorService queue) {
@@ -195,7 +195,7 @@ class QueryExecutor {
         return fields;
     }
 
-    private Set<String> executeQueryTree(QueryNode node, SQLDatabase db) {
+    protected Set<String> executeQueryTree(QueryNode node, SQLDatabase db) {
         if (node instanceof AndQueryNode) {
             Set<String> accumulator = null;
 

--- a/sync-core/src/main/java/com/cloudant/sync/query/QueryValidator.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/QueryValidator.java
@@ -16,6 +16,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  *  This class contains common validation options for the
@@ -27,6 +29,8 @@ class QueryValidator {
     public static final String OR = "$or";
     public static final String EQ = "$eq";
 
+    private static final Logger logger = Logger.getLogger(QueryValidator.class.getName());
+
     /**
      *  Expand implicit operators in a query, and validate
      */
@@ -35,6 +39,12 @@ class QueryValidator {
         boolean isWildCard = false;
         if (query.isEmpty()) {
             isWildCard = true;
+        }
+
+        if (!validateQueryValue(query)) {
+            String msg = String.format("Invalid value encountered in query: %s", query.toString());
+            logger.log(Level.SEVERE, msg);
+            return null;
         }
 
         // First expand the query to include a leading compound predicate
@@ -157,6 +167,23 @@ class QueryValidator {
     private static boolean validateCompoundOperatorClauses(List<Object> clauses) {
         // TODO - implement logic...
         return true;
+    }
+
+    private static boolean validateQueryValue(Object value) {
+        boolean valid = true;
+        if (value instanceof Map) {
+            for (Object key: ((Map) value).keySet()) {
+                valid = valid && validateQueryValue(((Map) value).get(key));
+            }
+        } else if (value instanceof List) {
+            for (Object element : (List) value) {
+                valid = valid && validateQueryValue(element);
+            }
+        } else if (value instanceof Float) {
+            valid = false;
+        }
+
+        return valid;
     }
 
 }

--- a/sync-core/src/main/java/com/cloudant/sync/query/UnindexedMatcher.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/UnindexedMatcher.java
@@ -1,4 +1,4 @@
-//  Copyright (c) 2014 Cloudant. All rights reserved.
+//  Copyright (c) 2015 Cloudant. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
 //  except in compliance with the License. You may obtain a copy of the License at
@@ -12,7 +12,13 @@
 
 package com.cloudant.sync.query;
 
+import com.cloudant.sync.datastore.DocumentRevision;
+
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  *  Determine whether a document matches a selector.
@@ -71,9 +77,11 @@ import java.util.Map;
  *
  *  These basic patterns can be composed into more complicate structures.
  */
-public class UnindexedMatcher {
+class UnindexedMatcher {
 
     private ChildrenQueryNode root;
+
+    private static final Logger logger = Logger.getLogger(UnindexedMatcher.class.getName());
 
     private static final String AND = "$and";
     private static final String OR = "$or";
@@ -98,14 +106,221 @@ public class UnindexedMatcher {
         return matcher;
     }
 
+    @SuppressWarnings("unchecked")
     private static ChildrenQueryNode buildExecutionTreeForSelector(Map<String, Object> selector) {
         // At this point we will have a root compound predicate, AND or OR, and
         // the query will be reduced to a single entry:
         // { "$and": [ ... predicates (possibly compound) ... ] }
         // { "$or": [ ... predicates (possibly compound) ... ] }
 
-        // TODO - build execution tree for selector
-        return null;
+        ChildrenQueryNode root = null;
+        List<Object> clauses = new ArrayList<Object>();
+
+        if (selector.get(AND) != null) {
+            clauses = (List<Object>) selector.get(AND);
+            root = new AndQueryNode();
+        } else if (selector.get(OR) != null) {
+            clauses = (List<Object>) selector.get(OR);
+            root = new OrQueryNode();
+        }
+
+        //
+        // First handle the simple "field": { "$operator": "value" } clauses.
+        //
+
+        List<Object> basicClauses = new ArrayList<Object>();
+
+        for (Object rawClause: clauses) {
+            Map<String, Object> clause = (Map<String, Object>) rawClause;
+            String field = (String) clause.keySet().toArray()[0];
+            if (!field.startsWith("$")) {
+                basicClauses.add(rawClause);
+            }
+        }
+
+        // Execution step will evaluate each child node and AND or OR the results.
+        for (Object expression: basicClauses) {
+            OperatorExpressionNode node = new OperatorExpressionNode();
+            node.expression = (Map<String, Object>) expression;
+            if (root != null) {
+                root.children.add(node);
+            }
+        }
+
+        //
+        // AND and OR subclauses are handled identically whatever the parent is.
+        // We go through the query twice to order the OR clauses before the AND
+        // clauses, for predictability.
+        //
+
+        // Add subclauses that are OR
+        // TODO - Handle OR subclauses
+
+        // Add subclauses that are AND
+        // TODO - Handle AND subclauses
+
+        return root;
+    }
+
+    /**
+     * Returns true is a document matches this matcher's selector.
+     *
+     * @param rev The document revision to match selector to.
+     * @return document and matcher's selector matching status.
+     */
+    public boolean matches(DocumentRevision rev) {
+        return executeSelectorTree(root, rev);
+    }
+
+    @SuppressWarnings("unchecked")
+    private boolean executeSelectorTree(QueryNode node, DocumentRevision rev) {
+        if (node instanceof AndQueryNode) {
+            boolean passed = true;
+
+            AndQueryNode andNode = (AndQueryNode) node;
+
+            for (QueryNode child: andNode.children) {
+                passed = passed && executeSelectorTree(child, rev);
+            }
+
+            return passed;
+        }
+        if (node instanceof OrQueryNode) {
+            boolean passed = false;
+
+            OrQueryNode orNode = (OrQueryNode) node;
+
+            for (QueryNode child: orNode.children) {
+                passed = passed || executeSelectorTree(child, rev);
+            }
+
+            return passed;
+        } else if (node instanceof OperatorExpressionNode) {
+            Map<String, Object> expression = ((OperatorExpressionNode) node).expression;
+
+            // Here we could have:
+            //   { fieldName: { operator: value } }
+            // or
+            //   { fieldName: { $not: { operator: value } } }
+
+            // Next evaluate the result
+            String fieldName = (String) expression.keySet().toArray()[0];
+            Map<String, Object> operatorExpression;
+            operatorExpression = (Map<String, Object>) expression.get(fieldName);
+
+            String operator = (String) operatorExpression.keySet().toArray()[0];
+
+            // First work out whether we need to invert the result when done
+            boolean invertResult = operator.equals(NOT);
+            if (invertResult) {
+                operatorExpression = (Map<String, Object>) operatorExpression.get(NOT);
+                operator = (String) operatorExpression.keySet().toArray()[0];
+            }
+
+            Object expected = operatorExpression.get(operator);
+            Object actual = ValueExtractor.extractValueForFieldName(fieldName, rev);
+
+            boolean passed = false;
+            // For array actual values, the operator expression is matched
+            // if any of the array values match it. We need to be careful
+            // to invert the match status of every candidate, rather than
+            // just flipping the result at the end.
+            //
+            // This is because { "$not": { "$eq": "white_cat" } } needs
+            // to be taken as an atomic check, meaning:
+            //   "there's an item in the array that matches `!= "white_cat"`"
+            // rather than:
+            //   "not (there's an item that matches white_cat)"
+            // The latter is satisfied using the $nin operator.
+            if (actual instanceof List) {
+                for (Object item: (List<Object>) actual) {
+                    // OR as any value in the array can match
+                    boolean currentItemPassed = valueCompare(item, operator, expected);
+                    passed = passed || (invertResult ? !currentItemPassed : currentItemPassed);
+                }
+            } else {
+                passed = valueCompare(actual, operator, expected);
+                passed = invertResult ? !passed : passed;
+            }
+
+            return passed;
+        } else {
+            // We constructed the tree, so shouldn't end up here; error if we do.
+            String msg = String.format("Found unexpected selector execution tree: %s", node);
+            logger.log(Level.SEVERE, msg);
+            return false;
+        }
+    }
+
+    private boolean valueCompare(Object actual, String operator, Object expected) {
+        boolean passed;
+
+        if (operator.equals("$eq")) {
+            passed = compareEq(actual, expected);
+        } else if (operator.equals("$ne")) {
+            passed = compareNE(actual, expected);
+        } else if (operator.equals("$lt")) {
+            passed = compareLT(actual, expected);
+        } else if (operator.equals("$lte")) {
+            passed = compareLTE(actual, expected);
+        } else if (operator.equals("$gt")) {
+            passed = compareGT(actual, expected);
+        } else if (operator.equals("$gte")) {
+            passed = compareGTE(actual, expected);
+        } else if (operator.equals("$exists")) {
+            boolean expectedBool = (Boolean) expected;
+            boolean exists = (actual != null);
+            passed = (exists == expectedBool);
+        } else {
+            String msg = String.format("Found unexpected operator in selector: %s", operator);
+            logger.log(Level.WARNING, msg);
+            passed = false;
+        }
+
+        return passed;
+    }
+
+    protected static boolean compareEq(Object l, Object r) {
+        if (l instanceof String && r instanceof String) {
+            return l.equals(r);
+        }
+        if (l instanceof Boolean && r instanceof Boolean) {
+            return l == r;
+        }
+        return l instanceof Number &&
+               r instanceof Number &&
+               !(l instanceof Float || r instanceof Float) &&
+               ((Number) l).doubleValue() == ((Number) r).doubleValue();
+    }
+
+    protected static boolean compareNE(Object l, Object r) {
+        return !(compareEq(l, r));
+    }
+
+    //
+    // Try to respect SQLite's ordering semantics:
+    //  1. NULL
+    //  2. INT/REAL
+    //  3. TEXT
+    //  4. BLOB
+    protected static boolean compareLT(Object l, Object r) {
+        // TODO: 275 - 309 CDTQUnindexedMatcher.m
+        return false;
+    }
+
+    protected static boolean compareLTE(Object l, Object r) {
+        // TODO: 311 - 323 CDTQUnindexedMatcher.m
+        return false;
+    }
+
+    protected static boolean compareGT(Object l, Object r) {
+        // TODO: 325 - 337 CDTQUnindexedMatcher.m
+        return false;
+    }
+
+    protected static boolean compareGTE(Object l, Object r) {
+        // TODO: 339 - 351 CDTQUnindexedMatcher.m
+        return false;
     }
 
 }

--- a/sync-core/src/test/java/com/cloudant/sync/query/AbstractQueryTestBase.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/AbstractQueryTestBase.java
@@ -17,27 +17,55 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 
+import com.cloudant.sync.datastore.DatastoreExtended;
+import com.cloudant.sync.datastore.DatastoreManager;
 import com.cloudant.sync.datastore.DocumentBodyFactory;
 import com.cloudant.sync.datastore.DocumentRevision;
 import com.cloudant.sync.datastore.MutableDocumentRevision;
+import com.cloudant.sync.sqlite.SQLDatabase;
+import com.cloudant.sync.util.TestUtils;
 
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class QueryExecutorTest extends AbstractIndexTestBase {
+/**
+ *  The aim is to make sure that the post hoc matcher class behaves the
+ *  same as the SQL query engine.
+ *
+ *  To accomplish this, we test the entire test execution pipeline contained
+ *  within this class using {@link com.cloudant.sync.query.QueryExecutorSQLOnlyTest}
+ *  which exercises the SQL query engine matching functionality.  We then test
+ *  the same test execution pipeline contained within this class using
+ *  {@link com.cloudant.sync.query.QueryExecutorMatcherTest} which in turn
+ *  exercises the post hoc matcher matching functionality.
+ */
+public abstract class AbstractQueryTestBase {
 
-    @Override
+    String factoryPath = null;
+    DatastoreManager factory = null;
+    DatastoreExtended ds = null;
+    IndexManager im = null;
+    SQLDatabase db = null;
+
+    @Before
     public void setUp() throws SQLException {
-        super.setUp();
+        factoryPath = TestUtils.createTempTestingDir(AbstractQueryTestBase.class.getName());
+        assertThat(factoryPath, is(notNullValue()));
+        factory = new DatastoreManager(factoryPath);
+        assertThat(factory, is(notNullValue()));
+        ds = (DatastoreExtended) factory.openDatastore(AbstractQueryTestBase.class.getSimpleName());
+        assertThat(ds, is(notNullValue()));
 
         MutableDocumentRevision rev = new MutableDocumentRevision();
         rev.docId = "mike12";
@@ -51,7 +79,6 @@ public class QueryExecutorTest extends AbstractIndexTestBase {
         } catch (IOException e) {
             e.printStackTrace();
             Assert.fail("Failed to create document revision");
-
         }
 
         rev.docId = "mike34";
@@ -105,13 +132,56 @@ public class QueryExecutorTest extends AbstractIndexTestBase {
             Assert.fail("Failed to create document revision");
         }
 
-        assertThat(im.ensureIndexed(Arrays.<Object>asList("name", "age"), "basic"), is("basic"));
-        assertThat(im.ensureIndexed(Arrays.<Object>asList("name", "pet"), "pet"), is("pet"));
+    }
+
+    @After
+    public void tearDown() {
+        im.close();
+        assertThat(im.getQueue().isShutdown(), is(true));
+        ds.close();
+        TestUtils.deleteDatabaseQuietly(db);
+        TestUtils.deleteTempTestingDir(factoryPath);
+
+        im = null;
+        ds = null;
+        factory = null;
+        factoryPath = null;
     }
 
     @Test
     public void returnsNullForNoQuery() {
-        Assert.assertNull(im.find(null));
+        assertThat(im.find(null), is(nullValue()));
+    }
+
+    @Test
+    // Since Floats are not allowed, the query is rejected when a Float is encountered as a value.
+    public void returnsNullWhenQueryContainsInvalidValue() {
+        // query - { "name" : { "eq" : "mike" }, "age" : { "$eq" : 12.0f } }
+        Map<String, Object> nameOperator = new HashMap<String, Object>();
+        nameOperator.put("$eq", "mike");
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("name", nameOperator);
+        Map<String, Object> ageOperator = new HashMap<String, Object>();
+        ageOperator.put("$eq", 12.0f);
+        query.put("age", ageOperator);
+        assertThat(im.find(query), is(nullValue()));
+    }
+
+    @Test
+    public void validateIteratorContentWithDocumentIdsList() {
+        // query - { "name" : "mike" }
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("name", "mike");
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.size(), is((long) queryResult.documentIds().size()));
+        List<String> docCheckList = new ArrayList<String>();
+        for (DocumentRevision rev: queryResult) {
+            assertThat(rev.getId(), is(notNullValue()));
+            assertThat(rev.getBody(), is(notNullValue()));
+            docCheckList.add(rev.getId());
+        }
+        assertThat(queryResult.size(), is((long) docCheckList.size()));
+        assertThat(queryResult.documentIds(), containsInAnyOrder(docCheckList.toArray()));
     }
 
     @Test
@@ -239,21 +309,96 @@ public class QueryExecutorTest extends AbstractIndexTestBase {
         assertThat(queryResult.size(), is(0l));
     }
 
+    // When limiting and offsetting results
+
     @Test
-    public void validateIteratorContentWithDocumentIdsList() {
-        // query - { "name" : "mike" }
+    public void returnsAllForSkip0Limit0() {
+        // query - { "name" : { "eq" : "mike" } }
+        Map<String, Object> operator = new HashMap<String, Object>();
+        operator.put("$eq", "mike");
         Map<String, Object> query = new HashMap<String, Object>();
-        query.put("name", "mike");
-        QueryResult queryResult = im.find(query);
-        assertThat(queryResult.size(), is((long) queryResult.documentIds().size()));
-        List<String> docCheckList = new ArrayList<String>();
-        for (DocumentRevision rev: queryResult) {
-            assertThat(rev.getId(), is(notNullValue()));
-            assertThat(rev.getBody(), is(notNullValue()));
-            docCheckList.add(rev.getId());
-        }
-        assertThat(queryResult.size(), is((long) docCheckList.size()));
-        assertThat(queryResult.documentIds(), containsInAnyOrder(docCheckList.toArray()));
+        query.put("name", operator);
+        QueryResult queryResult = im.find(query, 0, 0, null, null);
+        assertThat(queryResult.documentIds(), containsInAnyOrder("mike12", "mike34", "mike72"));
+    }
+
+    @Test
+    public void limitsQueryResults() {
+        // query - { "name" : { "eq" : "mike" } }
+        Map<String, Object> operator = new HashMap<String, Object>();
+        operator.put("$eq", "mike");
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("name", operator);
+        QueryResult queryResult = im.find(query, 0, 1, null, null);
+        assertThat(queryResult.size(), is(1l));
+    }
+
+    @Test
+    public void limitsQueryAndOffsetsStartingPoint() {
+        // query - { "name" : { "eq" : "mike" } }
+        Map<String, Object> operator = new HashMap<String, Object>();
+        operator.put("$eq", "mike");
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("name", operator);
+        QueryResult offsetResults = im.find(query, 1, 1, null, null);
+        QueryResult results = im.find(query, 0, 2, null, null);
+        assertThat(results.size(), is(2l));
+        assertThat(results.documentIds().get(1), is(offsetResults.documentIds().get(0)));
+    }
+
+    @Test
+    public void disablesLimitFor0() {
+        // query - { "name" : { "eq" : "mike" } }
+        Map<String, Object> operator = new HashMap<String, Object>();
+        operator.put("$eq", "mike");
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("name", operator);
+        QueryResult queryResult = im.find(query, 1, 0, null, null);
+        assertThat(queryResult.size(), is(2l));
+    }
+
+    @Test
+    public void returnsAllWhenLimitOverResultBounds() {
+        // query - { "name" : { "eq" : "mike" } }
+        Map<String, Object> operator = new HashMap<String, Object>();
+        operator.put("$eq", "mike");
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("name", operator);
+        QueryResult queryResult = im.find(query, 0, 4, null, null);
+        assertThat(queryResult.size(), is(3l));
+    }
+
+    @Test
+    public void returnsAllWhenLimitVeryLarge() {
+        // query - { "name" : { "eq" : "mike" } }
+        Map<String, Object> operator = new HashMap<String, Object>();
+        operator.put("$eq", "mike");
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("name", operator);
+        QueryResult queryResult = im.find(query, 0, 1000, null, null);
+        assertThat(queryResult.size(), is(3l));
+    }
+
+    @Test
+    public void returnsEmptyResultSetWhenRangeOutOfBounds() {
+        // query - { "name" : { "eq" : "mike" } }
+        Map<String, Object> operator = new HashMap<String, Object>();
+        operator.put("$eq", "mike");
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("name", operator);
+        QueryResult queryResult = im.find(query, 4, 4, null, null);
+        assertThat(queryResult.size(), is(0l));
+    }
+
+    @Test
+    public void returnsAppropriateResultsSkipAndLargeLimitUsed() {
+        // query - { "name" : { "eq" : "mike" } }
+        Map<String, Object> operator = new HashMap<String, Object>();
+        operator.put("$eq", "mike");
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("name", operator);
+        QueryResult queryResult = im.find(query, 1000, 1000, null, null);
+        assertThat(queryResult.size(), is(0l));
     }
 
 }

--- a/sync-core/src/test/java/com/cloudant/sync/query/MockMatcherIndexManager.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/MockMatcherIndexManager.java
@@ -1,0 +1,55 @@
+//  Copyright (c) 2015 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+package com.cloudant.sync.query;
+
+import com.cloudant.sync.datastore.Datastore;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This sub class of the {@link com.cloudant.sync.query.IndexManager} along with
+ * {@link com.cloudant.sync.query.MockMatcherQueryExecutor} is used by query
+ * executor tests to force the tests to exclusively exercise the post hoc matcher logic.
+ * This class is used for testing purposes only.
+ *
+ * @see com.cloudant.sync.query.IndexManager
+ * @see com.cloudant.sync.query.MockMatcherQueryExecutor
+ */
+public class MockMatcherIndexManager extends IndexManager {
+
+    public MockMatcherIndexManager(Datastore datastore) {
+        super(datastore);
+    }
+
+    @Override
+    public QueryResult find(Map<String, Object> query,
+                            long skip,
+                            long limit,
+                            List<String> fields,
+                            List<Map<String, String>> sortDocument) {
+        if (query == null) {
+            return null;
+        }
+
+        if (!updateAllIndexes()) {
+            return null;
+        }
+
+        MockMatcherQueryExecutor queryExecutor = new MockMatcherQueryExecutor(getDatabase(),
+                                                                              getDatastore(),
+                                                                              getQueue());
+        Map<String, Object> indexes = listIndexes();
+        return queryExecutor.find(query, indexes, skip, limit, fields, sortDocument);
+    }
+}

--- a/sync-core/src/test/java/com/cloudant/sync/query/MockMatcherQueryExecutor.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/MockMatcherQueryExecutor.java
@@ -1,0 +1,76 @@
+//  Copyright (c) 2015 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+package com.cloudant.sync.query;
+
+import com.cloudant.sync.datastore.Datastore;
+import com.cloudant.sync.sqlite.Cursor;
+import com.cloudant.sync.sqlite.SQLDatabase;
+import com.cloudant.sync.util.DatabaseUtils;
+
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * This sub class of the {@link com.cloudant.sync.query.QueryExecutor} along with
+ * {@link com.cloudant.sync.query.MockMatcherIndexManager} is used by query
+ * executor tests to force the tests to exclusively exercise the post hoc matcher logic.
+ * This class is used for testing purposes only.
+ *
+ * @see com.cloudant.sync.query.QueryExecutor
+ * @see com.cloudant.sync.query.MockMatcherIndexManager
+ */
+public class MockMatcherQueryExecutor extends QueryExecutor{
+
+    MockMatcherQueryExecutor(SQLDatabase database, Datastore datastore, ExecutorService queue) {
+        super(database, datastore, queue);
+    }
+
+    // return just a blank node (we don't execute it anyway).
+    @Override
+    protected ChildrenQueryNode translateQuery(Map<String, Object> query,
+                                               Map<String, Object> indexes,
+                                               Boolean[] indexesCoverQuery) {
+        return new AndQueryNode();
+    }
+
+    // just return all doc IDs rather than executing the query nodes
+    @Override
+    protected Set<String> executeQueryTree(QueryNode node, SQLDatabase db) {
+        Map<String, Object> indexes = IndexManager.listIndexesInDatabase(db);
+
+        Set<String> docIdSet = new HashSet<String>();
+        Set<String> neededFields = new HashSet<String>(Arrays.asList("_id"));
+        String allDocsIndex = QuerySqlTranslator.chooseIndexForFields(neededFields, indexes);
+
+        String tableName = IndexManager.tableNameForIndex(allDocsIndex);
+        String sql = String.format("SELECT _id FROM %s", tableName);
+        Cursor cursor = null;
+        try {
+            cursor = db.rawQuery(sql, new String[]{});
+            while (cursor.moveToNext()) {
+                String docId = cursor.getString(0);
+                docIdSet.add(docId);
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        } finally {
+            DatabaseUtils.closeCursorQuietly(cursor);
+        }
+
+        return docIdSet;
+    }
+}

--- a/sync-core/src/test/java/com/cloudant/sync/query/MockSQLOnlyIndexManager.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/MockSQLOnlyIndexManager.java
@@ -1,0 +1,55 @@
+//  Copyright (c) 2015 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+package com.cloudant.sync.query;
+
+import com.cloudant.sync.datastore.Datastore;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This sub class of the {@link com.cloudant.sync.query.IndexManager} along with
+ * {@link com.cloudant.sync.query.MockSQLOnlyQueryExecutor} is used by query
+ * executor tests to force the tests to exclusively exercise the SQL engine logic.
+ * This class is used for testing purposes only.
+ *
+ * @see com.cloudant.sync.query.IndexManager
+ * @see com.cloudant.sync.query.MockSQLOnlyQueryExecutor
+ */
+public class MockSQLOnlyIndexManager extends IndexManager {
+
+    public MockSQLOnlyIndexManager(Datastore datastore) {
+        super(datastore);
+    }
+
+    @Override
+    public QueryResult find(Map<String, Object> query,
+                            long skip,
+                            long limit,
+                            List<String> fields,
+                            List<Map<String, String>> sortDocument) {
+        if (query == null) {
+            return null;
+        }
+
+        if (!updateAllIndexes()) {
+            return null;
+        }
+
+        MockSQLOnlyQueryExecutor queryExecutor = new MockSQLOnlyQueryExecutor(getDatabase(),
+                                                                              getDatastore(),
+                                                                              getQueue());
+        Map<String, Object> indexes = listIndexes();
+        return queryExecutor.find(query, indexes, skip, limit, fields, sortDocument);
+    }
+}

--- a/sync-core/src/test/java/com/cloudant/sync/query/MockSQLOnlyQueryExecutor.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/MockSQLOnlyQueryExecutor.java
@@ -1,0 +1,40 @@
+//  Copyright (c) 2015 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+package com.cloudant.sync.query;
+
+import com.cloudant.sync.datastore.Datastore;
+import com.cloudant.sync.sqlite.SQLDatabase;
+
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * This sub class of the {@link com.cloudant.sync.query.QueryExecutor} along with
+ * {@link com.cloudant.sync.query.MockSQLOnlyIndexManager} is used by query
+ * executor tests to force the tests to exclusively exercise the SQL engine logic.
+ * This class is used for testing purposes only.
+ *
+ * @see com.cloudant.sync.query.QueryExecutor
+ * @see com.cloudant.sync.query.MockSQLOnlyIndexManager
+ */
+public class MockSQLOnlyQueryExecutor extends QueryExecutor{
+
+    MockSQLOnlyQueryExecutor(SQLDatabase database, Datastore datastore, ExecutorService queue) {
+        super(database, datastore, queue);
+    }
+
+    @Override
+    protected UnindexedMatcher matcherForIndexCoverage(Boolean[] indexesCoverQuery, Map<String, Object> selector) {
+        return null;
+    }
+}

--- a/sync-core/src/test/java/com/cloudant/sync/query/QueryExecutorMatcherTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/QueryExecutorMatcherTest.java
@@ -1,0 +1,49 @@
+//  Copyright (c) 2015 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+package com.cloudant.sync.query;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import com.cloudant.sync.util.SQLDatabaseTestUtils;
+
+import java.sql.SQLException;
+import java.util.Arrays;
+
+/**
+ * This class uses the {@link com.cloudant.sync.query.MockMatcherIndexManager}, a mocked up,
+ * sub class of the {@link com.cloudant.sync.query.IndexManager} to force all tests defined in
+ * {@link com.cloudant.sync.query.AbstractQueryTestBase} to exclusively exercise the post hoc
+ * matcher logic.
+ *
+ * @see com.cloudant.sync.query.MockMatcherIndexManager
+ * @see com.cloudant.sync.query.IndexManager
+ * @see com.cloudant.sync.query.AbstractQueryTestBase
+ */
+public class QueryExecutorMatcherTest extends AbstractQueryTestBase {
+    @Override
+    public void setUp() throws SQLException {
+        super.setUp();
+        im = new MockMatcherIndexManager(ds);
+        assertThat(im, is(notNullValue()));
+        db = im.getDatabase();
+        assertThat(db, is(notNullValue()));
+        assertThat(im.getQueue(), is(notNullValue()));
+        String[] metadataTableList = new String[] { IndexManager.INDEX_METADATA_TABLE_NAME };
+        SQLDatabaseTestUtils.assertTablesExist(db, metadataTableList);
+
+        // Index needs to exist but definition is irrelevant.  All tests here use post hoc matcher.
+        assertThat(im.ensureIndexed(Arrays.<Object>asList("noField"), "bogus"), is("bogus"));
+    }
+}

--- a/sync-core/src/test/java/com/cloudant/sync/query/QueryExecutorSQLOnlyTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/QueryExecutorSQLOnlyTest.java
@@ -1,0 +1,49 @@
+//  Copyright (c) 2015 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+package com.cloudant.sync.query;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import com.cloudant.sync.util.SQLDatabaseTestUtils;
+
+import java.sql.SQLException;
+import java.util.Arrays;
+
+/**
+ * This class uses the {@link com.cloudant.sync.query.MockSQLOnlyIndexManager}, a mocked up,
+ * sub class of the {@link com.cloudant.sync.query.IndexManager} to force all tests defined in
+ * {@link com.cloudant.sync.query.AbstractQueryTestBase} to exclusively exercise the post hoc
+ * matcher logic.
+ *
+ * @see com.cloudant.sync.query.MockSQLOnlyIndexManager
+ * @see com.cloudant.sync.query.IndexManager
+ * @see com.cloudant.sync.query.AbstractQueryTestBase
+ */
+public class QueryExecutorSQLOnlyTest extends AbstractQueryTestBase {
+    @Override
+    public void setUp() throws SQLException {
+        super.setUp();
+        im = new MockSQLOnlyIndexManager(ds);
+        assertThat(im, is(notNullValue()));
+        db = im.getDatabase();
+        assertThat(db, is(notNullValue()));
+        assertThat(im.getQueue(), is(notNullValue()));
+        String[] metadataTableList = new String[] { IndexManager.INDEX_METADATA_TABLE_NAME };
+        SQLDatabaseTestUtils.assertTablesExist(db, metadataTableList);
+
+        assertThat(im.ensureIndexed(Arrays.<Object>asList("name", "age"), "basic"), is("basic"));
+        assertThat(im.ensureIndexed(Arrays.<Object>asList("name", "pet"), "pet"), is("pet"));
+    }
+}

--- a/sync-core/src/test/java/com/cloudant/sync/query/QueryExecutorStandardTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/QueryExecutorStandardTest.java
@@ -1,4 +1,4 @@
-//  Copyright (c) 2014 Cloudant. All rights reserved.
+//  Copyright (c) 2015 Cloudant. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
 //  except in compliance with the License. You may obtain a copy of the License at
@@ -16,33 +16,23 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
-import com.cloudant.sync.datastore.DatastoreExtended;
-import com.cloudant.sync.datastore.DatastoreManager;
-import com.cloudant.sync.sqlite.SQLDatabase;
 import com.cloudant.sync.util.SQLDatabaseTestUtils;
-import com.cloudant.sync.util.TestUtils;
-
-import org.junit.After;
-import org.junit.Before;
 
 import java.sql.SQLException;
+import java.util.Arrays;
 
-public abstract class AbstractIndexTestBase {
-
-    String factoryPath = null;
-    DatastoreManager factory = null;
-    DatastoreExtended ds = null;
-    IndexManager im = null;
-    SQLDatabase db = null;
-
-    @Before
+/**
+ * This class uses the {@link IndexManager}, to allow all tests defined in
+ * {@link AbstractQueryTestBase} to run in the standard manner that queries
+ * would normally execute in a production setting.
+ *
+ * @see IndexManager
+ * @see AbstractQueryTestBase
+ */
+public class QueryExecutorStandardTest extends AbstractQueryTestBase {
+    @Override
     public void setUp() throws SQLException {
-        factoryPath = TestUtils.createTempTestingDir(AbstractIndexTestBase.class.getName());
-        assertThat(factoryPath, is(notNullValue()));
-        factory = new DatastoreManager(factoryPath);
-        assertThat(factory, is(notNullValue()));
-        ds = (DatastoreExtended) factory.openDatastore(AbstractIndexTestBase.class.getSimpleName());
-        assertThat(ds, is(notNullValue()));
+        super.setUp();
         im = new IndexManager(ds);
         assertThat(im, is(notNullValue()));
         db = im.getDatabase();
@@ -50,20 +40,8 @@ public abstract class AbstractIndexTestBase {
         assertThat(im.getQueue(), is(notNullValue()));
         String[] metadataTableList = new String[] { IndexManager.INDEX_METADATA_TABLE_NAME };
         SQLDatabaseTestUtils.assertTablesExist(db, metadataTableList);
+
+        assertThat(im.ensureIndexed(Arrays.<Object>asList("name", "age"), "basic"), is("basic"));
+        assertThat(im.ensureIndexed(Arrays.<Object>asList("name", "pet"), "pet"), is("pet"));
     }
-
-    @After
-    public void tearDown() {
-        im.close();
-        assertThat(im.getQueue().isShutdown(), is(true));
-        ds.close();
-        TestUtils.deleteDatabaseQuietly(db);
-        TestUtils.deleteTempTestingDir(factoryPath);
-
-        im = null;
-        ds = null;
-        factory = null;
-        factoryPath = null;
-    }
-
 }

--- a/sync-core/src/test/java/com/cloudant/sync/query/UnindexedMatcherTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/UnindexedMatcherTest.java
@@ -1,0 +1,404 @@
+//  Copyright (c) 2015 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+package com.cloudant.sync.query;
+
+import static com.cloudant.sync.query.UnindexedMatcher.compareEq;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import com.cloudant.sync.datastore.DocumentBody;
+import com.cloudant.sync.datastore.DocumentBodyFactory;
+import com.cloudant.sync.datastore.DocumentRevision;
+import com.cloudant.sync.datastore.DocumentRevisionBuilder;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+public class UnindexedMatcherTest {
+
+    DocumentRevision rev;
+
+    @Before
+    public void setUp() {
+        // body content: { "name" : "mike",
+        //                 "age" : 31,
+        //                 "pets" : [ "white_cat", "black_cat" ],
+        //                 "address" : { "number" : "1", "road" : "infinite loop" }
+        //               }
+        Map<String, Object> bodyMap = new HashMap<String, Object>();
+        bodyMap.put("name", "mike");
+        bodyMap.put("age", 31);
+        bodyMap.put("pets", Arrays.asList("white_cat", "black_cat"));
+        Map<String, String> addressDetail = new HashMap<String, String>();
+        addressDetail.put("number", "1");
+        addressDetail.put("road", "infinite loop");
+        bodyMap.put("address", addressDetail);
+        DocumentBody body = DocumentBodyFactory.create(bodyMap);
+        DocumentRevisionBuilder builder = new DocumentRevisionBuilder();
+        builder.setDocId("dsfsdfdfs");
+        builder.setRevId("1-qweqeqwewqe");
+        builder.setBody(body);
+        rev = builder.build();
+    }
+
+    @Test
+    @SuppressWarnings("UnnecessaryBoxing")
+    public void compareEqNulls() {
+        assertThat(compareEq(null, null), is(false));
+        assertThat(compareEq(null, "mike"), is(false));
+        assertThat(compareEq("mike", null), is(false));
+        assertThat(compareEq(null, new Double(1.1)), is(false));
+        assertThat(compareEq(new Double(1.1), null), is(false));
+        assertThat(compareEq(null, new Long(1l)), is(false));
+        assertThat(compareEq(new Long(1l), null), is(false));
+        assertThat(compareEq(null, 1), is(false));
+        assertThat(compareEq(1, null), is(false));
+    }
+
+    // Floats are not allowed.  Result should always be false.
+    @Test
+    @SuppressWarnings("UnnecessaryBoxing")
+    public void compareEqFloats() {
+        assertThat(compareEq(new Float(1.0f), new Float(1.0f)), is(false));
+        assertThat(compareEq(new Float(1.0f), new Double(1.0)), is(false));
+        assertThat(compareEq(new Double(1.0), new Float(1.0f)), is(false));
+        assertThat(compareEq(new Float(1.0f), new Long(1l)), is(false));
+        assertThat(compareEq(new Long(1l), new Float(1.0f)), is(false));
+        assertThat(compareEq(new Float(1.0f), new Integer(1)), is(false));
+        assertThat(compareEq(new Integer(1), new Float(1.0f)), is(false));
+
+        assertThat(compareEq(new Float(1.0f), new Float(1.1f)), is(false));
+        assertThat(compareEq(new Float(1.1f), new Float(1.0f)), is(false));
+        assertThat(compareEq(new Float(1.1f), new Double(1.0)), is(false));
+        assertThat(compareEq(new Double(1.0), new Float(1.1f)), is(false));
+        assertThat(compareEq(new Float(1.1f), new Long(1l)), is(false));
+        assertThat(compareEq(new Long(1l), new Float(1.1f)), is(false));
+        assertThat(compareEq(new Float(1.1f), new Integer(1)), is(false));
+        assertThat(compareEq(new Integer(1), new Float(1.1f)), is(false));
+    }
+
+    @Test
+    public void compareEqStringToString() {
+        assertThat(compareEq("mike", "mike"), is(true));
+        assertThat(compareEq("mike", "Mike"), is(false));
+    }
+
+    @Test
+    @SuppressWarnings("UnnecessaryBoxing")
+    public void compareEqStringToNumber() {
+        assertThat(compareEq("1", new Integer(1)), is(false));
+        assertThat(compareEq(new Integer(1), "1"), is(false));
+    }
+
+    @Test
+    @SuppressWarnings("UnnecessaryBoxing")
+    public void compareEqDoubleToDouble() {
+        assertThat(compareEq(new Double(1.0), new Double(1.0)), is(true));
+        assertThat(compareEq(new Double(1.0), new Double(1.00)), is(true));
+        assertThat(compareEq(new Double(1.0), new Double(1.1)), is(false));
+        assertThat(compareEq(new Double(1.1), new Double(1.0)), is(false));
+    }
+
+    @Test
+    @SuppressWarnings("UnnecessaryBoxing")
+    public void compareEqDoubleToLong() {
+        assertThat(compareEq(new Double(1.0), new Long(1l)), is(true));
+        assertThat(compareEq(new Long(1l), new Double(1.0)), is(true));
+        assertThat(compareEq(new Double(1.1), new Long(1l)), is(false));
+        assertThat(compareEq(new Long(1l), new Double(1.1)), is(false));
+    }
+
+    @Test
+    @SuppressWarnings("UnnecessaryBoxing")
+    public void compareEqDoubleToInt() {
+        assertThat(compareEq(new Double(1.0), new Integer(1)), is(true));
+        assertThat(compareEq(new Integer(1), new Double(1.0)), is(true));
+        assertThat(compareEq(new Double(1.1), new Integer(1)), is(false));
+        assertThat(compareEq(new Integer(1), new Double(1.1)), is(false));
+    }
+
+    @Test
+    @SuppressWarnings("UnnecessaryBoxing")
+    public void compareEqLongToLong() {
+        assertThat(compareEq(new Long(1l), new Long(1l)), is(true));
+        assertThat(compareEq(new Long(1l), new Long(2l)), is(false));
+        assertThat(compareEq(new Long(2l), new Long(1l)), is(false));
+    }
+
+    @Test
+    @SuppressWarnings("UnnecessaryBoxing")
+    public void compareEqLongToInt() {
+        assertThat(compareEq(new Long(1l), new Integer(1)), is(true));
+        assertThat(compareEq(new Integer(1), new Long(1l)), is(true));
+        assertThat(compareEq(new Long(1l), new Integer(2)), is(false));
+        assertThat(compareEq(new Integer(2), new Long(1l)), is(false));
+    }
+
+    @Test
+    public void singleEqMatch() {
+        // Selector - { "name" : { "$eq" : "mike" } }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        Map<String, Object> eq = new HashMap<String, Object>();
+        eq.put("$eq", "mike");
+        selector.put("name", eq);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher, is(notNullValue()));
+        assertThat(matcher.matches(rev), is(true));
+    }
+
+    @Test
+    public void singleEqNoMatch() {
+        // Selector - { "name" : { "$eq" : "fred" } }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        Map<String, Object> eq = new HashMap<String, Object>();
+        eq.put("$eq", "fred");
+        selector.put("name", eq);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher, is(notNullValue()));
+        assertThat(matcher.matches(rev), is(false));
+    }
+
+    @Test
+    public void singleEqNoMatchBadField() {
+        // Selector - { "species" : { "$eq" : "fred" } }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        Map<String, Object> eq = new HashMap<String, Object>();
+        eq.put("$eq", "fred");
+        selector.put("species", eq);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher, is(notNullValue()));
+        assertThat(matcher.matches(rev), is(false));
+    }
+
+    @Test
+    public void singleImpliedEqMatch() {
+        // Selector - { "name" : "mike" }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        selector.put("name", "mike");
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher, is(notNullValue()));
+        assertThat(matcher.matches(rev), is(true));
+    }
+
+    @Test
+    public void singleImpliedEqNoMatch() {
+        // Selector - { "name" : "fred" }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        selector.put("name", "fred");
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher, is(notNullValue()));
+        assertThat(matcher.matches(rev), is(false));
+    }
+
+    @Test
+    public void singleImpliedEqNoMatchBadField() {
+        // Selector - { "species" : "fred" }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        selector.put("species", "fred");
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher, is(notNullValue()));
+        assertThat(matcher.matches(rev), is(false));
+    }
+
+    @Test
+    public void singleNeMatch() {
+        // Selector - { "name" : { "$ne" : "fred" } }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        Map<String, Object> ne = new HashMap<String, Object>();
+        ne.put("$ne", "fred");
+        selector.put("name", ne);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher, is(notNullValue()));
+        assertThat(matcher.matches(rev), is(true));
+    }
+
+    @Test
+    public void singleNeNoMatch() {
+        // Selector - { "name" : { "$ne" : "mike" } }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        Map<String, Object> ne = new HashMap<String, Object>();
+        ne.put("$ne", "mike");
+        selector.put("name", ne);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher, is(notNullValue()));
+        assertThat(matcher.matches(rev), is(false));
+    }
+
+    @Test
+    public void singleMatchesOnBadField() {
+        // Selector - { "species" : { "$ne" : "fred" } }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        Map<String, Object> ne = new HashMap<String, Object>();
+        ne.put("$ne", "fred");
+        selector.put("species", ne);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher, is(notNullValue()));
+        assertThat(matcher.matches(rev), is(true));
+    }
+
+    @Test
+    public void singleExistingMatch() {
+        // Selector - { "name" : { "$exists" : true } }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        Map<String, Object> exists = new HashMap<String, Object>();
+        exists.put("$exists", true);
+        selector.put("name", exists);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher, is(notNullValue()));
+        assertThat(matcher.matches(rev), is(true));
+    }
+
+    @Test
+    public void singleExistingNoMatch() {
+        // Selector - { "name" : { "$exists" : false } }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        Map<String, Object> exists = new HashMap<String, Object>();
+        exists.put("$exists", false);
+        selector.put("name", exists);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher, is(notNullValue()));
+        assertThat(matcher.matches(rev), is(false));
+    }
+
+    @Test
+    public void singleExistingMatchOnMissing() {
+        // Selector - { "species" : { "$exists" : false } }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        Map<String, Object> exists = new HashMap<String, Object>();
+        exists.put("$exists", false);
+        selector.put("species", exists);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher, is(notNullValue()));
+        assertThat(matcher.matches(rev), is(true));
+    }
+
+    @Test
+    public void singleExistingNoMatchOnMissing() {
+        // Selector - { "species" : { "$exists" : true } }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        Map<String, Object> exists = new HashMap<String, Object>();
+        exists.put("$exists", true);
+        selector.put("species", exists);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher, is(notNullValue()));
+        assertThat(matcher.matches(rev), is(false));
+    }
+
+    @Test
+    public void compoundAndMatchAll() {
+        // Selector - { "$and" : [ { "name" : { "$eq" : "mike" } }, { "age" : { "$eq" : 31 } } ] }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        Map<String, Object> eqName = new HashMap<String, Object>();
+        eqName.put("$eq", "mike");
+        Map<String, Object> name = new HashMap<String, Object>();
+        name.put("name", eqName);
+        Map<String, Object> eqAge = new HashMap<String, Object>();
+        eqAge.put("$eq", 31);
+        Map<String, Object> age = new HashMap<String, Object>();
+        age.put("age", eqAge);
+        selector.put("$and", Arrays.<Object>asList(name, age));
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher, is(notNullValue()));
+        assertThat(matcher.matches(rev), is(true));
+    }
+
+    @Test
+    public void compoundAndNoMatchSome() {
+        // Selector - { "$and" : [ { "name" : { "$eq" : "mike" } }, { "age" : { "$eq" : 12 } } ] }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        Map<String, Object> eqName = new HashMap<String, Object>();
+        eqName.put("$eq", "mike");
+        Map<String, Object> name = new HashMap<String, Object>();
+        name.put("name", eqName);
+        Map<String, Object> eqAge = new HashMap<String, Object>();
+        eqAge.put("$eq", 12);
+        Map<String, Object> age = new HashMap<String, Object>();
+        age.put("age", eqAge);
+        selector.put("$and", Arrays.<Object>asList(name, age));
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher, is(notNullValue()));
+        assertThat(matcher.matches(rev), is(false));
+    }
+
+    @Test
+    public void compoundAndNoMatchAny() {
+        // Selector - { "$and" : [ { "name" : { "$eq" : "fred" } }, { "age" : { "$eq" : 12 } } ] }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        Map<String, Object> eqName = new HashMap<String, Object>();
+        eqName.put("$eq", "fred");
+        Map<String, Object> name = new HashMap<String, Object>();
+        name.put("name", eqName);
+        Map<String, Object> eqAge = new HashMap<String, Object>();
+        eqAge.put("$eq", 12);
+        Map<String, Object> age = new HashMap<String, Object>();
+        age.put("age", eqAge);
+        selector.put("$and", Arrays.<Object>asList(name, age));
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher, is(notNullValue()));
+        assertThat(matcher.matches(rev), is(false));
+    }
+
+    @Test
+    public void compoundImplicitAndMatch() {
+        // Selector - { "name" : { "$eq" : "mike" }, "age" : { "$eq" : 31 } }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        Map<String, Object> eqName = new HashMap<String, Object>();
+        eqName.put("$eq", "mike");
+        Map<String, Object> eqAge = new HashMap<String, Object>();
+        eqAge.put("$eq", 31);
+        selector.put("name", eqName);
+        selector.put("age", eqAge);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher, is(notNullValue()));
+        assertThat(matcher.matches(rev), is(true));
+    }
+
+    @Test
+    public void compoundImplicitAndNoMatch() {
+        // Selector - { "name" : { "$eq" : "mike" }, "age" : { "$eq" : 12 } }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        Map<String, Object> eqName = new HashMap<String, Object>();
+        eqName.put("$eq", "mike");
+        Map<String, Object> eqAge = new HashMap<String, Object>();
+        eqAge.put("$eq", 12);
+        selector.put("name", eqName);
+        selector.put("age", eqAge);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher, is(notNullValue()));
+        assertThat(matcher.matches(rev), is(false));
+    }
+
+}


### PR DESCRIPTION
This pull request provides simple, single level AND-able post hoc matcher functionality to complement the current set of Cloudant query SQL engine matching functionality.

@mikerhodes - points of interest in this PR are:

- The "match" implementation in QueryResult 
https://github.com/cloudant/sync-android/commit/f59f7bf3f8432fd0a1c51ced7286b03f6b8ce0f0#diff-5f5fe154c6c97af9fc67a7b9f8ae9c87R39

- The query rejection in SQLQueryTranslator when floats are found in a query object.  
https://github.com/cloudant/sync-android/commit/f59f7bf3f8432fd0a1c51ced7286b03f6b8ce0f0#diff-10b697b5119c2ac1b73822d862ec16dcR44
https://github.com/cloudant/sync-android/commit/f59f7bf3f8432fd0a1c51ced7286b03f6b8ce0f0#diff-10b697b5119c2ac1b73822d862ec16dcR172

The rest of the code is pretty much a straight port from iOS.
