### PR TITLE
Add support for $in and $nin operators in query

### DIFF
--- a/sync-core/src/main/java/com/cloudant/sync/query/QueryConstants.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/QueryConstants.java
@@ -26,6 +26,14 @@ final class QueryConstants {
 
     public static final String NE = "$ne";
 
+    public static final String LT = "$lt";
+
+    public static final String LTE = "$lte";
+
+    public static final String GT = "$gt";
+
+    public static final String GTE = "$gte";
+
     public static final String IN = "$in";
 
     public static final String NIN = "$nin";

--- a/sync-core/src/main/java/com/cloudant/sync/query/QueryConstants.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/QueryConstants.java
@@ -28,8 +28,10 @@ final class QueryConstants {
 
     public static final String IN = "$in";
 
+    public static final String NIN = "$nin";
+
     private QueryConstants() {
         throw new AssertionError();
     }
-    
+
 }

--- a/sync-core/src/main/java/com/cloudant/sync/query/QueryConstants.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/QueryConstants.java
@@ -26,6 +26,8 @@ final class QueryConstants {
 
     public static final String NE = "$ne";
 
+    public static final String IN = "$in";
+
     private QueryConstants() {
         throw new AssertionError();
     }

--- a/sync-core/src/main/java/com/cloudant/sync/query/QuerySqlTranslator.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/QuerySqlTranslator.java
@@ -374,12 +374,12 @@ class QuerySqlTranslator {
         List<Object> sqlParameters = new ArrayList<Object>();
 
         Map<String, String> operatorMap = new HashMap<String, String>();
-        operatorMap.put("$eq", "=");
-        operatorMap.put("$gt", ">");
-        operatorMap.put("$gte", ">=");
-        operatorMap.put("$lt", "<");
-        operatorMap.put("$lte", "<=");
-        operatorMap.put("$in", "IN");
+        operatorMap.put(EQ, "=");
+        operatorMap.put(GT, ">");
+        operatorMap.put(GTE, ">=");
+        operatorMap.put(LT, "<");
+        operatorMap.put(LTE, "<=");
+        operatorMap.put(IN, "IN");
 
         for (Object rawComponent: clause) {
             Map<String, Object> component = (Map<String, Object>) rawComponent;

--- a/sync-core/src/main/java/com/cloudant/sync/query/QueryValidator.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/QueryValidator.java
@@ -29,13 +29,14 @@ import java.util.logging.Logger;
 class QueryValidator {
 
     // negatedShortHand is used for operator shorthand processing.
-    // A shorthand operator like $ne has a longhand representation
+    // For example:
+    // The shorthand operator $ne has a longhand representation
     // that is { "$not" : { "$eq" : ... } }.  Therefore the negation
-    // of the $ne operator is $eq.
-    // Presently only $ne is supported.  More to come soon...
+    // of the $ne operator is the $eq operator.
     private static final Map<String, String> negatedShortHand = new HashMap<String, String>() {
         {
             put(NE, EQ);
+            put(NIN, IN);
         }
     };
     private static final Logger logger = Logger.getLogger(QueryValidator.class.getName());

--- a/sync-core/src/main/java/com/cloudant/sync/query/QueryValidator.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/QueryValidator.java
@@ -35,7 +35,7 @@ class QueryValidator {
     // Presently only $ne is supported.  More to come soon...
     private static final Map<String, String> negatedShortHand = new HashMap<String, String>() {
         {
-            put(NE,EQ);
+            put(NE, EQ);
         }
     };
     private static final Logger logger = Logger.getLogger(QueryValidator.class.getName());
@@ -48,12 +48,6 @@ class QueryValidator {
         boolean isWildCard = false;
         if (query.isEmpty()) {
             isWildCard = true;
-        }
-
-        if (!validateQueryValue(query)) {
-            String msg = String.format("Invalid value encountered in query: %s", query.toString());
-            logger.log(Level.SEVERE, msg);
-            return null;
         }
 
         // First expand the query to include a leading compound predicate
@@ -336,7 +330,7 @@ class QueryValidator {
 
     private static boolean validateCompoundOperatorOperand(Object operand) {
         if (!(operand instanceof List)) {
-            String msg = String.format("Argument to compound operator is not an NSArray: %s",
+            String msg = String.format("Argument to compound operator is not a List: %s",
                                        operand.toString());
             logger.log(Level.SEVERE, msg);
             return false;
@@ -385,12 +379,12 @@ class QueryValidator {
             }
 
             String key = (String) clause.keySet().toArray()[0];
-            if (Arrays.asList("$or", "$not", "$and").contains(key)) {
+            if (Arrays.asList(OR, NOT, AND).contains(key)) {
                 // this should have a list as top level type
                 Object compoundClauses = clause.get(key);
                 if (validateCompoundOperatorOperand(compoundClauses)) {
                     // validate list
-                    valid = validateCompoundOperatorClauses((List) compoundClauses);
+                    valid = validateCompoundOperatorClauses((List<Object>) compoundClauses);
                 }
             } else if (!(key.startsWith("$"))) {
                 // this should have a map
@@ -403,7 +397,7 @@ class QueryValidator {
             }
 
             if (!valid) {
-                break;  // if we have gotten here with valid being no, we should abort
+                break;  // if we have gotten here with valid being false, we should abort
             }
         }
 
@@ -417,19 +411,24 @@ class QueryValidator {
                                                     "$gt",
                                                     "$exists",
                                                     "$not",
-                                                    "$ne",
                                                     "$gte",
-                                                    "$lte");
+                                                    "$lte",
+                                                    "$in");
         if (clause.size() == 1) {
             String operator = (String) clause.keySet().toArray()[0];
             if (validOperators.contains(operator)) {
                 // contains correct operator
                 Object clauseOperand = clause.get(operator);
-                // handle special case, $not is the only op that expects a dict
-                if (operator.equals("$not") && clauseOperand instanceof Map) {
-                    return validateClause((Map) clauseOperand);
-                } else if (validatePredicateValue(clauseOperand, operator)) {
-                    return true;
+                // Handle special cases:
+                //  - $not is the only operator that expects a Map
+                //  - $in is the only operator that expects a List
+                if (operator.equals(NOT)) {
+                    return clauseOperand instanceof Map && validateClause((Map) clauseOperand);
+                } else if (operator.equals(IN)) {
+                    return clauseOperand instanceof List &&
+                           validateInListValues((List<Object>) clauseOperand);
+                } else {
+                    return validatePredicateValue(clauseOperand, operator);
                 }
             }
         }
@@ -437,13 +436,27 @@ class QueryValidator {
         return false;
     }
 
-    private static boolean validatePredicateValue(Object predicateValue, String operator) {
-        if (operator.equals("$exists")) {
-            return validateExistsArgument(predicateValue);
-        } else {
-            return (predicateValue instanceof String ||
-                    predicateValue instanceof Number && !(predicateValue instanceof Float));
+    private static boolean validateInListValues(List<Object> inListValues) {
+        boolean valid = true;
+
+        for (Object value : inListValues) {
+            if (!validatePredicateValue(value, IN)) {
+                valid = false;
+                break;
+            }
         }
+
+        return valid;
+    }
+
+    private static boolean validatePredicateValue(Object predicateValue, String operator) {
+        if (operator.equals(EXISTS)) {
+            return validateExistsArgument(predicateValue);
+        } else if (validateNotAFloat(predicateValue)) {
+            return (predicateValue instanceof String || predicateValue instanceof Number);
+        }
+
+        return false;
     }
 
     private static boolean validateExistsArgument(Object exists) {
@@ -457,18 +470,12 @@ class QueryValidator {
         return valid;
     }
 
-    private static boolean validateQueryValue(Object value) {
+    private static boolean validateNotAFloat(Object value) {
         boolean valid = true;
-        if (value instanceof Map) {
-            for (Object key: ((Map) value).keySet()) {
-                valid = valid && validateQueryValue(((Map) value).get(key));
-            }
-        } else if (value instanceof List) {
-            for (Object element : (List) value) {
-                valid = valid && validateQueryValue(element);
-            }
-        } else if (value instanceof Float) {
+
+        if (value instanceof Float) {
             valid = false;
+            logger.log(Level.SEVERE, "Float value encountered in query");
         }
 
         return valid;

--- a/sync-core/src/main/java/com/cloudant/sync/query/QueryValidator.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/QueryValidator.java
@@ -476,7 +476,7 @@ class QueryValidator {
 
         if (value instanceof Float) {
             valid = false;
-            logger.log(Level.SEVERE, "Float value encountered in query");
+            logger.log(Level.SEVERE, "Float value found in query: %f - Use Double instead.", value);
         }
 
         return valid;

--- a/sync-core/src/main/java/com/cloudant/sync/query/UnindexedMatcher.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/UnindexedMatcher.java
@@ -270,17 +270,17 @@ class UnindexedMatcher {
     private boolean valueCompare(Object actual, String operator, Object expected) {
         boolean passed;
 
-        if (operator.equals("$eq")) {
+        if (operator.equals(EQ)) {
             passed = compareEq(actual, expected);
-        } else if (operator.equals("$lt")) {
+        } else if (operator.equals(LT)) {
             passed = compareLT(actual, expected);
-        } else if (operator.equals("$lte")) {
+        } else if (operator.equals(LTE)) {
             passed = compareLTE(actual, expected);
-        } else if (operator.equals("$gt")) {
+        } else if (operator.equals(GT)) {
             passed = compareGT(actual, expected);
-        } else if (operator.equals("$gte")) {
+        } else if (operator.equals(GTE)) {
             passed = compareGTE(actual, expected);
-        } else if (operator.equals("$exists")) {
+        } else if (operator.equals(EXISTS)) {
             boolean expectedBool = (Boolean) expected;
             boolean exists = (actual != null);
             passed = (exists == expectedBool);

--- a/sync-core/src/main/java/com/cloudant/sync/query/UnindexedMatcher.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/UnindexedMatcher.java
@@ -234,22 +234,27 @@ class UnindexedMatcher {
                 operator = (String) operatorExpression.keySet().toArray()[0];
             }
 
-            Object expectedValues = operatorExpression.get(operator);
-            if (!(expectedValues instanceof List)) {
-                expectedValues = Arrays.asList(expectedValues);
-            }
+            Object expected = operatorExpression.get(operator);
             Object actual = ValueExtractor.extractValueForFieldName(fieldName, rev);
+            // Since $in is the same as a series of $eq comparisons -
+            // Treat them the same by:
+            // - Ensuring that both expected and actual are Lists.
+            // - Convert the $in operator to the $eq operator.
+            if (!(expected instanceof List)) {
+                expected = Arrays.asList(expected);
+            }
+            if (!(actual instanceof List)) {
+                actual = Arrays.asList(actual);
+            }
+            if (operator.equals(IN)) {
+                operator = EQ;
+            }
 
             boolean passed = false;
-            for (Object expected : (List<Object>) expectedValues) {
-                if (actual instanceof List) {
-                    for (Object actualItem: (List<Object>) actual) {
-                        // OR since any actual item can match any value in the expected list
-                        passed = passed || valueCompare(actualItem, operator, expected);
-                    }
-                } else {
-                    // OR since any value in the expected list can match the actual
-                    passed = passed || valueCompare(actual, operator, expected);
+            for (Object expectedItem : (List<Object>) expected) {
+                for (Object actualItem: (List<Object>) actual) {
+                    // OR since any actual item can match any value in the expected list
+                    passed = passed || valueCompare(actualItem, operator, expectedItem);
                 }
             }
 
@@ -265,7 +270,7 @@ class UnindexedMatcher {
     private boolean valueCompare(Object actual, String operator, Object expected) {
         boolean passed;
 
-        if (operator.equals("$eq") || operator.equals("$in")) {
+        if (operator.equals("$eq")) {
             passed = compareEq(actual, expected);
         } else if (operator.equals("$lt")) {
             passed = compareLT(actual, expected);
@@ -293,10 +298,6 @@ class UnindexedMatcher {
             return l.equals(r);
         } else if (l instanceof Boolean && r instanceof Boolean) {
             return l == r;
-        } else if (l instanceof Float || r instanceof Float) {
-            String msg = String.format("Value in comparison is a Float: %s, %s", l, r);
-            logger.log(Level.WARNING, msg);
-            return false;
         } else {
             return l instanceof Number && r instanceof Number &&
                     ((Number) l).doubleValue() == ((Number) r).doubleValue();
@@ -333,13 +334,7 @@ class UnindexedMatcher {
             Number lNum = (Number) l;
             Number rNum = (Number) r;
 
-            if (l instanceof Float || r instanceof Float) {
-                String msg = String.format("Value in comparison is a Float: %s, %s", l, r);
-                logger.log(Level.WARNING, msg);
-                return false;
-            } else {
-                return lNum.doubleValue() < rNum.doubleValue();
-            }
+            return lNum.doubleValue() < rNum.doubleValue();
         }
     }
 
@@ -351,13 +346,7 @@ class UnindexedMatcher {
             logger.log(Level.WARNING, msg);
             return false;  // Not sure how to compare values that are not numbers or strings
         } else {
-            if (l instanceof Float || r instanceof Float) {
-                String msg = String.format("Value in comparison is a Float: %s, %s", l, r);
-                logger.log(Level.WARNING, msg);
-                return false;
-            } else {
-                return compareLT(l, r) || compareEq(l, r);
-            }
+            return compareLT(l, r) || compareEq(l, r);
         }
     }
 
@@ -369,13 +358,7 @@ class UnindexedMatcher {
             logger.log(Level.WARNING, msg);
             return false;  // Not sure how to compare values that are not numbers or strings
         } else {
-            if (l instanceof Float || r instanceof Float) {
-                String msg = String.format("Value in comparison is a Float: %s, %s", l, r);
-                logger.log(Level.WARNING, msg);
-                return false;
-            } else {
-                return !compareLTE(l, r);
-            }
+            return !compareLTE(l, r);
         }
     }
 
@@ -387,13 +370,7 @@ class UnindexedMatcher {
             logger.log(Level.WARNING, msg);
             return false;  // Not sure how to compare values that are not numbers or strings
         } else {
-            if (l instanceof Float || r instanceof Float) {
-                String msg = String.format("Value in comparison is a Float: %s, %s", l, r);
-                logger.log(Level.WARNING, msg);
-                return false;
-            } else {
-                return !compareLT(l, r);
-            }
+            return !compareLT(l, r);
         }
     }
 

--- a/sync-core/src/test/java/com/cloudant/sync/query/AbstractQueryTestBase.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/AbstractQueryTestBase.java
@@ -273,6 +273,7 @@ public abstract class AbstractQueryTestBase {
 
     // Used to setup document data testing:
     // - When indexing array fields
+    // - When querying using $in operator
     public void setUpArrayIndexingData() throws Exception {
         MutableDocumentRevision rev = new MutableDocumentRevision();
         rev.docId = "mike12";

--- a/sync-core/src/test/java/com/cloudant/sync/query/QueryCoveringIndexesTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/QueryCoveringIndexesTest.java
@@ -1380,9 +1380,9 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         System.out.println(query);
         QueryResult queryResult = im.find(query);
         assertThat(queryResult.documentIds(), containsInAnyOrder("mike12",
-                "mike34",
-                "mike72",
-                "fred34"));
+                                                                 "mike34",
+                                                                 "mike72",
+                                                                 "fred34"));
     }
 
     @Test
@@ -1414,6 +1414,71 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         query.put("pet", notOp);
         QueryResult queryResult = im.find(query);
         assertThat(queryResult.documentIds(), contains("fred12"));
+    }
+
+    // When querying using $in operator
+
+    @Test
+    public void canFindDocumentsWithArraysUsingIN() throws Exception {
+        setUpArrayIndexingData();
+        // query - { "pet" : { "$in" : [ "fish", "hamster" ] } }
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$in", Arrays.<Object>asList("fish", "hamster"));
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("pet", op);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), containsInAnyOrder("mike34", "john44"));
+    }
+
+    @Test
+    public void canFindDocumentWithoutArraysUsingIN() throws Exception {
+        setUpArrayIndexingData();
+        // query - { "pet" : { "$in" : [ "parrot", "turtle" ] } }
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$in", Arrays.<Object>asList("parrot", "turtle"));
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("pet", op);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), contains("fred34"));
+    }
+
+    @Test
+    public void canFindDocumentsWithAndWithoutArraysUsingIN() throws Exception {
+        setUpArrayIndexingData();
+        // query - { "pet" : { "$in" : [ "cat", "dog" ] } }
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$in", Arrays.<Object>asList("cat", "dog"));
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("pet", op);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), containsInAnyOrder("mike12", "mike34", "john22"));
+    }
+
+    @Test
+    public void returnsEmptyResultWhenNoMatchUsingIN() throws Exception {
+        setUpArrayIndexingData();
+        // query - { "pet" : { "$in" : [ "turtle", "pig" ] } }
+        Map<String, Object> op = new HashMap<String, Object>();
+        //op.put("$in", Arrays.<Object>asList("turtle", "pig"));
+        op.put("$eq", "turtle");
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("pet", op);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.size(), is(0));
+    }
+
+    @Test
+    public void canFindDocumentsWithAndWithoutArraysUsingNOTIN() throws Exception {
+        setUpArrayIndexingData();
+        // query - { "pet" : { "$not" : { "$in" : [ "cat", "dog" ] } } }
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$in", Arrays.<Object>asList("cat", "dog"));
+        Map<String, Object> notOp = new HashMap<String, Object>();
+        notOp.put("$not", op);
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("pet", notOp);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), containsInAnyOrder("fred12", "fred34", "john44"));
     }
 
     // When there is a large result set

--- a/sync-core/src/test/java/com/cloudant/sync/query/QuerySqlTranslatorTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/QuerySqlTranslatorTest.java
@@ -783,7 +783,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         name.put("name", op);
 
         SqlParts where = QuerySqlTranslator.whereSqlForAndClause(Arrays.<Object>asList(name),
-                         indexName);
+                                                                 indexName);
         String expected = "\"name\" = ?";
         assertThat(where.sqlWithPlaceHolders, is(expected));
         assertThat(where.placeHolderValues, is(arrayContaining("mike")));

--- a/sync-core/src/test/java/com/cloudant/sync/query/QuerySqlTranslatorTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/QuerySqlTranslatorTest.java
@@ -35,6 +35,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
     Map<String, Object> indexes;
     Boolean[] indexesCoverQuery;
     String indexName;
+    String indexTable;
 
     @Override
     public void setUp() throws Exception {
@@ -44,6 +45,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         indexes = im.listIndexes();
         assertThat(indexes, is(notNullValue()));
         indexesCoverQuery = new Boolean[]{ false };
+        indexTable = String.format("_t_cloudant_sync_query_index_%s", indexName);
     }
 
     // When creating a tree
@@ -773,6 +775,34 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         assertThat(where.sqlWithPlaceHolders, is(expected));
     }
 
+    @Test
+    public void constructsValidWhereClauseForINUsingSingleElement() {
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$in", Arrays.<Object>asList("mike"));
+        Map<String, Object> name = new HashMap<String, Object>();
+        name.put("name", op);
+
+        SqlParts where = QuerySqlTranslator.whereSqlForAndClause(Arrays.<Object>asList(name),
+                         indexName);
+        String expected = "\"name\" IN ( ? )";
+        assertThat(where.sqlWithPlaceHolders, is(expected));
+        assertThat(where.placeHolderValues, is(arrayContaining("mike")));
+    }
+
+    @Test
+    public void constructsValidWhereClauseForINUsingMultipleElements() {
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$in", Arrays.<Object>asList("mike", "fred"));
+        Map<String, Object> name = new HashMap<String, Object>();
+        name.put("name", op);
+
+        SqlParts where = QuerySqlTranslator.whereSqlForAndClause(Arrays.<Object>asList(name),
+                                                                 indexName);
+        String expected = "\"name\" IN ( ?, ? )";
+        assertThat(where.sqlWithPlaceHolders, is(expected));
+        assertThat(where.placeHolderValues, is(arrayContaining("mike", "fred")));
+    }
+
     // When generating query WHERE clauses with $not
 
     @Test
@@ -786,7 +816,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         SqlParts where = QuerySqlTranslator.whereSqlForAndClause(Arrays.<Object>asList(name),
                                                                  indexName);
         String expected = String.format("_id NOT IN (SELECT _id FROM %s WHERE \"name\" = ?)",
-                                        IndexManager.tableNameForIndex(indexName));
+                                        indexTable);
         assertThat(where.sqlWithPlaceHolders, is(expected));
         assertThat(where.placeHolderValues, is(arrayContaining("mike")));
     }
@@ -816,10 +846,10 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         SqlParts where = QuerySqlTranslator.whereSqlForAndClause(clauses, indexName);
 
         String expectedName = String.format("_id NOT IN (SELECT _id FROM %s WHERE \"name\" = ?)",
-                                            IndexManager.tableNameForIndex(indexName));
+                                            indexTable);
         String expectedAge = "\"age\" = ?";
         String expectedPet = String.format("_id NOT IN (SELECT _id FROM %s WHERE \"pet\" = ?)",
-                                           IndexManager.tableNameForIndex(indexName));
+                                           indexTable);
         String expected = String.format("%s AND %s AND %s", expectedName, expectedAge, expectedPet);
 
         assertThat(where.sqlWithPlaceHolders, is(expected));
@@ -838,7 +868,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         SqlParts where = QuerySqlTranslator.whereSqlForAndClause(Arrays.<Object>asList(name),
                                                                  indexName);
         String expected = String.format("_id NOT IN (SELECT _id FROM %s WHERE \"name\" > ?)",
-                                        IndexManager.tableNameForIndex(indexName));
+                                        indexTable);
         assertThat(where.sqlWithPlaceHolders, is(expected));
         assertThat(where.placeHolderValues, is(arrayContaining("mike")));
     }
@@ -855,7 +885,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         SqlParts where = QuerySqlTranslator.whereSqlForAndClause(Arrays.<Object>asList(name),
                                                                  indexName);
         String expected = String.format("_id NOT IN (SELECT _id FROM %s WHERE \"name\" >= ?)",
-                                        IndexManager.tableNameForIndex(indexName));
+                                        indexTable);
         assertThat(where.sqlWithPlaceHolders, is(expected));
         assertThat(where.placeHolderValues, is(arrayContaining("mike")));
     }
@@ -872,7 +902,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         SqlParts where = QuerySqlTranslator.whereSqlForAndClause(Arrays.<Object>asList(name),
                                                                  indexName);
         String expected = String.format("_id NOT IN (SELECT _id FROM %s WHERE \"name\" < ?)",
-                                        IndexManager.tableNameForIndex(indexName));
+                                        indexTable);
         assertThat(where.sqlWithPlaceHolders, is(expected));
         assertThat(where.placeHolderValues, is(arrayContaining("mike")));
     }
@@ -889,9 +919,28 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         SqlParts where = QuerySqlTranslator.whereSqlForAndClause(Arrays.<Object>asList(name),
                                                                  indexName);
         String expected = String.format("_id NOT IN (SELECT _id FROM %s WHERE \"name\" <= ?)",
-                                        IndexManager.tableNameForIndex(indexName));
+                                        indexTable);
         assertThat(where.sqlWithPlaceHolders, is(expected));
         assertThat(where.placeHolderValues, is(arrayContaining("mike")));
+    }
+
+    @Test
+    public void constructsValidWhereClauseForNOTIN() {
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$in", Arrays.<Object>asList("mike", "fred"));
+        Map<String, Object> notOp = new HashMap<String, Object>();
+        notOp.put("$not", op);
+        Map<String, Object> name = new HashMap<String, Object>();
+        name.put("name", notOp);
+
+        SqlParts where = QuerySqlTranslator.whereSqlForAndClause(Arrays.<Object>asList(name),
+                                                                 indexName);
+        String expectedSubWhere = "WHERE \"name\" IN ( ?, ? ))";
+        String expected = String.format("_id NOT IN (SELECT _id FROM %s %s",
+                                        indexTable,
+                                        expectedSubWhere);
+        assertThat(where.sqlWithPlaceHolders, is(expected));
+        assertThat(where.placeHolderValues, is(arrayContaining("mike", "fred")));
     }
 
     @Test
@@ -910,7 +959,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         SqlParts where = QuerySqlTranslator.whereSqlForAndClause(Arrays.<Object>asList(c1, c2),
                                                                  indexName);
         String notEqName = String.format("_id NOT IN (SELECT _id FROM %s WHERE \"name\" = ?)",
-                                         IndexManager.tableNameForIndex(indexName));
+                                         indexTable);
         String eqName = "\"name\" = ?";
         String expected = String.format("%s AND %s", notEqName, eqName);
         assertThat(where.sqlWithPlaceHolders, is(expected));
@@ -948,7 +997,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         String ageLte = "\"age\" <= ?";
         String nameEq = "\"name\" = ?";
         String ageNe = String.format("_id NOT IN (SELECT _id FROM %s WHERE \"age\" = ?)",
-                                     IndexManager.tableNameForIndex(indexName));
+                                     indexTable);
         String ageEq = "\"age\" = ?";
         String expected = String.format("%s AND %s AND %s AND %s AND %s",
                                         ageGt,

--- a/sync-core/src/test/java/com/cloudant/sync/query/QuerySqlTranslatorTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/QuerySqlTranslatorTest.java
@@ -784,7 +784,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
 
         SqlParts where = QuerySqlTranslator.whereSqlForAndClause(Arrays.<Object>asList(name),
                                                                  indexName);
-        String expected = "\"name\" = ?";
+        String expected = "\"name\" IN ( ? )";
         assertThat(where.sqlWithPlaceHolders, is(expected));
         assertThat(where.placeHolderValues, is(arrayContaining("mike")));
     }
@@ -935,10 +935,9 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
 
         SqlParts where = QuerySqlTranslator.whereSqlForAndClause(Arrays.<Object>asList(name),
                                                                  indexName);
-        String expectedSubWhere = "WHERE \"name\" IN ( ?, ? ))";
-        String expected = String.format("_id NOT IN (SELECT _id FROM %s %s",
+        String expected = String.format("_id NOT IN (SELECT _id FROM %s %s)",
                                         indexTable,
-                                        expectedSubWhere);
+                                        "WHERE \"name\" IN ( ?, ? )");
         assertThat(where.sqlWithPlaceHolders, is(expected));
         assertThat(where.placeHolderValues, is(arrayContaining("mike", "fred")));
     }

--- a/sync-core/src/test/java/com/cloudant/sync/query/QuerySqlTranslatorTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/QuerySqlTranslatorTest.java
@@ -784,7 +784,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
 
         SqlParts where = QuerySqlTranslator.whereSqlForAndClause(Arrays.<Object>asList(name),
                          indexName);
-        String expected = "\"name\" IN ( ? )";
+        String expected = "\"name\" = ?";
         assertThat(where.sqlWithPlaceHolders, is(expected));
         assertThat(where.placeHolderValues, is(arrayContaining("mike")));
     }

--- a/sync-core/src/test/java/com/cloudant/sync/query/UnindexedMatcherTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/UnindexedMatcherTest.java
@@ -1078,14 +1078,116 @@ public class UnindexedMatcherTest {
     public void matchBadItemWithNe() {
         // Selector - { "pets" : { "$ne" : "tabby_cat" } }
         Map<String, Object> op = new HashMap<String, Object>();
-        op.put("$eq", "tabby_cat");
-        Map<String, Object> not = new HashMap<String, Object>();
-        not.put("$not", op);
+        op.put("$ne", "tabby_cat");
         Map<String, Object> selector = new HashMap<String, Object>();
-        selector.put("pets", not);
+        selector.put("pets", op);
         selector = QueryValidator.normaliseAndValidateQuery(selector);
         UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
         assertThat(matcher.matches(rev), is(true));
+    }
+
+    @Test
+    public void matchOnArrayUsingIn() {
+        // Selector - { "pets" : { "$in" : [ "white_cat", "tabby_cat" ] } }
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$in", Arrays.<Object>asList("white_cat", "tabby_cat"));
+        Map<String, Object> selector = new HashMap<String, Object>();
+        selector.put("pets", op);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(true));
+    }
+
+    @Test
+    public void noMatchOnArrayUsingIn() {
+        // Selector - { "pets" : { "$in" : [ "grey_cat", "tabby_cat" ] } }
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$in", Arrays.<Object>asList("grey_cat", "tabby_cat"));
+        Map<String, Object> selector = new HashMap<String, Object>();
+        selector.put("pets", op);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(false));
+    }
+
+    @Test
+    public void matchOnNonArrayUsingIn() {
+        // Selector - { "name" : { "$in" : [ "mike", "fred" ] } }
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$in", Arrays.<Object>asList("mike", "fred"));
+        Map<String, Object> selector = new HashMap<String, Object>();
+        selector.put("name", op);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(true));
+    }
+
+    @Test
+    public void noMatchOnNonArrayUsingIn() {
+        // Selector - { "name" : { "$in" : [ "john", "fred" ] } }
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$in", Arrays.<Object>asList("john", "fred"));
+        Map<String, Object> selector = new HashMap<String, Object>();
+        selector.put("name", op);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(false));
+    }
+
+    @Test
+    public void matchOnArrayUsingNotIn() {
+        // Selector - { "pets" : { "$not" : { "$in" : [ "grey_cat", "tabby_cat" ] } } }
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$in", Arrays.<Object>asList("grey_cat", "tabby_cat"));
+        Map<String, Object> notOp = new HashMap<String, Object>();
+        notOp.put("$not", op);
+        Map<String, Object> selector = new HashMap<String, Object>();
+        selector.put("pets", notOp);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(true));
+    }
+
+    @Test
+    public void noMatchOnArrayUsingNotIn() {
+        // Selector - { "pets" : { "$not" : { "$in" : [ "white_cat", "tabby_cat" ] } } }
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$in", Arrays.<Object>asList("white_cat", "tabby_cat"));
+        Map<String, Object> notOp = new HashMap<String, Object>();
+        notOp.put("$not", op);
+        Map<String, Object> selector = new HashMap<String, Object>();
+        selector.put("pets", notOp);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(false));
+    }
+
+    @Test
+    public void matchOnNonArrayUsingNotIn() {
+        // Selector - { "name" : { "$not" : { "$in" : [ "john", "fred" ] } } }
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$in", Arrays.<Object>asList("john", "fred"));
+        Map<String, Object> notOp = new HashMap<String, Object>();
+        notOp.put("$not", op);
+        Map<String, Object> selector = new HashMap<String, Object>();
+        selector.put("name", notOp);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(true));
+    }
+
+    @Test
+    public void noMatchOnNonArrayUsingNotIn() {
+        // Selector - { "name" : { "$not" : { "$in" : [ "mike", "fred" ] } } }
+        Map<String, Object> op = new HashMap<String, Object>();
+        op.put("$in", Arrays.<Object>asList("mike", "fred"));
+        Map<String, Object> notOp = new HashMap<String, Object>();
+        notOp.put("$not", op);
+        Map<String, Object> selector = new HashMap<String, Object>();
+        selector.put("name", notOp);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(false));
     }
 
     @Test

--- a/sync-core/src/test/java/com/cloudant/sync/query/UnindexedMatcherTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/UnindexedMatcherTest.java
@@ -93,36 +93,6 @@ public class UnindexedMatcherTest {
         assertThat(compareGTE(1, null), is(false));
     }
 
-    // Floats are not allowed.  Result should always be false.
-    @Test
-    @SuppressWarnings("UnnecessaryBoxing")
-    public void compareFloats() {
-        assertThat(compareEq(new Float(1.0f), new Integer(1)), is(false));
-        assertThat(compareEq(new Integer(1), new Float(1.0f)), is(false));
-        assertThat(compareEq(new Float(1.1f), new Integer(1)), is(false));
-        assertThat(compareEq(new Integer(1), new Float(1.1f)), is(false));
-
-        assertThat(compareLT(new Float(1.0f), new Integer(1)), is(false));
-        assertThat(compareLT(new Integer(1), new Float(1.0f)), is(false));
-        assertThat(compareLT(new Float(1.1f), new Integer(1)), is(false));
-        assertThat(compareLT(new Integer(1), new Float(1.1f)), is(false));
-
-        assertThat(compareLTE(new Float(1.0f), new Integer(1)), is(false));
-        assertThat(compareLTE(new Integer(1), new Float(1.0f)), is(false));
-        assertThat(compareLTE(new Float(1.1f), new Integer(1)), is(false));
-        assertThat(compareLTE(new Integer(1), new Float(1.1f)), is(false));
-
-        assertThat(compareGT(new Float(1.0f), new Integer(1)), is(false));
-        assertThat(compareGT(new Integer(1), new Float(1.0f)), is(false));
-        assertThat(compareGT(new Float(1.1f), new Integer(1)), is(false));
-        assertThat(compareGT(new Integer(1), new Float(1.1f)), is(false));
-
-        assertThat(compareGTE(new Float(1.0f), new Integer(1)), is(false));
-        assertThat(compareGTE(new Integer(1), new Float(1.0f)), is(false));
-        assertThat(compareGTE(new Float(1.1f), new Integer(1)), is(false));
-        assertThat(compareGTE(new Integer(1), new Float(1.1f)), is(false));
-    }
-
     @Test
     public void compareStringToString() {
         assertThat(compareEq("mike", "mike"), is(true));


### PR DESCRIPTION
This PR adds the $in and $nin operator support to Query.  Additionally, there was some code clean up and  refactoring done to the SQL Translator logic to aid in future maintenance, readability and some SQL optimization.