### PR TITLE
Add support for text indexing

### DIFF
--- a/sync-core/src/main/java/com/cloudant/sync/query/Index.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/Index.java
@@ -21,7 +21,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -71,16 +70,16 @@ class Index {
      * @param indexName the index name
      * @return the Index object or null if arguments passed in were invalid.
      */
-    public static Index setUp(List<Object> fieldNames, String indexName) {
-        return setUp(fieldNames, indexName, JSON_TYPE);
+    public static Index getInstance(List<Object> fieldNames, String indexName) {
+        return getInstance(fieldNames, indexName, JSON_TYPE);
     }
 
-    public static Index setUp(List<Object> fieldNames, String indexName, String indexType) {
-        return setUp(fieldNames, indexName, indexType, null);
+    public static Index getInstance(List<Object> fieldNames, String indexName, String indexType) {
+        return getInstance(fieldNames, indexName, indexType, null);
     }
 
     /**
-     * The setUp method handles index specific validation and ensures that the constructed
+     * This method handles index specific validation and ensures that the constructed
      * Index object is valid.
      *
      * @param fieldNames the field names in the index
@@ -90,7 +89,7 @@ class Index {
      *                      Only supported parameter is 'tokenize' for text indexes only.
      * @return the Index object or null if arguments passed in were invalid.
      */
-    public static Index setUp(List<Object> fieldNames,
+    public static Index getInstance(List<Object> fieldNames,
                               String indexName,
                               String indexType,
                               Map<String, String> indexSettings) {
@@ -175,6 +174,25 @@ class Index {
         // We perform a deep comparison of hash maps to ensure that both objects
         // and any sub-objects are equal regardless of order within the maps.
         return this.indexSettings.equals(settings);
+    }
+
+    /**
+     * Converts the index settings to a JSON string
+     *
+     * @return the JSON representation of the index settings
+     */
+    protected String settingsAsJSON() {
+        String json = null;
+        if (indexSettings != null) {
+            try {
+                json = getObjectMapper().writeValueAsString(indexSettings);
+            } catch (JsonProcessingException e) {
+                String msg = String.format("Error processing index settings %s",
+                                           this.indexSettings.toString());
+                logger.log(Level.SEVERE, msg, e);
+            }
+        }
+        return json;
     }
 
     private ObjectMapper getObjectMapper() {

--- a/sync-core/src/main/java/com/cloudant/sync/query/IndexUpdater.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/IndexUpdater.java
@@ -56,7 +56,7 @@ class IndexUpdater {
     /**
      *  Update all indexes in a set.
      *
-     *  This indexes are assumed to already exist.
+     *  These indexes are assumed to already exist.
      *
      *  @param indexes Map of indexes and their definitions.
      *  @param database The local database

--- a/sync-core/src/main/java/com/cloudant/sync/query/QueryConstants.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/QueryConstants.java
@@ -42,4 +42,21 @@ final class QueryConstants {
         throw new AssertionError();
     }
 
+    public static String[] getSchemaVersion1() {
+        return new String[] {
+                "CREATE TABLE " + IndexManager.INDEX_METADATA_TABLE_NAME + " ( " +
+                "        index_name TEXT NOT NULL, " +
+                "        index_type TEXT NOT NULL, " +
+                "        field_name TEXT NOT NULL, " +
+                "        last_sequence INTEGER NOT NULL);"
+        };
+    }
+
+    public static String[] getSchemaVersion2() {
+        return new String[] {
+                "ALTER TABLE " + IndexManager.INDEX_METADATA_TABLE_NAME +
+                "        ADD COLUMN index_settings TEXT NULL;"
+        };
+    }
+
 }

--- a/sync-core/src/main/java/com/cloudant/sync/query/QuerySqlTranslator.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/QuerySqlTranslator.java
@@ -327,6 +327,15 @@ class QuerySqlTranslator {
         String chosenIndex = null;
         for (String indexName: indexes.keySet()) {
             Map<String, Object> indexDefinition = (Map<String, Object>) indexes.get(indexName);
+
+            // TODO - Remove once the query component of full text search is added.
+            String indexType = (String) indexDefinition.get("type");
+            if (indexType.equalsIgnoreCase("text")) {
+                logger.log(Level.INFO, "Full text search is not yet supported.  " +
+                        String.format("Text index %s is being ignored.", indexName));
+                continue;
+            }
+
             List<String> fieldList = (List<String>) indexDefinition.get("fields");
             Set<String> providedFields = new HashSet<String>(fieldList);
             if (providedFields.containsAll(neededFields)) {

--- a/sync-core/src/test/java/com/cloudant/sync/query/IndexManagerTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/IndexManagerTest.java
@@ -120,4 +120,26 @@ public class IndexManagerTest extends AbstractIndexTestBase {
         assertThat(im.listIndexes().keySet(), containsInAnyOrder("basic", "basic3"));
     }
 
+    @Test
+    public void deleteATextIndex() throws Exception {
+        for (int i = 0; i < 4; i++) {
+            MutableDocumentRevision rev = new MutableDocumentRevision();
+            Map<String, Object> bodyMap = new HashMap<String, Object>();
+            bodyMap.put("name", "mike");
+            bodyMap.put("age", 12);
+            Map<String, Object> petMap = new HashMap<String, Object>();
+            petMap.put("species", "cat");
+            petMap.put("name", "mike");
+            bodyMap.put("pet", petMap);
+            rev.body = DocumentBodyFactory.create(bodyMap);
+            ds.createDocumentFromRevision(rev);
+        }
+
+        im.ensureIndexed(Arrays.<Object>asList("name", "address"), "basic", "text");
+        assertThat(im.listIndexes().keySet(), contains("basic"));
+
+        assertThat(im.deleteIndexNamed("basic"), is(true));
+        assertThat(im.listIndexes().isEmpty(), is(true));
+    }
+
 }

--- a/sync-core/src/test/java/com/cloudant/sync/query/IndexTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/IndexTest.java
@@ -39,7 +39,7 @@ public class IndexTest {
 
     @Test
     public void constructsIndexWithDefaultType() {
-        Index index = Index.setUp(fieldNames, indexName);
+        Index index = Index.getInstance(fieldNames, indexName);
         assertThat(index.indexName, is("basic"));
         assertThat(index.fieldNames, is(Arrays.<Object>asList("name", "age")));
         assertThat(index.indexType, is("json"));
@@ -48,7 +48,7 @@ public class IndexTest {
 
     @Test
     public void constructsIndexWithTextTypeDefaultSettings() {
-        Index index = Index.setUp(fieldNames, indexName, "text");
+        Index index = Index.getInstance(fieldNames, indexName, "text");
         assertThat(index.indexName, is("basic"));
         assertThat(index.fieldNames, is(Arrays.<Object>asList("name", "age")));
         assertThat(index.indexType, is("text"));
@@ -58,34 +58,34 @@ public class IndexTest {
 
     @Test
     public void returnsNullWhenNoFields() {
-        Index index = Index.setUp(null, indexName);
+        Index index = Index.getInstance(null, indexName);
         assertThat(index, is(nullValue()));
 
-        index = Index.setUp(new ArrayList<Object>(), indexName);
+        index = Index.getInstance(new ArrayList<Object>(), indexName);
         assertThat(index, is(nullValue()));
     }
 
     @Test
     public void returnsNullWhenNoIndexName() {
-        Index index = Index.setUp(fieldNames, null);
+        Index index = Index.getInstance(fieldNames, null);
         assertThat(index, is(nullValue()));
 
-        index = Index.setUp(fieldNames, "");
+        index = Index.getInstance(fieldNames, "");
         assertThat(index, is(nullValue()));
     }
 
     @Test
     public void returnsNullWhenNoIndexType() {
-        Index index = Index.setUp(fieldNames, indexName, null);
+        Index index = Index.getInstance(fieldNames, indexName, null);
         assertThat(index, is(nullValue()));
 
-        index = Index.setUp(fieldNames, indexName, "");
+        index = Index.getInstance(fieldNames, indexName, "");
         assertThat(index, is(nullValue()));
     }
 
     @Test
     public void returnsNullWhenInvalidIndexType() {
-        Index index = Index.setUp(fieldNames, indexName, "blah");
+        Index index = Index.getInstance(fieldNames, indexName, "blah");
         assertThat(index, is(nullValue()));
     }
 
@@ -93,7 +93,7 @@ public class IndexTest {
     public void returnsNullWhenInvalidIndexSettings() {
         Map<String, String> indexSettings = new HashMap<String, String>();
         indexSettings.put("foo", "bar");
-        Index index = Index.setUp(fieldNames, indexName, "text", indexSettings);
+        Index index = Index.getInstance(fieldNames, indexName, "text", indexSettings);
         assertThat(index, is(nullValue()));
     }
 
@@ -102,7 +102,7 @@ public class IndexTest {
         Map<String, String> indexSettings = new HashMap<String, String>();
         indexSettings.put("tokenize", "porter");
         // json indexes do not support index settings.  Index settings will be ignored.
-        Index index = Index.setUp(fieldNames, indexName, "json", indexSettings);
+        Index index = Index.getInstance(fieldNames, indexName, "json", indexSettings);
         assertThat(index.indexSettings, is(nullValue()));
     }
 
@@ -111,33 +111,45 @@ public class IndexTest {
         Map<String, String> indexSettings = new HashMap<String, String>();
         indexSettings.put("tokenize", "porter");
         // text indexes support the tokenize setting.
-        Index index = Index.setUp(fieldNames, indexName, "text", indexSettings);
+        Index index = Index.getInstance(fieldNames, indexName, "text", indexSettings);
         assertThat(index.indexSettings.size(), is(1));
         assertThat(index.indexSettings.get("tokenize"), is("porter"));
     }
 
     @Test
     public void comparesIndexTypeAndReturnsInEquality() {
-        Index index = Index.setUp(fieldNames, indexName);
+        Index index = Index.getInstance(fieldNames, indexName);
         assertThat(index.compareIndexTypeTo("text", null), is(false));
     }
 
     @Test
     public void comparesIndexTypeAndReturnsEquality() {
-        Index index = Index.setUp(fieldNames, indexName);
+        Index index = Index.getInstance(fieldNames, indexName);
         assertThat(index.compareIndexTypeTo("json", null), is(true));
     }
 
     @Test
     public void comparesIndexSettingsAndReturnsInEquality() {
-        Index index = Index.setUp(fieldNames, indexName, "text");
+        Index index = Index.getInstance(fieldNames, indexName, "text");
         assertThat(index.compareIndexTypeTo("text", "{\"tokenize\":\"porter\"}"), is(false));
     }
 
     @Test
     public void comparesIndexSettingsAndReturnsEquality() {
-        Index index = Index.setUp(fieldNames, indexName, "text");
+        Index index = Index.getInstance(fieldNames, indexName, "text");
         assertThat(index.compareIndexTypeTo("text", "{\"tokenize\":\"simple\"}"), is(true));
+    }
+
+    @Test
+    public void returnsIndexSettingsAsAString() {
+        Index index = Index.getInstance(fieldNames, indexName, "text");
+        assertThat(index.settingsAsJSON(), is("{\"tokenize\":\"simple\"}"));
+    }
+
+    @Test
+    public void returnsNullIndexSettingsAsAString() {
+        Index index = Index.getInstance(fieldNames, indexName);
+        assertThat(index.settingsAsJSON(), is(nullValue()));
     }
 
 }


### PR DESCRIPTION
This PR adds the ability to use text indexing with Query.  Text indexing is necessary in order to
perform full text search queries.  This PR concentrates on index management while a separate/later PR will add full text search querying capabilities.

_Some things to look for are:_

1.  The way the metadata structure is constructed, both for a new implementation as well as a
migration from a previous release.
2.  The creation of the full text search index in SQLite (VIRTUAL TABLE).
3.  The new public IndexManager.ensureIndexed method that provides the developer with a way 
to set custom index settings.  Right now this is only used for changing the default tokenizer of the
VIRTUAL TABLE.
4.  I've temporarily added logic to ignore a text index when choosing indexes for a query.
This ensures that if a text index is created it will not compromise any current query processing.  This 
will be removed once support for `$text` and `$search` are added in a separate PR.

_New tests (of note):_

- Test the migration of metadata for current users from a previous release to this one.
- Update IndexUpdaterTest to make separate passes for JSON index testing and TEXT index testing.

reviewer @mikerhodes 
reviewer @rhyshort 

BugId: 46057