### PR TITLE
Fix NOT processing logic in query

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+
+# 0.11.0 (Unreleased)
+
+- [FIX] Using MongoDB query as the "gold" standard, query support for `NOT` has been fixed to return result sets correctly (as in MongoDB query).  Previously, the result set from a query like `{ "pet": { "$not" { "$eq": "dog" } } }` would include a document like `{ "pet" : [ "cat", "dog" ], ... }` because the array contains an object that isn't `dog`.  The new behavior is that `$not` now inverts the result set, so this document will no longer be included because it has an array element that matches `dog`.
+
+
+
 # 0.10.0 (2015-02-16)
 
 - [NEW] Added `listAllDatastores` method to `DatastoreManager`.

--- a/doc/query.md
+++ b/doc/query.md
@@ -315,14 +315,13 @@ Each value of the array is treated as a separate entry in the index. This means 
 { pet: { $eq: cat } }
 ```
 
-Will return the document `mike32`. Negation may be slightly confusing:
+Will return the document `mike32`. Negation such as:
 
 ```
 { pet: { $not: { $eq: cat } } }
 ```
 
-Will also return `mike32` because there are values in the array that are not `cat`. That is,
-this operator is matching for "any values that do not equal 'cat'".
+Will not return `mike32` because negation returns the set of documents that are not in the set of documents returned by the non-negated query.  In other words the negated query above will return all of the documents that are not in the set of documents returned by `{ pet: { $eq: cat } }`.
 
 #### Restrictions
 

--- a/sync-core/src/test/java/com/cloudant/sync/query/AbstractIndexTestBase.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/AbstractIndexTestBase.java
@@ -25,8 +25,6 @@ import com.cloudant.sync.util.TestUtils;
 import org.junit.After;
 import org.junit.Before;
 
-import java.sql.SQLException;
-
 public abstract class AbstractIndexTestBase {
 
     String factoryPath = null;

--- a/sync-core/src/test/java/com/cloudant/sync/query/AbstractQueryTestBase.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/AbstractQueryTestBase.java
@@ -24,11 +24,8 @@ import com.cloudant.sync.sqlite.SQLDatabase;
 import com.cloudant.sync.util.TestUtils;
 
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 
-import java.io.IOException;
-import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -285,11 +282,43 @@ public abstract class AbstractQueryTestBase {
         bodyMap.put("pet", Arrays.<Object>asList("cat", "dog"));
         rev.body = DocumentBodyFactory.create(bodyMap);
         ds.createDocumentFromRevision(rev);
+
         rev.docId = "fred34";
         bodyMap.clear();
         bodyMap.put("name", "fred");
         bodyMap.put("age", 34);
         bodyMap.put("pet", "parrot");
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        ds.createDocumentFromRevision(rev);
+
+        rev.docId = "mike34";
+        bodyMap.clear();
+        bodyMap.put("name", "mike");
+        bodyMap.put("age", 34);
+        bodyMap.put("pet", Arrays.<Object>asList("cat", "dog", "fish"));
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        ds.createDocumentFromRevision(rev);
+
+        rev.docId = "fred12";
+        bodyMap.clear();
+        bodyMap.put("name", "fred");
+        bodyMap.put("age", 12);
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        ds.createDocumentFromRevision(rev);
+
+        rev.docId = "john44";
+        bodyMap.clear();
+        bodyMap.put("name", "john");
+        bodyMap.put("age", 44);
+        bodyMap.put("pet", Arrays.<Object>asList("hamster", "snake"));
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        ds.createDocumentFromRevision(rev);
+
+        rev.docId = "john22";
+        bodyMap.clear();
+        bodyMap.put("name", "john");
+        bodyMap.put("age", 22);
+        bodyMap.put("pet", "cat");
         rev.body = DocumentBodyFactory.create(bodyMap);
         ds.createDocumentFromRevision(rev);
 

--- a/sync-core/src/test/java/com/cloudant/sync/query/IndexManagerTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/IndexManagerTest.java
@@ -21,10 +21,8 @@ import static org.hamcrest.Matchers.nullValue;
 import com.cloudant.sync.datastore.DocumentBodyFactory;
 import com.cloudant.sync.datastore.MutableDocumentRevision;
 
-import org.junit.Assert;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;

--- a/sync-core/src/test/java/com/cloudant/sync/query/IndexUpdaterTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/IndexUpdaterTest.java
@@ -31,7 +31,6 @@ import com.cloudant.sync.util.TestUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -80,7 +79,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         Map<String, Object> bodyMap = new HashMap<String, Object>();
         bodyMap.put("name", "mike");
         rev.body = DocumentBodyFactory.create(bodyMap);
-        BasicDocumentRevision saved = null;
+        BasicDocumentRevision saved;
         saved = ds.createDocumentFromRevision(rev);
 
 
@@ -134,7 +133,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         bodyMap.put("name", "mike");
         bodyMap.put("age", 12);
         rev.body = DocumentBodyFactory.create(bodyMap);
-        BasicDocumentRevision saved = null;
+        BasicDocumentRevision saved;
         saved = ds.createDocumentFromRevision(rev);
 
         assertThat(IndexUpdater.updateIndex("basic", fields, db, ds, im.getQueue()), is(true));
@@ -196,7 +195,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         bodyMap.put("car", "mini");
         bodyMap.put("ignored", "something");
         rev.body = DocumentBodyFactory.create(bodyMap);
-        BasicDocumentRevision saved = null;
+        BasicDocumentRevision saved;
         saved = ds.createDocumentFromRevision(rev);
 
         assertThat(IndexUpdater.updateIndex("basic", fields, db, ds, im.getQueue()), is(true));
@@ -257,7 +256,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         bodyMap.put("pet", "cat");
         bodyMap.put("ignored", "something");
         rev.body = DocumentBodyFactory.create(bodyMap);
-        BasicDocumentRevision saved = null;
+        BasicDocumentRevision saved;
         saved = ds.createDocumentFromRevision(rev);
 
         assertThat(IndexUpdater.updateIndex("basic", fields, db, ds, im.getQueue()), is(true));
@@ -318,7 +317,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         bodyMap.put("pet", "cat");
         bodyMap.put("ignored", "something");
         rev.body = DocumentBodyFactory.create(bodyMap);
-        BasicDocumentRevision saved = null;
+        BasicDocumentRevision saved;
         saved = ds.createDocumentFromRevision(rev);
 
         assertThat(IndexUpdater.updateIndex("basic", fields, db, ds, im.getQueue()), is(true));
@@ -376,7 +375,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         List<String> pets = Arrays.asList("cat", "dog", "parrot");
         bodyMap.put("pet", pets);
         rev.body = DocumentBodyFactory.create(bodyMap);
-        BasicDocumentRevision saved = null;
+        BasicDocumentRevision saved;
         saved = ds.createDocumentFromRevision(rev);
 
         assertThat(IndexUpdater.updateIndex("basic", fields, db, ds, im.getQueue()), is(true));
@@ -437,7 +436,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         pets.put("species", species);
         bodyMap.put("pet", pets);
         rev.body = DocumentBodyFactory.create(bodyMap);
-        BasicDocumentRevision saved = null;
+        BasicDocumentRevision saved;
         saved = ds.createDocumentFromRevision(rev);
 
         assertThat(IndexUpdater.updateIndex("basic", fields, db, ds, im.getQueue()), is(true));
@@ -496,7 +495,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         List<String> pets = Arrays.asList("cat", "dog", "parrot");
         goodBodyMap.put("pet", pets);
         goodRev.body = DocumentBodyFactory.create(goodBodyMap);
-        BasicDocumentRevision saved = null;
+        BasicDocumentRevision saved;
 
         MutableDocumentRevision badRev = new MutableDocumentRevision();
         badRev.docId = "id456";

--- a/sync-core/src/test/java/com/cloudant/sync/query/QueryFilterFieldsTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/QueryFilterFieldsTest.java
@@ -30,11 +30,8 @@ import com.cloudant.sync.util.SQLDatabaseTestUtils;
 import com.cloudant.sync.util.TestUtils;
 
 import org.junit.Assert;
-
 import org.junit.Test;
 
-import java.io.IOException;
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;

--- a/sync-core/src/test/java/com/cloudant/sync/query/QuerySortTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/QuerySortTest.java
@@ -24,7 +24,6 @@ import com.cloudant.sync.util.TestUtils;
 
 import org.junit.Test;
 
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;

--- a/sync-core/src/test/java/com/cloudant/sync/query/QueryValidatorTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/QueryValidatorTest.java
@@ -132,4 +132,26 @@ public class QueryValidatorTest {
         assertThat(QueryValidator.normaliseAndValidateQuery(query), is(notNullValue()));
     }
 
+    @Test
+    public void returnsNullForInvalidOperator() {
+        Map<String, Object> query = new HashMap<String, Object>();
+        // query - { "name" : { "$blah" : "mike" } }
+        Map<String, Object> blah = new HashMap<String, Object>();
+        blah.put("$blah", "mike");
+        query.put("name", blah);
+        assertThat(QueryValidator.normaliseAndValidateQuery(query), is(nullValue()));
+    }
+
+    @Test
+    public void returnsNullForInvalidOperatorWithNOT() {
+        Map<String, Object> query = new HashMap<String, Object>();
+        // query - { "name" : { "$blah" : "mike" } }
+        Map<String, Object> blah = new HashMap<String, Object>();
+        blah.put("$blah", "mike");
+        Map<String, Object> notBlah = new HashMap<String, Object>();
+        notBlah.put("$not", blah);
+        query.put("name", notBlah);
+        assertThat(QueryValidator.normaliseAndValidateQuery(query), is(nullValue()));
+    }
+
 }

--- a/sync-core/src/test/java/com/cloudant/sync/query/QueryWithoutCoveringIndexesTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/QueryWithoutCoveringIndexesTest.java
@@ -26,7 +26,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;

--- a/sync-core/src/test/java/com/cloudant/sync/query/UnindexedMatcherTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/UnindexedMatcherTest.java
@@ -17,7 +17,6 @@ import static com.cloudant.sync.query.UnindexedMatcher.compareGT;
 import static com.cloudant.sync.query.UnindexedMatcher.compareGTE;
 import static com.cloudant.sync.query.UnindexedMatcher.compareLT;
 import static com.cloudant.sync.query.UnindexedMatcher.compareLTE;
-import static com.cloudant.sync.query.UnindexedMatcher.compareNE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
@@ -69,12 +68,6 @@ public class UnindexedMatcherTest {
         assertThat(compareEq(null, 1), is(false));
         assertThat(compareEq(1, null), is(false));
 
-        assertThat(compareNE(null, null), is(false));
-        assertThat(compareNE(null, "mike"), is(true));
-        assertThat(compareNE("mike", null), is(true));
-        assertThat(compareNE(null, 1), is(true));
-        assertThat(compareNE(1, null), is(true));
-
         assertThat(compareLT(null, null), is(false));
         assertThat(compareLT(null, "mike"), is(false));
         assertThat(compareLT("mike", null), is(false));
@@ -109,11 +102,6 @@ public class UnindexedMatcherTest {
         assertThat(compareEq(new Float(1.1f), new Integer(1)), is(false));
         assertThat(compareEq(new Integer(1), new Float(1.1f)), is(false));
 
-        assertThat(compareNE(new Float(1.0f), new Integer(1)), is(false));
-        assertThat(compareNE(new Integer(1), new Float(1.0f)), is(false));
-        assertThat(compareNE(new Float(1.1f), new Integer(1)), is(false));
-        assertThat(compareNE(new Integer(1), new Float(1.1f)), is(false));
-
         assertThat(compareLT(new Float(1.0f), new Integer(1)), is(false));
         assertThat(compareLT(new Integer(1), new Float(1.0f)), is(false));
         assertThat(compareLT(new Float(1.1f), new Integer(1)), is(false));
@@ -140,9 +128,6 @@ public class UnindexedMatcherTest {
         assertThat(compareEq("mike", "mike"), is(true));
         assertThat(compareEq("mike", "Mike"), is(false));
 
-        assertThat(compareNE("mike", "mike"), is(false));
-        assertThat(compareNE("mike", "Mike"), is(true));
-
         assertThat(compareLT("mike", "mike"), is(false));
         assertThat(compareLT("mike", "fred"), is(false));
         assertThat(compareLT("fred", "mike"), is(true));
@@ -166,9 +151,6 @@ public class UnindexedMatcherTest {
         assertThat(compareEq("1", new Integer(1)), is(false));
         assertThat(compareEq(new Integer(1), "1"), is(false));
 
-        assertThat(compareNE("1", new Integer(1)), is(true));
-        assertThat(compareNE(new Integer(1), "1"), is(true));
-
         assertThat(compareLT("1", new Integer(1)), is(false));
         assertThat(compareLT(new Integer(1), "1"), is(true));
 
@@ -189,11 +171,6 @@ public class UnindexedMatcherTest {
         assertThat(compareEq(new Double(1.0), new Double(1.00)), is(true));
         assertThat(compareEq(new Double(1.0), new Double(1.1)), is(false));
         assertThat(compareEq(new Double(1.1), new Double(1.0)), is(false));
-
-        assertThat(compareNE(new Double(1.0), new Double(1.0)), is(false));
-        assertThat(compareNE(new Double(1.0), new Double(1.00)), is(false));
-        assertThat(compareNE(new Double(1.0), new Double(1.1)), is(true));
-        assertThat(compareNE(new Double(1.1), new Double(1.0)), is(true));
 
         assertThat(compareLT(new Double(1.0), new Double(1.0)), is(false));
         assertThat(compareLT(new Double(1.0), new Double(1.00)), is(false));
@@ -223,11 +200,6 @@ public class UnindexedMatcherTest {
         assertThat(compareEq(new Long(1l), new Double(1.0)), is(true));
         assertThat(compareEq(new Double(1.1), new Long(1l)), is(false));
         assertThat(compareEq(new Long(1l), new Double(1.1)), is(false));
-
-        assertThat(compareNE(new Double(1.0), new Long(1l)), is(false));
-        assertThat(compareNE(new Long(1l), new Double(1.0)), is(false));
-        assertThat(compareNE(new Double(1.1), new Long(1l)), is(true));
-        assertThat(compareNE(new Long(1l), new Double(1.1)), is(true));
 
         assertThat(compareLT(new Double(1.0), new Long(1l)), is(false));
         assertThat(compareLT(new Long(1l), new Double(1.0)), is(false));
@@ -267,11 +239,6 @@ public class UnindexedMatcherTest {
         assertThat(compareEq(new Double(1.1), new Integer(1)), is(false));
         assertThat(compareEq(new Integer(1), new Double(1.1)), is(false));
 
-        assertThat(compareNE(new Double(1.0), new Integer(1)), is(false));
-        assertThat(compareNE(new Integer(1), new Double(1.0)), is(false));
-        assertThat(compareNE(new Double(1.1), new Integer(1)), is(true));
-        assertThat(compareNE(new Integer(1), new Double(1.1)), is(true));
-
         assertThat(compareLT(new Double(1.0), new Integer(1)), is(false));
         assertThat(compareLT(new Integer(1), new Double(1.0)), is(false));
         assertThat(compareLT(new Double(1.1), new Integer(1)), is(false));
@@ -308,10 +275,6 @@ public class UnindexedMatcherTest {
         assertThat(compareEq(new Long(1l), new Long(2l)), is(false));
         assertThat(compareEq(new Long(2l), new Long(1l)), is(false));
 
-        assertThat(compareNE(new Long(1l), new Long(1l)), is(false));
-        assertThat(compareNE(new Long(1l), new Long(2l)), is(true));
-        assertThat(compareNE(new Long(2l), new Long(1l)), is(true));
-
         assertThat(compareLT(new Long(1l), new Long(1l)), is(false));
         assertThat(compareLT(new Long(1l), new Long(2l)), is(true));
         assertThat(compareLT(new Long(2l), new Long(1l)), is(false));
@@ -336,11 +299,6 @@ public class UnindexedMatcherTest {
         assertThat(compareEq(new Integer(1), new Long(1l)), is(true));
         assertThat(compareEq(new Long(1l), new Integer(2)), is(false));
         assertThat(compareEq(new Integer(2), new Long(1l)), is(false));
-
-        assertThat(compareNE(new Long(1l), new Integer(1)), is(false));
-        assertThat(compareNE(new Integer(1), new Long(1l)), is(false));
-        assertThat(compareNE(new Long(1l), new Integer(2)), is(true));
-        assertThat(compareNE(new Integer(2), new Long(1l)), is(true));
 
         assertThat(compareLT(new Long(1l), new Integer(1)), is(false));
         assertThat(compareLT(new Integer(1), new Long(1l)), is(false));
@@ -947,13 +905,40 @@ public class UnindexedMatcherTest {
         assertThat(matcher.matches(rev), is(false));
     }
 
-    // ($not) We can be fairly simple here as we know that the internal is that $not just negates.
+    // ($not) - We can be fairly simple here as we know that the internal is that $not just negates.
+    // ($ne)  - $ne translates to $not..$eq
 
     @Test
      public void noMatchNotEq() {
         // Selector - { "name" : { "$not" : { "$eq" : "mike" } } }
         Map<String, Object> op = new HashMap<String, Object>();
         op.put("$eq", "mike");
+        Map<String, Object> not = new HashMap<String, Object>();
+        not.put("$not", op);
+        Map<String, Object> selector = new HashMap<String, Object>();
+        selector.put("name", not);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(false));
+    }
+
+    @Test
+    public void noMatchNe() {
+        // Selector - { "name" : { "$ne" : "mike" } }
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$ne", "mike");
+        Map<String, Object> selector = new HashMap<String, Object>();
+        selector.put("name", op);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(false));
+    }
+
+    @Test
+    public void noMatchNotNe() {
+        // Selector - { "name" : { "$not" : { "$ne" : "fred" } } }
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$ne", "fred");
         Map<String, Object> not = new HashMap<String, Object>();
         not.put("$not", op);
         Map<String, Object> selector = new HashMap<String, Object>();
@@ -978,6 +963,32 @@ public class UnindexedMatcherTest {
     }
 
     @Test
+    public void matchNe() {
+        // Selector - { "name" : { "$ne" : "fred" } }
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$ne", "fred");
+        Map<String, Object> selector = new HashMap<String, Object>();
+        selector.put("name", op);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(true));
+    }
+
+    @Test
+    public void matchNotNe() {
+        // Selector - { "name" : { "$not" : { "$ne" : "mike" } } }
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$ne", "mike");
+        Map<String, Object> not = new HashMap<String, Object>();
+        not.put("$not", op);
+        Map<String, Object> selector = new HashMap<String, Object>();
+        selector.put("name", not);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(true));
+    }
+
+    @Test
     public void matchNotEqBadField() {
         // Selector - { "species" : { "$not" : { "$eq" : "fred" } } }
         Map<String, Object> op = new HashMap<String, Object>();
@@ -986,6 +997,18 @@ public class UnindexedMatcherTest {
         not.put("$not", op);
         Map<String, Object> selector = new HashMap<String, Object>();
         selector.put("species", not);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(true));
+    }
+
+    @Test
+    public void matchNeBadField() {
+        // Selector - { "species" : { "$ne" : "fred" } }
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$ne", "fred");
+        Map<String, Object> selector = new HashMap<String, Object>();
+        selector.put("species", op);
         selector = QueryValidator.normaliseAndValidateQuery(selector);
         UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
         assertThat(matcher.matches(rev), is(true));
@@ -1002,7 +1025,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void matchGoodItemWithNot() {
+    public void noMatchGoodItemWithNot() {
         // Selector - { "pets" : { "$not" : { "$eq" : "white_cat" } } }
         Map<String, Object> op = new HashMap<String, Object>();
         op.put("$eq", "white_cat");
@@ -1012,7 +1035,19 @@ public class UnindexedMatcherTest {
         selector.put("pets", not);
         selector = QueryValidator.normaliseAndValidateQuery(selector);
         UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
-        assertThat(matcher.matches(rev), is(true));
+        assertThat(matcher.matches(rev), is(false));
+    }
+
+    @Test
+    public void noMatchGoodItemWithNe() {
+        // Selector - { "pets" : { "$ne" : "white_cat" } }
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$ne", "white_cat");
+        Map<String, Object> selector = new HashMap<String, Object>();
+        selector.put("pets", op);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(false));
     }
 
     @Test
@@ -1028,6 +1063,20 @@ public class UnindexedMatcherTest {
     @Test
     public void matchBadItemWithNot() {
         // Selector - { "pets" : { "$not" : { "$eq" : "tabby_cat" } } }
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$eq", "tabby_cat");
+        Map<String, Object> not = new HashMap<String, Object>();
+        not.put("$not", op);
+        Map<String, Object> selector = new HashMap<String, Object>();
+        selector.put("pets", not);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(true));
+    }
+
+    @Test
+    public void matchBadItemWithNe() {
+        // Selector - { "pets" : { "$ne" : "tabby_cat" } }
         Map<String, Object> op = new HashMap<String, Object>();
         op.put("$eq", "tabby_cat");
         Map<String, Object> not = new HashMap<String, Object>();


### PR DESCRIPTION
This PR addresses a bug that was found related to NOT processing in Query.  Using MongoDB query results as the "gold" standard and our baseline, changes were made to both the SQL engine and the post hoc matcher logic to fix NOT processing to essentially return results sets that contain documents that are NOT in the positive version of the query.  This is keeping in line with how MongoDB query handles NOT processing.