### PR TITLE
Set library version in sample to latest.release

### DIFF
--- a/sample/todo-sync/build.gradle
+++ b/sample/todo-sync/build.gradle
@@ -18,8 +18,8 @@ repositories {
 }
 
 dependencies {
-    compile(group: 'com.cloudant', name: 'cloudant-sync-datastore-android', version:'0.10.0')
-    compile(group: 'com.cloudant', name: 'cloudant-sync-datastore-core', version:'0.10.0')
+    compile(group: 'com.cloudant', name: 'cloudant-sync-datastore-android', version:'latest.release')
+    compile(group: 'com.cloudant', name: 'cloudant-sync-datastore-core', version:'latest.release')
 }
 
 android {


### PR DESCRIPTION
Change the sample build file to dynamic resolve the latest released version of sync-android. `latest.release` is a place holder for the latest released version of a dependancy. Making this change reduces the number of steps involved in a release.