### PR TITLE
Fix bug where stub=true is sometimes incorrectly sent

### DIFF
--- a/sync-core/src/main/java/com/cloudant/mazha/CouchClient.java
+++ b/sync-core/src/main/java/com/cloudant/mazha/CouchClient.java
@@ -528,7 +528,7 @@ public class CouchClient  {
      *
      * @see <a href="http://wiki.apache.org/couchdb/HttpPostRevsDiff">HttpPostRevsDiff documentation</a>
      */
-    public Map<String, Set<String>> revsDiff(Map<String, Set<String>> revisions) {
+    public Map<String, MissingRevisions> revsDiff(Map<String, Set<String>> revisions) {
         Preconditions.checkNotNull(revisions, "Input revisions must not be null");
         URI uri = this.uriHelper.revsDiffUri();
         String payload = this.jsonHelper.toJson(revisions);
@@ -537,11 +537,7 @@ public class CouchClient  {
             is = this.httpClient.post(uri, payload);
             Map<String, MissingRevisions> diff = jsonHelper.fromJson(new InputStreamReader(is),
                     new TypeReference<Map<String, MissingRevisions>>() { });
-            Map<String, Set<String>> res = new HashMap<String, Set<String>>();
-            for(Map.Entry<String, MissingRevisions> e : diff.entrySet()) {
-                res.put(e.getKey(), e.getValue().missing);
-            }
-            return res;
+            return diff;
         } finally {
             closeQuietly(is);
         }
@@ -558,6 +554,7 @@ public class CouchClient  {
     }
 
     public static class MissingRevisions {
+        public Set<String> possible_ancestors;
         public Set<String> missing;
     }
 

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/MultipartAttachmentWriter.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/MultipartAttachmentWriter.java
@@ -52,7 +52,7 @@ import java.util.ArrayList;
  * <p>
  * The stream consists of a first MIME body which is the JSON document itself, which needs to have
  * the <code>_attachments</code> object correctly populated. This is currently done by
- * {@link com.cloudant.sync.datastore.RevisionHistoryHelper#addAttachments(java.util.List, BasicDocumentRevision, java.util.Map, com.cloudant.sync.replication.PushAttachmentsInline)}
+ * {@link com.cloudant.sync.datastore.RevisionHistoryHelper#addAttachments(java.util.List, java.util.Map, com.cloudant.sync.replication.PushAttachmentsInline, int)}
  * </p>
  *
  * <p>
@@ -61,7 +61,7 @@ import java.util.ArrayList;
  * </p>
  *
  * @see com.cloudant.mazha.CouchClient#putMultipart(MultipartAttachmentWriter)
- * @see com.cloudant.sync.datastore.RevisionHistoryHelper#addAttachments(java.util.List, BasicDocumentRevision, java.util.Map, com.cloudant.sync.replication.PushAttachmentsInline)
+ * @see com.cloudant.sync.datastore.RevisionHistoryHelper#addAttachments(java.util.List, java.util.Map, com.cloudant.sync.replication.PushAttachmentsInline, int)
  * @see <a href=http://couchdb.readthedocs.org/en/latest/api/document/common.html#creating-multiple-attachments>Creating Multiple Attachments</a>
  * @see <a href=http://tools.ietf.org/html/rfc2387>RFC 2387</a>
  *

--- a/sync-core/src/main/java/com/cloudant/sync/replication/CouchClientWrapper.java
+++ b/sync-core/src/main/java/com/cloudant/sync/replication/CouchClientWrapper.java
@@ -237,7 +237,7 @@ public class CouchClientWrapper implements CouchDB {
     }
 
     @Override
-    public Map<String, Set<String>> revsDiff(Map<String, Set<String>> revisions) {
+    public Map<String, CouchClient.MissingRevisions> revsDiff(Map<String, Set<String>> revisions) {
         return this.couchClient.revsDiff(revisions);
     }
 

--- a/sync-core/src/main/java/com/cloudant/sync/replication/CouchDB.java
+++ b/sync-core/src/main/java/com/cloudant/sync/replication/CouchDB.java
@@ -15,6 +15,7 @@
 package com.cloudant.sync.replication;
 
 import com.cloudant.mazha.ChangesResult;
+import com.cloudant.mazha.CouchClient;
 import com.cloudant.mazha.DocumentRevs;
 import com.cloudant.mazha.Response;
 import com.cloudant.sync.datastore.BasicDocumentRevision;
@@ -52,6 +53,6 @@ interface CouchDB {
     public void bulk(List<BasicDocumentRevision> revisions);
     public void bulkSerializedDocs(List<String> serializedDocs);
     public List<Response> putMultiparts(List<MultipartAttachmentWriter> multiparts);
-    public Map<String, Set<String>> revsDiff(Map<String, Set<String>> revisions);
+    public Map<String, CouchClient.MissingRevisions> revsDiff(Map<String, Set<String>> revisions);
     public UnsavedStreamAttachment getAttachmentStream(String id, String rev, String attachmentName, String contentType, String encoding);
 }

--- a/sync-core/src/test/java/com/cloudant/mazha/CouchClientBasicTest.java
+++ b/sync-core/src/test/java/com/cloudant/mazha/CouchClientBasicTest.java
@@ -384,7 +384,7 @@ public class CouchClientBasicTest extends CouchClientTestBase {
 
     @Test
     public void revsDiff_emptyInput_returnNothing() {
-        Map<String, Set<String>> diffs = client.revsDiff(new HashMap<String, Set<String>>());
+        Map<String, CouchClient.MissingRevisions> diffs = client.revsDiff(new HashMap<String, Set<String>>());
         Assert.assertEquals(0, diffs.size());
     }
 
@@ -395,11 +395,11 @@ public class CouchClientBasicTest extends CouchClientTestBase {
             revisions.add(String.valueOf(i + "-a" ));
         }
         Map<String, Set<String>> revs = ImmutableMap.of("A", revisions);
-        Map<String, Set<String>> diffs = client.revsDiff(revs);
+        Map<String, CouchClient.MissingRevisions> diffs = client.revsDiff(revs);
 
         Assert.assertEquals(1, diffs.size());
-        Assert.assertEquals(10000, diffs.get("A").size());
-        Assert.assertThat(diffs.get("A"), hasItems("0-a", "9999-a"));
+        Assert.assertEquals(10000, diffs.get("A").missing.size());
+        Assert.assertThat(diffs.get("A").missing, hasItems("0-a", "9999-a"));
     }
 
     @Test
@@ -408,15 +408,15 @@ public class CouchClientBasicTest extends CouchClientTestBase {
         Set<String> revs2 = ImmutableSet.of("1-c", "2-d");
         Map<String, Set<String>> revs = ImmutableMap.of("A", revs1, "B", revs2);
 
-        Map<String, Set<String>> diffs = client.revsDiff(revs);
+        Map<String, CouchClient.MissingRevisions> diffs = client.revsDiff(revs);
         Assert.assertEquals(2, diffs.size());
         Assert.assertThat(diffs.keySet(), hasItems("A", "B"));
 
-        Assert.assertEquals(2, diffs.get("A").size());
-        Assert.assertEquals(2, diffs.get("B").size());
+        Assert.assertEquals(2, diffs.get("A").missing.size());
+        Assert.assertEquals(2, diffs.get("B").missing.size());
 
-        Assert.assertThat(diffs.get("A"), hasItems("1-a", "2-b"));
-        Assert.assertThat(diffs.get("B"), hasItems("1-c", "2-d"));
+        Assert.assertThat(diffs.get("A").missing, hasItems("1-a", "2-b"));
+        Assert.assertThat(diffs.get("B").missing, hasItems("1-c", "2-d"));
     }
 
     @Test
@@ -426,7 +426,7 @@ public class CouchClientBasicTest extends CouchClientTestBase {
         Set<String> revs1 = ImmutableSet.of(res.getRev());
         Map<String, Set<String>> revs = ImmutableMap.of(res.getId(), revs1);
 
-        Map<String, Set<String>> diffs = client.revsDiff(revs);
+        Map<String, CouchClient.MissingRevisions> diffs = client.revsDiff(revs);
         Assert.assertEquals(0, diffs.size());
     }
 
@@ -437,10 +437,10 @@ public class CouchClientBasicTest extends CouchClientTestBase {
         Set<String> revs1 = ImmutableSet.of(res.getRev(), "2-a");
         Map<String, Set<String>> revs = ImmutableMap.of(res.getId(), revs1);
 
-        Map<String, Set<String>> diffs = client.revsDiff(revs);
+        Map<String, CouchClient.MissingRevisions> diffs = client.revsDiff(revs);
         Assert.assertEquals(1, diffs.size());
-        Assert.assertEquals(1, diffs.get(res.getId()).size());
-        Assert.assertThat(diffs.get(res.getId()), hasItem("2-a"));
+        Assert.assertEquals(1, diffs.get(res.getId()).missing.size());
+        Assert.assertThat(diffs.get(res.getId()).missing, hasItem("2-a"));
     }
 
     private boolean isDbExist(String dbName) {

--- a/sync-core/src/test/java/com/cloudant/sync/replication/BasicPushStrategyMockTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/replication/BasicPushStrategyMockTest.java
@@ -15,6 +15,7 @@
 package com.cloudant.sync.replication;
 
 import com.cloudant.common.RequireRunningCouchDB;
+import com.cloudant.mazha.CouchClient;
 import com.google.common.eventbus.Subscribe;
 import org.junit.Assert;
 import org.junit.Test;
@@ -98,7 +99,7 @@ public class BasicPushStrategyMockTest extends ReplicationTestBase {
 
         when(mockRemoteDb.getCheckpoint(anyString())).thenReturn("0", "1");
         when(mockRemoteDb.exists()).thenReturn(true);
-        when(mockRemoteDb.revsDiff(any(Map.class))).thenReturn(new HashMap<String, Set<String>>());
+        when(mockRemoteDb.revsDiff(any(Map.class))).thenReturn(new HashMap<String, CouchClient.MissingRevisions>());
 
         // Exec
         pushStrategy.run();


### PR DESCRIPTION
See https://groups.google.com/forum/#!topic/cloudant-sync/xAgWtuSsrk8
for details.

We now use possible_ancestors to correctly determine the minRevPos
value and correctly stub out attachments.

reviewer: @mikerhodes 
reviewer: @rhyshort 