### PR TITLE
Remove IGNORE_MULTIPART_ATTACHMENTS option

### DIFF
--- a/sync-core/src/test/java/com/cloudant/common/CouchTestBase.java
+++ b/sync-core/src/test/java/com/cloudant/common/CouchTestBase.java
@@ -36,10 +36,6 @@ public abstract class CouchTestBase {
     public static final Boolean IGNORE_AUTH_HEADERS = Boolean.valueOf(
             System.getProperty("test.couch.ignore.auth.headers",Boolean.FALSE.toString()));
 
-    //See FB (Cloudant internal issue tracker) 45086 for reason why this option exists
-    public static final Boolean IGNORE_MULTIPART_ATTACHMENTS = Boolean.valueOf(
-            System.getProperty("test.couch.ignore.multipart.attachments",Boolean.TRUE.toString()));
-
     public CouchConfig getCouchConfig(String db) {
 
         if (SPECIFIED_COUCH) {

--- a/sync-core/src/test/java/com/cloudant/sync/replication/AttachmentsPushTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/replication/AttachmentsPushTest.java
@@ -114,7 +114,6 @@ public class AttachmentsPushTest extends ReplicationTestBase {
 
     @Test
     public void pushAttachmentsTest() throws Exception {
-        Assume.assumeFalse(IGNORE_MULTIPART_ATTACHMENTS);
         // simple 1-rev attachment
         String attachmentName = "attachment_1.txt";
         populateSomeDataInLocalDatastore();
@@ -139,7 +138,6 @@ public class AttachmentsPushTest extends ReplicationTestBase {
 
     @Test
     public void pushBigAttachmentsTest() throws Exception {
-        Assume.assumeFalse(IGNORE_MULTIPART_ATTACHMENTS);
         // simple 1-rev attachment
         String attachmentName = "bonsai-boston.jpg";
         populateSomeDataInLocalDatastore();
@@ -164,7 +162,6 @@ public class AttachmentsPushTest extends ReplicationTestBase {
 
     @Test
     public void pushAttachmentsTest2() throws Exception {
-        Assume.assumeFalse(IGNORE_MULTIPART_ATTACHMENTS);
         // more complex test with attachments changing between revisions
         String attachmentName1 = "attachment_1.txt";
         String attachmentName2 = "attachment_2.txt";


### PR DESCRIPTION
Remove multipart attachments option from test cases. The issue
making this option needed has been resolved.

See FB 45086 for resolution to issue.