### PR TITLE
Add full text query support

### DIFF
--- a/sync-core/src/main/java/com/cloudant/sync/query/QueryConstants.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/QueryConstants.java
@@ -22,6 +22,8 @@ final class QueryConstants {
 
     public static final String EXISTS = "$exists";
 
+    public static final String TEXT = "$text";
+
     public static final String EQ = "$eq";
 
     public static final String NE = "$ne";
@@ -37,6 +39,8 @@ final class QueryConstants {
     public static final String IN = "$in";
 
     public static final String NIN = "$nin";
+
+    public static final String SEARCH = "$search";
 
     private QueryConstants() {
         throw new AssertionError();

--- a/sync-core/src/main/java/com/cloudant/sync/query/QueryValidator.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/QueryValidator.java
@@ -407,8 +407,12 @@ class QueryValidator {
             } else if (key.equalsIgnoreCase(TEXT)) {
                 // this should have a map
                 // send this for validation
-                valid = validateTextClause(clause.get(key),
-                                           textClauseLimitReached);
+
+                // TODO Enable text search as part of text search unit tests PR.
+                // valid = validateTextClause(clause.get(key),
+                //                           textClauseLimitReached);
+                logger.log(Level.INFO, "Text search is currently not supported.");
+                break;
             } else {
                 String msg = String.format("%s operator cannot be a top level operator", key);
                 logger.log(Level.SEVERE, msg);

--- a/sync-core/src/main/java/com/cloudant/sync/query/TranslatorState.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/TranslatorState.java
@@ -27,11 +27,15 @@ class TranslatorState {
     public boolean atLeastOneIndexUsed;
     public boolean atLeastOneIndexMissing;
     public boolean atLeastOneORIndexMissing;
+    public boolean textIndexRequired;
+    public boolean textIndexMissing;
 
     TranslatorState() {
         atLeastOneIndexUsed = false;
         atLeastOneIndexMissing = false;
         atLeastOneORIndexMissing = false;
+        textIndexRequired = false;
+        textIndexMissing = false;
     }
 
 }


### PR DESCRIPTION
_What_

This PR adds support for the `$text` and `$search` operators in Query.

_Why_

The change is to provide full text search capabilities in Query.

_How_

The normalization/validation process is updated to handle the new operators and the SQL translation process is updated to ensure correct generation of SQL and node placement in the query node tree. 

_Notes_

This PR does not include the unit tests.  Unit tests will be included in a following PR.  Logic has been temporarily added to deactivate the full text search logic until the unit tests are delivered.

reviewer @mikerhodes 
reviewer @rhyshort 

BugId: 45395