### PR TITLE
Fix OR query bug when some indexes are missing

### DIFF
--- a/sync-core/src/main/java/com/cloudant/sync/query/TranslatorState.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/TranslatorState.java
@@ -26,10 +26,12 @@ class TranslatorState {
 
     public boolean atLeastOneIndexUsed;
     public boolean atLeastOneIndexMissing;
+    public boolean atLeastOneORIndexMissing;
 
     TranslatorState() {
         atLeastOneIndexUsed = false;
         atLeastOneIndexMissing = false;
+        atLeastOneORIndexMissing = false;
     }
 
 }

--- a/sync-core/src/test/java/com/cloudant/sync/query/AbstractQueryTestBase.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/AbstractQueryTestBase.java
@@ -408,7 +408,8 @@ public abstract class AbstractQueryTestBase {
     }
 
     // Used to setup document data testing for queries without covering indexes:
-    // - When executing queries
+    // - When executing AND queries
+    // - When executing OR queries
     public void setUpWithoutCoveringIndexesQueryData() {
         MutableDocumentRevision rev = new MutableDocumentRevision();
         rev.docId = "mike12";

--- a/sync-core/src/test/java/com/cloudant/sync/query/QueryWithoutCoveringIndexesTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/QueryWithoutCoveringIndexesTest.java
@@ -130,6 +130,25 @@ public class QueryWithoutCoveringIndexesTest extends AbstractQueryTestBase {
         assertThat(queryResult.documentIds(), contains("mike12"));
     }
 
+    @Test
+    public void postHocMatchesProjectingOverNonQueriedFields() {
+        setUpWithoutCoveringIndexesQueryData();
+        // query - { "town" : "bristol" }
+        // indexes - { "basic" : { "name" : "basic", "type" : "json", "fields" : [ "_id",
+        //                                                                         "_rev",
+        //                                                                         "name",
+        //                                                                         "age" ] } }
+        //
+        //         - { "pet" : { "name" : "pet", "type" : "json", "fields" : [ "_id",
+        //                                                                     "_rev",
+        //                                                                     "name",
+        //                                                                     "pet" ] } }
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("town", "bristol");
+        QueryResult queryResult = im.find(query, 0, 0, Arrays.asList("name"), null);
+        assertThat(queryResult.documentIds(), containsInAnyOrder("mike72", "fred12"));
+    }
+
     // When executing OR queries
 
     @Test


### PR DESCRIPTION
Each clause in an OR query is treated separately.  If an index does not exist to handle a clause in an OR-ed query then the post hoc matcher must handle the query results.  This PR addresses the bug where the post hoc matcher was previously using a subset of the full list of documents to provide the (incorrect) query results.  With the work included here the full list of documents is now used. 