### PR TITLE
Fix local Document APIs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 # 0.11.0 (Unreleased)
 
 - [FIX] Using MongoDB query as the "gold" standard, query support for `NOT` has been fixed to return result sets correctly (as in MongoDB query).  Previously, the result set from a query like `{ "pet": { "$not" { "$eq": "dog" } } }` would include a document like `{ "pet" : [ "cat", "dog" ], ... }` because the array contains an object that isn't `dog`.  The new behavior is that `$not` now inverts the result set, so this document will no longer be included because it has an array element that matches `dog`.
+- [BREAKING CHANGE] Changed local document APIs. createLocalDocument and updateLocalDocument have been removed and replaced by insertLocalDocument. The return type of getLocalDocument has been changed to LocalDocument.
+- [NEW] getVersion API added to SQLDatabaseQueue
+- [NEW] Datastore will not be created if the database version is not supported by the version of the library opening it. 
 
 
 

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/BasicDocumentRevision.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/BasicDocumentRevision.java
@@ -128,10 +128,6 @@ public class BasicDocumentRevision implements DocumentRevision, Comparable<Basic
         return body;
     }
 
-    public boolean isLocal(){
-        return revision.endsWith("-local");
-    }
-
     /**
      * <p>Returns {@code true} if this revision is the current winner for the
      * document.</p>

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/DatastoreConstants.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/DatastoreConstants.java
@@ -110,4 +110,16 @@ class DatastoreConstants {
         };
     };
 
+    public static String[] getSchemaVersion6(){
+        return new String[]{
+                "    CREATE TABLE new_localdocs ( " +
+                "            docid TEXT UNIQUE NOT NULL, " +
+                "            json BLOB); ",
+                "    INSERT INTO new_localdocs SELECT docid, json FROM localdocs",
+                "    DROP TABLE localdocs",
+                "    ALTER TABLE new_localdocs RENAME TO localdocs",
+                "    CREATE INDEX localdocs_by_docid ON localdocs(docid); "
+        };
+    }
+
 }

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/DatastoreExtended.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/DatastoreExtended.java
@@ -39,60 +39,24 @@ import java.util.Map;
 public interface DatastoreExtended extends Datastore {
 
     /**
-     * <p>Adds a new local document with an ID and body.</p>
+     * <p>Inserts a local document with an ID and body. Replacing the current local document of the
+     * same id if one is present. </p>
      *
      * <p>Local documents are not replicated between datastores.</p>
      *
-     * @param documentId id for the document
+     * @param docId      The document id for the document
      * @param body       JSON body for the document
      * @return {@code DocumentRevision} of the newly created document
      */
-    public BasicDocumentRevision createLocalDocument(String documentId, DocumentBody body) throws DocumentException;
-
-    /**
-     * <p>Adds a new local document with an auto-generated ID.</p>
-     *
-     * <p>The document's ID will be auto-generated, and can be found by
-     * inspecting the returned {@code DocumentRevision}.</p>
-     *
-     * @param body JSON body for the document
-     * @return {@code DocumentRevision} of the newly created document
-     *
-     * @see DatastoreExtended#createLocalDocument(String, DocumentBody)
-     */
-    public BasicDocumentRevision createLocalDocument(DocumentBody body) throws DocumentException;
+    public LocalDocument insertLocalDocument(String docId, DocumentBody body) throws DocumentException;
 
     /**
      * <p>Returns the current winning revision of a local document.</p>
      *
      * @param documentId id of the local document
-     * @return {@code DocumentRevision} of the document
+     * @return {@code LocalDocument} of the document
      */
-    public BasicDocumentRevision getLocalDocument(String documentId);
-
-    /**
-     * <p>Returns a given revision local document.</p>
-     *
-     * @param documentId id of the document
-     * @param revisionId id of the revision
-     * @return specified revision as DocumentRevision of a local document
-     */
-    public BasicDocumentRevision getLocalDocument(String documentId, String revisionId);
-
-    /**
-     * <p>Updates a local document that exists in the datastore with a new
-     * revision.</p>
-     *
-     * <p>The {@code prevRevisionId} must match the current winning revision
-     * for the document.</p>
-     *
-     * @param documentId ID of the document
-     * @param prevRevisionId revision id of the document's current winning
-     *                       revision
-     * @param body body of the new revision
-     * @return {@code DocumentRevision} for the updated revision
-     */
-    public BasicDocumentRevision updateLocalDocument(String documentId, String prevRevisionId, DocumentBody body) throws DocumentException;
+    public LocalDocument getLocalDocument(String documentId) throws DocumentNotFoundException;
 
     /**
      * <p>Deletes a local document.</p>

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/DatastoreManager.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/DatastoreManager.java
@@ -229,6 +229,8 @@ public class DatastoreManager {
             throw new DatastoreNotCreatedException("Database not found: " + dbName, e);
         } catch (SQLException e) {
             throw new DatastoreNotCreatedException("Database not initialized correctly: " + dbName, e);
+        } catch (DatastoreException e){
+            throw new DatastoreNotCreatedException("Datastore not initialized correctly: " + dbName, e);
         }
     }
 

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/LocalDocument.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/LocalDocument.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2015 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.datastore;
+
+/**
+ * A local Document, this document does not have a history, or the concept of revisions
+ */
+public class LocalDocument {
+
+    /**
+     * The ID of the local document
+     */
+    public final String docId;
+    /**
+     * The body of the local document
+     */
+    public final DocumentBody body;
+
+    /**
+     * Creates a local document
+     * @param docId The documentId for this document
+     * @param body The body of the local document
+     */
+    public LocalDocument(String docId, DocumentBody body){
+        this.docId = docId;
+        this.body = body;
+    }
+
+
+}

--- a/sync-core/src/test/java/com/cloudant/sync/datastore/BasicDBObjectTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/datastore/BasicDBObjectTest.java
@@ -49,24 +49,8 @@ public class BasicDBObjectTest {
         BasicDocumentRevision td = this.builder.build();
         Assert.assertEquals(DOCUMENT_ID, td.getId());
         Assert.assertEquals(REVISION_ID, td.getRevision());
-        Assert.assertFalse(td.isLocal());
         Assert.assertTrue(td.isDeleted());
         Assert.assertFalse(td.isCurrent());
-        Assert.assertEquals("test data", (String) td.getBody().asMap().get("a"));
-    }
-
-    @Test
-    public void constructor_localObject_localObjectShouldBeCreated() {
-        this.builder.setDocId(DOCUMENT_ID);
-        this.builder.setRevId(LOCAL_REVISION_ID);
-        this.builder.setBody(new BasicDocumentBody(JSON_BODY));
-
-        BasicDocumentRevision td = this.builder.buildBasicDBObjectLocalDocument();
-        Assert.assertEquals(DOCUMENT_ID, td.getId());
-        Assert.assertEquals(LOCAL_REVISION_ID, td.getRevision());
-        Assert.assertTrue(td.isLocal());
-        Assert.assertFalse(td.isDeleted());
-        Assert.assertTrue(td.isCurrent());
         Assert.assertEquals("test data", (String) td.getBody().asMap().get("a"));
     }
 

--- a/sync-core/src/test/java/com/cloudant/sync/datastore/BasicDatastoreCRUDTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/datastore/BasicDatastoreCRUDTest.java
@@ -139,26 +139,12 @@ public class BasicDatastoreCRUDTest extends BasicDatastoreTestBase {
         return m;
     }
 
-    @Test
-    public void createLocalDocument_bodyOnly_success() throws Exception {
-        BasicDocumentRevision rev = datastore.createLocalDocument(bodyOne);
-        validateNewlyCreateLocalDocument(rev);
-    }
 
     @Test
     public void createLocalDocument_docIdAndBody_success() throws Exception {
         String docId = CouchUtils.generateDocumentId();
-        BasicDocumentRevision rev = datastore.createLocalDocument(docId, bodyOne);
-        validateNewlyCreateLocalDocument(rev);
-        Assert.assertEquals(docId, rev.getId());
-    }
-
-    @Test(expected = DocumentException.class)
-    public void createLocalDocument_existDocId_exception() throws Exception {
-        String docId = CouchUtils.generateDocumentId();
-        BasicDocumentRevision rev = datastore.createLocalDocument(docId, bodyOne);
-        validateNewlyCreateLocalDocument(rev);
-        datastore.createLocalDocument(docId, bodyOne);
+        LocalDocument localDocument = datastore.insertLocalDocument(docId, bodyOne);
+        Assert.assertEquals(docId, localDocument.docId);
     }
 
     @Test
@@ -357,28 +343,15 @@ public class BasicDatastoreCRUDTest extends BasicDatastoreTestBase {
     }
 
     @Test
-    public void getLocalDocument_twoDoc() throws Exception {
-        BasicDocumentRevision rev_1 = datastore.createLocalDocument(bodyOne);
-        validateNewlyCreateLocalDocument(rev_1);
-
-        BasicDocumentRevision revRead = datastore.getLocalDocument(rev_1.getId());
-        Assert.assertTrue(revRead.isLocal());
-    }
-
-    @Test
     public void updateLocalDocument_existingDocument_success() throws Exception {
-        BasicDocumentRevision rev_1 = datastore.createLocalDocument(bodyOne);
-        validateNewlyCreateLocalDocument(rev_1);
+        LocalDocument rev_1 = datastore.insertLocalDocument("docid",bodyOne);
 
-        BasicDocumentRevision rev_2 = datastore.updateLocalDocument(rev_1.getId(), rev_1.getRevision(), bodyTwo);
+        LocalDocument rev_2 = datastore.insertLocalDocument(rev_1.docId, bodyTwo);
         Assert.assertNotNull(rev_2);
-        Assert.assertEquals(2, CouchUtils.generationFromRevId(rev_2.getRevision()));
 
-        BasicDocumentRevision rev1Read = datastore.getLocalDocument(rev_1.getId(), rev_1.getRevision());
-        Assert.assertNull(rev1Read);
-
-        BasicDocumentRevision rev2Read = datastore.getLocalDocument(rev_2.getId(), rev_2.getRevision());
+        LocalDocument rev2Read = datastore.getLocalDocument(rev_2.docId);
         Assert.assertNotNull(rev2Read);
+        Assert.assertEquals(rev2Read.body.asMap(),bodyTwo.asMap());
     }
 
     @Test


### PR DESCRIPTION
Change getLocalDocument to throw a DocumentNotFoundException when an
ExecutionException occurs and only log error conditions at the site
they occur, not when an ExecutionException gets thrown.