### PR TITLE
Move $not/$ne processing to normalization stage

### DIFF
--- a/sync-core/src/main/java/com/cloudant/sync/query/QueryConstants.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/QueryConstants.java
@@ -1,0 +1,33 @@
+//  Copyright (c) 2015 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+package com.cloudant.sync.query;
+
+final class QueryConstants {
+
+    public static final String AND = "$and";
+
+    public static final String OR = "$or";
+
+    public static final String NOT = "$not";
+
+    public static final String EXISTS = "$exists";
+
+    public static final String EQ = "$eq";
+
+    public static final String NE = "$ne";
+
+    private QueryConstants() {
+        throw new AssertionError();
+    }
+    
+}

--- a/sync-core/src/main/java/com/cloudant/sync/query/QuerySqlTranslator.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/QuerySqlTranslator.java
@@ -12,6 +12,8 @@
 
 package com.cloudant.sync.query;
 
+import static com.cloudant.sync.query.QueryConstants.*;
+
 import com.google.common.base.Joiner;
 
 import java.util.ArrayList;
@@ -93,11 +95,6 @@ import java.util.logging.Logger;
  *  These basic patterns can be composed into more complicate structures.
  */
 class QuerySqlTranslator {
-
-    private static final String AND = "$and";
-    private static final String OR = "$or";
-    private static final String NOT = "$not";
-    private static final String EXISTS = "$exists";
 
     private static final Logger logger = Logger.getLogger(QuerySqlTranslator.class.getName());
 

--- a/sync-core/src/main/java/com/cloudant/sync/query/QuerySqlTranslator.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/QuerySqlTranslator.java
@@ -98,8 +98,6 @@ class QuerySqlTranslator {
     private static final String OR = "$or";
     private static final String NOT = "$not";
     private static final String EXISTS = "$exists";
-    private static final String EQ = "$eq";
-    private static final String NE = "$ne";  // $ne is used as shorthand for $not..$eq
 
     private static final Logger logger = Logger.getLogger(QuerySqlTranslator.class.getName());
 
@@ -167,75 +165,39 @@ class QuerySqlTranslator {
         // logic below.
         //
 
-        List<Object> basicClauses = new ArrayList<Object>();
+        List<Object> basicClauses = null;
 
         for (Object rawClause: clauses) {
             Map<String, Object> clause = (Map<String, Object>) rawClause;
             String field = (String) clause.keySet().toArray()[0];
             if (!field.startsWith("$")) {
+                if (basicClauses == null) {
+                    basicClauses = new ArrayList<Object>();
+                }
                 basicClauses.add(rawClause);
             }
         }
 
-        if (query.get(AND) != null) {
-            // For an AND query, we require a single compound index and we generate a
-            // single SQL statement to use that index to satisfy the clauses.
+        if (basicClauses != null) {
+            if (query.get(AND) != null) {
+                // For an AND query, we require a single compound index and we generate a
+                // single SQL statement to use that index to satisfy the clauses.
 
-            String chosenIndex = chooseIndexForAndClause(basicClauses, indexes);
-            if (chosenIndex == null || chosenIndex.isEmpty()) {
-                state.atLeastOneIndexMissing = true;
-                String msg = String.format("No single index contains all of %s; %s",
-                                           basicClauses.toString(),
-                                           "add index for these fields to query efficiently.");
-                logger.log(Level.WARNING, msg);
-            } else {
-                state.atLeastOneIndexUsed = true;
-
-                // Execute SQL on that index with appropriate values
-                SqlParts select = selectStatementForAndClause(basicClauses, chosenIndex);
-                if (select == null) {
-                    String msg = String.format("Error generating SELECT clause for %s",
-                                               basicClauses);
-                    logger.log(Level.SEVERE, msg);
-                    return null;
-                }
-
-                SqlQueryNode sqlNode = new SqlQueryNode();
-                sqlNode.sql = select;
-
-                if (root != null) {
-                    root.children.add(sqlNode);
-                }
-            }
-        } else if (query.get(OR) != null) {
-            // OR nodes require a query for each clause.
-            //
-            // We want to allow OR clauses to use separate indexes, unlike for AND, to allow
-            // users to query over multiple indexes during a single query. This prevents users
-            // having to create a single huge index just because one query in their application
-            // requires it, slowing execution of all the other queries down.
-            //
-            // We could optimise for OR parts where we have an appropriate compound index,
-            // but we don't for now.
-
-            for (Object basicClause : basicClauses) {
-                List<Object> wrappedClause = Arrays.asList(basicClause);
-                String chosenIndex = chooseIndexForAndClause(wrappedClause, indexes);
+                String chosenIndex = chooseIndexForAndClause(basicClauses, indexes);
                 if (chosenIndex == null || chosenIndex.isEmpty()) {
                     state.atLeastOneIndexMissing = true;
-                    state.atLeastOneORIndexMissing = true;
                     String msg = String.format("No single index contains all of %s; %s",
-                                               basicClauses.toString(),
-                                               "add index for these fields to query efficiently.");
+                            basicClauses.toString(),
+                            "add index for these fields to query efficiently.");
                     logger.log(Level.WARNING, msg);
                 } else {
                     state.atLeastOneIndexUsed = true;
 
                     // Execute SQL on that index with appropriate values
-                    SqlParts select = selectStatementForAndClause(wrappedClause, chosenIndex);
+                    SqlParts select = selectStatementForAndClause(basicClauses, chosenIndex);
                     if (select == null) {
                         String msg = String.format("Error generating SELECT clause for %s",
-                                                   basicClauses);
+                                basicClauses);
                         logger.log(Level.SEVERE, msg);
                         return null;
                     }
@@ -245,6 +207,47 @@ class QuerySqlTranslator {
 
                     if (root != null) {
                         root.children.add(sqlNode);
+                    }
+                }
+            } else if (query.get(OR) != null) {
+                // OR nodes require a query for each clause.
+                //
+                // We want to allow OR clauses to use separate indexes, unlike for AND, to allow
+                // users to query over multiple indexes during a single query. This prevents users
+                // having to create a single huge index just because one query in their application
+                // requires it, slowing execution of all the other queries down.
+                //
+                // We could optimise for OR parts where we have an appropriate compound index,
+                // but we don't for now.
+
+                for (Object basicClause : basicClauses) {
+                    List<Object> wrappedClause = Arrays.asList(basicClause);
+                    String chosenIndex = chooseIndexForAndClause(wrappedClause, indexes);
+                    if (chosenIndex == null || chosenIndex.isEmpty()) {
+                        state.atLeastOneIndexMissing = true;
+                        state.atLeastOneORIndexMissing = true;
+                        String msg = String.format("No single index contains all of %s; %s",
+                                basicClauses.toString(),
+                                "add index for these fields to query efficiently.");
+                        logger.log(Level.WARNING, msg);
+                    } else {
+                        state.atLeastOneIndexUsed = true;
+
+                        // Execute SQL on that index with appropriate values
+                        SqlParts select = selectStatementForAndClause(wrappedClause, chosenIndex);
+                        if (select == null) {
+                            String msg = String.format("Error generating SELECT clause for %s",
+                                    basicClauses);
+                            logger.log(Level.SEVERE, msg);
+                            return null;
+                        }
+
+                        SqlQueryNode sqlNode = new SqlQueryNode();
+                        sqlNode.sql = select;
+
+                        if (root != null) {
+                            root.children.add(sqlNode);
+                        }
                     }
                 }
             }
@@ -423,15 +426,9 @@ class QuerySqlTranslator {
                     // since this clause is negated we need to negate the bool value
                     whereClauses.add(convertExistsToSqlClauseForFieldName(fieldName, exists));
                 } else {
-                    String whereClause;
-                    if (operator.equals(NE)) {
-                        // Treat $not..$ne as $eq
-                        whereClause = String.format("\"%s\" %s ?", fieldName, operatorMap.get(EQ));
-                    } else {
-                        String sqlOperator = operatorMap.get(operator);
-                        String tableName = IndexManager.tableNameForIndex(indexName);
-                        whereClause = whereClauseForNot(fieldName, sqlOperator, tableName);
-                    }
+                    String sqlOperator = operatorMap.get(operator);
+                    String tableName = IndexManager.tableNameForIndex(indexName);
+                    String whereClause = whereClauseForNot(fieldName, sqlOperator, tableName);
 
                     whereClauses.add(whereClause);
                     predicateValue = negatedPredicate.get(operator);
@@ -448,16 +445,8 @@ class QuerySqlTranslator {
                     boolean exists = (Boolean) predicate.get(operator);
                     whereClauses.add(convertExistsToSqlClauseForFieldName(fieldName, exists));
                 } else {
-                    String whereClause;
-                    if (operator.equals(NE)) {
-                        String tableName = IndexManager.tableNameForIndex(indexName);
-                        whereClause = whereClauseForNot(fieldName,
-                                                        operatorMap.get(EQ),
-                                                        tableName);
-                    } else {
-                        String sqlOperator = operatorMap.get(operator);
-                        whereClause = String.format("\"%s\" %s ?", fieldName, sqlOperator);
-                    }
+                    String sqlOperator = operatorMap.get(operator);
+                    String whereClause = String.format("\"%s\" %s ?", fieldName, sqlOperator);
 
                     whereClauses.add(whereClause);
                     Object predicateValue = predicate.get(operator);

--- a/sync-core/src/main/java/com/cloudant/sync/query/QueryValidator.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/QueryValidator.java
@@ -12,6 +12,8 @@
 
 package com.cloudant.sync.query;
 
+import static com.cloudant.sync.query.QueryConstants.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -25,12 +27,6 @@ import java.util.logging.Logger;
  *  two different implementations of query.
  */
 class QueryValidator {
-
-    private static final String AND = "$and";
-    private static final String OR = "$or";
-    private static final String EQ = "$eq";
-    private static final String NOT = "$not";
-    private static final String NE = "$ne";
 
     // negatedShortHand is used for operator shorthand processing.
     // A shorthand operator like $ne has a longhand representation

--- a/sync-core/src/main/java/com/cloudant/sync/query/UnindexedMatcher.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/UnindexedMatcher.java
@@ -14,6 +14,8 @@ package com.cloudant.sync.query;
 
 import com.cloudant.sync.datastore.DocumentRevision;
 
+import static com.cloudant.sync.query.QueryConstants.*;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -82,10 +84,6 @@ class UnindexedMatcher {
     private ChildrenQueryNode root;
 
     private static final Logger logger = Logger.getLogger(UnindexedMatcher.class.getName());
-
-    private static final String AND = "$and";
-    private static final String OR = "$or";
-    private static final String NOT = "$not";
 
     /**
      *  Return a new initialised matcher.

--- a/sync-core/src/main/java/com/cloudant/sync/query/UnindexedMatcher.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/UnindexedMatcher.java
@@ -15,7 +15,6 @@ package com.cloudant.sync.query;
 import com.cloudant.sync.datastore.DocumentRevision;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
@@ -87,8 +86,6 @@ class UnindexedMatcher {
     private static final String AND = "$and";
     private static final String OR = "$or";
     private static final String NOT = "$not";
-    private static final String NE = "$ne";
-    private static final String EQ = "$eq";
 
     /**
      *  Return a new initialised matcher.
@@ -137,13 +134,7 @@ class UnindexedMatcher {
             Map<String, Object> clause = (Map<String, Object>) rawClause;
             String field = (String) clause.keySet().toArray()[0];
             if (!field.startsWith("$")) {
-                Object converted = convertNeClauseToNotEq(field,
-                                                          (Map<String, Object>) clause.get(field));
-                if (converted == null) {
-                    basicClauses.add(rawClause);
-                } else {
-                    basicClauses.add(converted);
-                }
+                basicClauses.add(rawClause);
             }
         }
 
@@ -187,36 +178,6 @@ class UnindexedMatcher {
         }
 
         return root;
-    }
-
-    @SuppressWarnings("unchecked")
-    private static Map<String, Object> convertNeClauseToNotEq(String field,
-                                                              Map<String, Object> clause) {
-        // We either have { "$not" : { "$operator" : "value" } }
-        //     or         { "$operator" : "value" }
-        Map<String, Object> converted = null;
-        String operator = (String) clause.keySet().toArray()[0];
-        if (operator.equals(NE)) {
-            // Convert { "$ne" : "value" } to { "$not" : { "$eq" : "value" } }
-            Map<String, Object> eqClause = new HashMap<String, Object>();
-            eqClause.put(EQ, clause.get(operator));
-            Map<String, Object> notClause = new HashMap<String, Object>();
-            notClause.put(NOT, eqClause);
-            converted = new HashMap<String, Object>();
-            converted.put(field, notClause);
-        } else if (operator.equals(NOT)) {
-            Map<String, Object> subClause = (Map<String, Object>) clause.get(operator);
-            String subOperator = (String) subClause.keySet().toArray()[0];
-            if (subOperator.equals(NE)) {
-                // Convert { "$not" : { "$ne" : "value" } } to { "$eq" : "value" }
-                Map<String, Object> eqClause = new HashMap<String, Object>();
-                eqClause.put(EQ, subClause.get(subOperator));
-                converted = new HashMap<String, Object>();
-                converted.put(field, eqClause);
-            }
-        }
-
-        return converted;
     }
 
     /**

--- a/sync-core/src/test/java/com/cloudant/sync/query/QuerySqlTranslatorTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/QuerySqlTranslatorTest.java
@@ -718,21 +718,6 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-     public void correctlyTranslatesNeSQLOperatorToNotIn() {
-        Map<String, Object> op = new HashMap<String, Object>();
-        op.put("$ne", "mike");
-        Map<String, Object> name = new HashMap<String, Object>();
-        name.put("name", op);
-
-        SqlParts where = QuerySqlTranslator.whereSqlForAndClause(Arrays.<Object>asList(name),
-                                                                 indexName);
-        String expected = String.format("_id NOT IN (SELECT _id FROM %s WHERE \"name\" = ?)",
-                                        IndexManager.tableNameForIndex(indexName));
-        assertThat(where.sqlWithPlaceHolders, is(expected));
-        assertThat(where.placeHolderValues, is(arrayContaining("mike")));
-    }
-
-    @Test
     public void usesCorrectSQLOperatorForEXISTSTrue() {
         Map<String, Object> op = new HashMap<String, Object>();
         op.put("$exists", true);
@@ -910,22 +895,6 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void usesCorrectSQLOperatorWhenUsingNOTNE() {
-        Map<String, Object> op = new HashMap<String, Object>();
-        op.put("$ne", "mike");
-        Map<String, Object> not = new HashMap<String, Object>();
-        not.put("$not", op);
-        Map<String, Object> name = new HashMap<String, Object>();
-        name.put("name", not);
-
-        SqlParts where = QuerySqlTranslator.whereSqlForAndClause(Arrays.<Object>asList(name),
-                                                                 indexName);
-        String expected = "\"name\" = ?";
-        assertThat(where.sqlWithPlaceHolders, is(expected));
-        assertThat(where.placeHolderValues, is(arrayContaining("mike")));
-    }
-
-    @Test
     public void returnsCorrectWhenTwoConditionsOneField() {
         Map<String, Object> c1op = new HashMap<String, Object>();
         c1op.put("$eq", "mike");
@@ -963,9 +932,11 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         Map<String, Object> c3 = new HashMap<String, Object>();
         c3.put("name", c3op);
         Map<String, Object> c4op = new HashMap<String, Object>();
-        c4op.put("$ne", 30);
+        c4op.put("$eq", 30);
+        Map<String, Object> c4NotOp = new HashMap<String, Object>();
+        c4NotOp.put("$not", c4op);
         Map<String, Object> c4 = new HashMap<String, Object>();
-        c4.put("age", c4op);
+        c4.put("age", c4NotOp);
         Map<String, Object> c5op = new HashMap<String, Object>();
         c5op.put("$eq", 42);
         Map<String, Object> c5 = new HashMap<String, Object>();


### PR DESCRIPTION
Move $not and $ne processing to be part of normalization instead of
having individual sets of logic to handle $not and $ne in both the
post hoc matcher and the SQL engine. This allows us to keep things
less complex in the matcher and the SQL engine logic and also allows us
to maintain one set of logic for $not and $ne processing instead of two.

Changes made:

Add logic to handle multiple $not operators in a row during normalization. This condition was previously unhandled.
Add logic to transform shorthand notion such as $ne into the long form. In the case of $ne it would be $not..$eq. All future shorthand processing will be handled as part of normalization.
Remove $not and $ne query manipulation from SQL translator logic.
Remove $not and $ne query manipulation from post hoc matcher logic.
Add additional tests to test the handling of sequential $not and $ne operators.
Remove WHERE clause tests that specifically use $ne in the query since a query will never have an $ne operator in it by the time it reaches the WHERE clause generation logic.