### PR TITLE
Add tests for full text search query

### DIFF
--- a/sync-core/src/main/java/com/cloudant/sync/query/IndexCreator.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/IndexCreator.java
@@ -167,11 +167,6 @@ class IndexCreator {
                 List<String> statements = new ArrayList<String>();
                 if (index.indexType.equalsIgnoreCase(Index.TEXT_TYPE)) {
                     List<String> settingsList = new ArrayList<String>();
-                    // Ensure that the _id and _rev columns are not included
-                    // when querying for a search term as part of a full
-                    // text search.
-                    settingsList.add("notindexed=\"_id\"");
-                    settingsList.add("notindexed=\"_rev\"");
                     // Add text settings
                     for (String key : index.indexSettings.keySet()) {
                         settingsList.add(String.format("%s=%s", key, index.indexSettings.get(key)));

--- a/sync-core/src/main/java/com/cloudant/sync/query/QuerySqlTranslator.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/QuerySqlTranslator.java
@@ -448,7 +448,7 @@ class QuerySqlTranslator {
         search = search.replace("'", "''");
 
         String sql = String.format("SELECT _id FROM %s WHERE %s MATCH ?", tableName, tableName);
-        return SqlParts.partsForSql(sql, new String[]{ String.format("'%s'", search) });
+        return SqlParts.partsForSql(sql, new String[]{ search });
     }
 
     @SuppressWarnings("unchecked")

--- a/sync-core/src/main/java/com/cloudant/sync/query/QueryValidator.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/QueryValidator.java
@@ -407,12 +407,7 @@ class QueryValidator {
             } else if (key.equalsIgnoreCase(TEXT)) {
                 // this should have a map
                 // send this for validation
-
-                // TODO Enable text search as part of text search unit tests PR.
-                // valid = validateTextClause(clause.get(key),
-                //                           textClauseLimitReached);
-                logger.log(Level.INFO, "Text search is currently not supported.");
-                break;
+                valid = validateTextClause(clause.get(key), textClauseLimitReached);
             } else {
                 String msg = String.format("%s operator cannot be a top level operator", key);
                 logger.log(Level.SEVERE, msg);

--- a/sync-core/src/test/java/com/cloudant/sync/query/QuerySqlTranslatorTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/QuerySqlTranslatorTest.java
@@ -1102,7 +1102,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         String select = "SELECT _id FROM _t_cloudant_sync_query_index_basic_text";
         String where = " WHERE _t_cloudant_sync_query_index_basic_text MATCH ?";
         assertThat(sql, is(String.format("%s%s", select, where)));
-        assertThat(placeHolderValues, is(arrayContainingInAnyOrder("'foo bar baz'")));
+        assertThat(placeHolderValues, is(arrayContainingInAnyOrder("foo bar baz")));
     }
 
     @Test
@@ -1145,7 +1145,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         select = "SELECT _id FROM _t_cloudant_sync_query_index_basic_text";
         where = " WHERE _t_cloudant_sync_query_index_basic_text MATCH ?";
         assertThat(sql, is(String.format("%s%s", select, where)));
-        assertThat(placeHolderValues, is(arrayContainingInAnyOrder("'foo bar baz'")));
+        assertThat(placeHolderValues, is(arrayContainingInAnyOrder("foo bar baz")));
     }
 
     @Test
@@ -1186,7 +1186,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
 
         sqlNode = (SqlQueryNode) orNode.children.get(1);
         assertThat(sqlNode.sql.sqlWithPlaceHolders, is(sqlRight));
-        assertThat(sqlNode.sql.placeHolderValues, is(arrayContainingInAnyOrder("'foo bar baz'")));
+        assertThat(sqlNode.sql.placeHolderValues, is(arrayContainingInAnyOrder("foo bar baz")));
     }
 
     @Test

--- a/sync-core/src/test/java/com/cloudant/sync/query/QueryTextSearchTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/QueryTextSearchTest.java
@@ -1,0 +1,519 @@
+//  Copyright (c) 2015 IBM Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+package com.cloudant.sync.query;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import com.cloudant.sync.datastore.DocumentBodyFactory;
+import com.cloudant.sync.datastore.MutableDocumentRevision;
+import com.cloudant.sync.util.SQLDatabaseTestUtils;
+import com.cloudant.sync.util.TestUtils;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class QueryTextSearchTest extends AbstractQueryTestBase {
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        im = new IndexManager(ds);
+        assertThat(im, is(notNullValue()));
+        db = TestUtils.getDatabaseConnectionToExistingDb(im.getDatabase());
+        assertThat(db, is(notNullValue()));
+        assertThat(im.getQueue(), is(notNullValue()));
+        String[] metadataTableList = new String[] { IndexManager.INDEX_METADATA_TABLE_NAME };
+        SQLDatabaseTestUtils.assertTablesExist(db, metadataTableList);
+
+        MutableDocumentRevision rev = new MutableDocumentRevision();
+        rev.docId = "mike12";
+        Map<String, Object> bodyMap = new HashMap<String, Object>();
+        bodyMap.put("name", "mike");
+        bodyMap.put("age", 12);
+        bodyMap.put("pet", "cat");
+        bodyMap.put("comment", "He lives in Bristol, UK and his best friend is Fred.");
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        ds.createDocumentFromRevision(rev);
+
+        rev.docId = "mike34";
+        bodyMap.clear();
+        bodyMap.put("name", "mike");
+        bodyMap.put("age", 34);
+        bodyMap.put("pet", "dog");
+        bodyMap.put("comment", "He lives in a van down by the river in Bristol.");
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        ds.createDocumentFromRevision(rev);
+
+        rev.docId = "mike72";
+        bodyMap.clear();
+        bodyMap.put("name", "mike");
+        bodyMap.put("age", 72);
+        bodyMap.put("pet", "cat");
+        bodyMap.put("comment",
+                    "He's retired and has memories of spending time with his cat Remus.");
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        ds.createDocumentFromRevision(rev);
+
+        rev.docId = "fred34";
+        bodyMap.clear();
+        bodyMap.put("name", "fred");
+        bodyMap.put("age", 34);
+        bodyMap.put("pet", "cat");
+        bodyMap.put("comment",
+                    "He lives next door to Mike and his cat Romulus is brother to Remus.");
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        ds.createDocumentFromRevision(rev);
+
+        rev.docId = "fred12";
+        bodyMap.clear();
+        bodyMap.put("name", "fred");
+        bodyMap.put("age", 12);
+        bodyMap.put("comment", "He lives in Bristol, UK and his best friend is Mike.");
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        ds.createDocumentFromRevision(rev);
+
+        rev.docId = "john34";
+        bodyMap.clear();
+        bodyMap.put("name", "john");
+        bodyMap.put("age", 34);
+        bodyMap.put("pet", "cat");
+        bodyMap.put("comment", "وهو يعيش في بريستول، المملكة المتحدة، وأفضل صديق له هو مايك.");
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        ds.createDocumentFromRevision(rev);
+    }
+
+    @Test
+    public void canMakeAQueryConsistingOfASingleTextSearch() {
+        assertThat(im.ensureIndexed(Arrays.<Object>asList("comment"), "basic_text", "text"),
+                                    is("basic_text"));
+
+        // query - { "$text" : { "$search" : "lives in Bristol" } }
+        Map<String, Object> search = new HashMap<String, Object>();
+        search.put("$search", "lives in Bristol");
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("$text", search);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), containsInAnyOrder("mike12", "mike34", "fred12"));
+    }
+
+    @Test
+    public void canMakeAPhraseSearch() {
+        assertThat(im.ensureIndexed(Arrays.<Object>asList("comment"), "basic_text", "text"),
+                                    is("basic_text"));
+
+        // query - { "$text" : { "$search" : "\"lives in Bristol\"" } }
+        Map<String, Object> search = new HashMap<String, Object>();
+        search.put("$search", "\"lives in Bristol\"");
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("$text", search);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), containsInAnyOrder("mike12", "fred12"));
+    }
+
+    @Test
+    public void canMakeAQueryTextSearchContainingAnApostrophe() {
+        assertThat(im.ensureIndexed(Arrays.<Object>asList("comment"), "basic_text", "text"),
+                                    is("basic_text"));
+
+        // query - { "$text" : { "$search" : "He's retired" } }
+        Map<String, Object> search = new HashMap<String, Object>();
+        search.put("$search", "He's retired");
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("$text", search);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), contains("mike72"));
+    }
+
+    @Test
+    public void canMakeAQueryConsistingOfASingleTextSearchWithASort() {
+        assertThat(im.ensureIndexed(Arrays.<Object>asList("name", "comment"), "basic_text", "text"),
+                                    is("basic_text"));
+
+        // query - { "$text" : { "$search" : "best friend" } }
+        Map<String, Object> search = new HashMap<String, Object>();
+        search.put("$search", "best friend");
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("$text", search);
+        List<Map<String, String>> sortDocument = new ArrayList<Map<String, String>>();
+        Map<String, String> sortByName = new HashMap<String, String>();
+        sortByName.put("name", "asc");
+        sortDocument.add(sortByName);
+        QueryResult queryResult = im.find(query, 0, 0, null, sortDocument);
+        assertThat(queryResult.documentIds(), containsInAnyOrder("mike12", "fred12"));
+        assertThat(queryResult.documentIds().get(0), is("fred12"));
+        assertThat(queryResult.documentIds().get(1), is("mike12"));
+    }
+
+    @Test
+    public void canMakeANDCompoundQueryWithATextSearch() {
+        assertThat(im.ensureIndexed(Arrays.<Object>asList("name"), "basic"), is("basic"));
+        assertThat(im.ensureIndexed(Arrays.<Object>asList("name", "comment"), "basic_text", "text"),
+                   is("basic_text"));
+
+        // query - { "name" : "mike", "$text" : { "$search" : "best friend" } }
+        Map<String, Object> search = new HashMap<String, Object>();
+        search.put("$search", "best friend");
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("name", "mike");
+        query.put("$text", search);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), contains("mike12"));
+    }
+
+    @Test
+    public void canMakeORCompoundQueryWithATextSearch() {
+        assertThat(im.ensureIndexed(Arrays.<Object>asList("name"), "basic"), is("basic"));
+        assertThat(im.ensureIndexed(Arrays.<Object>asList("comment"), "basic_text", "text"),
+                   is("basic_text"));
+
+        // query - { "$or" : [ { "name" : "mike" }, { "$text" : { "$search" : "best friend" } } ] }
+        Map<String, Object> search = new HashMap<String, Object>();
+        search.put("$search", "best friend");
+        Map<String, Object> text = new HashMap<String, Object>();
+        text.put("$text", search);
+        Map<String, Object> name = new HashMap<String, Object>();
+        name.put("name", "mike");
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("$or", Arrays.<Object>asList(name, text));
+
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), containsInAnyOrder("mike12",
+                                                                 "mike34",
+                                                                 "mike72",
+                                                                 "fred12"));
+    }
+
+    @Test
+    public void nullForTextSearchQueryWithoutATextIndex() {
+        assertThat(im.ensureIndexed(Arrays.<Object>asList("name"), "basic"), is("basic"));
+
+        // query - { "name" : "mike", "$text" : { "$search" : "best friend" } }
+        Map<String, Object> search = new HashMap<String, Object>();
+        search.put("$search", "best friend");
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("name", "mike");
+        query.put("$text", search);
+        assertThat(im.find(query), is(nullValue()));
+    }
+
+    @Test
+    public void nullForTextSearchQueryWhenAJsonIndexIsMissing() {
+        // All fields in a TEXT index only apply to the text search portion of any query.
+        // So even though "name" exists in the text index, the clause that { "name" : "mike" }
+        // expects a JSON index that contains the "name" field.  Since, this query includes a
+        // text search clause then all clauses of the query must be satisfied by existing indexes.
+        assertThat(im.ensureIndexed(Arrays.<Object>asList("name", "comment"), "basic_text", "text"),
+                   is("basic_text"));
+
+        // query - { "$or" : [ { "name" : "mike" }, { "$text" : { "$search" : "best friend" } } ] }
+        Map<String, Object> search = new HashMap<String, Object>();
+        search.put("$search", "best friend");
+        Map<String, Object> text = new HashMap<String, Object>();
+        text.put("$text", search);
+        Map<String, Object> name = new HashMap<String, Object>();
+        name.put("name", "mike");
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("$or", Arrays.<Object>asList(name, text));
+
+        assertThat(im.find(query), is(nullValue()));
+    }
+
+    @Test
+    public void canMakeATextSearchUsingNonAsciiValues() {
+        List<Object> fields = Collections.<Object>singletonList("comment");
+        assertThat(im.ensureIndexed(fields, "basic_text", "text"), is("basic_text"));
+
+        // query - { "$text" : { "$search" : "\"صديق له هو\"" } }
+        Map<String, Object> search = new HashMap<String, Object>();
+        search.put("$search", "\"صديق له هو\"");
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("$text", search);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), contains("john34"));
+    }
+
+    @Test
+    public void returnsEmptyResultSetForUnmatchedPhraseSearch() {
+        List<Object> fields = Collections.<Object>singletonList("comment");
+        assertThat(im.ensureIndexed(fields, "basic_text", "text"), is("basic_text"));
+
+        // query - { "$text" : { "$search" : "\"Remus Romulus\"" } }
+        Map<String, Object> search = new HashMap<String, Object>();
+        search.put("$search", "\"Remus Romulus\"");
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("$text", search);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), is(empty()));
+    }
+
+    @Test
+    public void returnsCorrectResultSetForNonContiguousWordSearch() {
+        List<Object> fields = Collections.<Object>singletonList("comment");
+        assertThat(im.ensureIndexed(fields, "basic_text", "text"), is("basic_text"));
+
+        // query - { "$text" : { "$search" : "Remus Romulus" } }
+        // - The search predicate "Remus Romulus" normalizes to "Remus AND Romulus" in SQLite
+        Map<String, Object> search = new HashMap<String, Object>();
+        search.put("$search", "Remus Romulus");
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("$text", search);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), contains("fred34"));
+    }
+
+    @Test
+    public void canQueryUsingEnhancedQuerySyntaxOR() {
+        List<Object> fields = Collections.<Object>singletonList("comment");
+        assertThat(im.ensureIndexed(fields, "basic_text", "text"), is("basic_text"));
+
+        // query - { "$text" : { "$search" : "Remus OR Romulus" } }
+        // - Enhanced Query Syntax - logical operators must be uppercase otherwise they will
+        //   be treated as a search token
+        Map<String, Object> search = new HashMap<String, Object>();
+        search.put("$search", "Remus OR Romulus");
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("$text", search);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), containsInAnyOrder("fred34", "mike72"));
+    }
+
+    @Test
+    public void canQueryUsingEnhancedQuerySyntaxNOT() {
+        List<Object> fields = Collections.<Object>singletonList("comment");
+        assertThat(im.ensureIndexed(fields, "basic_text", "text"), is("basic_text"));
+
+        // query - { "$text" : { "$search" : "Remus NOT Romulus" } }
+        // - Enhanced Query Syntax - logical operators must be uppercase otherwise they will
+        //   be treated as a search token
+        // - NOT operator only works between tokens as in (token1 NOT token2)
+        Map<String, Object> search = new HashMap<String, Object>();
+        search.put("$search", "Remus NOT Romulus");
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("$text", search);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), contains("mike72"));
+    }
+
+    @Test
+    public void canQueryUsingEnhancedQuerySyntaxParentheses() {
+        List<Object> fields = Collections.<Object>singletonList("comment");
+        assertThat(im.ensureIndexed(fields, "basic_text", "text"), is("basic_text"));
+
+        // query - { "$text" : { "$search" : "(Remus OR Romulus) AND \"lives next door\"" } }
+        // - Parentheses are used to override SQLite enhanced query syntax operator precedence
+        // - Operator precedence is NOT -> AND -> OR
+        Map<String, Object> search = new HashMap<String, Object>();
+        search.put("$search", "(Remus OR Romulus) AND \"lives next door\"");
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("$text", search);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), contains("fred34"));
+    }
+
+    @Test
+    public void canQueryUsingNEAR() {
+        List<Object> fields = Collections.<Object>singletonList("comment");
+        assertThat(im.ensureIndexed(fields, "basic_text", "text"), is("basic_text"));
+
+        // query - { "$text" : { "$search" : "\"he lives\" NEAR/2 Bristol" } }
+        // - NEAR provides the ability to search for terms/phrases in proximity to each other
+        // - By specifying a value for NEAR as in NEAR/2 you can define the range of proximity.
+        //   If left out it defaults to 10
+        Map<String, Object> search = new HashMap<String, Object>();
+        search.put("$search", "\"he lives\" NEAR/2 Bristol");
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("$text", search);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), containsInAnyOrder("mike12", "fred12"));
+    }
+
+    @Test
+    public void ignoresCapitalizationUsingDefaultTokenizer() {
+        List<Object> fields = Collections.<Object>singletonList("comment");
+        assertThat(im.ensureIndexed(fields, "basic_text", "text"), is("basic_text"));
+
+        // query - { "$text" : { "$search" : "rEmUs RoMuLuS" } }
+        // - Search is generally case-insensitive unless a custom tokenizer is provided
+        Map<String, Object> search = new HashMap<String, Object>();
+        search.put("$search", "rEmUs RoMuLuS");
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("$text", search);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), contains("fred34"));
+    }
+
+    @Test
+    public void queriesNonStringFieldAsAString() {
+        // Text index on age field
+        List<Object> fields = Collections.<Object>singletonList("age");
+        assertThat(im.ensureIndexed(fields, "basic_text", "text"), is("basic_text"));
+
+        // query - { "$text" : { "$search" : "12" } }
+        Map<String, Object> search = new HashMap<String, Object>();
+        search.put("$search", "12");
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("$text", search);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), containsInAnyOrder("mike12", "fred12"));
+    }
+
+    @Test
+    public void returnsNullWhenSearchCriteriaNotAString() {
+        // Text index on age field
+        List<Object> fields = Collections.<Object>singletonList("age");
+        assertThat(im.ensureIndexed(fields, "basic_text", "text"), is("basic_text"));
+
+        // query - { "$text" : { "$search" : 12 } }
+        Map<String, Object> search = new HashMap<String, Object>();
+        search.put("$search", 12);
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("$text", search);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult, is(nullValue()));
+    }
+
+    @Test
+    public void canQueryAcrossMultipleFields() {
+        // Text index on name and comment fields
+        List<Object> fields = Arrays.<Object>asList("name", "comment");
+        assertThat(im.ensureIndexed(fields, "basic_text", "text"), is("basic_text"));
+
+        // query - { "$text" : { "$search" : "Fred" } }
+        //       - Will find both fred12 and fred34 as well as mike12 since Fred is mentioned
+        //         in mike12's comment
+        Map<String, Object> search = new HashMap<String, Object>();
+        search.put("$search", "Fred");
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("$text", search);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), containsInAnyOrder("mike12", "fred12", "fred34"));
+    }
+
+    @Test
+    public void canQueryTargetingSpecificFields() {
+        // Text index on name and comment fields
+        List<Object> fields = Arrays.<Object>asList("name", "comment");
+        assertThat(im.ensureIndexed(fields, "basic_text", "text"), is("basic_text"));
+
+        // query - { "$text" : { "$search" : "name:fred comment:lives in Bristol" } }
+        //       - Will only find fred12 since he is the only named fred who's comment
+        //         states that he "lives in Bristol"
+        Map<String, Object> search = new HashMap<String, Object>();
+        search.put("$search", "name:fred comment:lives in Bristol");
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("$text", search);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), contains("fred12"));
+    }
+
+    @Test
+    public void canQueryUsingPrefixSearches() {
+        List<Object> fields = Collections.<Object>singletonList("comment");
+        assertThat(im.ensureIndexed(fields, "basic_text", "text"), is("basic_text"));
+
+        // query - { "$text" : { "$search" : "liv* riv*" } }
+        Map<String, Object> search = new HashMap<String, Object>();
+        search.put("$search", "liv* riv*");
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("$text", search);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), contains("mike34"));
+    }
+
+    @Test
+    public void returnsEmptyResultSetWhenPrefixSearchesMissingWildcards() {
+        List<Object> fields = Collections.<Object>singletonList("comment");
+        assertThat(im.ensureIndexed(fields, "basic_text", "text"), is("basic_text"));
+
+        // query - { "$text" : { "$search" : "liv riv" } }
+        Map<String, Object> search = new HashMap<String, Object>();
+        search.put("$search", "liv riv");
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("$text", search);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), is(empty()));
+    }
+
+    @Test
+    public void canQueryUsingID() {
+        List<Object> fields = Collections.<Object>singletonList("comment");
+        assertThat(im.ensureIndexed(fields, "basic_text", "text"), is("basic_text"));
+
+        // query - { "$text" : { "$search" : "_id:mike*" } }
+        Map<String, Object> search = new HashMap<String, Object>();
+        search.put("$search", "_id:mike*");
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("$text", search);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), containsInAnyOrder("mike12", "mike34", "mike72"));
+    }
+
+    @Test
+    public void canQueryUsingPorterTokenizerStemmer() {
+        List<Object> fields = Collections.<Object>singletonList("comment");
+        Map<String, String> indexSettings = new HashMap<String, String>();
+        indexSettings.put("tokenize", "porter");
+        assertThat(im.ensureIndexed(fields, "basic_text", "text", indexSettings), is("basic_text"));
+
+        // query - { "$text" : { "$search" : "live" } }
+        Map<String, Object> search = new HashMap<String, Object>();
+        search.put("$search", "retire memory");
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("$text", search);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), contains("mike72"));
+    }
+
+    @Test
+    public void returnsEmptyResultSetUsingDefaultTokenizerStemmer() {
+        List<Object> fields = Collections.<Object>singletonList("comment");
+        assertThat(im.ensureIndexed(fields, "basic_text", "text"), is("basic_text"));
+
+        // query - { "$text" : { "$search" : "live" } }
+        Map<String, Object> search = new HashMap<String, Object>();
+        search.put("$search", "retire memory");
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("$text", search);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), is(empty()));
+    }
+
+    @Test
+    public void canQueryUsingAnApostrophe() {
+        List<Object> fields = Collections.<Object>singletonList("comment");
+        assertThat(im.ensureIndexed(fields, "basic_text", "text"), is("basic_text"));
+
+        // query - { "$text" : { "$search" : "He's retired" } }
+        Map<String, Object> search = new HashMap<String, Object>();
+        search.put("$search", "He's retired");
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("$text", search);
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), contains("mike72"));
+    }
+
+}


### PR DESCRIPTION
_What_

Add unit tests for work included in PR https://github.com/cloudant/sync-android/pull/115 and enable full text search functionality.

_Why_

Tests are needed to validate and exercise the full text search query code.

_How_

- Add validation tests to QueryValidatorTest
- Add translation tests to SQLTranslatorTest
- Create a QueryTextSearchTest and add text search query execution tests to the class
- Enable full text search functionality via the validator.

reviewer @mikerhodes 
reviewer @rhyshort

BugId: 46310