### PR TITLE
Move $not/$ne processing to normalization stage

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 # 0.11.0 (Unreleased)
 
 - [FIX] Using MongoDB query as the "gold" standard, query support for `NOT` has been fixed to return result sets correctly (as in MongoDB query).  Previously, the result set from a query like `{ "pet": { "$not" { "$eq": "dog" } } }` would include a document like `{ "pet" : [ "cat", "dog" ], ... }` because the array contains an object that isn't `dog`.  The new behavior is that `$not` now inverts the result set, so this document will no longer be included because it has an array element that matches `dog`.
+- [BREAKING CHANGE] Changed local document APIs. createLocalDocument and updateLocalDocument have been removed and replaced by insertLocalDocument. The return type of getLocalDocument has been changed to LocalDocument.
+- [NEW] getVersion API added to SQLDatabaseQueue
+- [NEW] Datastore will not be created if the database version is not supported by the version of the library opening it. 
 
 
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ from gradle and maven build files.
 
 The library is Reguarly tested on the following platforms:
 
-Android (via emulated):
+Android (via emulator):
 
 * API Level 15
 * API Level 16

--- a/README.md
+++ b/README.md
@@ -117,6 +117,23 @@ _Note_: Older versions than 0.3.0 had a separate Mazha jar. This was rolled
 into the main jar for distribution simplicity. The dependency needs removing
 from gradle and maven build files.
 
+## Tested Platforms
+
+The library is Reguarly tested on the following platforms:
+
+Android (via emulated):
+
+* API Level 15
+* API Level 16
+* API Level 17
+* API Level 18
+* API Level 19
+* API Level 21
+
+Java:
+
+* 1.8 (Java 8)
+
 ## Example application
 
 There is a [sample application and a quickstart guide](/sample/).

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/BasicDocumentRevision.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/BasicDocumentRevision.java
@@ -128,10 +128,6 @@ public class BasicDocumentRevision implements DocumentRevision, Comparable<Basic
         return body;
     }
 
-    public boolean isLocal(){
-        return revision.endsWith("-local");
-    }
-
     /**
      * <p>Returns {@code true} if this revision is the current winner for the
      * document.</p>

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/DatastoreConstants.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/DatastoreConstants.java
@@ -110,4 +110,16 @@ class DatastoreConstants {
         };
     };
 
+    public static String[] getSchemaVersion6(){
+        return new String[]{
+                "    CREATE TABLE new_localdocs ( " +
+                "            docid TEXT UNIQUE NOT NULL, " +
+                "            json BLOB); ",
+                "    INSERT INTO new_localdocs SELECT docid, json FROM localdocs",
+                "    DROP TABLE localdocs",
+                "    ALTER TABLE new_localdocs RENAME TO localdocs",
+                "    CREATE INDEX localdocs_by_docid ON localdocs(docid); "
+        };
+    }
+
 }

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/DatastoreExtended.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/DatastoreExtended.java
@@ -39,60 +39,24 @@ import java.util.Map;
 public interface DatastoreExtended extends Datastore {
 
     /**
-     * <p>Adds a new local document with an ID and body.</p>
+     * <p>Inserts a local document with an ID and body. Replacing the current local document of the
+     * same id if one is present. </p>
      *
      * <p>Local documents are not replicated between datastores.</p>
      *
-     * @param documentId id for the document
+     * @param docId      The document id for the document
      * @param body       JSON body for the document
      * @return {@code DocumentRevision} of the newly created document
      */
-    public BasicDocumentRevision createLocalDocument(String documentId, DocumentBody body) throws DocumentException;
-
-    /**
-     * <p>Adds a new local document with an auto-generated ID.</p>
-     *
-     * <p>The document's ID will be auto-generated, and can be found by
-     * inspecting the returned {@code DocumentRevision}.</p>
-     *
-     * @param body JSON body for the document
-     * @return {@code DocumentRevision} of the newly created document
-     *
-     * @see DatastoreExtended#createLocalDocument(String, DocumentBody)
-     */
-    public BasicDocumentRevision createLocalDocument(DocumentBody body) throws DocumentException;
+    public LocalDocument insertLocalDocument(String docId, DocumentBody body) throws DocumentException;
 
     /**
      * <p>Returns the current winning revision of a local document.</p>
      *
      * @param documentId id of the local document
-     * @return {@code DocumentRevision} of the document
+     * @return {@code LocalDocument} of the document
      */
-    public BasicDocumentRevision getLocalDocument(String documentId);
-
-    /**
-     * <p>Returns a given revision local document.</p>
-     *
-     * @param documentId id of the document
-     * @param revisionId id of the revision
-     * @return specified revision as DocumentRevision of a local document
-     */
-    public BasicDocumentRevision getLocalDocument(String documentId, String revisionId);
-
-    /**
-     * <p>Updates a local document that exists in the datastore with a new
-     * revision.</p>
-     *
-     * <p>The {@code prevRevisionId} must match the current winning revision
-     * for the document.</p>
-     *
-     * @param documentId ID of the document
-     * @param prevRevisionId revision id of the document's current winning
-     *                       revision
-     * @param body body of the new revision
-     * @return {@code DocumentRevision} for the updated revision
-     */
-    public BasicDocumentRevision updateLocalDocument(String documentId, String prevRevisionId, DocumentBody body) throws DocumentException;
+    public LocalDocument getLocalDocument(String documentId) throws DocumentNotFoundException;
 
     /**
      * <p>Deletes a local document.</p>

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/DatastoreManager.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/DatastoreManager.java
@@ -229,6 +229,8 @@ public class DatastoreManager {
             throw new DatastoreNotCreatedException("Database not found: " + dbName, e);
         } catch (SQLException e) {
             throw new DatastoreNotCreatedException("Database not initialized correctly: " + dbName, e);
+        } catch (DatastoreException e){
+            throw new DatastoreNotCreatedException("Datastore not initialized correctly: " + dbName, e);
         }
     }
 

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/LocalDocument.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/LocalDocument.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2015 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.datastore;
+
+/**
+ * A local Document, this document does not have a history, or the concept of revisions
+ */
+public class LocalDocument {
+
+    /**
+     * The ID of the local document
+     */
+    public final String docId;
+    /**
+     * The body of the local document
+     */
+    public final DocumentBody body;
+
+    /**
+     * Creates a local document
+     * @param docId The documentId for this document
+     * @param body The body of the local document
+     */
+    public LocalDocument(String docId, DocumentBody body){
+        this.docId = docId;
+        this.body = body;
+    }
+
+
+}

--- a/sync-core/src/main/java/com/cloudant/sync/query/QueryConstants.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/QueryConstants.java
@@ -1,0 +1,33 @@
+//  Copyright (c) 2015 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+package com.cloudant.sync.query;
+
+final class QueryConstants {
+
+    public static final String AND = "$and";
+
+    public static final String OR = "$or";
+
+    public static final String NOT = "$not";
+
+    public static final String EXISTS = "$exists";
+
+    public static final String EQ = "$eq";
+
+    public static final String NE = "$ne";
+
+    private QueryConstants() {
+        throw new AssertionError();
+    }
+    
+}

--- a/sync-core/src/main/java/com/cloudant/sync/query/QuerySqlTranslator.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/QuerySqlTranslator.java
@@ -12,6 +12,8 @@
 
 package com.cloudant.sync.query;
 
+import static com.cloudant.sync.query.QueryConstants.*;
+
 import com.google.common.base.Joiner;
 
 import java.util.ArrayList;
@@ -93,11 +95,6 @@ import java.util.logging.Logger;
  *  These basic patterns can be composed into more complicate structures.
  */
 class QuerySqlTranslator {
-
-    private static final String AND = "$and";
-    private static final String OR = "$or";
-    private static final String NOT = "$not";
-    private static final String EXISTS = "$exists";
 
     private static final Logger logger = Logger.getLogger(QuerySqlTranslator.class.getName());
 

--- a/sync-core/src/main/java/com/cloudant/sync/query/QuerySqlTranslator.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/QuerySqlTranslator.java
@@ -98,8 +98,6 @@ class QuerySqlTranslator {
     private static final String OR = "$or";
     private static final String NOT = "$not";
     private static final String EXISTS = "$exists";
-    private static final String EQ = "$eq";
-    private static final String NE = "$ne";  // $ne is used as shorthand for $not..$eq
 
     private static final Logger logger = Logger.getLogger(QuerySqlTranslator.class.getName());
 
@@ -167,75 +165,39 @@ class QuerySqlTranslator {
         // logic below.
         //
 
-        List<Object> basicClauses = new ArrayList<Object>();
+        List<Object> basicClauses = null;
 
         for (Object rawClause: clauses) {
             Map<String, Object> clause = (Map<String, Object>) rawClause;
             String field = (String) clause.keySet().toArray()[0];
             if (!field.startsWith("$")) {
+                if (basicClauses == null) {
+                    basicClauses = new ArrayList<Object>();
+                }
                 basicClauses.add(rawClause);
             }
         }
 
-        if (query.get(AND) != null) {
-            // For an AND query, we require a single compound index and we generate a
-            // single SQL statement to use that index to satisfy the clauses.
+        if (basicClauses != null) {
+            if (query.get(AND) != null) {
+                // For an AND query, we require a single compound index and we generate a
+                // single SQL statement to use that index to satisfy the clauses.
 
-            String chosenIndex = chooseIndexForAndClause(basicClauses, indexes);
-            if (chosenIndex == null || chosenIndex.isEmpty()) {
-                state.atLeastOneIndexMissing = true;
-                String msg = String.format("No single index contains all of %s; %s",
-                                           basicClauses.toString(),
-                                           "add index for these fields to query efficiently.");
-                logger.log(Level.WARNING, msg);
-            } else {
-                state.atLeastOneIndexUsed = true;
-
-                // Execute SQL on that index with appropriate values
-                SqlParts select = selectStatementForAndClause(basicClauses, chosenIndex);
-                if (select == null) {
-                    String msg = String.format("Error generating SELECT clause for %s",
-                                               basicClauses);
-                    logger.log(Level.SEVERE, msg);
-                    return null;
-                }
-
-                SqlQueryNode sqlNode = new SqlQueryNode();
-                sqlNode.sql = select;
-
-                if (root != null) {
-                    root.children.add(sqlNode);
-                }
-            }
-        } else if (query.get(OR) != null) {
-            // OR nodes require a query for each clause.
-            //
-            // We want to allow OR clauses to use separate indexes, unlike for AND, to allow
-            // users to query over multiple indexes during a single query. This prevents users
-            // having to create a single huge index just because one query in their application
-            // requires it, slowing execution of all the other queries down.
-            //
-            // We could optimise for OR parts where we have an appropriate compound index,
-            // but we don't for now.
-
-            for (Object basicClause : basicClauses) {
-                List<Object> wrappedClause = Arrays.asList(basicClause);
-                String chosenIndex = chooseIndexForAndClause(wrappedClause, indexes);
+                String chosenIndex = chooseIndexForAndClause(basicClauses, indexes);
                 if (chosenIndex == null || chosenIndex.isEmpty()) {
                     state.atLeastOneIndexMissing = true;
-                    state.atLeastOneORIndexMissing = true;
                     String msg = String.format("No single index contains all of %s; %s",
-                                               basicClauses.toString(),
-                                               "add index for these fields to query efficiently.");
+                            basicClauses.toString(),
+                            "add index for these fields to query efficiently.");
                     logger.log(Level.WARNING, msg);
                 } else {
                     state.atLeastOneIndexUsed = true;
 
                     // Execute SQL on that index with appropriate values
-                    SqlParts select = selectStatementForAndClause(wrappedClause, chosenIndex);
+                    SqlParts select = selectStatementForAndClause(basicClauses, chosenIndex);
                     if (select == null) {
                         String msg = String.format("Error generating SELECT clause for %s",
-                                                   basicClauses);
+                                basicClauses);
                         logger.log(Level.SEVERE, msg);
                         return null;
                     }
@@ -245,6 +207,47 @@ class QuerySqlTranslator {
 
                     if (root != null) {
                         root.children.add(sqlNode);
+                    }
+                }
+            } else if (query.get(OR) != null) {
+                // OR nodes require a query for each clause.
+                //
+                // We want to allow OR clauses to use separate indexes, unlike for AND, to allow
+                // users to query over multiple indexes during a single query. This prevents users
+                // having to create a single huge index just because one query in their application
+                // requires it, slowing execution of all the other queries down.
+                //
+                // We could optimise for OR parts where we have an appropriate compound index,
+                // but we don't for now.
+
+                for (Object basicClause : basicClauses) {
+                    List<Object> wrappedClause = Arrays.asList(basicClause);
+                    String chosenIndex = chooseIndexForAndClause(wrappedClause, indexes);
+                    if (chosenIndex == null || chosenIndex.isEmpty()) {
+                        state.atLeastOneIndexMissing = true;
+                        state.atLeastOneORIndexMissing = true;
+                        String msg = String.format("No single index contains all of %s; %s",
+                                basicClauses.toString(),
+                                "add index for these fields to query efficiently.");
+                        logger.log(Level.WARNING, msg);
+                    } else {
+                        state.atLeastOneIndexUsed = true;
+
+                        // Execute SQL on that index with appropriate values
+                        SqlParts select = selectStatementForAndClause(wrappedClause, chosenIndex);
+                        if (select == null) {
+                            String msg = String.format("Error generating SELECT clause for %s",
+                                    basicClauses);
+                            logger.log(Level.SEVERE, msg);
+                            return null;
+                        }
+
+                        SqlQueryNode sqlNode = new SqlQueryNode();
+                        sqlNode.sql = select;
+
+                        if (root != null) {
+                            root.children.add(sqlNode);
+                        }
                     }
                 }
             }
@@ -423,15 +426,9 @@ class QuerySqlTranslator {
                     // since this clause is negated we need to negate the bool value
                     whereClauses.add(convertExistsToSqlClauseForFieldName(fieldName, exists));
                 } else {
-                    String whereClause;
-                    if (operator.equals(NE)) {
-                        // Treat $not..$ne as $eq
-                        whereClause = String.format("\"%s\" %s ?", fieldName, operatorMap.get(EQ));
-                    } else {
-                        String sqlOperator = operatorMap.get(operator);
-                        String tableName = IndexManager.tableNameForIndex(indexName);
-                        whereClause = whereClauseForNot(fieldName, sqlOperator, tableName);
-                    }
+                    String sqlOperator = operatorMap.get(operator);
+                    String tableName = IndexManager.tableNameForIndex(indexName);
+                    String whereClause = whereClauseForNot(fieldName, sqlOperator, tableName);
 
                     whereClauses.add(whereClause);
                     predicateValue = negatedPredicate.get(operator);
@@ -448,16 +445,8 @@ class QuerySqlTranslator {
                     boolean exists = (Boolean) predicate.get(operator);
                     whereClauses.add(convertExistsToSqlClauseForFieldName(fieldName, exists));
                 } else {
-                    String whereClause;
-                    if (operator.equals(NE)) {
-                        String tableName = IndexManager.tableNameForIndex(indexName);
-                        whereClause = whereClauseForNot(fieldName,
-                                                        operatorMap.get(EQ),
-                                                        tableName);
-                    } else {
-                        String sqlOperator = operatorMap.get(operator);
-                        whereClause = String.format("\"%s\" %s ?", fieldName, sqlOperator);
-                    }
+                    String sqlOperator = operatorMap.get(operator);
+                    String whereClause = String.format("\"%s\" %s ?", fieldName, sqlOperator);
 
                     whereClauses.add(whereClause);
                     Object predicateValue = predicate.get(operator);

--- a/sync-core/src/main/java/com/cloudant/sync/query/QueryValidator.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/QueryValidator.java
@@ -12,6 +12,8 @@
 
 package com.cloudant.sync.query;
 
+import static com.cloudant.sync.query.QueryConstants.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -25,12 +27,6 @@ import java.util.logging.Logger;
  *  two different implementations of query.
  */
 class QueryValidator {
-
-    private static final String AND = "$and";
-    private static final String OR = "$or";
-    private static final String EQ = "$eq";
-    private static final String NOT = "$not";
-    private static final String NE = "$ne";
 
     // negatedShortHand is used for operator shorthand processing.
     // A shorthand operator like $ne has a longhand representation

--- a/sync-core/src/main/java/com/cloudant/sync/query/UnindexedMatcher.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/UnindexedMatcher.java
@@ -14,6 +14,8 @@ package com.cloudant.sync.query;
 
 import com.cloudant.sync.datastore.DocumentRevision;
 
+import static com.cloudant.sync.query.QueryConstants.*;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -82,10 +84,6 @@ class UnindexedMatcher {
     private ChildrenQueryNode root;
 
     private static final Logger logger = Logger.getLogger(UnindexedMatcher.class.getName());
-
-    private static final String AND = "$and";
-    private static final String OR = "$or";
-    private static final String NOT = "$not";
 
     /**
      *  Return a new initialised matcher.

--- a/sync-core/src/main/java/com/cloudant/sync/query/UnindexedMatcher.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/UnindexedMatcher.java
@@ -15,7 +15,6 @@ package com.cloudant.sync.query;
 import com.cloudant.sync.datastore.DocumentRevision;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
@@ -87,8 +86,6 @@ class UnindexedMatcher {
     private static final String AND = "$and";
     private static final String OR = "$or";
     private static final String NOT = "$not";
-    private static final String NE = "$ne";
-    private static final String EQ = "$eq";
 
     /**
      *  Return a new initialised matcher.
@@ -137,13 +134,7 @@ class UnindexedMatcher {
             Map<String, Object> clause = (Map<String, Object>) rawClause;
             String field = (String) clause.keySet().toArray()[0];
             if (!field.startsWith("$")) {
-                Object converted = convertNeClauseToNotEq(field,
-                                                          (Map<String, Object>) clause.get(field));
-                if (converted == null) {
-                    basicClauses.add(rawClause);
-                } else {
-                    basicClauses.add(converted);
-                }
+                basicClauses.add(rawClause);
             }
         }
 
@@ -187,36 +178,6 @@ class UnindexedMatcher {
         }
 
         return root;
-    }
-
-    @SuppressWarnings("unchecked")
-    private static Map<String, Object> convertNeClauseToNotEq(String field,
-                                                              Map<String, Object> clause) {
-        // We either have { "$not" : { "$operator" : "value" } }
-        //     or         { "$operator" : "value" }
-        Map<String, Object> converted = null;
-        String operator = (String) clause.keySet().toArray()[0];
-        if (operator.equals(NE)) {
-            // Convert { "$ne" : "value" } to { "$not" : { "$eq" : "value" } }
-            Map<String, Object> eqClause = new HashMap<String, Object>();
-            eqClause.put(EQ, clause.get(operator));
-            Map<String, Object> notClause = new HashMap<String, Object>();
-            notClause.put(NOT, eqClause);
-            converted = new HashMap<String, Object>();
-            converted.put(field, notClause);
-        } else if (operator.equals(NOT)) {
-            Map<String, Object> subClause = (Map<String, Object>) clause.get(operator);
-            String subOperator = (String) subClause.keySet().toArray()[0];
-            if (subOperator.equals(NE)) {
-                // Convert { "$not" : { "$ne" : "value" } } to { "$eq" : "value" }
-                Map<String, Object> eqClause = new HashMap<String, Object>();
-                eqClause.put(EQ, subClause.get(subOperator));
-                converted = new HashMap<String, Object>();
-                converted.put(field, eqClause);
-            }
-        }
-
-        return converted;
     }
 
     /**

--- a/sync-core/src/test/java/com/cloudant/sync/datastore/BasicDBObjectTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/datastore/BasicDBObjectTest.java
@@ -49,24 +49,8 @@ public class BasicDBObjectTest {
         BasicDocumentRevision td = this.builder.build();
         Assert.assertEquals(DOCUMENT_ID, td.getId());
         Assert.assertEquals(REVISION_ID, td.getRevision());
-        Assert.assertFalse(td.isLocal());
         Assert.assertTrue(td.isDeleted());
         Assert.assertFalse(td.isCurrent());
-        Assert.assertEquals("test data", (String) td.getBody().asMap().get("a"));
-    }
-
-    @Test
-    public void constructor_localObject_localObjectShouldBeCreated() {
-        this.builder.setDocId(DOCUMENT_ID);
-        this.builder.setRevId(LOCAL_REVISION_ID);
-        this.builder.setBody(new BasicDocumentBody(JSON_BODY));
-
-        BasicDocumentRevision td = this.builder.buildBasicDBObjectLocalDocument();
-        Assert.assertEquals(DOCUMENT_ID, td.getId());
-        Assert.assertEquals(LOCAL_REVISION_ID, td.getRevision());
-        Assert.assertTrue(td.isLocal());
-        Assert.assertFalse(td.isDeleted());
-        Assert.assertTrue(td.isCurrent());
         Assert.assertEquals("test data", (String) td.getBody().asMap().get("a"));
     }
 

--- a/sync-core/src/test/java/com/cloudant/sync/datastore/BasicDatastoreCRUDTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/datastore/BasicDatastoreCRUDTest.java
@@ -139,26 +139,12 @@ public class BasicDatastoreCRUDTest extends BasicDatastoreTestBase {
         return m;
     }
 
-    @Test
-    public void createLocalDocument_bodyOnly_success() throws Exception {
-        BasicDocumentRevision rev = datastore.createLocalDocument(bodyOne);
-        validateNewlyCreateLocalDocument(rev);
-    }
 
     @Test
     public void createLocalDocument_docIdAndBody_success() throws Exception {
         String docId = CouchUtils.generateDocumentId();
-        BasicDocumentRevision rev = datastore.createLocalDocument(docId, bodyOne);
-        validateNewlyCreateLocalDocument(rev);
-        Assert.assertEquals(docId, rev.getId());
-    }
-
-    @Test(expected = DocumentException.class)
-    public void createLocalDocument_existDocId_exception() throws Exception {
-        String docId = CouchUtils.generateDocumentId();
-        BasicDocumentRevision rev = datastore.createLocalDocument(docId, bodyOne);
-        validateNewlyCreateLocalDocument(rev);
-        datastore.createLocalDocument(docId, bodyOne);
+        LocalDocument localDocument = datastore.insertLocalDocument(docId, bodyOne);
+        Assert.assertEquals(docId, localDocument.docId);
     }
 
     @Test
@@ -357,28 +343,15 @@ public class BasicDatastoreCRUDTest extends BasicDatastoreTestBase {
     }
 
     @Test
-    public void getLocalDocument_twoDoc() throws Exception {
-        BasicDocumentRevision rev_1 = datastore.createLocalDocument(bodyOne);
-        validateNewlyCreateLocalDocument(rev_1);
-
-        BasicDocumentRevision revRead = datastore.getLocalDocument(rev_1.getId());
-        Assert.assertTrue(revRead.isLocal());
-    }
-
-    @Test
     public void updateLocalDocument_existingDocument_success() throws Exception {
-        BasicDocumentRevision rev_1 = datastore.createLocalDocument(bodyOne);
-        validateNewlyCreateLocalDocument(rev_1);
+        LocalDocument rev_1 = datastore.insertLocalDocument("docid",bodyOne);
 
-        BasicDocumentRevision rev_2 = datastore.updateLocalDocument(rev_1.getId(), rev_1.getRevision(), bodyTwo);
+        LocalDocument rev_2 = datastore.insertLocalDocument(rev_1.docId, bodyTwo);
         Assert.assertNotNull(rev_2);
-        Assert.assertEquals(2, CouchUtils.generationFromRevId(rev_2.getRevision()));
 
-        BasicDocumentRevision rev1Read = datastore.getLocalDocument(rev_1.getId(), rev_1.getRevision());
-        Assert.assertNull(rev1Read);
-
-        BasicDocumentRevision rev2Read = datastore.getLocalDocument(rev_2.getId(), rev_2.getRevision());
+        LocalDocument rev2Read = datastore.getLocalDocument(rev_2.docId);
         Assert.assertNotNull(rev2Read);
+        Assert.assertEquals(rev2Read.body.asMap(),bodyTwo.asMap());
     }
 
     @Test

--- a/sync-core/src/test/java/com/cloudant/sync/query/QuerySqlTranslatorTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/QuerySqlTranslatorTest.java
@@ -718,21 +718,6 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-     public void correctlyTranslatesNeSQLOperatorToNotIn() {
-        Map<String, Object> op = new HashMap<String, Object>();
-        op.put("$ne", "mike");
-        Map<String, Object> name = new HashMap<String, Object>();
-        name.put("name", op);
-
-        SqlParts where = QuerySqlTranslator.whereSqlForAndClause(Arrays.<Object>asList(name),
-                                                                 indexName);
-        String expected = String.format("_id NOT IN (SELECT _id FROM %s WHERE \"name\" = ?)",
-                                        IndexManager.tableNameForIndex(indexName));
-        assertThat(where.sqlWithPlaceHolders, is(expected));
-        assertThat(where.placeHolderValues, is(arrayContaining("mike")));
-    }
-
-    @Test
     public void usesCorrectSQLOperatorForEXISTSTrue() {
         Map<String, Object> op = new HashMap<String, Object>();
         op.put("$exists", true);
@@ -910,22 +895,6 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void usesCorrectSQLOperatorWhenUsingNOTNE() {
-        Map<String, Object> op = new HashMap<String, Object>();
-        op.put("$ne", "mike");
-        Map<String, Object> not = new HashMap<String, Object>();
-        not.put("$not", op);
-        Map<String, Object> name = new HashMap<String, Object>();
-        name.put("name", not);
-
-        SqlParts where = QuerySqlTranslator.whereSqlForAndClause(Arrays.<Object>asList(name),
-                                                                 indexName);
-        String expected = "\"name\" = ?";
-        assertThat(where.sqlWithPlaceHolders, is(expected));
-        assertThat(where.placeHolderValues, is(arrayContaining("mike")));
-    }
-
-    @Test
     public void returnsCorrectWhenTwoConditionsOneField() {
         Map<String, Object> c1op = new HashMap<String, Object>();
         c1op.put("$eq", "mike");
@@ -963,9 +932,11 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         Map<String, Object> c3 = new HashMap<String, Object>();
         c3.put("name", c3op);
         Map<String, Object> c4op = new HashMap<String, Object>();
-        c4op.put("$ne", 30);
+        c4op.put("$eq", 30);
+        Map<String, Object> c4NotOp = new HashMap<String, Object>();
+        c4NotOp.put("$not", c4op);
         Map<String, Object> c4 = new HashMap<String, Object>();
-        c4.put("age", c4op);
+        c4.put("age", c4NotOp);
         Map<String, Object> c5op = new HashMap<String, Object>();
         c5op.put("$eq", 42);
         Map<String, Object> c5 = new HashMap<String, Object>();


### PR DESCRIPTION
Move $not and $ne processing to be part of normalization instead of
having individual sets of logic to handle $not and $ne in both the
post hoc matcher and the SQL engine.  This allows us to keep things
less complex in the matcher and the SQL engine logic and also allows us
to maintain one set of logic for $not and $ne processing instead of two.

Changes made:

- Add logic to handle multiple $not operators in a row during
normalization.  This condition was previously unhandled.
- Add logic to transform shorthand notion such as $ne into the long
form.  In the case of $ne it would be $not..$eq.  All future shorthand
processing will be handled as part of normalization.
- Remove $not and $ne query manipulation from SQL translator logic.
- Remove $not and $ne query manipulation from post hoc matcher logic.
- Add additional tests to test the handling of sequential $not and $ne
operators.
- Remove WHERE clause tests that specifically use $ne in the query
since a query will never have an $ne operator in it by the time it
reaches the WHERE clause generation logic.