### PR TITLE
Match MutableDocumentRevision Behaviour with iOS

### DIFF
--- a/sync-core/src/main/java/com/cloudant/sync/datastore/BasicDatastore.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/BasicDatastore.java
@@ -1780,14 +1780,16 @@ class BasicDatastore implements Datastore, DatastoreExtended {
     }
 
     @Override
-    public BasicDocumentRevision createDocumentFromRevision(MutableDocumentRevision rev)
+    public BasicDocumentRevision createDocumentFromRevision(final MutableDocumentRevision rev)
             throws DocumentException, AttachmentException {
         Preconditions.checkNotNull(rev, "DocumentRevision can not be null");
         Preconditions.checkState(isOpen(), "Datastore is closed");
-        final MutableDocumentRevision copy = rev.copy();
+        final String docId;
         // create docid if docid is null
-        if (copy.docId == null) {
-            copy.docId = CouchUtils.generateDocumentId();
+        if (rev.docId == null) {
+            docId = CouchUtils.generateDocumentId();
+        } else {
+            docId = rev.docId;
         }
         final AttachmentManager.PreparedAndSavedAttachments preparedAndSavedAttachments =
                 attachmentManager.prepareAttachments(rev.attachments != null ? rev.attachments.values() : null);
@@ -1797,7 +1799,7 @@ class BasicDatastore implements Datastore, DatastoreExtended {
                 @Override
                 public BasicDocumentRevision call(SQLDatabase db) throws Exception {
                         // save document with body
-                        BasicDocumentRevision saved = createDocument(db,copy.docId, copy.body);
+                        BasicDocumentRevision saved = createDocument(db,docId, rev.body);
                         // set attachments
                         attachmentManager.setAttachments(db,saved, preparedAndSavedAttachments);
                         // now re-fetch the revision with updated attachments

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/BasicDatastore.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/BasicDatastore.java
@@ -1780,13 +1780,14 @@ class BasicDatastore implements Datastore, DatastoreExtended {
     }
 
     @Override
-    public BasicDocumentRevision createDocumentFromRevision(final MutableDocumentRevision rev)
+    public BasicDocumentRevision createDocumentFromRevision(MutableDocumentRevision rev)
             throws DocumentException, AttachmentException {
         Preconditions.checkNotNull(rev, "DocumentRevision can not be null");
         Preconditions.checkState(isOpen(), "Datastore is closed");
+        final MutableDocumentRevision copy = rev.copy();
         // create docid if docid is null
-        if (rev.docId == null) {
-            rev.docId = CouchUtils.generateDocumentId();
+        if (copy.docId == null) {
+            copy.docId = CouchUtils.generateDocumentId();
         }
         final AttachmentManager.PreparedAndSavedAttachments preparedAndSavedAttachments =
                 attachmentManager.prepareAttachments(rev.attachments != null ? rev.attachments.values() : null);
@@ -1796,7 +1797,7 @@ class BasicDatastore implements Datastore, DatastoreExtended {
                 @Override
                 public BasicDocumentRevision call(SQLDatabase db) throws Exception {
                         // save document with body
-                        BasicDocumentRevision saved = createDocument(db,rev.docId, rev.body);
+                        BasicDocumentRevision saved = createDocument(db,copy.docId, copy.body);
                         // set attachments
                         attachmentManager.setAttachments(db,saved, preparedAndSavedAttachments);
                         // now re-fetch the revision with updated attachments

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/MutableDocumentRevision.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/MutableDocumentRevision.java
@@ -74,13 +74,4 @@ public class MutableDocumentRevision implements DocumentRevision
     }
 
 
-    MutableDocumentRevision copy() {
-        MutableDocumentRevision copy =  new MutableDocumentRevision();
-        copy.docId = docId;
-        copy.body = body;
-        copy.attachments = attachments;
-        return copy;
-    }
-
-
 }

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/MutableDocumentRevision.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/MutableDocumentRevision.java
@@ -74,4 +74,13 @@ public class MutableDocumentRevision implements DocumentRevision
     }
 
 
+    MutableDocumentRevision copy() {
+        MutableDocumentRevision copy =  new MutableDocumentRevision();
+        copy.docId = docId;
+        copy.body = body;
+        copy.attachments = attachments;
+        return copy;
+    }
+
+
 }

--- a/sync-core/src/test/java/com/cloudant/sync/datastore/BasicDatastoreCRUDTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/datastore/BasicDatastoreCRUDTest.java
@@ -89,6 +89,7 @@ public class BasicDatastoreCRUDTest extends BasicDatastoreTestBase {
         rev_mut.body = bodyOne;
         BasicDocumentRevision rev = datastore.createDocumentFromRevision(rev_mut);
         validateNewlyCreatedDocument(rev);
+        Assert.assertNull(rev_mut.docId);
     }
 
     @Test


### PR DESCRIPTION
iOS MutableDocumentRevisions do not have a docId set after calling
the create method. Fix sync-android behaviour to match.

BugzID: 45090

reviewer @tomblench 
reviewer @gadamc 