### PR TITLE
Add field projection support to query

### DIFF
--- a/sync-core/src/main/java/com/cloudant/sync/datastore/DocumentRevisionBuilder.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/DocumentRevisionBuilder.java
@@ -59,6 +59,7 @@ public class DocumentRevisionBuilder {
     private long docInternalId = -1;
     private long parent = -1;
     private List<? extends Attachment> attachments = null;
+    private Datastore datastore = null;
 
     /**
      * <p>Builds and returns the {@code BasicDocumentRevision} for this builder.</p>
@@ -200,6 +201,16 @@ public class DocumentRevisionBuilder {
     }
 
     /**
+     * <p>Sets the datastore for this builder.</p>
+     * @param datastore the datastore
+     * @return the builder object for chained calls
+     */
+    public DocumentRevisionBuilder setDatastore(Datastore datastore) {
+        this.datastore = datastore;
+        return this;
+    }
+
+    /**
      * Builds and returns the {@link com.cloudant.sync.datastore.MutableDocumentRevision} for this builder.
      * @return {@link com.cloudant.sync.datastore.MutableDocumentRevision} for this builder.
      */
@@ -208,6 +219,21 @@ public class DocumentRevisionBuilder {
         revision.body = this.body;
         revision.docId = this.docId;
         return revision;
+    }
+
+    /**
+     * Builds and returns the {@link com.cloudant.sync.datastore.ProjectedDocumentRevision} for this builder.
+     * @return {@link com.cloudant.sync.datastore.ProjectedDocumentRevision} for this builder.
+     */
+    public ProjectedDocumentRevision buildProjected() {
+        BasicDocumentRevision.BasicDocumentRevisionOptions options = new BasicDocumentRevision.BasicDocumentRevisionOptions();
+        options.sequence = sequence;
+        options.docInternalId = docInternalId;
+        options.deleted = deleted;
+        options.current = current;
+        options.parent = parent;
+        options.attachments = attachments;
+        return new ProjectedDocumentRevision(docId, revId, body, options, datastore);
     }
 
     /**

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/ProjectedDocumentRevision.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/ProjectedDocumentRevision.java
@@ -1,0 +1,49 @@
+//  Copyright (c) 2015 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+package com.cloudant.sync.datastore;
+
+/**
+ *  A document revision that has been projected.
+ *
+ *  This class implements a version of mutableCopy which returns the full
+ *  document when called, to prevent accidental data loss which might come
+ *  from saving a projected document.
+ */
+public class ProjectedDocumentRevision extends BasicDocumentRevision {
+
+    Datastore datastore;
+
+    ProjectedDocumentRevision(String docId,
+                              String revId,
+                              DocumentBody body,
+                              BasicDocumentRevisionOptions options,
+                              Datastore datastore) {
+        super(docId, revId, body, options);
+        this.datastore = datastore;
+    }
+
+    @Override
+    public MutableDocumentRevision mutableCopy() {
+        BasicDocumentRevision rev = datastore.getDocument(this.getId());
+        if (rev == null) {
+            return null;
+        }
+
+        // Don't want to return an updated version, breaks contract of mutableCopy
+        if (!rev.getRevision().equals(this.getRevision())) {
+            return null;
+        }
+
+        return rev.mutableCopy();
+    }
+}

--- a/sync-core/src/main/java/com/cloudant/sync/query/QueryExecutor.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/QueryExecutor.java
@@ -230,9 +230,7 @@ class QueryExecutor {
                 if (accumulator == null) {
                     accumulator = new HashSet<String>(childIds);
                 } else {
-                    if (childIds != null) {
-                        accumulator = Sets.intersection(accumulator, childIds);
-                    }
+                    accumulator = Sets.intersection(accumulator, childIds);
                 }
             }
 
@@ -250,9 +248,7 @@ class QueryExecutor {
                 if (accumulator == null) {
                     accumulator = new HashSet<String>(childIds);
                 } else {
-                    if (childIds != null) {
-                        accumulator = Sets.union(accumulator, childIds);
-                    }
+                    accumulator = Sets.union(accumulator, childIds);
                 }
             }
 

--- a/sync-core/src/main/java/com/cloudant/sync/query/QueryExecutor.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/QueryExecutor.java
@@ -196,7 +196,7 @@ class QueryExecutor {
             return true;
         }
         for (String field: fields) {
-            if (field.contains("\\.")) {
+            if (field.contains(".")) {
                 String msg = String.format("Projection field cannot use dotted notation: %s",
                         field);
                 logger.log(Level.SEVERE, msg);

--- a/sync-core/src/main/java/com/cloudant/sync/query/QueryResult.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/QueryResult.java
@@ -152,9 +152,7 @@ public class QueryResult implements Iterable<DocumentRevision> {
                         innerRev = projectFields(fields, rev, datastore);
                     }
 
-                    if (innerRev != null) {
-                        docList.add(innerRev);
-                    }
+                    docList.add(innerRev);
 
                     // Apply limit (limit == 0 means disable)
                     nReturned = nReturned + 1;
@@ -189,10 +187,6 @@ public class QueryResult implements Iterable<DocumentRevision> {
             if (fields.contains(key)) {
                 body.put(key, originalBody.get(key));
             }
-        }
-
-        if (body.isEmpty()) {
-            return null;
         }
 
         DocumentRevisionBuilder revBuilder = new DocumentRevisionBuilder();

--- a/sync-core/src/test/java/com/cloudant/sync/query/AbstractQueryTestSetUp.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/AbstractQueryTestSetUp.java
@@ -82,6 +82,7 @@ public abstract class AbstractQueryTestSetUp {
     // - When querying using _rev
     // - When querying using $not operator
     // - When querying using $exists operator
+    // - When filtering fields on find
     public void setUpBasicQueryData() {
         MutableDocumentRevision rev = new MutableDocumentRevision();
         rev.docId = "mike12";

--- a/sync-core/src/test/java/com/cloudant/sync/query/QueryFilterFieldsTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/QueryFilterFieldsTest.java
@@ -99,8 +99,12 @@ public class QueryFilterFieldsTest extends AbstractQueryTestSetUp {
         // query - { "name" : "mike" }
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", "mike");
-        assertThat(im.find(query, 0, Long.MAX_VALUE, Arrays.asList("name.blah"), null),
-                is(nullValue()));
+        QueryResult queryResult = im.find(query,
+                                          0,
+                                          Long.MAX_VALUE,
+                                          Arrays.asList("name.blah"),
+                                          null);
+        assertThat(queryResult, is(nullValue()));
     }
 
     @Test
@@ -190,8 +194,9 @@ public class QueryFilterFieldsTest extends AbstractQueryTestSetUp {
             assertThat((String) revBody.get("name"), is("mike"));
 
             try {
-                assertThat(ds.deleteDocumentFromRevision((ProjectedDocumentRevision) rev),
-                        is(notNullValue()));
+                DocumentRevision deleted = null;
+                deleted = ds.deleteDocumentFromRevision((ProjectedDocumentRevision) rev);
+                assertThat(deleted, is(notNullValue()));
             } catch (ConflictException e) {
                 Assert.fail("Failed to delete document revision");
                 e.printStackTrace();

--- a/sync-core/src/test/java/com/cloudant/sync/query/QueryFilterFieldsTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/QueryFilterFieldsTest.java
@@ -1,0 +1,203 @@
+//  Copyright (c) 2015 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+package com.cloudant.sync.query;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import com.cloudant.sync.datastore.BasicDocumentRevision;
+import com.cloudant.sync.datastore.ConflictException;
+import com.cloudant.sync.datastore.DocumentBodyFactory;
+import com.cloudant.sync.datastore.DocumentRevision;
+import com.cloudant.sync.datastore.MutableDocumentRevision;
+import com.cloudant.sync.datastore.ProjectedDocumentRevision;
+import com.cloudant.sync.util.SQLDatabaseTestUtils;
+
+import org.junit.Assert;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+public class QueryFilterFieldsTest extends AbstractQueryTestSetUp {
+
+    @Override
+    public void setUp() throws SQLException {
+        super.setUp();
+        im = new IndexManager(ds);
+        assertThat(im, is(notNullValue()));
+        db = im.getDatabase();
+        assertThat(db, is(notNullValue()));
+        assertThat(im.getQueue(), is(notNullValue()));
+        String[] metadataTableList = new String[] { IndexManager.INDEX_METADATA_TABLE_NAME };
+        SQLDatabaseTestUtils.assertTablesExist(db, metadataTableList);
+
+        setUpBasicQueryData();
+    }
+
+    // When filtering fields on find
+
+    @Test
+    public void returnsFieldSpecifiedOnly() {
+        // query - { "name" : "mike" }
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("name", "mike");
+        QueryResult queryResult = im.find(query, 0, Long.MAX_VALUE, Arrays.asList("name"), null);
+        for (DocumentRevision rev : queryResult) {
+            Map<String, Object> revBody = rev.getBody().asMap();
+            assertThat(revBody.keySet(), contains("name"));
+        }
+    }
+
+    @Test
+    public void returnsAllFieldsWhenFieldsArrayEmpty() {
+        // query - { "name" : "mike" }
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("name", "mike");
+        QueryResult queryResult = im.find(query, 0, Long.MAX_VALUE, new ArrayList<String>(), null);
+        for (DocumentRevision rev : queryResult) {
+            Map<String, Object> revBody = rev.getBody().asMap();
+            assertThat(revBody.keySet(), containsInAnyOrder("name", "pet", "age"));
+        }
+    }
+
+    @Test
+    public void returnsAllFieldsWhenFieldsArrayNull() {
+        // query - { "name" : "mike" }
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("name", "mike");
+        QueryResult queryResult = im.find(query, 0, Long.MAX_VALUE, null, null);
+        for (DocumentRevision rev : queryResult) {
+            Map<String, Object> revBody = rev.getBody().asMap();
+            assertThat(revBody.keySet(), containsInAnyOrder("name", "pet", "age"));
+        }
+    }
+
+    @Test
+    public void returnsNullWhenUsingDottedNotation() {
+        // query - { "name" : "mike" }
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("name", "mike");
+        assertThat(im.find(query, 0, Long.MAX_VALUE, Arrays.asList("name.blah"), null),
+                is(nullValue()));
+    }
+
+    @Test
+    public void returnsOnlyFieldsSpecified() {
+        // query - { "name" : "mike" }
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("name", "mike");
+        QueryResult queryResult = im.find(query,
+                                          0,
+                                          Long.MAX_VALUE,
+                                          Arrays.asList("name", "pet"),
+                                          null);
+        for (DocumentRevision rev : queryResult) {
+            Map<String, Object> revBody = rev.getBody().asMap();
+            assertThat(revBody.keySet(), containsInAnyOrder("name", "pet"));
+        }
+    }
+
+    @Test
+    public void returnsFullMutableCopyOfProjectedDoc() {
+        // query - { "name" : "mike", "age" : 12 }
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("name", "mike");
+        query.put("age", 12);
+        QueryResult queryResult = im.find(query, 0, Long.MAX_VALUE, Arrays.asList("name"), null);
+        assertThat(queryResult.size(), is(1));
+        for (DocumentRevision rev : queryResult) {
+            Map<String, Object> revBody = rev.getBody().asMap();
+            assertThat(revBody.keySet(), contains("name"));
+            assertThat((String) revBody.get("name"), is("mike"));
+
+            assertThat(rev, instanceOf(ProjectedDocumentRevision.class));
+            MutableDocumentRevision mutable = ((ProjectedDocumentRevision) rev).mutableCopy();
+            Map<String, Object> mutableBody = mutable.getBody().asMap();
+            assertThat(mutableBody.keySet(), containsInAnyOrder("name", "age", "pet"));
+            assertThat((String) mutableBody.get("name"), is("mike"));
+            assertThat((Integer) mutableBody.get("age"), is(12));
+            assertThat((String) mutableBody.get("pet"), is("cat"));
+        }
+    }
+
+    @Test
+    public void returnsNullMutableCopyWhenDocUpdated() {
+        // query - { "name" : "mike", "age" : 12 }
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("name", "mike");
+        query.put("age", 12);
+        QueryResult queryResult = im.find(query, 0, Long.MAX_VALUE, Arrays.asList("name"), null);
+        assertThat(queryResult.size(), is(1));
+        for (DocumentRevision rev : queryResult) {
+            assertThat(rev, is(instanceOf(ProjectedDocumentRevision.class)));
+            Map<String, Object> revBody = rev.getBody().asMap();
+            assertThat(revBody.keySet(), contains("name"));
+            assertThat((String) revBody.get("name"), is("mike"));
+
+            BasicDocumentRevision original = ds.getDocument(rev.getId());
+            MutableDocumentRevision update = original.mutableCopy();
+            Map<String, Object> updateBody = original.getBody().asMap();
+            updateBody.put("name", "charles");
+            update.body = DocumentBodyFactory.create(updateBody);
+            try {
+                assertThat(ds.updateDocumentFromRevision(update), is(notNullValue()));
+            } catch (ConflictException e) {
+                Assert.fail("Failed to update document revision");
+                e.printStackTrace();
+            } catch (IOException e) {
+                Assert.fail("Failed to update document revision");
+                e.printStackTrace();
+            }
+
+            assertThat(((ProjectedDocumentRevision) rev).mutableCopy(), is(nullValue()));
+        }
+    }
+
+    @Test
+    public void returnsNullMutableCopyWhenDocDeleted() {
+        // query - { "name" : "mike", "age" : 12 }
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("name", "mike");
+        query.put("age", 12);
+        QueryResult queryResult = im.find(query, 0, Long.MAX_VALUE, Arrays.asList("name"), null);
+        assertThat(queryResult.size(), is(1));
+        for (DocumentRevision rev : queryResult) {
+            assertThat(rev, is(instanceOf(ProjectedDocumentRevision.class)));
+            Map<String, Object> revBody = rev.getBody().asMap();
+            assertThat(revBody.keySet(), contains("name"));
+            assertThat((String) revBody.get("name"), is("mike"));
+
+            try {
+                assertThat(ds.deleteDocumentFromRevision((ProjectedDocumentRevision) rev),
+                        is(notNullValue()));
+            } catch (ConflictException e) {
+                Assert.fail("Failed to delete document revision");
+                e.printStackTrace();
+            }
+
+            assertThat(((ProjectedDocumentRevision) rev).mutableCopy(), is(nullValue()));
+        }
+    }
+
+}

--- a/sync-core/src/test/java/com/cloudant/sync/query/QueryFilterFieldsTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/QueryFilterFieldsTest.java
@@ -27,6 +27,7 @@ import com.cloudant.sync.datastore.DocumentRevision;
 import com.cloudant.sync.datastore.MutableDocumentRevision;
 import com.cloudant.sync.datastore.ProjectedDocumentRevision;
 import com.cloudant.sync.util.SQLDatabaseTestUtils;
+import com.cloudant.sync.util.TestUtils;
 
 import org.junit.Assert;
 
@@ -46,7 +47,7 @@ public class QueryFilterFieldsTest extends AbstractQueryTestSetUp {
         super.setUp();
         im = new IndexManager(ds);
         assertThat(im, is(notNullValue()));
-        db = im.getDatabase();
+        db = TestUtils.getDatabaseConnectionToExistingDb(im.getDatabase());
         assertThat(db, is(notNullValue()));
         assertThat(im.getQueue(), is(notNullValue()));
         String[] metadataTableList = new String[] { IndexManager.INDEX_METADATA_TABLE_NAME };


### PR DESCRIPTION
- Update QueryResult to handle field projection.
- Create ProjectedDocumentRevision a sub-class of
BasicDocumentRevision used to ensure that the mutableCopy contract is
upheld when dealing with documents retrieved using query field
projection.
- Add method to DocumentRevisionBuilder to build a
ProjectedDocumentRevision.
- Add query field projection tests.