### PR TITLE
Support all test command line options on android

### DIFF
--- a/AndroidTest/app/build.gradle
+++ b/AndroidTest/app/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'com.android.application'
 def testResultsFile = "testResults_"+UUID.randomUUID().toString()+".xml"
 def scriptLocation = project.projectDir.getAbsolutePath(); //this is the location of THIS file
 def testSrcDir = "../../sync-core/src/test/java/" // this is the location of your test code, relative to this file
+def testConfig = convertTestSysPropsToHash()
 
 android {
     def classes = findAllTestClasses(new File("$scriptLocation/$testSrcDir")).toString().replace("[","{").replace("]","}");
@@ -19,6 +20,11 @@ android {
         buildConfigField "Class[]", "classToTests", "$classes"
         buildConfigField "String", "testOutputFile", "\"$testResultsFile\""
         buildConfigField "Class[]", "testExcludes", "{com.cloudant.common.SystemTest.class, com.cloudant.common.RequireRunningCouchDB.class, com.cloudant.common.PerformanceTest.class}"
+
+        //pass test config as key value pairs
+
+        buildConfigField "String[][]", "TEST_CONFIG", testConfig
+
     }
 
     productFlavors {
@@ -101,6 +107,17 @@ task(uploadFixtures,type:Exec) {
     // this will work irrespective of current working directory due to use of $scriptLocation
     def android = "$System.env.ANDROID_HOME"
     commandLine "$android/platform-tools/adb","push", "-p", "$scriptLocation/../../fixture", "/sdcard/fixture"
+}
+
+def convertTestSysPropsToHash (){
+
+    return "{" +
+        System.properties
+        .grep { prop -> prop.key.startsWith("test") }
+        .collect(new ArrayList()) { prop -> "{\""+prop.key+"\",\""+ prop.value+"\"}"}
+        .join(",") +
+        "}"
+
 }
 
 def findAllTestClasses(File root){

--- a/AndroidTest/app/src/main/java/cloudant/com/androidtest/MyActivity.java
+++ b/AndroidTest/app/src/main/java/cloudant/com/androidtest/MyActivity.java
@@ -49,8 +49,8 @@ public class MyActivity extends ListActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        //set up dexcache this is a workaround for https://code.google.com/p/dexmaker/issues/detail?id=2
-        System.setProperty( "dexmaker.dexcache", this.getCacheDir().getPath() );
+
+        setTestProperties();
 
         trs = TestResultStorage.getInstance();
         mAdapter = new ArrayAdapter<TestResults>(this,R.layout.list_view_text);
@@ -155,6 +155,16 @@ public class MyActivity extends ListActivity {
         intent.putExtra(BundleConstants.EXCEPTION_STACK,tr.exceptionStack());
 
         this.startActivity(intent); // start display
+
+    }
+
+    private void setTestProperties(){
+        //set up dexcache this is a workaround for https://code.google.com/p/dexmaker/issues/detail?id=2
+        System.setProperty( "dexmaker.dexcache", this.getCacheDir().getPath() );
+
+        for(String[] testOption : BuildConfig.TEST_CONFIG){
+                System.setProperty(testOption[0], testOption[1]);
+        }
 
     }
 }


### PR DESCRIPTION
Removed android specific couch configuration from tests, the test runner
now handles the conversion. Android will always use the specified
couch config.

build.gradle adds all commandline options with their defaults, exception
to this is username and password which has defaults of empty strings.