### PR TITLE
Change AndroidTest target SDK to version 19

### DIFF
--- a/AndroidTest/app/build.gradle
+++ b/AndroidTest/app/build.gradle
@@ -14,7 +14,7 @@ android {
     defaultConfig {
         applicationId "cloudant.com.androidtest"
         minSdkVersion 14
-        targetSdkVersion 20
+        targetSdkVersion 19
         versionCode 1
         versionName "1.0"
         buildConfigField "Class[]", "classToTests", "$classes"


### PR DESCRIPTION
The AndroidTest application should be targeting an version of android which runs on a phone, rather than only on wearables. This PR lowers the target SDK version to API level 19 (Android 4.4).

Reviewer @mikerhodes 
Reviewer @indisoluble 