### PR TITLE
Add support for complex querying

### DIFF
--- a/sync-core/src/main/java/com/cloudant/sync/query/IndexUpdater.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/IndexUpdater.java
@@ -311,14 +311,7 @@ class IndexUpdater {
         for (String fieldName: fieldNames) {
             // Fields in initialIncludedFields already have values in the other initial* array,
             // so it need not be included again.
-            boolean skip = false;
-            for (String initField: initialIncludedFields) {
-                if (initField.equalsIgnoreCase(fieldName)) {
-                    skip = true;
-                    break;
-                }
-            }
-            if (skip) {
+            if (initialIncludedFields.contains(fieldName)) {
                 continue;
             }
 
@@ -354,8 +347,7 @@ class IndexUpdater {
             } else if (argument instanceof String) {
                 contentValues.put(fieldName, (String) argument);
             } else {
-                logger.log(Level.SEVERE, "Invalid argument type.");
-                return null;
+                contentValues.put(fieldName, (String) null);
             }
             argIndex = argIndex + 1;
         }

--- a/sync-core/src/main/java/com/cloudant/sync/query/QueryExecutor.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/QueryExecutor.java
@@ -207,15 +207,23 @@ class QueryExecutor {
                 } else {
                     accumulator = Sets.intersection(accumulator, childIds);
                 }
-
-                // TODO optimisation is to bail here if accumulator is empty
             }
 
             return accumulator;
         }
         if (node instanceof OrQueryNode) {
             Set<String> accumulator = null;
-            // TODO - OR execute query tree logic...
+
+            OrQueryNode orNode = (OrQueryNode) node;
+            for (QueryNode qNode: orNode.children) {
+                Set<String> childIds = executeQueryTree(qNode, db);
+                if (accumulator == null) {
+                    accumulator = new HashSet<String>(childIds);
+                } else {
+                    accumulator = Sets.union(accumulator, childIds);
+                }
+            }
+
             return accumulator;
         } else if (node instanceof SqlQueryNode) {
             SqlQueryNode sqlNode = (SqlQueryNode) node;

--- a/sync-core/src/main/java/com/cloudant/sync/query/QueryResult.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/QueryResult.java
@@ -57,7 +57,7 @@ public class QueryResult implements Iterable<DocumentRevision> {
      *
      *  @return the number of documents {@code DocumentRevision} in this query result.
      */
-    public long size() {
+    public int size() {
         return documentIds().size();
     }
 

--- a/sync-core/src/test/java/com/cloudant/sync/query/AbstractQueryExtendedTestBase.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/AbstractQueryExtendedTestBase.java
@@ -1,0 +1,72 @@
+//  Copyright (c) 2014 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+package com.cloudant.sync.query;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ *  The aim is to make sure that the post hoc matcher class behaves the
+ *  same as the SQL query engine.
+ *
+ *  To accomplish this, we test the entire test execution pipeline contained
+ *  within this class using {@link com.cloudant.sync.query.QueryExecutorMatcherTest}
+ *  which in exercises the post hoc matcher matching functionality.  We then test the
+ *  execution pipeline with {@link com.cloudant.sync.query.QueryExecutorStandardTest}
+ *  which tests query functionality under standard "production" conditions.
+ *
+ *  Note: We do not execute the tests contained within this abstract class against the
+ *  {@link com.cloudant.sync.query.MockSQLOnlyQueryExecutor} since the queries contained
+ *  within this class specifically only test queries without covering indexes.  Therefore
+ *  these tests would all fail.
+ *
+ *  @see com.cloudant.sync.query.QueryExecutorSQLOnlyTest
+ *  @see com.cloudant.sync.query.QueryExecutorMatcherTest
+ *  @see com.cloudant.sync.query.MockSQLOnlyQueryExecutor
+ */
+public abstract class AbstractQueryExtendedTestBase extends AbstractQueryTestBase {
+
+    // When executing AND queries
+
+    @Test
+    public void canQueryWithoutIndexSingleClause() {
+        setUpWithoutCoveringIndexesQueryData();
+        // query - { "town" : "bristol" }
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("town", "bristol");
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), containsInAnyOrder("mike72", "fred12"));
+    }
+
+    @Test
+    public void canQueryWithoutIndexMultiClause() {
+        setUpWithoutCoveringIndexesQueryData();
+        // query - { "pet" : { "$eq" : "cat" }, { "age" : { "$eq" : 12 } }
+        Map<String, Object> op1 = new HashMap<String, Object>();
+        op1.put("$eq", "cat");
+        Map<String, Object> op2 = new HashMap<String, Object>();
+        op2.put("$eq", 12);
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("pet", op1);
+        query.put("age", op2);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), contains("mike12"));
+    }
+
+}

--- a/sync-core/src/test/java/com/cloudant/sync/query/AbstractQueryTestBase.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/AbstractQueryTestBase.java
@@ -15,26 +15,17 @@ package com.cloudant.sync.query;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
-import com.cloudant.sync.datastore.DatastoreExtended;
-import com.cloudant.sync.datastore.DatastoreManager;
-import com.cloudant.sync.datastore.DocumentBodyFactory;
 import com.cloudant.sync.datastore.DocumentRevision;
-import com.cloudant.sync.datastore.MutableDocumentRevision;
-import com.cloudant.sync.sqlite.SQLDatabase;
-import com.cloudant.sync.util.TestUtils;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
-import java.io.IOException;
-import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -48,114 +39,28 @@ import java.util.Map;
  *  which exercises the SQL query engine matching functionality.  We then test
  *  the same test execution pipeline contained within this class using
  *  {@link com.cloudant.sync.query.QueryExecutorMatcherTest} which in turn
- *  exercises the post hoc matcher matching functionality.
+ *  exercises the post hoc matcher matching functionality.  Finally we test the
+ *  execution pipeline with {@link com.cloudant.sync.query.QueryExecutorStandardTest}
+ *  which tests query functionality under standard "production" conditions.
+ *
+ *  @see com.cloudant.sync.query.QueryExecutorSQLOnlyTest
+ *  @see com.cloudant.sync.query.QueryExecutorMatcherTest
+ *  @see com.cloudant.sync.query.QueryExecutorStandardTest
  */
-public abstract class AbstractQueryTestBase {
+public abstract class AbstractQueryTestBase extends AbstractQueryTestSetUp {
 
-    String factoryPath = null;
-    DatastoreManager factory = null;
-    DatastoreExtended ds = null;
-    IndexManager im = null;
-    SQLDatabase db = null;
-
-    @Before
-    public void setUp() throws SQLException {
-        factoryPath = TestUtils.createTempTestingDir(AbstractQueryTestBase.class.getName());
-        assertThat(factoryPath, is(notNullValue()));
-        factory = new DatastoreManager(factoryPath);
-        assertThat(factory, is(notNullValue()));
-        ds = (DatastoreExtended) factory.openDatastore(AbstractQueryTestBase.class.getSimpleName());
-        assertThat(ds, is(notNullValue()));
-
-        MutableDocumentRevision rev = new MutableDocumentRevision();
-        rev.docId = "mike12";
-        Map<String, Object> bodyMap = new HashMap<String, Object>();
-        bodyMap.put("name", "mike");
-        bodyMap.put("age", 12);
-        bodyMap.put("pet", "cat");
-        rev.body = DocumentBodyFactory.create(bodyMap);
-        try {
-            ds.createDocumentFromRevision(rev);
-        } catch (IOException e) {
-            e.printStackTrace();
-            Assert.fail("Failed to create document revision");
-        }
-
-        rev.docId = "mike34";
-        bodyMap.clear();
-        bodyMap.put("name", "mike");
-        bodyMap.put("age", 34);
-        bodyMap.put("pet", "dog");
-        rev.body = DocumentBodyFactory.create(bodyMap);
-        try {
-            ds.createDocumentFromRevision(rev);
-        } catch (IOException e) {
-            e.printStackTrace();
-            Assert.fail("Failed to create document revision");
-        }
-
-        rev.docId = "mike72";
-        bodyMap.clear();
-        bodyMap.put("name", "mike");
-        bodyMap.put("age", 72);
-        bodyMap.put("pet", "cat");
-        rev.body = DocumentBodyFactory.create(bodyMap);
-        try {
-            ds.createDocumentFromRevision(rev);
-        } catch (IOException e) {
-            e.printStackTrace();
-            Assert.fail("Failed to create document revision");
-        }
-
-        rev.docId = "fred34";
-        bodyMap.clear();
-        bodyMap.put("name", "fred");
-        bodyMap.put("age", 34);
-        bodyMap.put("pet", "cat");
-        rev.body = DocumentBodyFactory.create(bodyMap);
-        try {
-            ds.createDocumentFromRevision(rev);
-        } catch (IOException e) {
-            e.printStackTrace();
-            Assert.fail("Failed to create document revision");
-        }
-
-        rev.docId = "fred12";
-        bodyMap.clear();
-        bodyMap.put("name", "fred");
-        bodyMap.put("age", 12);
-        rev.body = DocumentBodyFactory.create(bodyMap);
-        try {
-            ds.createDocumentFromRevision(rev);
-        } catch (IOException e) {
-            e.printStackTrace();
-            Assert.fail("Failed to create document revision");
-        }
-
-    }
-
-    @After
-    public void tearDown() {
-        im.close();
-        assertThat(im.getQueue().isShutdown(), is(true));
-        ds.close();
-        TestUtils.deleteDatabaseQuietly(db);
-        TestUtils.deleteTempTestingDir(factoryPath);
-
-        im = null;
-        ds = null;
-        factory = null;
-        factoryPath = null;
-    }
+    // When executing AND queries
 
     @Test
     public void returnsNullForNoQuery() {
+        setUpBasicQueryData();
         assertThat(im.find(null), is(nullValue()));
     }
 
     @Test
     // Since Floats are not allowed, the query is rejected when a Float is encountered as a value.
     public void returnsNullWhenQueryContainsInvalidValue() {
+        setUpBasicQueryData();
         // query - { "name" : { "eq" : "mike" }, "age" : { "$eq" : 12.0f } }
         Map<String, Object> nameOperator = new HashMap<String, Object>();
         nameOperator.put("$eq", "mike");
@@ -169,79 +74,92 @@ public abstract class AbstractQueryTestBase {
 
     @Test
     public void validateIteratorContentWithDocumentIdsList() {
+        setUpBasicQueryData();
         // query - { "name" : "mike" }
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", "mike");
         QueryResult queryResult = im.find(query);
-        assertThat(queryResult.size(), is((long) queryResult.documentIds().size()));
         List<String> docCheckList = new ArrayList<String>();
         for (DocumentRevision rev: queryResult) {
             assertThat(rev.getId(), is(notNullValue()));
             assertThat(rev.getBody(), is(notNullValue()));
             docCheckList.add(rev.getId());
         }
-        assertThat(queryResult.size(), is((long) docCheckList.size()));
+        assertThat(queryResult.size(), is(docCheckList.size()));
         assertThat(queryResult.documentIds(), containsInAnyOrder(docCheckList.toArray()));
+	}
+
+    @Test
+    public void returnsAllDocsForEmptyQuery() {
+        setUpBasicQueryData();
+        Map<String, Object> query = new HashMap<String, Object>();
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), containsInAnyOrder("mike12",
+                                                                 "mike34",
+                                                                 "mike72",
+                                                                 "fred34",
+                                                                 "fred12"));
     }
 
     @Test
     public void canQueryOverOneStringField() {
+        setUpBasicQueryData();
         // query - { "name" : "mike" }
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", "mike");
         QueryResult queryResult = im.find(query);
-        assertThat(queryResult.size(), is(3l));
         assertThat(queryResult.documentIds(), containsInAnyOrder("mike12", "mike34", "mike72"));
     }
 
     @Test
     public void canQueryOverOneStringFieldNormalized() {
-        // query - { "name" : { "eq" : "mike" } }
+        setUpBasicQueryData();
+        // query - { "name" : { "$eq" : "mike" } }
         Map<String, Object> operator = new HashMap<String, Object>();
         operator.put("$eq", "mike");
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", operator);
         QueryResult queryResult = im.find(query);
-        assertThat(queryResult.size(), is(3l));
         assertThat(queryResult.documentIds(), containsInAnyOrder("mike12", "mike34", "mike72"));
     }
 
     @Test
     public void canQueryOverOneNumberField() {
+        setUpBasicQueryData();
         // query - { "age" : 12 }
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("age", 12);
         QueryResult queryResult = im.find(query);
-        assertThat(queryResult.size(), is(2l));
         assertThat(queryResult.documentIds(), containsInAnyOrder("mike12", "fred12"));
     }
 
     @Test
     public void canQueryOverOneNumberFieldNormalized() {
-        // query - { "age" : { "eq" : 12 } }
+        setUpBasicQueryData();
+        // query - { "age" : { "$eq" : 12 } }
         Map<String, Object> operator = new HashMap<String, Object>();
         operator.put("$eq", 12);
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("age", operator);
         QueryResult queryResult = im.find(query);
-        assertThat(queryResult.size(), is(2l));
         assertThat(queryResult.documentIds(), containsInAnyOrder("mike12", "fred12"));
     }
 
     @Test
     public void canQueryOverTwoStringFields() {
+        setUpBasicQueryData();
         // query - { "name" : "mike", "pet" : "cat" }
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", "mike");
         query.put("pet", "cat");
         QueryResult queryResult = im.find(query);
-        assertThat(queryResult.size(), is(2l));
         assertThat(queryResult.documentIds(), containsInAnyOrder("mike12", "mike72"));
     }
 
     @Test
     public void canQueryOverTwoStringFieldsNormalized() {
-        // query - { "name" : { "eq" : "mike" }, "pet" : { "$eq" : "cat" } }
+        setUpBasicQueryData();
+        // query - { "name" : { "$eq" : "mike" }, "pet" : { "$eq" : "cat" } }
         Map<String, Object> nameOperator = new HashMap<String, Object>();
         nameOperator.put("$eq", "mike");
         Map<String, Object> query = new HashMap<String, Object>();
@@ -250,24 +168,24 @@ public abstract class AbstractQueryTestBase {
         petOperator.put("$eq", "cat");
         query.put("pet", petOperator);
         QueryResult queryResult = im.find(query);
-        assertThat(queryResult.size(), is(2l));
         assertThat(queryResult.documentIds(), containsInAnyOrder("mike12", "mike72"));
     }
 
     @Test
     public void canQueryOverTwoMixedFields() {
+        setUpBasicQueryData();
         // query - { "name" : "mike", "age" : "12" }
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", "mike");
         query.put("age", 12);
         QueryResult queryResult = im.find(query);
-        assertThat(queryResult.size(), is(1l));
         assertThat(queryResult.documentIds(), contains("mike12"));
     }
 
     @Test
     public void canQueryOverTwoMixedFieldsNormalized() {
-        // query - { "name" : { "eq" : "mike" }, "age" : { "$eq" : 12 } }
+        setUpBasicQueryData();
+        // query - { "name" : { "$eq" : "mike" }, "age" : { "$eq" : 12 } }
         Map<String, Object> nameOperator = new HashMap<String, Object>();
         nameOperator.put("$eq", "mike");
         Map<String, Object> query = new HashMap<String, Object>();
@@ -276,44 +194,221 @@ public abstract class AbstractQueryTestBase {
         ageOperator.put("$eq", 12);
         query.put("age", ageOperator);
         QueryResult queryResult = im.find(query);
-        assertThat(queryResult.size(), is(1l));
         assertThat(queryResult.documentIds(), contains("mike12"));
     }
 
     @Test
     public void noResultsWhenQueryOverOneFieldIsMismatched() {
+        setUpBasicQueryData();
         // query - { "name" : "bill" }
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", "bill");
         QueryResult queryResult = im.find(query);
-        assertThat(queryResult.size(), is(0l));
+        assertThat(queryResult.size(), is(0));
     }
 
     @Test
     public void noResultsWhenQueryOverTwoFieldsOneIsMismatched() {
+        setUpBasicQueryData();
         // query - { "name" : "bill", "age" : 12 }
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", "bill");
         query.put("age", 12);
         QueryResult queryResult = im.find(query);
-        assertThat(queryResult.size(), is(0l));
+        assertThat(queryResult.size(), is(0));
     }
 
     @Test
     public void noResultsWhenQueryOverTwoFieldsBothAreMismatched() {
+        setUpBasicQueryData();
         // query - { "name" : "bill", "age" : 17 }
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", "bill");
         query.put("age", 17);
         QueryResult queryResult = im.find(query);
-        assertThat(queryResult.size(), is(0l));
+        assertThat(queryResult.size(), is(0));
+    }
+
+    @Test
+    public void failsWhenUsingUnsupportedOperator() {
+        setUpBasicQueryData();
+        // query - { "age" : { "$blah" : 12 } }
+        Map<String, Object> operator = new HashMap<String, Object>();
+        operator.put("$blah", 12);
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("age", operator);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult, is(nullValue()));
+    }
+
+    @Test
+    public void worksWhenUsingGTOperatorAlone() {
+        setUpBasicQueryData();
+        // query - { "age" : { "$gt" : 12 } }
+        Map<String, Object> operator = new HashMap<String, Object>();
+        operator.put("$gt", 12);
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("age", operator);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), containsInAnyOrder("mike34", "mike72", "fred34"));
+    }
+
+    @Test
+    public void worksWhenUsingGTOperatorWithOthers() {
+        setUpBasicQueryData();
+        // query - { "name" : { "$eq" : "mike" }, "age" : { "$gt" : 12 } }
+        Map<String, Object> eqOp = new HashMap<String, Object>();
+        eqOp.put("$eq", "mike");
+        Map<String, Object> gtOp = new HashMap<String, Object>();
+        gtOp.put("$gt", 12);
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("name", eqOp);
+        query.put("age", gtOp);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), containsInAnyOrder("mike34", "mike72"));
+    }
+
+    @Test
+    public void canCompareStringsWhenUsingGTOperator() {
+        setUpBasicQueryData();
+        // query - { "name" : { "$gt" : "fred" } }
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$gt", "fred");
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("name", op);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), containsInAnyOrder("mike12", "mike34", "mike72"));
+    }
+
+    @Test
+    public void canCompareStringsAsPartOfANDQueryWhenUsingGTOperator() {
+        setUpBasicQueryData();
+        // query - { "name" : { "$gt" : "fred" }, "age" : 34 }
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$gt", "fred");
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("name", op);
+        query.put("age", 34);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), contains("mike34"));
+    }
+
+    @Test
+    public void worksWhenUsingGTEOperatorAlone() {
+        setUpBasicQueryData();
+        // query - { "age" : { "$gte" : 12 } }
+        Map<String, Object> operator = new HashMap<String, Object>();
+        operator.put("$gte", 12);
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("age", operator);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), containsInAnyOrder("mike12",
+                                                                 "mike34",
+                                                                 "mike72",
+                                                                 "fred12",
+                                                                 "fred34"));
+    }
+
+    @Test
+    public void worksWhenUsingGTEOperatorWithOthers() {
+        setUpBasicQueryData();
+        // query - { "name" : { "$eq" : "mike" }, "age" : { "$gte" : 12 } }
+        Map<String, Object> eqOp = new HashMap<String, Object>();
+        eqOp.put("$eq", "mike");
+        Map<String, Object> gteOp = new HashMap<String, Object>();
+        gteOp.put("$gte", 12);
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("name", eqOp);
+        query.put("age", gteOp);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), containsInAnyOrder("mike12", "mike34", "mike72"));
+    }
+
+    @Test
+    public void worksWhenUsingLTOperatorAlone() {
+        setUpBasicQueryData();
+        // query - { "age" : { "$lt" : 12 } }
+        Map<String, Object> operator = new HashMap<String, Object>();
+        operator.put("$lt", 12);
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("age", operator);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.size(), is(0));
+    }
+
+    @Test
+    public void worksWhenUsingLTOperatorWithOthers() {
+        setUpBasicQueryData();
+        // query - { "name" : { "$eq" : "mike" }, "age" : { "$lt" : 12 } }
+        Map<String, Object> eqOp = new HashMap<String, Object>();
+        eqOp.put("$eq", "mike");
+        Map<String, Object> ltOp = new HashMap<String, Object>();
+        ltOp.put("$lt", 12);
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("name", eqOp);
+        query.put("age", ltOp);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.size(), is(0));
+    }
+
+    @Test
+    public void canCompareStringsWhenUsingLTOperator() {
+        setUpBasicQueryData();
+        // query - { "name" : { "$lt" : "mike" } }
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$lt", "mike");
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("name", op);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), containsInAnyOrder("fred12", "fred34"));
+    }
+
+    @Test
+    public void canCompareStringsAsPartOfANDQueryWhenUsingLTOperator() {
+        setUpBasicQueryData();
+        // query - { "name" : { "$lt" : "mike" }, "age" : 34 }
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$lt", "mike");
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("name", op);
+        query.put("age", 34);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), contains("fred34"));
+    }
+
+    @Test
+    public void worksWhenUsingLTEOperatorAlone() {
+        setUpBasicQueryData();
+        // query - { "age" : { "$lte" : 12 } }
+        Map<String, Object> operator = new HashMap<String, Object>();
+        operator.put("$lte", 12);
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("age", operator);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), containsInAnyOrder("mike12", "fred12"));
+    }
+
+    @Test
+    public void worksWhenUsingLTEOperatorWithOthers() {
+        setUpBasicQueryData();
+        // query - { "name" : { "$eq" : "mike" }, "age" : { "$lte" : 12 } }
+        Map<String, Object> eqOp = new HashMap<String, Object>();
+        eqOp.put("$eq", "mike");
+        Map<String, Object> lteOp = new HashMap<String, Object>();
+        lteOp.put("$lte", 12);
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("name", eqOp);
+        query.put("age", lteOp);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), contains("mike12"));
     }
 
     // When limiting and offsetting results
 
     @Test
     public void returnsAllForSkip0Limit0() {
-        // query - { "name" : { "eq" : "mike" } }
+        setUpBasicQueryData();
+        // query - { "name" : { "$eq" : "mike" } }
         Map<String, Object> operator = new HashMap<String, Object>();
         operator.put("$eq", "mike");
         Map<String, Object> query = new HashMap<String, Object>();
@@ -324,81 +419,841 @@ public abstract class AbstractQueryTestBase {
 
     @Test
     public void limitsQueryResults() {
-        // query - { "name" : { "eq" : "mike" } }
+        setUpBasicQueryData();
+        // query - { "name" : { "$eq" : "mike" } }
         Map<String, Object> operator = new HashMap<String, Object>();
         operator.put("$eq", "mike");
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", operator);
         QueryResult queryResult = im.find(query, 0, 1, null, null);
-        assertThat(queryResult.size(), is(1l));
+        assertThat(queryResult.size(), is(1));
     }
 
     @Test
     public void limitsQueryAndOffsetsStartingPoint() {
-        // query - { "name" : { "eq" : "mike" } }
+        setUpBasicQueryData();
+        // query - { "name" : { "$eq" : "mike" } }
         Map<String, Object> operator = new HashMap<String, Object>();
         operator.put("$eq", "mike");
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", operator);
         QueryResult offsetResults = im.find(query, 1, 1, null, null);
         QueryResult results = im.find(query, 0, 2, null, null);
-        assertThat(results.size(), is(2l));
+        assertThat(results.size(), is(2));
         assertThat(results.documentIds().get(1), is(offsetResults.documentIds().get(0)));
     }
 
     @Test
     public void disablesLimitFor0() {
-        // query - { "name" : { "eq" : "mike" } }
+        setUpBasicQueryData();
+        // query - { "name" : { "$eq" : "mike" } }
         Map<String, Object> operator = new HashMap<String, Object>();
         operator.put("$eq", "mike");
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", operator);
         QueryResult queryResult = im.find(query, 1, 0, null, null);
-        assertThat(queryResult.size(), is(2l));
+        assertThat(queryResult.size(), is(2));
     }
 
     @Test
     public void returnsAllWhenLimitOverResultBounds() {
-        // query - { "name" : { "eq" : "mike" } }
+        setUpBasicQueryData();
+        // query - { "name" : { "$eq" : "mike" } }
         Map<String, Object> operator = new HashMap<String, Object>();
         operator.put("$eq", "mike");
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", operator);
         QueryResult queryResult = im.find(query, 0, 4, null, null);
-        assertThat(queryResult.size(), is(3l));
+        assertThat(queryResult.size(), is(3));
     }
 
     @Test
     public void returnsAllWhenLimitVeryLarge() {
-        // query - { "name" : { "eq" : "mike" } }
+        setUpBasicQueryData();
+        // query - { "name" : { "$eq" : "mike" } }
         Map<String, Object> operator = new HashMap<String, Object>();
         operator.put("$eq", "mike");
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", operator);
         QueryResult queryResult = im.find(query, 0, 1000, null, null);
-        assertThat(queryResult.size(), is(3l));
+        assertThat(queryResult.size(), is(3));
     }
 
     @Test
     public void returnsEmptyResultSetWhenRangeOutOfBounds() {
-        // query - { "name" : { "eq" : "mike" } }
+        setUpBasicQueryData();
+        // query - { "name" : { "$eq" : "mike" } }
         Map<String, Object> operator = new HashMap<String, Object>();
         operator.put("$eq", "mike");
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", operator);
         QueryResult queryResult = im.find(query, 4, 4, null, null);
-        assertThat(queryResult.size(), is(0l));
+        assertThat(queryResult.size(), is(0));
     }
 
     @Test
     public void returnsAppropriateResultsSkipAndLargeLimitUsed() {
-        // query - { "name" : { "eq" : "mike" } }
+        setUpBasicQueryData();
+        // query - { "name" : { "$eq" : "mike" } }
         Map<String, Object> operator = new HashMap<String, Object>();
         operator.put("$eq", "mike");
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", operator);
         QueryResult queryResult = im.find(query, 1000, 1000, null, null);
-        assertThat(queryResult.size(), is(0l));
+        assertThat(queryResult.size(), is(0));
+    }
+
+    // When using dotted notation
+
+    @Test
+    public void noResultsTwoLevelDottedQuery() {
+        setUpDottedQueryData();
+        // query - { "pet.name" : { "$eq" : "fred" }, "age" : { "$eq" : 12 } }
+        Map<String, Object> op1 = new HashMap<String, Object>();
+        op1.put("$eq", "fred");
+        Map<String, Object> op2 = new HashMap<String, Object>();
+        op2.put("$eq", 12);
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("pet.name", op1);
+        query.put("age", op2);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult, is(notNullValue()));
+        assertThat(queryResult.documentIds(), is(empty()));
+    }
+
+    @Test
+    public void oneResultTwoLevelDottedQuery() {
+        setUpDottedQueryData();
+        // query - { "pet.name" : { "$eq" : "mike" }, "age" : { "$eq" : 12 } }
+        Map<String, Object> op1 = new HashMap<String, Object>();
+        op1.put("$eq", "mike");
+        Map<String, Object> op2 = new HashMap<String, Object>();
+        op2.put("$eq", 12);
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("pet.name", op1);
+        query.put("age", op2);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), contains("mike12"));
+    }
+
+    @Test
+    public void multiResultTwoLevelDottedQuery() {
+        setUpDottedQueryData();
+        // query - { "pet.species" : { "$eq" : "cat" } }
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$eq", "cat");
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("pet.species", op);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), containsInAnyOrder("mike12", "mike23", "mike34"));
+    }
+
+    @Test
+    public void resultThreeLevelDottedQuery() {
+        setUpDottedQueryData();
+        // query - { "pet.name.first" : { "$eq" : "mike" } }
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$eq", "mike");
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("pet.name.first", op);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), contains("mike23"));
+    }
+
+    // When using non-ascii text
+
+    @Test
+    public void canQueryForNonAsciiValues() {
+        setUpNonAsciiQueryData();
+        assertThat(im.ensureIndexed(Arrays.<Object>asList("name"), "nonascii"), is("nonascii"));
+        // query - { "name" : { "$eq" : "اسم" } }
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$eq", "اسم");
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("name", op);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), contains("اسم34"));
+    }
+
+    @Test
+    public void canQueryUsingFieldsWithOddNames() {
+        setUpNonAsciiQueryData();
+        assertThat(im.ensureIndexed(Arrays.<Object>asList("اسم", "datatype", "age"), "nonascii"),
+                is("nonascii"));
+        // query - { "اسم" : { "$eq" : "fred" }, "age" : { "$eq" : 12 } }
+        Map<String, Object> op1 = new HashMap<String, Object>();
+        op1.put("$eq", "fred");
+        Map<String, Object> op2 = new HashMap<String, Object>();
+        op2.put("$eq", 12);
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("اسم", op1);
+        query.put("age", op2);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), contains("fredarabic"));
+
+        // query - { "datatype" : { "$eq" : "fred" }, "age" : { "$eq" : 12 } }
+        query.clear();
+        query.put("datatype", op1);
+        query.put("age", op2);
+        queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), contains("freddatatype"));
+    }
+
+    // When using OR queries
+
+    @Test
+    public void supportsUsingOR() {
+        setUpOrQueryData();
+        // query - { "$or" : [ { "name" : "mike" }, { "pet" : "cat" } ] }
+        Map<String, Object> op1 = new HashMap<String, Object>();
+        op1.put("name", "mike");
+        Map<String, Object> op2 = new HashMap<String, Object>();
+        op2.put("pet", "cat");
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("$or", Arrays.<Object>asList(op1, op2));
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), containsInAnyOrder("mike12",
+                                                                 "mike23",
+                                                                 "mike34",
+                                                                 "mike72",
+                                                                 "fred34"));
+    }
+
+    @Test
+    public void supportsUsingORWithSpecifiedOperator() {
+        setUpOrQueryData();
+        // query - { "$or" : [ { "name" : "mike" }, { "age" : { "$gt" : 30 } } ] }
+        Map<String, Object> op1 = new HashMap<String, Object>();
+        op1.put("name", "mike");  // 4
+        Map<String, Object> gtAge = new HashMap<String, Object>();
+        gtAge.put("$gt", 30);
+        Map<String, Object> op2 = new HashMap<String, Object>();
+        op2.put("age", gtAge);    // 1
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("$or", Arrays.<Object>asList(op1, op2));
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), containsInAnyOrder("mike12",
+                                                                 "mike23",
+                                                                 "mike34",
+                                                                 "mike72",
+                                                                 "fred34"));
+    }
+
+    @Test
+    public void supportsUsingORInSubTrees() {
+        setUpOrQueryData();
+        // query - { "$or" : [ { "name" : "fred" },
+        //                     { "$or" : [ { "age" : 12 },
+        //                                 { "pet" : "cat" }
+        //                               ]
+        //                     }
+        //                   ]
+        //         }
+        Map<String, Object> op1 = new HashMap<String, Object>();
+        op1.put("name", "fred");
+        Map<String, Object> eqAge = new HashMap<String, Object>();
+        eqAge.put("age", 12);
+        Map<String, Object> eqPet = new HashMap<String, Object>();
+        eqPet.put("pet", "cat");
+        Map<String, Object> op2 = new HashMap<String, Object>();
+        op2.put("$or", Arrays.<Object>asList(eqAge, eqPet));
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("$or", Arrays.<Object>asList(op1, op2));
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), containsInAnyOrder("fred12",
+                                                                 "fred34",
+                                                                 "mike12",
+                                                                 "mike72"));
+    }
+
+    @Test
+    public void supportsUsingORWithSingleOperand() {
+        setUpOrQueryData();
+        // query - { "$or" : [ { "name" : "mike" } ] }
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("name", "mike");
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("$or", Arrays.<Object>asList(op));
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), containsInAnyOrder("mike12",
+                                                                 "mike23",
+                                                                 "mike34",
+                                                                 "mike72"));
+    }
+
+    // When using nested queries
+
+    @Test
+    public void queryWithTwoLevels() {
+        setUpNestedQueryData();
+        // query - { "$or" : [ { "name" : "mike" },
+        //                     { "age" : 34 },
+        //                     { "$and" : [ { "name" : "fred" },
+        //                                  { "pet" : "snake" }
+        //                                ]
+        //                     }
+        //                   ]
+        //         }
+        Map<String, Object> nameMapLvl1 = new HashMap<String, Object>();
+        nameMapLvl1.put("name", "mike");
+        Map<String, Object> ageMapLvl1 = new HashMap<String, Object>();
+        ageMapLvl1.put("age", 34);
+        Map<String, Object> nameMapLvl2 = new HashMap<String, Object>();
+        nameMapLvl2.put("name", "fred");
+        Map<String, Object> petMapLvl2 = new HashMap<String, Object>();
+        petMapLvl2.put("pet", "snake");
+        Map<String, Object> opLvl2 = new HashMap<String, Object>();
+        opLvl2.put("$and", Arrays.<Object>asList(nameMapLvl2, petMapLvl2));
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("$or", Arrays.<Object>asList(nameMapLvl1, ageMapLvl1, opLvl2));
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), containsInAnyOrder("mike12",
+                                                                 "mike23",
+                                                                 "mike34",
+                                                                 "john34",
+                                                                 "fred43"));
+    }
+
+    @Test
+    public void queryORWithSubOR() {
+        setUpNestedQueryData();
+        // query - { "$or" : [ { "name" : "mike" },
+        //                     { "age" : 34 },
+        //                     { "$or" : [ { "name" : "fred" },
+        //                                  { "pet" : "hamster" }
+        //                                ]
+        //                     }
+        //                   ]
+        //         }
+        Map<String, Object> nameMapLvl1 = new HashMap<String, Object>();
+        nameMapLvl1.put("name", "mike");
+        Map<String, Object> ageMapLvl1 = new HashMap<String, Object>();
+        ageMapLvl1.put("age", 34);
+        Map<String, Object> nameMapLvl2 = new HashMap<String, Object>();
+        nameMapLvl2.put("name", "fred");
+        Map<String, Object> petMapLvl2 = new HashMap<String, Object>();
+        petMapLvl2.put("pet", "hamster");
+        Map<String, Object> opLvl2 = new HashMap<String, Object>();
+        opLvl2.put("$or", Arrays.<Object>asList(nameMapLvl2, petMapLvl2));
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("$or", Arrays.<Object>asList(nameMapLvl1, ageMapLvl1, opLvl2));
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), containsInAnyOrder("mike12",
+                                                                 "mike23",
+                                                                 "mike34",
+                                                                 "john34",
+                                                                 "fred43",
+                                                                 "fred12"));
+    }
+
+    @Test
+    public void queryANDWithSubAND() {
+        setUpNestedQueryData();
+        // No docs match all of these
+        //
+        // query - { "$and" : [ { "name" : "mike" },
+        //                      { "age" : 34 },
+        //                      { "$and" : [ { "name" : "fred" },
+        //                                   { "pet" : "snake" }
+        //                                 ]
+        //                      }
+        //                    ]
+        //         }
+        Map<String, Object> nameMapLvl1 = new HashMap<String, Object>();
+        nameMapLvl1.put("name", "mike");
+        Map<String, Object> ageMapLvl1 = new HashMap<String, Object>();
+        ageMapLvl1.put("age", 34);
+        Map<String, Object> nameMapLvl2 = new HashMap<String, Object>();
+        nameMapLvl2.put("name", "fred");
+        Map<String, Object> petMapLvl2 = new HashMap<String, Object>();
+        petMapLvl2.put("pet", "snake");
+        Map<String, Object> opLvl2 = new HashMap<String, Object>();
+        opLvl2.put("$and", Arrays.<Object>asList(nameMapLvl2, petMapLvl2));
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("$and", Arrays.<Object>asList(nameMapLvl1, ageMapLvl1, opLvl2));
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), is(empty()));
+    }
+
+    @Test
+    public void queryORWithSubAND() {
+        setUpNestedQueryData();
+        // No docs match all of these
+        //
+        // query - { "$or" : [ { "name" : "mike" },
+        //                     { "age" : 34 },
+        //                     { "$and" : [ { "name" : "fred" },
+        //                                  { "pet" : "cat" }
+        //                                ]
+        //                     }
+        //                   ]
+        //         }
+        Map<String, Object> nameMapLvl1 = new HashMap<String, Object>();
+        nameMapLvl1.put("name", "mike");
+        Map<String, Object> ageMapLvl1 = new HashMap<String, Object>();
+        ageMapLvl1.put("age", 34);
+        Map<String, Object> nameMapLvl2 = new HashMap<String, Object>();
+        nameMapLvl2.put("name", "fred");
+        Map<String, Object> petMapLvl2 = new HashMap<String, Object>();
+        petMapLvl2.put("pet", "cat");
+        Map<String, Object> opLvl2 = new HashMap<String, Object>();
+        opLvl2.put("$and", Arrays.<Object>asList(nameMapLvl2, petMapLvl2));
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("$or", Arrays.<Object>asList(nameMapLvl1, ageMapLvl1, opLvl2));
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), containsInAnyOrder("mike12",
+                                                                 "mike23",
+                                                                 "mike34",
+                                                                 "john34"));
+    }
+
+    @Test
+    public void queryANDWithSubOR() {
+        setUpNestedQueryData();
+        // No docs match all of these
+        //
+        // query - { "$and" : [ { "name" : "mike" },
+        //                      { "age" : 34 },
+        //                      { "$or" : [ { "name" : "fred" },
+        //                                  { "pet" : "cat" }
+        //                                ]
+        //                      }
+        //                    ]
+        //         }
+        Map<String, Object> nameMapLvl1 = new HashMap<String, Object>();
+        nameMapLvl1.put("name", "mike");
+        Map<String, Object> ageMapLvl1 = new HashMap<String, Object>();
+        ageMapLvl1.put("age", 34);
+        Map<String, Object> nameMapLvl2 = new HashMap<String, Object>();
+        nameMapLvl2.put("name", "fred");
+        Map<String, Object> petMapLvl2 = new HashMap<String, Object>();
+        petMapLvl2.put("pet", "dog");
+        Map<String, Object> opLvl2 = new HashMap<String, Object>();
+        opLvl2.put("$or", Arrays.<Object>asList(nameMapLvl2, petMapLvl2));
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("$and", Arrays.<Object>asList(nameMapLvl1, ageMapLvl1, opLvl2));
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), contains("mike34"));
+    }
+
+    @Test
+    public void queryMatchANDWithSubANDWithSubAND() {
+        setUpNestedQueryData();
+        // query - { "$and" : [ { "name" : "mike" },
+        //                      { "age" : { "$gt" : 10} },
+        //                      { "age" : { "$lt" : 30} },
+        //                      { "$and" : [ { "$and" : [ { "pet" : "cat" },
+        //                                                { "pet" : { "$gt" : "ant" }
+        //                                              ]
+        //                                   }
+        //                                 ]
+        //                      }
+        //                    ]
+        //         }
+        Map<String, Object> nameMapLvl1 = new HashMap<String, Object>();
+        nameMapLvl1.put("name", "mike");
+        Map<String, Object> ageGtOp = new HashMap<String, Object>();
+        ageGtOp.put("$gt", 10);
+        Map<String, Object> ageLtOp = new HashMap<String, Object>();
+        ageLtOp.put("$lt", 30);
+        Map<String, Object> ageMapGtLvl1 = new HashMap<String, Object>();
+        ageMapGtLvl1.put("age", ageGtOp);
+        Map<String, Object> ageMapLtLvl1 = new HashMap<String, Object>();
+        ageMapLtLvl1.put("age", ageLtOp);
+        Map<String, Object> petMapEqLvl3 = new HashMap<String, Object>();
+        petMapEqLvl3.put("pet", "cat");
+        Map<String, Object> petGtOpLvl3 = new HashMap<String, Object>();
+        petGtOpLvl3.put("$gt", "ant");
+        Map<String, Object> petMapGtLvl3 = new HashMap<String, Object>();
+        petMapGtLvl3.put("pet", petGtOpLvl3);
+        Map<String, Object> opLvl3 = new HashMap<String, Object>();
+        opLvl3.put("$and", Arrays.<Object>asList(petMapEqLvl3, petMapGtLvl3));
+        Map<String, Object> opLvl2 = new HashMap<String, Object>();
+        opLvl2.put("$and", Arrays.<Object>asList(opLvl3));
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("$and", Arrays.<Object>asList(nameMapLvl1, ageMapGtLvl1, ageMapLtLvl1, opLvl2));
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), contains("mike12"));
+    }
+
+    @Test
+    public void queryNoMatchANDWithSubANDWithSubAND() {
+        setUpNestedQueryData();
+        // query - { "$and" : [ { "name" : "mike" },
+        //                      { "age" : { "$gt" : 10} },
+        //                      { "age" : { "$lt" : 12} },
+        //                      { "$and" : [ { "$and" : [ { "pet" : "cat" },
+        //                                                { "pet" : { "$gt" : "ant" }
+        //                                              ]
+        //                                   }
+        //                                 ]
+        //                      }
+        //                    ]
+        //         }
+        Map<String, Object> nameMapLvl1 = new HashMap<String, Object>();
+        nameMapLvl1.put("name", "mike");
+        Map<String, Object> ageGtOp = new HashMap<String, Object>();
+        ageGtOp.put("$gt", 10);
+        Map<String, Object> ageLtOp = new HashMap<String, Object>();
+        ageLtOp.put("$lt", 12);
+        Map<String, Object> ageMapGtLvl1 = new HashMap<String, Object>();
+        ageMapGtLvl1.put("age", ageGtOp);
+        Map<String, Object> ageMapLtLvl1 = new HashMap<String, Object>();
+        ageMapLtLvl1.put("age", ageLtOp);
+        Map<String, Object> petMapEqLvl3 = new HashMap<String, Object>();
+        petMapEqLvl3.put("pet", "cat");
+        Map<String, Object> petGtOpLvl3 = new HashMap<String, Object>();
+        petGtOpLvl3.put("$gt", "ant");
+        Map<String, Object> petMapGtLvl3 = new HashMap<String, Object>();
+        petMapGtLvl3.put("pet", petGtOpLvl3);
+        Map<String, Object> opLvl3 = new HashMap<String, Object>();
+        opLvl3.put("$and", Arrays.<Object>asList(petMapEqLvl3, petMapGtLvl3));
+        Map<String, Object> opLvl2 = new HashMap<String, Object>();
+        opLvl2.put("$and", Arrays.<Object>asList(opLvl3));
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("$and", Arrays.<Object>asList(nameMapLvl1, ageMapGtLvl1, ageMapLtLvl1, opLvl2));
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), is(empty()));
+    }
+
+    @Test
+    public void queryORWithSubORAndSubAND() {
+        setUpNestedQueryData();
+        // query - { "$or" : [ { "name" : "mike" },
+        //                     { "pet" : "cat" },
+        //                     { "$or" : [ { "name" : "mike" },
+        //                                 { "pet" : "snake" }
+        //                               ]
+        //                     },
+        //                     { "$and" : [ { "name" : "mike" },
+        //                                  { "pet" : "snake" }
+        //                                ]
+        //                     }
+        //                   ]
+        //         }
+        Map<String, Object> nameMapLvl1 = new HashMap<String, Object>();
+        nameMapLvl1.put("name", "mike");
+        Map<String, Object> petMapLvl1 = new HashMap<String, Object>();
+        petMapLvl1.put("pet", "cat");
+        Map<String, Object> nameMapOrLvl2 = new HashMap<String, Object>();
+        nameMapOrLvl2.put("name", "mike");
+        Map<String, Object> petMapOrLvl2 = new HashMap<String, Object>();
+        petMapOrLvl2.put("pet", "snake");
+        Map<String, Object> orOpLvl2 = new HashMap<String, Object>();
+        orOpLvl2.put("$or", Arrays.<Object>asList(nameMapOrLvl2, petMapOrLvl2));
+        Map<String, Object> nameMapAndLvl2 = new HashMap<String, Object>();
+        nameMapAndLvl2.put("name", "mike");
+        Map<String, Object> petMapAndLvl2 = new HashMap<String, Object>();
+        petMapAndLvl2.put("pet", "snake");
+        Map<String, Object> andOpLvl2 = new HashMap<String, Object>();
+        andOpLvl2.put("$and", Arrays.<Object>asList(nameMapAndLvl2, petMapAndLvl2));
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("$or", Arrays.<Object>asList(nameMapLvl1, petMapLvl1, orOpLvl2, andOpLvl2));
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), containsInAnyOrder("mike12",
+                                                                 "mike23",
+                                                                 "mike34",
+                                                                 "fred43"));
+    }
+
+    // When querying using _id
+
+    @Test
+    public void queryUsing_idWorksAsASingleClause() {
+        setUpBasicQueryData();
+        // query - { "_id" : "mike12" }
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("_id", "mike12");
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), contains("mike12"));
+    }
+
+    @Test
+    public void queryUsing_idWorksWithOtherClauses() {
+        setUpBasicQueryData();
+        // query - { "_id" : "mike12", "name" : "mike" }
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("_id", "mike12");
+        query.put("name", "mike");
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), contains("mike12"));
+    }
+
+    // When querying using _rev
+
+    @Test
+    public void queryUsing_revWorksAsASingleClause() {
+        setUpBasicQueryData();
+        String docRev = ds.getDocument("mike12").getRevision();
+        // query - { "_rev" : <docRev> }
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("_rev", docRev);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), contains("mike12"));
+    }
+
+    @Test
+    public void queryUsing_revWorksWithOtherClauses() {
+        setUpBasicQueryData();
+        String docRev = ds.getDocument("mike12").getRevision();
+        // query - { "_rev" : <docRev>, "name" : "mike" }
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("_rev", docRev);
+        query.put("name", "mike");
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), contains("mike12"));
+    }
+
+    // When querying using $not operator
+
+    @Test
+    public void canQueryOverOneStringFieldUsingNOT() {
+        setUpBasicQueryData();
+        // query - { "name" : { "$not" : { "$eq" : "mike" } } }
+        Map<String, Object> eqOp = new HashMap<String, Object>();
+        eqOp.put("$eq", "mike");
+        Map<String, Object> notOp = new HashMap<String, Object>();
+        notOp.put("$not", eqOp);
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("name", notOp);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), containsInAnyOrder("fred12", "fred34"));
+    }
+
+    @Test
+    public void canQueryOverOneIntegerFieldUsingNOT() {
+        setUpBasicQueryData();
+        // query - { "age" : { "$not" : { "$gt" : 34 } } }
+        Map<String, Object> gtOp = new HashMap<String, Object>();
+        gtOp.put("$gt", 34);
+        Map<String, Object> notOp = new HashMap<String, Object>();
+        notOp.put("$not", gtOp);
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("age", notOp);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), containsInAnyOrder("fred12",
+                                                                 "fred34",
+                                                                 "mike12",
+                                                                 "mike34"));
+    }
+
+    @Test
+    public void includesDocumentsWithoutFieldIndexedUsingNOT() {
+        setUpBasicQueryData();
+        // query - { "pet" : { "$not" : { "$eq" : "cat" } } }
+        Map<String, Object> eqOp = new HashMap<String, Object>();
+        eqOp.put("$eq", "cat");
+        Map<String, Object> notOp = new HashMap<String, Object>();
+        notOp.put("$not", eqOp);
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("pet", notOp);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), containsInAnyOrder("fred12", "mike34"));
+    }
+
+    @Test
+    public void queryMatchWithANDCompoundOperatorUsingNOT() {
+        setUpBasicQueryData();
+        // query - { "$and: [ { "pet" : { "$not" : { "$eq" : "cat" } } },
+        //                    { "pet" : { "$not" : { "$eq" : "dog" } } }
+        //                  ]
+        //         }
+        Map<String, Object> eqOp1 = new HashMap<String, Object>();
+        eqOp1.put("$eq", "cat");
+        Map<String, Object> notOp1 = new HashMap<String, Object>();
+        notOp1.put("$not", eqOp1);
+        Map<String, Object> petMap1 = new HashMap<String, Object>();
+        petMap1.put("pet", notOp1);
+        Map<String, Object> eqOp2 = new HashMap<String, Object>();
+        eqOp2.put("$eq", "dog");
+        Map<String, Object> notOp2 = new HashMap<String, Object>();
+        notOp2.put("$not", eqOp2);
+        Map<String, Object> petMap2 = new HashMap<String, Object>();
+        petMap2.put("pet", notOp2);
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("$and", Arrays.<Object>asList(petMap1, petMap2));
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), containsInAnyOrder("fred12"));
+    }
+
+    @Test
+    public void queryNoMatchWithANDCompoundOperatorUsingNOT() {
+        setUpBasicQueryData();
+        // query - { "$and: [ { "pet" : { "$not" : { "$eq" : "cat" } } },
+        //                    { "pet" : { "$eq" : "cat" } }
+        //                  ]
+        //         }
+        Map<String, Object> eqOp1 = new HashMap<String, Object>();
+        eqOp1.put("$eq", "cat");
+        Map<String, Object> notOp1 = new HashMap<String, Object>();
+        notOp1.put("$not", eqOp1);
+        Map<String, Object> petMap1 = new HashMap<String, Object>();
+        petMap1.put("pet", notOp1);
+        Map<String, Object> eqOp2 = new HashMap<String, Object>();
+        eqOp2.put("$eq", "cat");
+        Map<String, Object> petMap2 = new HashMap<String, Object>();
+        petMap2.put("pet", eqOp2);
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("$and", Arrays.<Object>asList(petMap1, petMap2));
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), is(empty()));
+    }
+
+    @Test
+    public void queryMatchWithORCompoundOperatorUsingNOT() {
+        setUpBasicQueryData();
+        // query - { "$or: [ { "pet" : { "$not" : { "$eq" : "cat" } } },
+        //                   { "pet" : { "$not" : { "$eq" : "dog" } } }
+        //                 ]
+        //         }
+        Map<String, Object> eqOp1 = new HashMap<String, Object>();
+        eqOp1.put("$eq", "cat");
+        Map<String, Object> notOp1 = new HashMap<String, Object>();
+        notOp1.put("$not", eqOp1);
+        Map<String, Object> petMap1 = new HashMap<String, Object>();
+        petMap1.put("pet", notOp1);
+        Map<String, Object> eqOp2 = new HashMap<String, Object>();
+        eqOp2.put("$eq", "dog");
+        Map<String, Object> notOp2 = new HashMap<String, Object>();
+        notOp2.put("$not", eqOp2);
+        Map<String, Object> petMap2 = new HashMap<String, Object>();
+        petMap2.put("pet", notOp2);
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("$or", Arrays.<Object>asList(petMap1, petMap2));
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), containsInAnyOrder("mike12",
+                                                                 "mike34",
+                                                                 "mike72",
+                                                                 "fred34",
+                                                                 "fred12"));
+    }
+
+    // When indexing array fields
+
+    @Test
+    public void canFindDocumentWithArray() {
+        setUpArrayIndexingData();
+        // query - { "pet" : { "$eq" : "dog" } }
+        Map<String, Object> operator = new HashMap<String, Object>();
+        operator.put("$eq", "dog");
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("pet", operator);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), containsInAnyOrder("mike12"));
+    }
+
+    @Test
+    public void canFindDocumentWithoutArray() {
+        setUpArrayIndexingData();
+        // query - { "pet" : { "$eq" : "parrot" } }
+        Map<String, Object> operator = new HashMap<String, Object>();
+        operator.put("$eq", "parrot");
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("pet", operator);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), containsInAnyOrder("fred34"));
+    }
+
+    @Test
+    public void canFindDocumentsWithAndWithoutArraysUsingNOT() {
+        setUpArrayIndexingData();
+        // query - { "pet" : { "$not" : { "$eq" : "dog" } } }
+        Map<String, Object> eqOp = new HashMap<String, Object>();
+        eqOp.put("$eq", "dog");
+        Map<String, Object> notOp = new HashMap<String, Object>();
+        notOp.put("$not", eqOp);
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("pet", notOp);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), containsInAnyOrder("mike12", "fred34"));
+    }
+
+    // When querying using $exists operator
+
+    @Test
+    public void canFindDocumentWhereFieldDoesNotExist() {
+        setUpBasicQueryData();
+        // query - { "pet" : { "$exists" : false } }
+        Map<String, Object> operator = new HashMap<String, Object>();
+        operator.put("$exists", false);
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("pet", operator);
+        System.out.println(query);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), contains("fred12"));
+    }
+
+    @Test
+    public void canFindDocumentWhereFieldDoesExist() {
+        setUpBasicQueryData();
+        // query - { "pet" : { "$exists" : true } }
+        Map<String, Object> operator = new HashMap<String, Object>();
+        operator.put("$exists", true);
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("pet", operator);
+        System.out.println(query);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), containsInAnyOrder("mike12",
+                "mike34",
+                "mike72",
+                "fred34"));
+    }
+
+    @Test
+    public void canFindDocumentWhereFieldDoesExistUsingNOT() {
+        setUpBasicQueryData();
+        // query - { "pet" : { "$not" : { "$exists" : false } } }
+        Map<String, Object> existsOp = new HashMap<String, Object>();
+        existsOp.put("$exists", false);
+        Map<String, Object> notOp = new HashMap<String, Object>();
+        notOp.put("$not", existsOp);
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("pet", notOp);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), containsInAnyOrder("mike12",
+                                                                 "mike34",
+                                                                 "mike72",
+                                                                 "fred34"));
+    }
+
+    @Test
+    public void canFindDocumentWhereFieldDoesNotExistUsingNOT() {
+        setUpBasicQueryData();
+        // query - { "pet" : { "$not" : { "$exists" : true } } }
+        Map<String, Object> existsOp = new HashMap<String, Object>();
+        existsOp.put("$exists", true);
+        Map<String, Object> notOp = new HashMap<String, Object>();
+        notOp.put("$not", existsOp);
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("pet", notOp);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), contains("fred12"));
+    }
+
+    // When there is a large result set
+
+    @Test
+     public void limitsCorrectlyWithLargeResultSet() {
+        setUpLargeResultSetQueryData();
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("large_field", "cat");
+        QueryResult queryResult = im.find(query, 0, 60, null, null);
+        assertThat(queryResult.documentIds().size(), is(60));
+    }
+
+    @Test
+    public void skipsAndLimitsAcrossBatchBorder() {
+        setUpLargeResultSetQueryData();
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("large_field", "cat");
+        QueryResult queryResult = im.find(query, 90, 20, null, null);
+        assertThat(queryResult.size(), is(20));
+        // Uncomment remainder of test after query sorting is implemented
+        //List<String> expected = new ArrayList<String>();
+        //for (int i = 90; i < 110; i++) {
+        //    expected.add(String.format("d%d", i));
+        //}
+        //assertThat(queryResult, containsInAnyOrder(expected.toArray()));
     }
 
 }

--- a/sync-core/src/test/java/com/cloudant/sync/query/AbstractQueryTestSetUp.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/AbstractQueryTestSetUp.java
@@ -1,0 +1,574 @@
+//  Copyright (c) 2014 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+package com.cloudant.sync.query;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import com.cloudant.sync.datastore.DatastoreExtended;
+import com.cloudant.sync.datastore.DatastoreManager;
+import com.cloudant.sync.datastore.DocumentBodyFactory;
+import com.cloudant.sync.datastore.MutableDocumentRevision;
+import com.cloudant.sync.sqlite.SQLDatabase;
+import com.cloudant.sync.util.TestUtils;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ *  The purpose of this abstract class is to provide setup methods that include
+ *  the loading of test data and the creation of indexes for use by the
+ *  {@link com.cloudant.sync.query.AbstractQueryTestBase} class and the
+ *  {@link com.cloudant.sync.query.AbstractQueryExtendedTestBase} class test methods.
+ *
+ *  @see com.cloudant.sync.query.AbstractQueryTestBase
+ *  @see com.cloudant.sync.query.AbstractQueryExtendedTestBase
+ */
+public abstract class AbstractQueryTestSetUp {
+
+    String factoryPath = null;
+    DatastoreManager factory = null;
+    DatastoreExtended ds = null;
+    IndexManager im = null;
+    SQLDatabase db = null;
+
+    @Before
+    public void setUp() throws SQLException {
+        factoryPath = TestUtils.createTempTestingDir(AbstractQueryTestSetUp.class.getName());
+        assertThat(factoryPath, is(notNullValue()));
+        factory = new DatastoreManager(factoryPath);
+        assertThat(factory, is(notNullValue()));
+        String datastoreName = AbstractQueryTestSetUp.class.getSimpleName();
+        ds = (DatastoreExtended) factory.openDatastore(datastoreName);
+        assertThat(ds, is(notNullValue()));
+    }
+
+    @After
+    public void tearDown() {
+        im.close();
+        assertThat(im.getQueue().isShutdown(), is(true));
+        ds.close();
+        TestUtils.deleteDatabaseQuietly(db);
+        TestUtils.deleteTempTestingDir(factoryPath);
+
+        im = null;
+        ds = null;
+        factory = null;
+        factoryPath = null;
+    }
+
+    // Used to setup document data testing:
+    // - When executing AND queries
+    // - When limiting and offsetting results
+    // - When querying using _id
+    // - When querying using _rev
+    // - When querying using $not operator
+    // - When querying using $exists operator
+    public void setUpBasicQueryData() {
+        MutableDocumentRevision rev = new MutableDocumentRevision();
+        rev.docId = "mike12";
+        Map<String, Object> bodyMap = new HashMap<String, Object>();
+        bodyMap.put("name", "mike");
+        bodyMap.put("age", 12);
+        bodyMap.put("pet", "cat");
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        try {
+            ds.createDocumentFromRevision(rev);
+        } catch (IOException e) {
+            e.printStackTrace();
+            Assert.fail("Failed to create document revision");
+        }
+
+        rev.docId = "mike34";
+        bodyMap.clear();
+        bodyMap.put("name", "mike");
+        bodyMap.put("age", 34);
+        bodyMap.put("pet", "dog");
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        try {
+            ds.createDocumentFromRevision(rev);
+        } catch (IOException e) {
+            e.printStackTrace();
+            Assert.fail("Failed to create document revision");
+        }
+
+        rev.docId = "mike72";
+        bodyMap.clear();
+        bodyMap.put("name", "mike");
+        bodyMap.put("age", 72);
+        bodyMap.put("pet", "cat");
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        try {
+            ds.createDocumentFromRevision(rev);
+        } catch (IOException e) {
+            e.printStackTrace();
+            Assert.fail("Failed to create document revision");
+        }
+
+        rev.docId = "fred34";
+        bodyMap.clear();
+        bodyMap.put("name", "fred");
+        bodyMap.put("age", 34);
+        bodyMap.put("pet", "cat");
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        try {
+            ds.createDocumentFromRevision(rev);
+        } catch (IOException e) {
+            e.printStackTrace();
+            Assert.fail("Failed to create document revision");
+        }
+
+        rev.docId = "fred12";
+        bodyMap.clear();
+        bodyMap.put("name", "fred");
+        bodyMap.put("age", 12);
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        try {
+            ds.createDocumentFromRevision(rev);
+        } catch (IOException e) {
+            e.printStackTrace();
+            Assert.fail("Failed to create document revision");
+        }
+
+        assertThat(im.ensureIndexed(Arrays.<Object>asList("name", "age"), "basic"), is("basic"));
+        assertThat(im.ensureIndexed(Arrays.<Object>asList("name", "pet"), "pet"), is("pet"));
+    }
+
+    // Used to setup document data testing:
+    // - When using dotted notation
+    public void setUpDottedQueryData() {
+        setUpSharedDocs();
+
+        assertThat(im.ensureIndexed(Arrays.<Object>asList("age", "pet.name", "pet.species"), "pet"),
+                is("pet"));
+        assertThat(im.ensureIndexed(Arrays.<Object>asList("name", "pet.name.first"), "firstname"),
+                is("firstname"));
+    }
+
+    // Used to setup document data testing:
+    // - When using non-ascii text
+    public void setUpNonAsciiQueryData() {
+        MutableDocumentRevision rev = new MutableDocumentRevision();
+        rev.docId = "mike12";
+        Map<String, Object> bodyMap = new HashMap<String, Object>();
+        bodyMap.put("name", "mike");
+        bodyMap.put("age", 12);
+        bodyMap.put("pet", "cat");
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        try {
+            ds.createDocumentFromRevision(rev);
+        } catch (IOException e) {
+            e.printStackTrace();
+            Assert.fail("Failed to create document revision");
+        }
+
+        rev.docId = "mike34";
+        bodyMap.clear();
+        bodyMap.put("name", "mike");
+        bodyMap.put("age", 34);
+        bodyMap.put("pet", "dog");
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        try {
+            ds.createDocumentFromRevision(rev);
+        } catch (IOException e) {
+            e.printStackTrace();
+            Assert.fail("Failed to create document revision");
+        }
+
+        rev.docId = "mike72";
+        bodyMap.clear();
+        bodyMap.put("name", "mike");
+        bodyMap.put("age", 72);
+        bodyMap.put("pet", "cat");
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        try {
+            ds.createDocumentFromRevision(rev);
+        } catch (IOException e) {
+            e.printStackTrace();
+            Assert.fail("Failed to create document revision");
+        }
+
+        rev.docId = "اسم34";
+        bodyMap.clear();
+        bodyMap.put("name", "اسم");
+        bodyMap.put("age", 34);
+        bodyMap.put("pet", "cat");
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        try {
+            ds.createDocumentFromRevision(rev);
+        } catch (IOException e) {
+            e.printStackTrace();
+            Assert.fail("Failed to create document revision");
+        }
+
+        rev.docId = "fred12";
+        bodyMap.clear();
+        bodyMap.put("name", "fred");
+        bodyMap.put("age", 12);
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        try {
+            ds.createDocumentFromRevision(rev);
+        } catch (IOException e) {
+            e.printStackTrace();
+            Assert.fail("Failed to create document revision");
+        }
+
+        rev.docId = "fredarabic";
+        bodyMap.clear();
+        bodyMap.put("اسم", "fred");
+        bodyMap.put("age", 12);
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        try {
+            ds.createDocumentFromRevision(rev);
+        } catch (IOException e) {
+            e.printStackTrace();
+            Assert.fail("Failed to create document revision");
+        }
+
+        rev.docId = "freddatatype";
+        bodyMap.clear();
+        bodyMap.put("datatype", "fred");
+        bodyMap.put("age", 12);
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        try {
+            ds.createDocumentFromRevision(rev);
+        } catch (IOException e) {
+            e.printStackTrace();
+            Assert.fail("Failed to create document revision");
+        }
+    }
+
+    // Used to setup document data testing:
+    // - When using OR queries
+    public void setUpOrQueryData() {
+        setUpSharedDocs();
+
+        assertThat(im.ensureIndexed(Arrays.<Object>asList("age", "pet", "name"), "basic"),
+                is("basic"));
+        assertThat(im.ensureIndexed(Arrays.<Object>asList("age", "pet.name", "pet.species"), "pet"),
+                is("pet"));
+        assertThat(im.ensureIndexed(Arrays.<Object>asList("age", "pet.name.first"), "firstname"),
+                is("firstname"));
+    }
+
+    // Used to setup document data testing:
+    // - When using nested queries
+    public void setUpNestedQueryData() {
+        MutableDocumentRevision rev = new MutableDocumentRevision();
+        rev.docId = "mike12";
+        Map<String, Object> bodyMap = new HashMap<String, Object>();
+        bodyMap.put("name", "mike");
+        bodyMap.put("age", 12);
+        bodyMap.put("pet", "cat");
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        try {
+            ds.createDocumentFromRevision(rev);
+        } catch (IOException e) {
+            e.printStackTrace();
+            Assert.fail("Failed to create document revision");
+        }
+        rev.docId = "mike23";
+        bodyMap.clear();
+        bodyMap.put("name", "mike");
+        bodyMap.put("age", 23);
+        bodyMap.put("pet", "parrot");
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        try {
+            ds.createDocumentFromRevision(rev);
+        } catch (IOException e) {
+            e.printStackTrace();
+            Assert.fail("Failed to create document revision");
+        }
+
+        rev.docId = "mike34";
+        bodyMap.clear();
+        bodyMap.put("name", "mike");
+        bodyMap.put("age", 34);
+        bodyMap.put("pet", "dog");
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        try {
+            ds.createDocumentFromRevision(rev);
+        } catch (IOException e) {
+            e.printStackTrace();
+            Assert.fail("Failed to create document revision");
+        }
+        rev.docId = "john34";
+        bodyMap.clear();
+        bodyMap.put("name", "john");
+        bodyMap.put("age", 34);
+        bodyMap.put("pet", "fish");
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        try {
+            ds.createDocumentFromRevision(rev);
+        } catch (IOException e) {
+            e.printStackTrace();
+            Assert.fail("Failed to create document revision");
+        }
+
+        rev.docId = "fred43";
+        bodyMap.clear();
+        bodyMap.put("name", "fred");
+        bodyMap.put("age", 43);
+        bodyMap.put("pet", "snake");
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        try {
+            ds.createDocumentFromRevision(rev);
+        } catch (IOException e) {
+            e.printStackTrace();
+            Assert.fail("Failed to create document revision");
+        }
+
+        rev.docId = "fred12";
+        bodyMap.clear();
+        bodyMap.put("name", "fred");
+        bodyMap.put("age", 12);
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        try {
+            ds.createDocumentFromRevision(rev);
+        } catch (IOException e) {
+            e.printStackTrace();
+            Assert.fail("Failed to create document revision");
+        }
+
+        assertThat(im.ensureIndexed(Arrays.<Object>asList("age", "pet", "name"), "basic"),
+                is("basic"));
+    }
+
+    // Used to setup document data testing:
+    // - When indexing array fields
+    public void setUpArrayIndexingData() {
+        MutableDocumentRevision rev = new MutableDocumentRevision();
+        rev.docId = "mike12";
+        Map<String, Object> bodyMap = new HashMap<String, Object>();
+        bodyMap.put("name", "mike");
+        bodyMap.put("age", 12);
+        bodyMap.put("pet", Arrays.<Object>asList("cat", "dog"));
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        try {
+            ds.createDocumentFromRevision(rev);
+        } catch (IOException e) {
+            e.printStackTrace();
+            Assert.fail("Failed to create document revision");
+        }
+        rev.docId = "fred34";
+        bodyMap.clear();
+        bodyMap.put("name", "fred");
+        bodyMap.put("age", 34);
+        bodyMap.put("pet", "parrot");
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        try {
+            ds.createDocumentFromRevision(rev);
+        } catch (IOException e) {
+            e.printStackTrace();
+            Assert.fail("Failed to create document revision");
+        }
+
+        assertThat(im.ensureIndexed(Arrays.<Object>asList("name", "pet", "age"), "pet"),
+                is("pet"));
+    }
+
+    // Used to setup document data testing:
+    // - When there is a large result set
+    public void setUpLargeResultSetQueryData() {
+        MutableDocumentRevision rev = new MutableDocumentRevision();
+        for (int i = 0; i < 150; i++) {
+            rev.docId = String.format("d%d", i);
+            Map<String, Object> bodyMap = new HashMap<String, Object>();
+            bodyMap.put("large_field", "cat");
+            bodyMap.put("idx", i);
+            rev.body = DocumentBodyFactory.create(bodyMap);
+            try {
+                ds.createDocumentFromRevision(rev);
+            } catch (IOException e) {
+                e.printStackTrace();
+                Assert.fail("Failed to create document revision");
+            }
+        }
+        assertThat(im.ensureIndexed(Arrays.<Object>asList("large_field", "idx"), "large"),
+                is("large"));
+    }
+
+    // Used to setup document data testing for queries without covering indexes:
+    // - When executing queries
+    public void setUpWithoutCoveringIndexesQueryData() {
+        MutableDocumentRevision rev = new MutableDocumentRevision();
+        rev.docId = "mike12";
+        Map<String, Object> bodyMap = new HashMap<String, Object>();
+        bodyMap.put("name", "mike");
+        bodyMap.put("age", 12);
+        bodyMap.put("pet", "cat");
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        try {
+            ds.createDocumentFromRevision(rev);
+        } catch (IOException e) {
+            e.printStackTrace();
+            Assert.fail("Failed to create document revision");
+        }
+
+        rev.docId = "mike34";
+        bodyMap.clear();
+        bodyMap.put("name", "mike");
+        bodyMap.put("age", 34);
+        bodyMap.put("pet", "dog");
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        try {
+            ds.createDocumentFromRevision(rev);
+        } catch (IOException e) {
+            e.printStackTrace();
+            Assert.fail("Failed to create document revision");
+        }
+
+        rev.docId = "mike72";
+        bodyMap.clear();
+        bodyMap.put("name", "mike");
+        bodyMap.put("age", 72);
+        bodyMap.put("pet", "cat");
+        bodyMap.put("town", "bristol");
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        try {
+            ds.createDocumentFromRevision(rev);
+        } catch (IOException e) {
+            e.printStackTrace();
+            Assert.fail("Failed to create document revision");
+        }
+
+        rev.docId = "fred34";
+        bodyMap.clear();
+        bodyMap.put("name", "fred");
+        bodyMap.put("age", 34);
+        bodyMap.put("pet", "cat");
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        try {
+            ds.createDocumentFromRevision(rev);
+        } catch (IOException e) {
+            e.printStackTrace();
+            Assert.fail("Failed to create document revision");
+        }
+
+        rev.docId = "fred12";
+        bodyMap.clear();
+        bodyMap.put("name", "fred");
+        bodyMap.put("age", 12);
+        bodyMap.put("town", "bristol");
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        try {
+            ds.createDocumentFromRevision(rev);
+        } catch (IOException e) {
+            e.printStackTrace();
+            Assert.fail("Failed to create document revision");
+        }
+
+        assertThat(im.ensureIndexed(Arrays.<Object>asList("name", "age"), "basic"), is("basic"));
+        assertThat(im.ensureIndexed(Arrays.<Object>asList("name", "pet"), "pet"), is("pet"));
+    }
+
+    private void setUpSharedDocs() {
+        MutableDocumentRevision rev = new MutableDocumentRevision();
+        rev.docId = "mike12";
+        Map<String, Object> bodyMap = new HashMap<String, Object>();
+        bodyMap.put("name", "mike");
+        bodyMap.put("age", 12);
+        Map<String, Object> petMap = new HashMap<String, Object>();
+        petMap.put("species", "cat");
+        petMap.put("name", "mike");
+        bodyMap.put("pet", petMap);
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        try {
+            ds.createDocumentFromRevision(rev);
+        } catch (IOException e) {
+            e.printStackTrace();
+            Assert.fail("Failed to create document revision");
+        }
+
+        rev.docId = "mike23";
+        bodyMap.clear();
+        bodyMap.put("name", "mike");
+        bodyMap.put("age", 23);
+        petMap.clear();
+        petMap.put("species", "cat");
+        Map<String, Object> petNameMap = new HashMap<String, Object>();
+        petNameMap.put("first", "mike");
+        petMap.put("name", petNameMap);
+        bodyMap.put("pet", petMap);
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        try {
+            ds.createDocumentFromRevision(rev);
+        } catch (IOException e) {
+            e.printStackTrace();
+            Assert.fail("Failed to create document revision");
+        }
+
+        rev.docId = "mike34";
+        bodyMap.clear();
+        bodyMap.put("name", "mike");
+        bodyMap.put("age", 34);
+        petMap.clear();
+        petMap.put("species", "cat");
+        petMap.put("name", "mike");
+        bodyMap.put("pet", petMap);
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        try {
+            ds.createDocumentFromRevision(rev);
+        } catch (IOException e) {
+            e.printStackTrace();
+            Assert.fail("Failed to create document revision");
+        }
+
+        rev.docId = "mike72";
+        bodyMap.clear();
+        bodyMap.put("name", "mike");
+        bodyMap.put("age", 72);
+        bodyMap.put("pet", "cat");
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        try {
+            ds.createDocumentFromRevision(rev);
+        } catch (IOException e) {
+            e.printStackTrace();
+            Assert.fail("Failed to create document revision");
+        }
+
+        rev.docId = "fred34";
+        bodyMap.clear();
+        bodyMap.put("name", "fred");
+        bodyMap.put("age", 34);
+        bodyMap.put("pet", "cat");
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        try {
+            ds.createDocumentFromRevision(rev);
+        } catch (IOException e) {
+            e.printStackTrace();
+            Assert.fail("Failed to create document revision");
+        }
+
+        rev.docId = "fred12";
+        bodyMap.clear();
+        bodyMap.put("name", "fred");
+        bodyMap.put("age", 12);
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        try {
+            ds.createDocumentFromRevision(rev);
+        } catch (IOException e) {
+            e.printStackTrace();
+            Assert.fail("Failed to create document revision");
+        }
+    }
+
+}

--- a/sync-core/src/test/java/com/cloudant/sync/query/QueryExecutorMatcherTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/QueryExecutorMatcherTest.java
@@ -19,19 +19,18 @@ import static org.hamcrest.Matchers.notNullValue;
 import com.cloudant.sync.util.SQLDatabaseTestUtils;
 
 import java.sql.SQLException;
-import java.util.Arrays;
 
 /**
  * This class uses the {@link com.cloudant.sync.query.MockMatcherIndexManager}, a mocked up,
  * sub class of the {@link com.cloudant.sync.query.IndexManager} to force all tests defined in
- * {@link com.cloudant.sync.query.AbstractQueryTestBase} to exclusively exercise the post hoc
- * matcher logic.
+ * {@link com.cloudant.sync.query.AbstractQueryExtendedTestBase} to exclusively exercise the
+ * post hoc matcher logic.
  *
  * @see com.cloudant.sync.query.MockMatcherIndexManager
  * @see com.cloudant.sync.query.IndexManager
- * @see com.cloudant.sync.query.AbstractQueryTestBase
+ * @see com.cloudant.sync.query.AbstractQueryExtendedTestBase
  */
-public class QueryExecutorMatcherTest extends AbstractQueryTestBase {
+public class QueryExecutorMatcherTest extends AbstractQueryExtendedTestBase {
     @Override
     public void setUp() throws SQLException {
         super.setUp();
@@ -42,8 +41,5 @@ public class QueryExecutorMatcherTest extends AbstractQueryTestBase {
         assertThat(im.getQueue(), is(notNullValue()));
         String[] metadataTableList = new String[] { IndexManager.INDEX_METADATA_TABLE_NAME };
         SQLDatabaseTestUtils.assertTablesExist(db, metadataTableList);
-
-        // Index needs to exist but definition is irrelevant.  All tests here use post hoc matcher.
-        assertThat(im.ensureIndexed(Arrays.<Object>asList("noField"), "bogus"), is("bogus"));
     }
 }

--- a/sync-core/src/test/java/com/cloudant/sync/query/QueryExecutorSQLOnlyTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/QueryExecutorSQLOnlyTest.java
@@ -19,13 +19,12 @@ import static org.hamcrest.Matchers.notNullValue;
 import com.cloudant.sync.util.SQLDatabaseTestUtils;
 
 import java.sql.SQLException;
-import java.util.Arrays;
 
 /**
  * This class uses the {@link com.cloudant.sync.query.MockSQLOnlyIndexManager}, a mocked up,
  * sub class of the {@link com.cloudant.sync.query.IndexManager} to force all tests defined in
- * {@link com.cloudant.sync.query.AbstractQueryTestBase} to exclusively exercise the post hoc
- * matcher logic.
+ * {@link com.cloudant.sync.query.AbstractQueryTestBase} to exclusively exercise the
+ * SQL Engine logic.
  *
  * @see com.cloudant.sync.query.MockSQLOnlyIndexManager
  * @see com.cloudant.sync.query.IndexManager
@@ -42,8 +41,5 @@ public class QueryExecutorSQLOnlyTest extends AbstractQueryTestBase {
         assertThat(im.getQueue(), is(notNullValue()));
         String[] metadataTableList = new String[] { IndexManager.INDEX_METADATA_TABLE_NAME };
         SQLDatabaseTestUtils.assertTablesExist(db, metadataTableList);
-
-        assertThat(im.ensureIndexed(Arrays.<Object>asList("name", "age"), "basic"), is("basic"));
-        assertThat(im.ensureIndexed(Arrays.<Object>asList("name", "pet"), "pet"), is("pet"));
     }
 }

--- a/sync-core/src/test/java/com/cloudant/sync/query/QueryExecutorStandardTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/QueryExecutorStandardTest.java
@@ -19,17 +19,16 @@ import static org.hamcrest.Matchers.notNullValue;
 import com.cloudant.sync.util.SQLDatabaseTestUtils;
 
 import java.sql.SQLException;
-import java.util.Arrays;
 
 /**
  * This class uses the {@link IndexManager}, to allow all tests defined in
- * {@link AbstractQueryTestBase} to run in the standard manner that queries
+ * {@link AbstractQueryExtendedTestBase} to run in the standard manner that queries
  * would normally execute in a production setting.
  *
  * @see IndexManager
- * @see AbstractQueryTestBase
+ * @see AbstractQueryExtendedTestBase
  */
-public class QueryExecutorStandardTest extends AbstractQueryTestBase {
+public class QueryExecutorStandardTest extends AbstractQueryExtendedTestBase {
     @Override
     public void setUp() throws SQLException {
         super.setUp();
@@ -40,8 +39,5 @@ public class QueryExecutorStandardTest extends AbstractQueryTestBase {
         assertThat(im.getQueue(), is(notNullValue()));
         String[] metadataTableList = new String[] { IndexManager.INDEX_METADATA_TABLE_NAME };
         SQLDatabaseTestUtils.assertTablesExist(db, metadataTableList);
-
-        assertThat(im.ensureIndexed(Arrays.<Object>asList("name", "age"), "basic"), is("basic"));
-        assertThat(im.ensureIndexed(Arrays.<Object>asList("name", "pet"), "pet"), is("pet"));
     }
 }

--- a/sync-core/src/test/java/com/cloudant/sync/query/QuerySqlTranslatorTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/QuerySqlTranslatorTest.java
@@ -115,14 +115,13 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
 
     @Test
     public void copesWithLongHandSingleLevelANDedQuery() {
-        // query - { "and" : [ { "name" : "mike" }, { "pet" : "cat" } ] }
+        // query - { "$and" : [ { "name" : "mike" }, { "pet" : "cat" } ] }
         Map<String, Object> nameMap = new HashMap<String, Object>();
         nameMap.put("name", "mike");
         Map<String, Object> petMap = new HashMap<String, Object>();
         petMap.put("pet", "cat");
-        List<Object> fields = Arrays.<Object>asList(nameMap, petMap);
         Map<String, Object> query = new LinkedHashMap<String, Object>();
-        query.put("$and", fields);
+        query.put("$and", Arrays.<Object>asList(nameMap, petMap));
         query = QueryValidator.normaliseAndValidateQuery(query);
 
         QueryNode node = QuerySqlTranslator.translateQuery(query, indexes, indexesCoverQuery);
@@ -138,6 +137,328 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         String where = " WHERE \"name\" = ? AND \"pet\" = ?";
         assertThat(sql, is(String.format("%s%s", select, where)));
         assertThat(placeHolderValues, is(arrayContainingInAnyOrder("mike", "cat")));
+    }
+
+    @Test
+    public void copesWithLongHandTwoLevelANDedQuery() {
+        // query - { "$and" : [ { "name" : "mike" },
+        //                      { "pet" : "cat" },
+        //                      { "$and" : [ { "name" : "mike" }, { "pet" : "cat" } ] } ] }
+        Map<String, Object> nameMap = new HashMap<String, Object>();
+        nameMap.put("name", "mike");
+        Map<String, Object> petMap = new HashMap<String, Object>();
+        petMap.put("pet", "cat");
+        Map<String, Object> lvl2 = new HashMap<String, Object>();
+        lvl2.put("$and", Arrays.<Object>asList(nameMap, petMap));
+        Map<String, Object> query = new LinkedHashMap<String, Object>();
+        query.put("$and", Arrays.<Object>asList(nameMap, petMap, lvl2));
+        query = QueryValidator.normaliseAndValidateQuery(query);
+
+        QueryNode node = QuerySqlTranslator.translateQuery(query, indexes, indexesCoverQuery);
+        assertThat(node, is(instanceOf(AndQueryNode.class)));
+        assertThat(indexesCoverQuery[0], is(true));
+
+        //        AND
+        //       /  \
+        //     sql  AND
+        //           \
+        //           sql
+
+        AndQueryNode andNode = (AndQueryNode) node;
+        assertThat(andNode.children.size(), is(2));
+
+        String select = "SELECT _id FROM _t_cloudant_sync_query_index_basic";
+        String where = " WHERE \"name\" = ? AND \"pet\" = ?";
+        String sql = String.format("%s%s", select, where);
+
+        // As the embedded AND is the same as the top-level AND, both
+        // children should have the same embedded SQL.
+
+        SqlQueryNode sqlNode = (SqlQueryNode) andNode.children.get(0);
+        assertThat(sqlNode.sql.sqlWithPlaceHolders, is(sql));
+        assertThat(sqlNode.sql.placeHolderValues, is(arrayContainingInAnyOrder("mike", "cat")));
+
+        sqlNode = (SqlQueryNode) ((AndQueryNode) andNode.children.get(1)).children.get(0);
+        assertThat(sqlNode.sql.sqlWithPlaceHolders, is(sql));
+        assertThat(sqlNode.sql.placeHolderValues, is(arrayContainingInAnyOrder("mike", "cat")));
+    }
+
+    @Test
+    public void ordersANDNodesLastInTrees() {
+        // query - { "$and" : [ { "$and" : [ { "name" : "mike" }, { "pet" : "cat" } ] },
+        //                      { "name" : "mike" },
+        //                      { "pet" : "cat" } ] }
+        Map<String, Object> nameMap = new HashMap<String, Object>();
+        nameMap.put("name", "mike");
+        Map<String, Object> petMap = new HashMap<String, Object>();
+        petMap.put("pet", "cat");
+        Map<String, Object> lvl2 = new HashMap<String, Object>();
+        lvl2.put("$and", Arrays.<Object>asList(nameMap, petMap));
+        Map<String, Object> query = new LinkedHashMap<String, Object>();
+        query.put("$and", Arrays.<Object>asList(lvl2, nameMap, petMap));
+        query = QueryValidator.normaliseAndValidateQuery(query);
+
+        QueryNode node = QuerySqlTranslator.translateQuery(query, indexes, indexesCoverQuery);
+        assertThat(node, is(instanceOf(AndQueryNode.class)));
+        assertThat(indexesCoverQuery[0], is(true));
+
+        //        AND
+        //       /  \
+        //     sql  AND
+        //           \
+        //           sql
+
+        AndQueryNode andNode = (AndQueryNode) node;
+        assertThat(andNode.children.size(), is(2));
+
+        String select = "SELECT _id FROM _t_cloudant_sync_query_index_basic";
+        String where = " WHERE \"name\" = ? AND \"pet\" = ?";
+        String sql = String.format("%s%s", select, where);
+
+        // As the embedded AND is the same as the top-level AND, both
+        // children should have the same embedded SQL.
+
+        SqlQueryNode sqlNode = (SqlQueryNode) andNode.children.get(0);
+        assertThat(sqlNode.sql.sqlWithPlaceHolders, is(sql));
+        assertThat(sqlNode.sql.placeHolderValues, is(arrayContainingInAnyOrder("mike", "cat")));
+
+        sqlNode = (SqlQueryNode) ((AndQueryNode) andNode.children.get(1)).children.get(0);
+        assertThat(sqlNode.sql.sqlWithPlaceHolders, is(sql));
+        assertThat(sqlNode.sql.placeHolderValues, is(arrayContainingInAnyOrder("mike", "cat")));
+    }
+
+    @Test
+    public void supportsOR() {
+        // query - { "$or" : [ { "name" : "mike" }, { "pet" : "cat" } ] }
+        Map<String, Object> nameMap = new HashMap<String, Object>();
+        nameMap.put("name", "mike");
+        Map<String, Object> petMap = new HashMap<String, Object>();
+        petMap.put("pet", "cat");
+        Map<String, Object> query = new LinkedHashMap<String, Object>();
+        query.put("$or", Arrays.<Object>asList(nameMap, petMap));
+        query = QueryValidator.normaliseAndValidateQuery(query);
+
+        QueryNode node = QuerySqlTranslator.translateQuery(query, indexes, indexesCoverQuery);
+        assertThat(node, is(instanceOf(OrQueryNode.class)));
+        assertThat(indexesCoverQuery[0], is(true));
+
+        //        _OR_
+        //       /    \
+        //     sql    sql
+
+        OrQueryNode orNode = (OrQueryNode) node;
+        assertThat(orNode.children.size(), is(2));
+
+        String select = "SELECT _id FROM _t_cloudant_sync_query_index_basic";
+        String whereLeft = " WHERE \"name\" = ?";
+        String whereRight = " WHERE \"pet\" = ?";
+        String sqlLeft = String.format("%s%s", select, whereLeft);
+        String sqlRight = String.format("%s%s", select, whereRight);
+
+        SqlQueryNode sqlNode = (SqlQueryNode) orNode.children.get(0);
+        assertThat(sqlNode.sql.sqlWithPlaceHolders, is(sqlLeft));
+        assertThat(sqlNode.sql.placeHolderValues, is(arrayContaining("mike")));
+
+        sqlNode = (SqlQueryNode) orNode.children.get(1);
+        assertThat(sqlNode.sql.sqlWithPlaceHolders, is(sqlRight));
+        assertThat(sqlNode.sql.placeHolderValues, is(arrayContaining("cat")));
+    }
+
+    @Test
+    public void supportsORInSubTrees() {
+        // query - { "$or" : [ { "name" : "mike" },
+        //                      { "pet" : "cat" },
+        //                      { "$or" : [ { "name" : "mike" }, { "pet" : "cat" } ] } ] }
+        Map<String, Object> nameMap = new HashMap<String, Object>();
+        nameMap.put("name", "mike");
+        Map<String, Object> petMap = new HashMap<String, Object>();
+        petMap.put("pet", "cat");
+        Map<String, Object> lvl2 = new HashMap<String, Object>();
+        lvl2.put("$or", Arrays.<Object>asList(nameMap, petMap));
+        Map<String, Object> query = new LinkedHashMap<String, Object>();
+        query.put("$or", Arrays.<Object>asList(nameMap, petMap, lvl2));
+        query = QueryValidator.normaliseAndValidateQuery(query);
+
+        QueryNode node = QuerySqlTranslator.translateQuery(query, indexes, indexesCoverQuery);
+        assertThat(node, is(instanceOf(OrQueryNode.class)));
+        assertThat(indexesCoverQuery[0], is(true));
+
+        //        OR______
+        //       /   \    \
+        //      sql  sql  OR
+        //               /  \
+        //             sql  sql
+
+        OrQueryNode orNode = (OrQueryNode) node;
+        assertThat(orNode.children.size(), is(3));
+
+        String select = "SELECT _id FROM _t_cloudant_sync_query_index_basic";
+        String whereLeft = " WHERE \"name\" = ?";
+        String whereRight = " WHERE \"pet\" = ?";
+        String sqlLeft = String.format("%s%s", select, whereLeft);
+        String sqlRight = String.format("%s%s", select, whereRight);
+
+        SqlQueryNode sqlNode = (SqlQueryNode) orNode.children.get(0);
+        assertThat(sqlNode.sql.sqlWithPlaceHolders, is(sqlLeft));
+        assertThat(sqlNode.sql.placeHolderValues, is(arrayContaining("mike")));
+
+        sqlNode = (SqlQueryNode) orNode.children.get(1);
+        assertThat(sqlNode.sql.sqlWithPlaceHolders, is(sqlRight));
+        assertThat(sqlNode.sql.placeHolderValues, is(arrayContaining("cat")));
+
+        QueryNode subOrNode = ((OrQueryNode) node).children.get(2);
+        assertThat(subOrNode, is(instanceOf(OrQueryNode.class)));
+
+        sqlNode = (SqlQueryNode) ((OrQueryNode) subOrNode).children.get(0);
+        assertThat(sqlNode.sql.sqlWithPlaceHolders, is(sqlLeft));
+        assertThat(sqlNode.sql.placeHolderValues, is(arrayContaining("mike")));
+
+        sqlNode = (SqlQueryNode) ((OrQueryNode) subOrNode).children.get(1);
+        assertThat(sqlNode.sql.sqlWithPlaceHolders, is(sqlRight));
+        assertThat(sqlNode.sql.placeHolderValues, is(arrayContaining("cat")));
+
+    }
+
+    @Test
+    public void supportsANDAndORInSubTreesTwoLevel() {
+        // query - { "$or" : [ { "name" : "mike" },
+        //                      { "pet" : "cat" },
+        //                      { "$or" : [ { "name" : "mike" }, { "pet" : "cat" } ] },
+        //                      { "$and" : [ { "name" : "mike" }, { "pet" : "cat" } ] } ] }
+        Map<String, Object> nameMap = new HashMap<String, Object>();
+        nameMap.put("name", "mike");
+        Map<String, Object> petMap = new HashMap<String, Object>();
+        petMap.put("pet", "cat");
+        Map<String, Object> lvl2or = new HashMap<String, Object>();
+        lvl2or.put("$or", Arrays.<Object>asList(nameMap, petMap));
+        Map<String, Object> lvl2and = new HashMap<String, Object>();
+        lvl2and.put("$and", Arrays.<Object>asList(nameMap, petMap));
+        Map<String, Object> query = new LinkedHashMap<String, Object>();
+        query.put("$or", Arrays.<Object>asList(nameMap, petMap, lvl2or, lvl2and));
+        query = QueryValidator.normaliseAndValidateQuery(query);
+
+        QueryNode node = QuerySqlTranslator.translateQuery(query, indexes, indexesCoverQuery);
+        assertThat(node, is(instanceOf(OrQueryNode.class)));
+        assertThat(indexesCoverQuery[0], is(true));
+
+        //        OR____________
+        //       /   \    \     \
+        //      sql  sql  OR    AND
+        //               /  \     \
+        //             sql  sql   sql
+
+        OrQueryNode orNode = (OrQueryNode) node;
+        assertThat(orNode.children.size(), is(4));
+
+        String select = "SELECT _id FROM _t_cloudant_sync_query_index_basic";
+        String whereLeft = " WHERE \"name\" = ?";
+        String whereRight = " WHERE \"pet\" = ?";
+        String whereAnd = " WHERE \"name\" = ? AND \"pet\" = ?";
+        String sqlLeft = String.format("%s%s", select, whereLeft);
+        String sqlRight = String.format("%s%s", select, whereRight);
+        String sqlAnd = String.format("%s%s", select, whereAnd);
+
+        SqlQueryNode sqlNode = (SqlQueryNode) orNode.children.get(0);
+        assertThat(sqlNode.sql.sqlWithPlaceHolders, is(sqlLeft));
+        assertThat(sqlNode.sql.placeHolderValues, is(arrayContaining("mike")));
+
+        sqlNode = (SqlQueryNode) orNode.children.get(1);
+        assertThat(sqlNode.sql.sqlWithPlaceHolders, is(sqlRight));
+        assertThat(sqlNode.sql.placeHolderValues, is(arrayContaining("cat")));
+
+        QueryNode subOrNode = ((OrQueryNode) node).children.get(2);
+        assertThat(subOrNode, is(instanceOf(OrQueryNode.class)));
+
+        sqlNode = (SqlQueryNode) ((OrQueryNode) subOrNode).children.get(0);
+        assertThat(sqlNode.sql.sqlWithPlaceHolders, is(sqlLeft));
+        assertThat(sqlNode.sql.placeHolderValues, is(arrayContaining("mike")));
+
+        sqlNode = (SqlQueryNode) ((OrQueryNode) subOrNode).children.get(1);
+        assertThat(sqlNode.sql.sqlWithPlaceHolders, is(sqlRight));
+        assertThat(sqlNode.sql.placeHolderValues, is(arrayContaining("cat")));
+
+        QueryNode subAndNode = orNode.children.get(3);
+        assertThat(subAndNode, is(instanceOf(AndQueryNode.class)));
+        assertThat(((AndQueryNode) subAndNode).children.size(), is(1));
+
+        sqlNode = (SqlQueryNode) ((AndQueryNode) subAndNode).children.get(0);
+        assertThat(sqlNode.sql.sqlWithPlaceHolders, is(sqlAnd));
+        assertThat(sqlNode.sql.placeHolderValues, is(arrayContainingInAnyOrder("mike", "cat")));
+    }
+
+    @Test
+    public void supportsANDAndORInSubTreesThreeLevel() {
+        // query - { "$or" : [ { "name" : "mike" },
+        //                      { "pet" : "cat" },
+        //                      { "$or" : [ { "name" : "mike" },
+        //                                  { "pet" : "cat" },
+        //                                  { "$and" : [ { "name" : "mike" }, { "pet" : "cat" } ] }
+        //                                ]
+        //                      }
+        //                   ]
+        //         }
+        Map<String, Object> nameMap = new HashMap<String, Object>();
+        nameMap.put("name", "mike");
+        Map<String, Object> petMap = new HashMap<String, Object>();
+        petMap.put("pet", "cat");
+        Map<String, Object> lvl2or = new HashMap<String, Object>();
+        Map<String, Object> lvl3and = new HashMap<String, Object>();
+        lvl3and.put("$and", Arrays.<Object>asList(nameMap, petMap));
+        lvl2or.put("$or", Arrays.<Object>asList(nameMap, petMap, lvl3and));
+        Map<String, Object> query = new LinkedHashMap<String, Object>();
+        query.put("$or", Arrays.<Object>asList(nameMap, petMap, lvl2or));
+        query = QueryValidator.normaliseAndValidateQuery(query);
+
+        QueryNode node = QuerySqlTranslator.translateQuery(query, indexes, indexesCoverQuery);
+        assertThat(node, is(instanceOf(OrQueryNode.class)));
+        assertThat(indexesCoverQuery[0], is(true));
+
+        //        OR______
+        //       /   \    \
+        //      sql  sql  OR______
+        //               /  \     \
+        //             sql  sql   AND
+        //                         |
+        //                        sql
+
+        OrQueryNode orNode = (OrQueryNode) node;
+        assertThat(orNode.children.size(), is(3));
+
+        String select = "SELECT _id FROM _t_cloudant_sync_query_index_basic";
+        String whereLeft = " WHERE \"name\" = ?";
+        String whereRight = " WHERE \"pet\" = ?";
+        String whereAnd = " WHERE \"name\" = ? AND \"pet\" = ?";
+        String sqlLeft = String.format("%s%s", select, whereLeft);
+        String sqlRight = String.format("%s%s", select, whereRight);
+        String sqlAnd = String.format("%s%s", select, whereAnd);
+
+        SqlQueryNode sqlNode = (SqlQueryNode) orNode.children.get(0);
+        assertThat(sqlNode.sql.sqlWithPlaceHolders, is(sqlLeft));
+        assertThat(sqlNode.sql.placeHolderValues, is(arrayContaining("mike")));
+
+        sqlNode = (SqlQueryNode) orNode.children.get(1);
+        assertThat(sqlNode.sql.sqlWithPlaceHolders, is(sqlRight));
+        assertThat(sqlNode.sql.placeHolderValues, is(arrayContaining("cat")));
+
+        QueryNode subOrNode = ((OrQueryNode) node).children.get(2);
+        assertThat(subOrNode, is(instanceOf(OrQueryNode.class)));
+        assertThat(((OrQueryNode) subOrNode).children.size(), is(3));
+
+        sqlNode = (SqlQueryNode) ((OrQueryNode) subOrNode).children.get(0);
+        assertThat(sqlNode.sql.sqlWithPlaceHolders, is(sqlLeft));
+        assertThat(sqlNode.sql.placeHolderValues, is(arrayContaining("mike")));
+
+        sqlNode = (SqlQueryNode) ((OrQueryNode) subOrNode).children.get(1);
+        assertThat(sqlNode.sql.sqlWithPlaceHolders, is(sqlRight));
+        assertThat(sqlNode.sql.placeHolderValues, is(arrayContaining("cat")));
+
+        QueryNode subAndNode = ((OrQueryNode) subOrNode).children.get(2);
+        assertThat(subAndNode, is(instanceOf(AndQueryNode.class)));
+        assertThat(((AndQueryNode) subAndNode).children.size(), is(1));
+
+        sqlNode = (SqlQueryNode) ((AndQueryNode) subAndNode).children.get(0);
+        assertThat(sqlNode.sql.sqlWithPlaceHolders, is(sqlAnd));
+        assertThat(sqlNode.sql.placeHolderValues, is(arrayContainingInAnyOrder("mike", "cat")));
     }
 
     // When selecting an index to use
@@ -267,7 +588,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
 
         String idx = QuerySqlTranslator.chooseIndexForAndClause(Arrays.<Object>asList(name, pet),
                                                                 indexes);
-        assertThat(idx, either(is("named")).or(is("bopped")));
+        assertThat(Arrays.asList("named", "bopped").contains(idx), is(true));
     }
 
     @Test
@@ -340,13 +661,315 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void nullWhereClauseForUnsupportedOperator() {
+     public void nullWhereClauseForUnsupportedOperator() {
         Map<String, Object> eq = new HashMap<String, Object>();
         eq.put("$blah", "mike");
         Map<String, Object> name = new HashMap<String, Object>();
         name.put("name", eq);
         assertThat(QuerySqlTranslator.whereSqlForAndClause(Arrays.<Object>asList(name)),
-                   is(nullValue()));
+                is(nullValue()));
+    }
+
+    @Test
+    public void usesCorrectSQLOperatorWhenUsingGT() {
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$gt", "mike");
+        Map<String, Object> name = new HashMap<String, Object>();
+        name.put("name", op);
+
+        SqlParts where = QuerySqlTranslator.whereSqlForAndClause(Arrays.<Object>asList(name));
+        String expected = "\"name\" > ?";
+        assertThat(where.sqlWithPlaceHolders, is(expected));
+        assertThat(where.placeHolderValues, is(arrayContaining("mike")));
+    }
+
+    @Test
+    public void usesCorrectSQLOperatorWhenUsingGTE() {
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$gte", "mike");
+        Map<String, Object> name = new HashMap<String, Object>();
+        name.put("name", op);
+
+        SqlParts where = QuerySqlTranslator.whereSqlForAndClause(Arrays.<Object>asList(name));
+        String expected = "\"name\" >= ?";
+        assertThat(where.sqlWithPlaceHolders, is(expected));
+        assertThat(where.placeHolderValues, is(arrayContaining("mike")));
+    }
+
+    @Test
+    public void usesCorrectSQLOperatorWhenUsingLT() {
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$lt", "mike");
+        Map<String, Object> name = new HashMap<String, Object>();
+        name.put("name", op);
+
+        SqlParts where = QuerySqlTranslator.whereSqlForAndClause(Arrays.<Object>asList(name));
+        String expected = "\"name\" < ?";
+        assertThat(where.sqlWithPlaceHolders, is(expected));
+        assertThat(where.placeHolderValues, is(arrayContaining("mike")));
+    }
+
+    @Test
+    public void usesCorrectSQLOperatorWhenUsingLTE() {
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$lte", "mike");
+        Map<String, Object> name = new HashMap<String, Object>();
+        name.put("name", op);
+
+        SqlParts where = QuerySqlTranslator.whereSqlForAndClause(Arrays.<Object>asList(name));
+        String expected = "\"name\" <= ?";
+        assertThat(where.sqlWithPlaceHolders, is(expected));
+        assertThat(where.placeHolderValues, is(arrayContaining("mike")));
+    }
+
+    @Test
+     public void usesCorrectSQLOperatorWhenUsingNE() {
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$ne", "mike");
+        Map<String, Object> name = new HashMap<String, Object>();
+        name.put("name", op);
+
+        SqlParts where = QuerySqlTranslator.whereSqlForAndClause(Arrays.<Object>asList(name));
+        String expected = "\"name\" != ?";
+        assertThat(where.sqlWithPlaceHolders, is(expected));
+        assertThat(where.placeHolderValues, is(arrayContaining("mike")));
+    }
+
+    @Test
+    public void usesCorrectSQLOperatorForEXISTSTrue() {
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$exists", true);
+        Map<String, Object> name = new HashMap<String, Object>();
+        name.put("name", op);
+
+        SqlParts where = QuerySqlTranslator.whereSqlForAndClause(Arrays.<Object>asList(name));
+        String expected = "(\"name\" IS NOT NULL)";
+        assertThat(where.sqlWithPlaceHolders, is(expected));
+    }
+
+    @Test
+    public void usesCorrectSQLOperatorForEXISTSFalse() {
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$exists", false);
+        Map<String, Object> name = new HashMap<String, Object>();
+        name.put("name", op);
+
+        SqlParts where = QuerySqlTranslator.whereSqlForAndClause(Arrays.<Object>asList(name));
+        String expected = "(\"name\" IS NULL)";
+        assertThat(where.sqlWithPlaceHolders, is(expected));
+    }
+
+    @Test
+    public void usesCorrectSQLOperatorForNOTEXISTSFalse() {
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$exists", false);
+        Map<String, Object> notOp = new HashMap<String, Object>();
+        notOp.put("$not", op);
+        Map<String, Object> name = new HashMap<String, Object>();
+        name.put("name", notOp);
+
+        SqlParts where = QuerySqlTranslator.whereSqlForAndClause(Arrays.<Object>asList(name));
+        String expected = "(\"name\" IS NOT NULL)";
+        assertThat(where.sqlWithPlaceHolders, is(expected));
+    }
+
+    @Test
+    public void usesCorrectSQLOperatorForNOTEXISTSTrue() {
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$exists", true);
+        Map<String, Object> notOp = new HashMap<String, Object>();
+        notOp.put("$not", op);
+        Map<String, Object> name = new HashMap<String, Object>();
+        name.put("name", notOp);
+
+        SqlParts where = QuerySqlTranslator.whereSqlForAndClause(Arrays.<Object>asList(name));
+        String expected = "(\"name\" IS NULL)";
+        assertThat(where.sqlWithPlaceHolders, is(expected));
+    }
+
+    // When generating query WHERE clauses with $not
+
+    @Test
+    public void validWhereNOTClauseForSingleTermEQ() {
+        Map<String, Object> eq = new HashMap<String, Object>();
+        eq.put("$eq", "mike");
+        Map<String, Object> not = new HashMap<String, Object>();
+        not.put("$not", eq);
+        Map<String, Object> name = new HashMap<String, Object>();
+        name.put("name", not);
+        SqlParts where = QuerySqlTranslator.whereSqlForAndClause(Arrays.<Object>asList(name));
+        assertThat(where.sqlWithPlaceHolders, is("(\"name\" != ? OR \"name\" IS NULL)"));
+        assertThat(where.placeHolderValues, is(arrayContaining("mike")));
+    }
+
+    @Test
+    public void validWhereNOTClauseForMultiTermEQ() {
+        Map<String, Object> eq = new HashMap<String, Object>();
+        eq.put("$eq", "mike");
+        Map<String, Object> not = new HashMap<String, Object>();
+        not.put("$not", eq);
+        Map<String, Object> name = new HashMap<String, Object>();
+        name.put("name", not);
+
+        Map<String, Object> ageEq = new HashMap<String, Object>();
+        ageEq.put("$eq", 12);
+        Map<String, Object> age = new HashMap<String, Object>();
+        age.put("age", ageEq);
+
+        Map<String, Object> petEq = new HashMap<String, Object>();
+        petEq.put("$eq", "cat");
+        Map<String, Object> notPet = new HashMap<String, Object>();
+        notPet.put("$not", petEq);
+        Map<String, Object> pet = new HashMap<String, Object>();
+        pet.put("pet", notPet);
+
+        SqlParts where = QuerySqlTranslator.whereSqlForAndClause(Arrays.<Object>asList(name,
+                                                                                       age,
+                                                                                       pet));
+        String expected = "(\"name\" != ? OR \"name\" IS NULL) AND \"age\" = ?";
+        expected += " AND (\"pet\" != ? OR \"pet\" IS NULL)";
+        assertThat(where.sqlWithPlaceHolders, is(expected));
+        assertThat(where.placeHolderValues, is(arrayContainingInAnyOrder("mike", "12", "cat")));
+    }
+
+    @Test
+    public void nullWhereNOTClauseForUnsupportedOperator() {
+        Map<String, Object> eq = new HashMap<String, Object>();
+        eq.put("$blah", "mike");
+        Map<String, Object> not = new HashMap<String, Object>();
+        not.put("$not", eq);
+        Map<String, Object> name = new HashMap<String, Object>();
+        name.put("name", not);
+        assertThat(QuerySqlTranslator.whereSqlForAndClause(Arrays.<Object>asList(name)),
+                is(nullValue()));
+    }
+
+    @Test
+    public void usesCorrectSQLOperatorWhenUsingNOTGT() {
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$gt", "mike");
+        Map<String, Object> not = new HashMap<String, Object>();
+        not.put("$not", op);
+        Map<String, Object> name = new HashMap<String, Object>();
+        name.put("name", not);
+
+        SqlParts where = QuerySqlTranslator.whereSqlForAndClause(Arrays.<Object>asList(name));
+        String expected = "(\"name\" <= ? OR \"name\" IS NULL)";
+        assertThat(where.sqlWithPlaceHolders, is(expected));
+        assertThat(where.placeHolderValues, is(arrayContaining("mike")));
+    }
+
+    @Test
+    public void usesCorrectSQLOperatorWhenUsingNOTGTE() {
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$gte", "mike");
+        Map<String, Object> not = new HashMap<String, Object>();
+        not.put("$not", op);
+        Map<String, Object> name = new HashMap<String, Object>();
+        name.put("name", not);
+
+        SqlParts where = QuerySqlTranslator.whereSqlForAndClause(Arrays.<Object>asList(name));
+        String expected = "(\"name\" < ? OR \"name\" IS NULL)";
+        assertThat(where.sqlWithPlaceHolders, is(expected));
+        assertThat(where.placeHolderValues, is(arrayContaining("mike")));
+    }
+
+    @Test
+    public void usesCorrectSQLOperatorWhenUsingNOTLT() {
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$lt", "mike");
+        Map<String, Object> not = new HashMap<String, Object>();
+        not.put("$not", op);
+        Map<String, Object> name = new HashMap<String, Object>();
+        name.put("name", not);
+
+        SqlParts where = QuerySqlTranslator.whereSqlForAndClause(Arrays.<Object>asList(name));
+        String expected = "(\"name\" >= ? OR \"name\" IS NULL)";
+        assertThat(where.sqlWithPlaceHolders, is(expected));
+        assertThat(where.placeHolderValues, is(arrayContaining("mike")));
+    }
+
+    @Test
+    public void usesCorrectSQLOperatorWhenUsingNOTLTE() {
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$lte", "mike");
+        Map<String, Object> not = new HashMap<String, Object>();
+        not.put("$not", op);
+        Map<String, Object> name = new HashMap<String, Object>();
+        name.put("name", not);
+
+        SqlParts where = QuerySqlTranslator.whereSqlForAndClause(Arrays.<Object>asList(name));
+        String expected = "(\"name\" > ? OR \"name\" IS NULL)";
+        assertThat(where.sqlWithPlaceHolders, is(expected));
+        assertThat(where.placeHolderValues, is(arrayContaining("mike")));
+    }
+
+    @Test
+    public void usesCorrectSQLOperatorWhenUsingNOTNE() {
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$ne", "mike");
+        Map<String, Object> not = new HashMap<String, Object>();
+        not.put("$not", op);
+        Map<String, Object> name = new HashMap<String, Object>();
+        name.put("name", not);
+
+        SqlParts where = QuerySqlTranslator.whereSqlForAndClause(Arrays.<Object>asList(name));
+        String expected = "(\"name\" = ? OR \"name\" IS NULL)";
+        assertThat(where.sqlWithPlaceHolders, is(expected));
+        assertThat(where.placeHolderValues, is(arrayContaining("mike")));
+    }
+
+    @Test
+    public void returnsCorrectWhenTwoConditionsOneField() {
+        Map<String, Object> c1op = new HashMap<String, Object>();
+        c1op.put("$eq", "mike");
+        Map<String, Object> c1not = new HashMap<String, Object>();
+        c1not.put("$not", c1op);
+        Map<String, Object> c1 = new HashMap<String, Object>();
+        c1.put("name", c1not);
+        Map<String, Object> c2op = new HashMap<String, Object>();
+        c2op.put("$eq", "john");
+        Map<String, Object> c2 = new HashMap<String, Object>();
+        c2.put("name", c2op);
+
+        SqlParts where = QuerySqlTranslator.whereSqlForAndClause(Arrays.<Object>asList(c1, c2));
+        String expected = "(\"name\" != ? OR \"name\" IS NULL) AND \"name\" = ?";
+        assertThat(where.sqlWithPlaceHolders, is(expected));
+        assertThat(where.placeHolderValues, is(arrayContaining("mike", "john")));
+    }
+
+    @Test
+    public void returnsCorrectWhenMultiConditionsMultiFields() {
+        Map<String, Object> c1op = new HashMap<String, Object>();
+        c1op.put("$gt", 12);
+        Map<String, Object> c1 = new HashMap<String, Object>();
+        c1.put("age", c1op);
+        Map<String, Object> c2op = new HashMap<String, Object>();
+        c2op.put("$lte", 54);
+        Map<String, Object> c2 = new HashMap<String, Object>();
+        c2.put("age", c2op);
+        Map<String, Object> c3op = new HashMap<String, Object>();
+        c3op.put("$eq", "mike");
+        Map<String, Object> c3 = new HashMap<String, Object>();
+        c3.put("name", c3op);
+        Map<String, Object> c4op = new HashMap<String, Object>();
+        c4op.put("$ne", 30);
+        Map<String, Object> c4 = new HashMap<String, Object>();
+        c4.put("age", c4op);
+        Map<String, Object> c5op = new HashMap<String, Object>();
+        c5op.put("$eq", 42);
+        Map<String, Object> c5 = new HashMap<String, Object>();
+        c5.put("age", c5op);
+
+        SqlParts where = QuerySqlTranslator.whereSqlForAndClause(Arrays.<Object>asList(c1,
+                                                                                       c2,
+                                                                                       c3,
+                                                                                       c4,
+                                                                                       c5));
+        String expected = "\"age\" > ? AND \"age\" <= ? AND \"name\" = ? AND \"age\" != ? AND ";
+        expected += "\"age\" = ?";
+        assertThat(where.sqlWithPlaceHolders, is(expected));
+        assertThat(where.placeHolderValues, is(arrayContaining("12", "54", "mike", "30", "42")));
     }
 
     // When generating query SELECT clauses

--- a/sync-core/src/test/java/com/cloudant/sync/query/UnindexedMatcherTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/UnindexedMatcherTest.java
@@ -13,9 +13,13 @@
 package com.cloudant.sync.query;
 
 import static com.cloudant.sync.query.UnindexedMatcher.compareEq;
+import static com.cloudant.sync.query.UnindexedMatcher.compareGT;
+import static com.cloudant.sync.query.UnindexedMatcher.compareGTE;
+import static com.cloudant.sync.query.UnindexedMatcher.compareLT;
+import static com.cloudant.sync.query.UnindexedMatcher.compareLTE;
+import static com.cloudant.sync.query.UnindexedMatcher.compareNE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
 
 import com.cloudant.sync.datastore.DocumentBody;
 import com.cloudant.sync.datastore.DocumentBodyFactory;
@@ -58,60 +62,158 @@ public class UnindexedMatcherTest {
 
     @Test
     @SuppressWarnings("UnnecessaryBoxing")
-    public void compareEqNulls() {
+    public void compareNulls() {
         assertThat(compareEq(null, null), is(false));
         assertThat(compareEq(null, "mike"), is(false));
         assertThat(compareEq("mike", null), is(false));
-        assertThat(compareEq(null, new Double(1.1)), is(false));
-        assertThat(compareEq(new Double(1.1), null), is(false));
-        assertThat(compareEq(null, new Long(1l)), is(false));
-        assertThat(compareEq(new Long(1l), null), is(false));
         assertThat(compareEq(null, 1), is(false));
         assertThat(compareEq(1, null), is(false));
+
+        assertThat(compareNE(null, null), is(false));
+        assertThat(compareNE(null, "mike"), is(true));
+        assertThat(compareNE("mike", null), is(true));
+        assertThat(compareNE(null, 1), is(true));
+        assertThat(compareNE(1, null), is(true));
+
+        assertThat(compareLT(null, null), is(false));
+        assertThat(compareLT(null, "mike"), is(false));
+        assertThat(compareLT("mike", null), is(false));
+        assertThat(compareLT(null, 1), is(false));
+        assertThat(compareLT(1, null), is(false));
+
+        assertThat(compareLTE(null, null), is(false));
+        assertThat(compareLTE(null, "mike"), is(false));
+        assertThat(compareLTE("mike", null), is(false));
+        assertThat(compareLTE(null, 1), is(false));
+        assertThat(compareLTE(1, null), is(false));
+
+        assertThat(compareGT(null, null), is(false));
+        assertThat(compareGT(null, "mike"), is(false));
+        assertThat(compareGT("mike", null), is(false));
+        assertThat(compareGT(null, 1), is(false));
+        assertThat(compareGT(1, null), is(false));
+
+        assertThat(compareGTE(null, null), is(false));
+        assertThat(compareGTE(null, "mike"), is(false));
+        assertThat(compareGTE("mike", null), is(false));
+        assertThat(compareGTE(null, 1), is(false));
+        assertThat(compareGTE(1, null), is(false));
     }
 
     // Floats are not allowed.  Result should always be false.
     @Test
     @SuppressWarnings("UnnecessaryBoxing")
-    public void compareEqFloats() {
-        assertThat(compareEq(new Float(1.0f), new Float(1.0f)), is(false));
-        assertThat(compareEq(new Float(1.0f), new Double(1.0)), is(false));
-        assertThat(compareEq(new Double(1.0), new Float(1.0f)), is(false));
-        assertThat(compareEq(new Float(1.0f), new Long(1l)), is(false));
-        assertThat(compareEq(new Long(1l), new Float(1.0f)), is(false));
+    public void compareFloats() {
         assertThat(compareEq(new Float(1.0f), new Integer(1)), is(false));
         assertThat(compareEq(new Integer(1), new Float(1.0f)), is(false));
-
-        assertThat(compareEq(new Float(1.0f), new Float(1.1f)), is(false));
-        assertThat(compareEq(new Float(1.1f), new Float(1.0f)), is(false));
-        assertThat(compareEq(new Float(1.1f), new Double(1.0)), is(false));
-        assertThat(compareEq(new Double(1.0), new Float(1.1f)), is(false));
-        assertThat(compareEq(new Float(1.1f), new Long(1l)), is(false));
-        assertThat(compareEq(new Long(1l), new Float(1.1f)), is(false));
         assertThat(compareEq(new Float(1.1f), new Integer(1)), is(false));
         assertThat(compareEq(new Integer(1), new Float(1.1f)), is(false));
+
+        assertThat(compareNE(new Float(1.0f), new Integer(1)), is(false));
+        assertThat(compareNE(new Integer(1), new Float(1.0f)), is(false));
+        assertThat(compareNE(new Float(1.1f), new Integer(1)), is(false));
+        assertThat(compareNE(new Integer(1), new Float(1.1f)), is(false));
+
+        assertThat(compareLT(new Float(1.0f), new Integer(1)), is(false));
+        assertThat(compareLT(new Integer(1), new Float(1.0f)), is(false));
+        assertThat(compareLT(new Float(1.1f), new Integer(1)), is(false));
+        assertThat(compareLT(new Integer(1), new Float(1.1f)), is(false));
+
+        assertThat(compareLTE(new Float(1.0f), new Integer(1)), is(false));
+        assertThat(compareLTE(new Integer(1), new Float(1.0f)), is(false));
+        assertThat(compareLTE(new Float(1.1f), new Integer(1)), is(false));
+        assertThat(compareLTE(new Integer(1), new Float(1.1f)), is(false));
+
+        assertThat(compareGT(new Float(1.0f), new Integer(1)), is(false));
+        assertThat(compareGT(new Integer(1), new Float(1.0f)), is(false));
+        assertThat(compareGT(new Float(1.1f), new Integer(1)), is(false));
+        assertThat(compareGT(new Integer(1), new Float(1.1f)), is(false));
+
+        assertThat(compareGTE(new Float(1.0f), new Integer(1)), is(false));
+        assertThat(compareGTE(new Integer(1), new Float(1.0f)), is(false));
+        assertThat(compareGTE(new Float(1.1f), new Integer(1)), is(false));
+        assertThat(compareGTE(new Integer(1), new Float(1.1f)), is(false));
     }
 
     @Test
-    public void compareEqStringToString() {
+    public void compareStringToString() {
         assertThat(compareEq("mike", "mike"), is(true));
         assertThat(compareEq("mike", "Mike"), is(false));
+
+        assertThat(compareNE("mike", "mike"), is(false));
+        assertThat(compareNE("mike", "Mike"), is(true));
+
+        assertThat(compareLT("mike", "mike"), is(false));
+        assertThat(compareLT("mike", "fred"), is(false));
+        assertThat(compareLT("fred", "mike"), is(true));
+
+        assertThat(compareLTE("mike", "mike"), is(true));
+        assertThat(compareLTE("mike", "fred"), is(false));
+        assertThat(compareLTE("fred", "mike"), is(true));
+
+        assertThat(compareGT("mike", "mike"), is(false));
+        assertThat(compareGT("mike", "fred"), is(true));
+        assertThat(compareGT("fred", "mike"), is(false));
+
+        assertThat(compareGTE("mike", "mike"), is(true));
+        assertThat(compareGTE("mike", "fred"), is(true));
+        assertThat(compareGTE("fred", "mike"), is(false));
     }
 
     @Test
     @SuppressWarnings("UnnecessaryBoxing")
-    public void compareEqStringToNumber() {
+    public void compareStringToNumber() {
         assertThat(compareEq("1", new Integer(1)), is(false));
         assertThat(compareEq(new Integer(1), "1"), is(false));
+
+        assertThat(compareNE("1", new Integer(1)), is(true));
+        assertThat(compareNE(new Integer(1), "1"), is(true));
+
+        assertThat(compareLT("1", new Integer(1)), is(false));
+        assertThat(compareLT(new Integer(1), "1"), is(true));
+
+        assertThat(compareLTE("1", new Integer(1)), is(false));
+        assertThat(compareLTE(new Integer(1), "1"), is(true));
+
+        assertThat(compareGT("1", new Integer(1)), is(true));
+        assertThat(compareGT(new Integer(1), "1"), is(false));
+
+        assertThat(compareGTE("1", new Integer(1)), is(true));
+        assertThat(compareGTE(new Integer(1), "1"), is(false));
     }
 
     @Test
     @SuppressWarnings("UnnecessaryBoxing")
-    public void compareEqDoubleToDouble() {
+    public void compareDoubleToDouble() {
         assertThat(compareEq(new Double(1.0), new Double(1.0)), is(true));
         assertThat(compareEq(new Double(1.0), new Double(1.00)), is(true));
         assertThat(compareEq(new Double(1.0), new Double(1.1)), is(false));
         assertThat(compareEq(new Double(1.1), new Double(1.0)), is(false));
+
+        assertThat(compareNE(new Double(1.0), new Double(1.0)), is(false));
+        assertThat(compareNE(new Double(1.0), new Double(1.00)), is(false));
+        assertThat(compareNE(new Double(1.0), new Double(1.1)), is(true));
+        assertThat(compareNE(new Double(1.1), new Double(1.0)), is(true));
+
+        assertThat(compareLT(new Double(1.0), new Double(1.0)), is(false));
+        assertThat(compareLT(new Double(1.0), new Double(1.00)), is(false));
+        assertThat(compareLT(new Double(1.0), new Double(1.1)), is(true));
+        assertThat(compareLT(new Double(1.1), new Double(1.0)), is(false));
+
+        assertThat(compareLTE(new Double(1.0), new Double(1.0)), is(true));
+        assertThat(compareLTE(new Double(1.0), new Double(1.00)), is(true));
+        assertThat(compareLTE(new Double(1.0), new Double(1.1)), is(true));
+        assertThat(compareLTE(new Double(1.1), new Double(1.0)), is(false));
+
+        assertThat(compareGT(new Double(1.0), new Double(1.0)), is(false));
+        assertThat(compareGT(new Double(1.0), new Double(1.00)), is(false));
+        assertThat(compareGT(new Double(1.0), new Double(1.1)), is(false));
+        assertThat(compareGT(new Double(1.1), new Double(1.0)), is(true));
+
+        assertThat(compareGTE(new Double(1.0), new Double(1.0)), is(true));
+        assertThat(compareGTE(new Double(1.0), new Double(1.00)), is(true));
+        assertThat(compareGTE(new Double(1.0), new Double(1.1)), is(false));
+        assertThat(compareGTE(new Double(1.1), new Double(1.0)), is(true));
     }
 
     @Test
@@ -121,6 +223,40 @@ public class UnindexedMatcherTest {
         assertThat(compareEq(new Long(1l), new Double(1.0)), is(true));
         assertThat(compareEq(new Double(1.1), new Long(1l)), is(false));
         assertThat(compareEq(new Long(1l), new Double(1.1)), is(false));
+
+        assertThat(compareNE(new Double(1.0), new Long(1l)), is(false));
+        assertThat(compareNE(new Long(1l), new Double(1.0)), is(false));
+        assertThat(compareNE(new Double(1.1), new Long(1l)), is(true));
+        assertThat(compareNE(new Long(1l), new Double(1.1)), is(true));
+
+        assertThat(compareLT(new Double(1.0), new Long(1l)), is(false));
+        assertThat(compareLT(new Long(1l), new Double(1.0)), is(false));
+        assertThat(compareLT(new Double(1.1), new Long(1l)), is(false));
+        assertThat(compareLT(new Long(2l), new Double(1.1)), is(false));
+        assertThat(compareLT(new Long(1l), new Double(1.1)), is(true));
+        assertThat(compareLT(new Double(1.1), new Long(2l)), is(true));
+
+        assertThat(compareLTE(new Double(1.0), new Long(1l)), is(true));
+        assertThat(compareLTE(new Long(1l), new Double(1.0)), is(true));
+        assertThat(compareLTE(new Double(1.1), new Long(1l)), is(false));
+        assertThat(compareLTE(new Long(2l), new Double(1.1)), is(false));
+        assertThat(compareLTE(new Long(1l), new Double(1.1)), is(true));
+        assertThat(compareLTE(new Double(1.1), new Long(2l)), is(true));
+
+        assertThat(compareGT(new Double(1.0), new Long(1l)), is(false));
+        assertThat(compareGT(new Long(1l), new Double(1.0)), is(false));
+        assertThat(compareGT(new Double(1.1), new Long(1l)), is(true));
+        assertThat(compareGT(new Long(2l), new Double(1.1)), is(true));
+        assertThat(compareGT(new Long(1l), new Double(1.1)), is(false));
+        assertThat(compareGT(new Double(1.1), new Long(2l)), is(false));
+
+        assertThat(compareGTE(new Double(1.0), new Long(1l)), is(true));
+        assertThat(compareGTE(new Long(1l), new Double(1.0)), is(true));
+        assertThat(compareGTE(new Double(1.1), new Long(1l)), is(true));
+        assertThat(compareGTE(new Long(2l), new Double(1.1)), is(true));
+        assertThat(compareGTE(new Long(1l), new Double(1.1)), is(false));
+        assertThat(compareGTE(new Double(1.1), new Long(2l)), is(false));
+
     }
 
     @Test
@@ -130,6 +266,39 @@ public class UnindexedMatcherTest {
         assertThat(compareEq(new Integer(1), new Double(1.0)), is(true));
         assertThat(compareEq(new Double(1.1), new Integer(1)), is(false));
         assertThat(compareEq(new Integer(1), new Double(1.1)), is(false));
+
+        assertThat(compareNE(new Double(1.0), new Integer(1)), is(false));
+        assertThat(compareNE(new Integer(1), new Double(1.0)), is(false));
+        assertThat(compareNE(new Double(1.1), new Integer(1)), is(true));
+        assertThat(compareNE(new Integer(1), new Double(1.1)), is(true));
+
+        assertThat(compareLT(new Double(1.0), new Integer(1)), is(false));
+        assertThat(compareLT(new Integer(1), new Double(1.0)), is(false));
+        assertThat(compareLT(new Double(1.1), new Integer(1)), is(false));
+        assertThat(compareLT(new Integer(2), new Double(1.1)), is(false));
+        assertThat(compareLT(new Integer(1), new Double(1.1)), is(true));
+        assertThat(compareLT(new Double(1.1), new Integer(2)), is(true));
+
+        assertThat(compareLTE(new Double(1.0), new Integer(1)), is(true));
+        assertThat(compareLTE(new Integer(1), new Double(1.0)), is(true));
+        assertThat(compareLTE(new Double(1.1), new Integer(1)), is(false));
+        assertThat(compareLTE(new Integer(2), new Double(1.1)), is(false));
+        assertThat(compareLTE(new Integer(1), new Double(1.1)), is(true));
+        assertThat(compareLTE(new Double(1.1), new Integer(2)), is(true));
+
+        assertThat(compareGT(new Double(1.0), new Integer(1)), is(false));
+        assertThat(compareGT(new Integer(1), new Double(1.0)), is(false));
+        assertThat(compareGT(new Double(1.1), new Integer(1)), is(true));
+        assertThat(compareGT(new Integer(2), new Double(1.1)), is(true));
+        assertThat(compareGT(new Integer(1), new Double(1.1)), is(false));
+        assertThat(compareGT(new Double(1.1), new Integer(2)), is(false));
+
+        assertThat(compareGTE(new Double(1.0), new Integer(1)), is(true));
+        assertThat(compareGTE(new Integer(1), new Double(1.0)), is(true));
+        assertThat(compareGTE(new Double(1.1), new Integer(1)), is(true));
+        assertThat(compareGTE(new Integer(2), new Double(1.1)), is(true));
+        assertThat(compareGTE(new Integer(1), new Double(1.1)), is(false));
+        assertThat(compareGTE(new Double(1.1), new Integer(2)), is(false));
     }
 
     @Test
@@ -138,6 +307,26 @@ public class UnindexedMatcherTest {
         assertThat(compareEq(new Long(1l), new Long(1l)), is(true));
         assertThat(compareEq(new Long(1l), new Long(2l)), is(false));
         assertThat(compareEq(new Long(2l), new Long(1l)), is(false));
+
+        assertThat(compareNE(new Long(1l), new Long(1l)), is(false));
+        assertThat(compareNE(new Long(1l), new Long(2l)), is(true));
+        assertThat(compareNE(new Long(2l), new Long(1l)), is(true));
+
+        assertThat(compareLT(new Long(1l), new Long(1l)), is(false));
+        assertThat(compareLT(new Long(1l), new Long(2l)), is(true));
+        assertThat(compareLT(new Long(2l), new Long(1l)), is(false));
+
+        assertThat(compareLTE(new Long(1l), new Long(1l)), is(true));
+        assertThat(compareLTE(new Long(1l), new Long(2l)), is(true));
+        assertThat(compareLTE(new Long(2l), new Long(1l)), is(false));
+
+        assertThat(compareGT(new Long(1l), new Long(1l)), is(false));
+        assertThat(compareGT(new Long(1l), new Long(2l)), is(false));
+        assertThat(compareGT(new Long(2l), new Long(1l)), is(true));
+
+        assertThat(compareGTE(new Long(1l), new Long(1l)), is(true));
+        assertThat(compareGTE(new Long(1l), new Long(2l)), is(false));
+        assertThat(compareGTE(new Long(2l), new Long(1l)), is(true));
     }
 
     @Test
@@ -147,6 +336,39 @@ public class UnindexedMatcherTest {
         assertThat(compareEq(new Integer(1), new Long(1l)), is(true));
         assertThat(compareEq(new Long(1l), new Integer(2)), is(false));
         assertThat(compareEq(new Integer(2), new Long(1l)), is(false));
+
+        assertThat(compareNE(new Long(1l), new Integer(1)), is(false));
+        assertThat(compareNE(new Integer(1), new Long(1l)), is(false));
+        assertThat(compareNE(new Long(1l), new Integer(2)), is(true));
+        assertThat(compareNE(new Integer(2), new Long(1l)), is(true));
+
+        assertThat(compareLT(new Long(1l), new Integer(1)), is(false));
+        assertThat(compareLT(new Integer(1), new Long(1l)), is(false));
+        assertThat(compareLT(new Long(2l), new Integer(1)), is(false));
+        assertThat(compareLT(new Integer(2), new Long(1l)), is(false));
+        assertThat(compareLT(new Integer(1), new Long(2l)), is(true));
+        assertThat(compareLT(new Long(1l), new Integer(2)), is(true));
+
+        assertThat(compareLTE(new Long(1l), new Integer(1)), is(true));
+        assertThat(compareLTE(new Integer(1), new Long(1l)), is(true));
+        assertThat(compareLTE(new Long(2l), new Integer(1)), is(false));
+        assertThat(compareLTE(new Integer(2), new Long(1l)), is(false));
+        assertThat(compareLTE(new Integer(1), new Long(2l)), is(true));
+        assertThat(compareLTE(new Long(1l), new Integer(2)), is(true));
+
+        assertThat(compareGT(new Long(1l), new Integer(1)), is(false));
+        assertThat(compareGT(new Integer(1), new Long(1l)), is(false));
+        assertThat(compareGT(new Long(2l), new Integer(1)), is(true));
+        assertThat(compareGT(new Integer(2), new Long(1l)), is(true));
+        assertThat(compareGT(new Integer(1), new Long(2l)), is(false));
+        assertThat(compareGT(new Long(1l), new Integer(2)), is(false));
+
+        assertThat(compareGTE(new Long(1l), new Integer(1)), is(true));
+        assertThat(compareGTE(new Integer(1), new Long(1l)), is(true));
+        assertThat(compareGTE(new Long(2l), new Integer(1)), is(true));
+        assertThat(compareGTE(new Integer(2), new Long(1l)), is(true));
+        assertThat(compareGTE(new Integer(1), new Long(2l)), is(false));
+        assertThat(compareGTE(new Long(1l), new Integer(2)), is(false));
     }
 
     @Test
@@ -158,7 +380,6 @@ public class UnindexedMatcherTest {
         selector.put("name", eq);
         selector = QueryValidator.normaliseAndValidateQuery(selector);
         UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
-        assertThat(matcher, is(notNullValue()));
         assertThat(matcher.matches(rev), is(true));
     }
 
@@ -171,7 +392,6 @@ public class UnindexedMatcherTest {
         selector.put("name", eq);
         selector = QueryValidator.normaliseAndValidateQuery(selector);
         UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
-        assertThat(matcher, is(notNullValue()));
         assertThat(matcher.matches(rev), is(false));
     }
 
@@ -184,7 +404,6 @@ public class UnindexedMatcherTest {
         selector.put("species", eq);
         selector = QueryValidator.normaliseAndValidateQuery(selector);
         UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
-        assertThat(matcher, is(notNullValue()));
         assertThat(matcher.matches(rev), is(false));
     }
 
@@ -195,7 +414,6 @@ public class UnindexedMatcherTest {
         selector.put("name", "mike");
         selector = QueryValidator.normaliseAndValidateQuery(selector);
         UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
-        assertThat(matcher, is(notNullValue()));
         assertThat(matcher.matches(rev), is(true));
     }
 
@@ -206,7 +424,6 @@ public class UnindexedMatcherTest {
         selector.put("name", "fred");
         selector = QueryValidator.normaliseAndValidateQuery(selector);
         UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
-        assertThat(matcher, is(notNullValue()));
         assertThat(matcher.matches(rev), is(false));
     }
 
@@ -217,7 +434,6 @@ public class UnindexedMatcherTest {
         selector.put("species", "fred");
         selector = QueryValidator.normaliseAndValidateQuery(selector);
         UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
-        assertThat(matcher, is(notNullValue()));
         assertThat(matcher.matches(rev), is(false));
     }
 
@@ -230,7 +446,6 @@ public class UnindexedMatcherTest {
         selector.put("name", ne);
         selector = QueryValidator.normaliseAndValidateQuery(selector);
         UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
-        assertThat(matcher, is(notNullValue()));
         assertThat(matcher.matches(rev), is(true));
     }
 
@@ -243,12 +458,11 @@ public class UnindexedMatcherTest {
         selector.put("name", ne);
         selector = QueryValidator.normaliseAndValidateQuery(selector);
         UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
-        assertThat(matcher, is(notNullValue()));
         assertThat(matcher.matches(rev), is(false));
     }
 
     @Test
-    public void singleMatchesOnBadField() {
+    public void singleNeMatchesOnBadField() {
         // Selector - { "species" : { "$ne" : "fred" } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> ne = new HashMap<String, Object>();
@@ -256,12 +470,299 @@ public class UnindexedMatcherTest {
         selector.put("species", ne);
         selector = QueryValidator.normaliseAndValidateQuery(selector);
         UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
-        assertThat(matcher, is(notNullValue()));
         assertThat(matcher.matches(rev), is(true));
     }
 
     @Test
-    public void singleExistingMatch() {
+    public void singleGtStringMatch() {
+        // Selector - { "name" : { "$gt" : "andy" } }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$gt", "andy");
+        selector.put("name", op);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(true));
+    }
+
+    @Test
+    public void singleGtIntMatch() {
+        // Selector - { "age" : { "$gt" : 12 } }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$gt", 12);
+        selector.put("age", op);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(true));
+    }
+
+    @Test
+    public void singleGtStringNoMatch() {
+        // Selector - { "name" : { "$gt" : "robert" } }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$gt", "robert");
+        selector.put("name", op);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(false));
+    }
+
+    @Test
+    public void singleGtIntNoMatch() {
+        // Selector - { "age" : { "$gt" : 45 } }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$gt", 45);
+        selector.put("age", op);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(false));
+    }
+
+    @Test
+    public void singleGtNoMatchBadField() {
+        // Selector - { "species" : { "$gt" : "fred" } }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$gt", "fred");
+        selector.put("species", op);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(false));
+    }
+
+    @Test
+    public void singleGteStringMatch() {
+        // Selector - { "name" : { "$gte" : "andy" } }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$gte", "andy");
+        selector.put("name", op);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(true));
+    }
+
+    @Test
+    public void singleGteStringMatchEq() {
+        // Selector - { "name" : { "$gte" : "mike" } }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$gte", "mike");
+        selector.put("name", op);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(true));
+    }
+
+    @Test
+    public void singleGteIntMatch() {
+        // Selector - { "age" : { "$gte" : 12 } }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$gte", 12);
+        selector.put("age", op);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(true));
+    }
+
+    @Test
+    public void singleGteIntMatchEq() {
+        // Selector - { "age" : { "$gte" : 31 } }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$gte", 31);
+        selector.put("age", op);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(true));
+    }
+
+    @Test
+    public void singleGteStringNoMatch() {
+        // Selector - { "name" : { "$gte" : "robert" } }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$gte", "robert");
+        selector.put("name", op);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(false));
+    }
+
+    @Test
+    public void singleGteIntNoMatch() {
+        // Selector - { "age" : { "$gte" : 45 } }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$gte", 45);
+        selector.put("age", op);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(false));
+    }
+
+    @Test
+    public void singleGteNoMatchBadField() {
+        // Selector - { "species" : { "$gte" : "fred" } }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$gte", "fred");
+        selector.put("species", op);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(false));
+    }
+
+    @Test
+    public void singleLtStringMatch() {
+        // Selector - { "name" : { "$lt" : "robert" } }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$lt", "robert");
+        selector.put("name", op);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(true));
+    }
+
+    @Test
+    public void singleLtIntMatch() {
+        // Selector - { "age" : { "$lt" : 45 } }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$lt", 45);
+        selector.put("age", op);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(true));
+    }
+
+    @Test
+    public void singleLtStringNoMatch() {
+        // Selector - { "name" : { "$lt" : "andy" } }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$lt", "andy");
+        selector.put("name", op);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(false));
+    }
+
+    @Test
+    public void singleLtIntNoMatch() {
+        // Selector - { "age" : { "$lt" : 12 } }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$lt", 12);
+        selector.put("age", op);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(false));
+    }
+
+    @Test
+    public void singleLtNoMatchBadField() {
+        // Selector - { "species" : { "$lt" : "fred" } }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$lt", "fred");
+        selector.put("species", op);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(false));
+    }
+
+    @Test
+    public void singleLteStringMatch() {
+        // Selector - { "name" : { "$lte" : "robert" } }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$lte", "robert");
+        selector.put("name", op);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(true));
+    }
+
+    @Test
+    public void singleLteStringMatchEq() {
+        // Selector - { "name" : { "$lte" : "mike" } }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$lte", "mike");
+        selector.put("name", op);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(true));
+    }
+
+    @Test
+    public void singleLteIntMatch() {
+        // Selector - { "age" : { "$lte" : 45 } }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$lte", 45);
+        selector.put("age", op);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(true));
+    }
+
+    @Test
+    public void singleLteIntMatchEq() {
+        // Selector - { "age" : { "$lte" : 31 } }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$lte", 31);
+        selector.put("age", op);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(true));
+    }
+
+    @Test
+    public void singleLteStringNoMatch() {
+        // Selector - { "name" : { "$lte" : "andy" } }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$lte", "andy");
+        selector.put("name", op);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(false));
+    }
+
+    @Test
+    public void singleLteIntNoMatch() {
+        // Selector - { "age" : { "$lte" : 12 } }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$lte", 12);
+        selector.put("age", op);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(false));
+    }
+
+    @Test
+    public void singleLteNoMatchBadField() {
+        // Selector - { "species" : { "$lte" : "fred" } }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$lte", "fred");
+        selector.put("species", op);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(false));
+    }
+
+    @Test
+    public void singleExistsMatch() {
         // Selector - { "name" : { "$exists" : true } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> exists = new HashMap<String, Object>();
@@ -269,12 +770,11 @@ public class UnindexedMatcherTest {
         selector.put("name", exists);
         selector = QueryValidator.normaliseAndValidateQuery(selector);
         UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
-        assertThat(matcher, is(notNullValue()));
         assertThat(matcher.matches(rev), is(true));
     }
 
     @Test
-    public void singleExistingNoMatch() {
+    public void singleExistsNoMatch() {
         // Selector - { "name" : { "$exists" : false } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> exists = new HashMap<String, Object>();
@@ -282,12 +782,11 @@ public class UnindexedMatcherTest {
         selector.put("name", exists);
         selector = QueryValidator.normaliseAndValidateQuery(selector);
         UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
-        assertThat(matcher, is(notNullValue()));
         assertThat(matcher.matches(rev), is(false));
     }
 
     @Test
-    public void singleExistingMatchOnMissing() {
+    public void singleExistsMatchOnMissing() {
         // Selector - { "species" : { "$exists" : false } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> exists = new HashMap<String, Object>();
@@ -295,12 +794,11 @@ public class UnindexedMatcherTest {
         selector.put("species", exists);
         selector = QueryValidator.normaliseAndValidateQuery(selector);
         UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
-        assertThat(matcher, is(notNullValue()));
         assertThat(matcher.matches(rev), is(true));
     }
 
     @Test
-    public void singleExistingNoMatchOnMissing() {
+    public void singleExistsNoMatchOnMissing() {
         // Selector - { "species" : { "$exists" : true } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> exists = new HashMap<String, Object>();
@@ -308,7 +806,6 @@ public class UnindexedMatcherTest {
         selector.put("species", exists);
         selector = QueryValidator.normaliseAndValidateQuery(selector);
         UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
-        assertThat(matcher, is(notNullValue()));
         assertThat(matcher.matches(rev), is(false));
     }
 
@@ -327,7 +824,6 @@ public class UnindexedMatcherTest {
         selector.put("$and", Arrays.<Object>asList(name, age));
         selector = QueryValidator.normaliseAndValidateQuery(selector);
         UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
-        assertThat(matcher, is(notNullValue()));
         assertThat(matcher.matches(rev), is(true));
     }
 
@@ -346,7 +842,6 @@ public class UnindexedMatcherTest {
         selector.put("$and", Arrays.<Object>asList(name, age));
         selector = QueryValidator.normaliseAndValidateQuery(selector);
         UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
-        assertThat(matcher, is(notNullValue()));
         assertThat(matcher.matches(rev), is(false));
     }
 
@@ -365,7 +860,6 @@ public class UnindexedMatcherTest {
         selector.put("$and", Arrays.<Object>asList(name, age));
         selector = QueryValidator.normaliseAndValidateQuery(selector);
         UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
-        assertThat(matcher, is(notNullValue()));
         assertThat(matcher.matches(rev), is(false));
     }
 
@@ -381,7 +875,6 @@ public class UnindexedMatcherTest {
         selector.put("age", eqAge);
         selector = QueryValidator.normaliseAndValidateQuery(selector);
         UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
-        assertThat(matcher, is(notNullValue()));
         assertThat(matcher.matches(rev), is(true));
     }
 
@@ -397,7 +890,172 @@ public class UnindexedMatcherTest {
         selector.put("age", eqAge);
         selector = QueryValidator.normaliseAndValidateQuery(selector);
         UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
-        assertThat(matcher, is(notNullValue()));
+        assertThat(matcher.matches(rev), is(false));
+    }
+
+    @Test
+    public void orMatchAllFields() {
+        // Selector - { "$or" : [ { "name" : { "$eq" : "mike" } }, { "age" : { "$eq" : 31 } } ] }
+        Map<String, Object> c1op = new HashMap<String, Object>();
+        c1op.put("$eq", "mike");
+        Map<String, Object> c1 = new HashMap<String, Object>();
+        c1.put("name", c1op);
+        Map<String, Object> c2op = new HashMap<String, Object>();
+        c2op.put("$eq", 31);
+        Map<String, Object> c2 = new HashMap<String, Object>();
+        c2.put("age", c2op);
+        Map<String, Object> selector = new HashMap<String, Object>();
+        selector.put("$or", Arrays.<Object>asList(c1, c2));
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(true));
+    }
+
+    @Test
+    public void orMatchOnOneField() {
+        // Selector - { "$or" : [ { "name" : { "$eq" : "mike" } }, { "age" : { "$eq" : 12 } } ] }
+        Map<String, Object> c1op = new HashMap<String, Object>();
+        c1op.put("$eq", "mike");
+        Map<String, Object> c1 = new HashMap<String, Object>();
+        c1.put("name", c1op);
+        Map<String, Object> c2op = new HashMap<String, Object>();
+        c2op.put("$eq", 12);
+        Map<String, Object> c2 = new HashMap<String, Object>();
+        c2.put("age", c2op);
+        Map<String, Object> selector = new HashMap<String, Object>();
+        selector.put("$or", Arrays.<Object>asList(c1, c2));
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(true));
+    }
+
+    @Test
+    public void orNoMatch() {
+        // Selector - { "$or" : [ { "name" : { "$eq" : "fred" } }, { "age" : { "$eq" : 12 } } ] }
+        Map<String, Object> c1op = new HashMap<String, Object>();
+        c1op.put("$eq", "fred");
+        Map<String, Object> c1 = new HashMap<String, Object>();
+        c1.put("name", c1op);
+        Map<String, Object> c2op = new HashMap<String, Object>();
+        c2op.put("$eq", 12);
+        Map<String, Object> c2 = new HashMap<String, Object>();
+        c2.put("age", c2op);
+        Map<String, Object> selector = new HashMap<String, Object>();
+        selector.put("$or", Arrays.<Object>asList(c1, c2));
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(false));
+    }
+
+    // ($not) We can be fairly simple here as we know that the internal is that $not just negates.
+
+    @Test
+     public void noMatchNotEq() {
+        // Selector - { "name" : { "$not" : { "$eq" : "mike" } } }
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$eq", "mike");
+        Map<String, Object> not = new HashMap<String, Object>();
+        not.put("$not", op);
+        Map<String, Object> selector = new HashMap<String, Object>();
+        selector.put("name", not);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(false));
+    }
+
+    @Test
+    public void matchNotEq() {
+        // Selector - { "name" : { "$not" : { "$eq" : "fred" } } }
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$eq", "fred");
+        Map<String, Object> not = new HashMap<String, Object>();
+        not.put("$not", op);
+        Map<String, Object> selector = new HashMap<String, Object>();
+        selector.put("name", not);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(true));
+    }
+
+    @Test
+    public void matchNotEqBadField() {
+        // Selector - { "species" : { "$not" : { "$eq" : "fred" } } }
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$eq", "fred");
+        Map<String, Object> not = new HashMap<String, Object>();
+        not.put("$not", op);
+        Map<String, Object> selector = new HashMap<String, Object>();
+        selector.put("species", not);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(true));
+    }
+
+    @Test
+    public void matchOnArrayFields() {
+        // Selector - { "pets" : "white_cat" }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        selector.put("pets", "white_cat");
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(true));
+    }
+
+    @Test
+    public void matchGoodItemWithNot() {
+        // Selector - { "pets" : { "$not" : { "$eq" : "white_cat" } } }
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$eq", "white_cat");
+        Map<String, Object> not = new HashMap<String, Object>();
+        not.put("$not", op);
+        Map<String, Object> selector = new HashMap<String, Object>();
+        selector.put("pets", not);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(true));
+    }
+
+    @Test
+    public void noMatchOnBadItem() {
+        // Selector - { "pets" : "tabby_cat" }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        selector.put("pets", "tabby_cat");
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(false));
+    }
+
+    @Test
+    public void matchBadItemWithNot() {
+        // Selector - { "pets" : { "$not" : { "$eq" : "tabby_cat" } } }
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$eq", "tabby_cat");
+        Map<String, Object> not = new HashMap<String, Object>();
+        not.put("$not", op);
+        Map<String, Object> selector = new HashMap<String, Object>();
+        selector.put("pets", not);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(true));
+    }
+
+    @Test
+    public void matchOnDottedFields() {
+        // Selector - { "address.number" : "1" }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        selector.put("address.number", "1");
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(true));
+    }
+
+    @Test
+    public void noMatchOnDottedFields() {
+        // Selector - { "address.number" : "2" }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        selector.put("address.number", "2");
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
         assertThat(matcher.matches(rev), is(false));
     }
 


### PR DESCRIPTION
- Update QueryExecutor to handle Or query nodes.
- Update QuerySqlTranslator to handle OR, OR and AND sub clauses, NOT,
and EXISTS.
- Update QueryValidator to handle compound clauses.
- Update UnindexedMatcher to handle OR, OR and AND sub clauses, NOT,
and EXISTS.
- Add tests to AbstractQueryTestBase to test all complex query
functionality.
- Add UnindexedMatcher, QuerySqlTranslator, and QueryValidator tests.
- Split out the set up of data into separate abstract class for tests.
- Create an extended query base test abstract class used to execute
tests for queries that are not covered by indexes.
- Fix bug in IndexUpdater that came up during dotted notation testing.
- Change return type for QueryResult.size() from long to int so that it
matches the return type of QueryResult.documentIds().size().