### PR TITLE
Ignore documents with empty ids in changes feed

### DIFF
--- a/fixture/testReplicationDocWithEmptyId_changes.json
+++ b/fixture/testReplicationDocWithEmptyId_changes.json
@@ -1,0 +1,23 @@
+{
+    "last_seq": 27,
+    "results": [
+      {
+        "changes":[
+          {
+            "rev": "1-bd42b942b8b672f0289cf3cd1f67044c"
+          }
+        ],
+        "id": "",
+        "seq": 27
+      },
+      {
+        "seq": 28,
+        "id": "4d3b3f01362649d79b31d9092799a7e0",
+        "changes": [
+          {
+            "rev": "1-13d33701a0954729ad029adf8fdc5a04"
+          }
+        ]
+      }
+     ]
+ }

--- a/fixture/testReplicationDocWithEmptyId_open_revs_1.json
+++ b/fixture/testReplicationDocWithEmptyId_open_revs_1.json
@@ -1,0 +1,15 @@
+[
+  {
+    "ok":{
+      "_id":"",
+      "_rev":"1-bd42b942b8b672f0289cf3cd1f67044c",
+      "hello":"foo",
+      "_revisions": {
+        "start": 1,
+        "ids": [
+        "bd42b942b8b672f0289cf3cd1f67044c"
+        ]
+      }
+    }
+  }
+]

--- a/fixture/testReplicationDocWithEmptyId_open_revs_2.json
+++ b/fixture/testReplicationDocWithEmptyId_open_revs_2.json
@@ -1,0 +1,15 @@
+[
+  {
+    "ok": {
+      "_id":"4d3b3f01362649d79b31d9092799a7e0",
+      "_rev":"1-13d33701a0954729ad029adf8fdc5a04",
+      "hello":"world",
+      "foo":"bar",
+      "_revisions": {
+        "start": 1,
+        "ids": ["13d33701a0954729ad029adf8fdc5a04"]
+      }
+    }
+  }
+]
+        

--- a/sync-core/src/main/java/com/cloudant/sync/replication/BasicPullStrategy.java
+++ b/sync-core/src/main/java/com/cloudant/sync/replication/BasicPullStrategy.java
@@ -387,6 +387,11 @@ class BasicPullStrategy implements ReplicationStrategy {
 
         List<Callable<DocumentRevsList>> tasks = new ArrayList<Callable<DocumentRevsList>>();
         for(String id : ids) {
+            //skip any document with an empty id
+            if(id.isEmpty()){
+                logger.info("Found document with empty ID in change feed, skipping");
+                continue;
+            }
             // get list for atts_since (these are possible ancestors we have, it's ok to be eager
             // and get all revision IDs higher up in the tree even if they're not our ancestors and
             // belong to a different subtree)

--- a/sync-core/src/test/java/com/cloudant/sync/replication/BasicPullStrategyMockTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/replication/BasicPullStrategyMockTest.java
@@ -15,13 +15,28 @@
 package com.cloudant.sync.replication;
 
 import com.cloudant.common.RequireRunningCouchDB;
+import com.cloudant.mazha.ChangesResult;
+import com.cloudant.mazha.DocumentRevs;
+import com.cloudant.mazha.OkOpenRevision;
+import com.cloudant.mazha.OpenRevision;
+import com.cloudant.mazha.json.JSONHelper;
+import com.cloudant.sync.util.TestUtils;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.eventbus.Subscribe;
+
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
+import java.io.FileReader;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -147,6 +162,52 @@ public class BasicPullStrategyMockTest extends ReplicationTestBase {
         verify(mockListener).complete(any(ReplicationStrategyCompleted.class));
         verify(mockListener, never()).error(any(ReplicationStrategyErrored.class));
     }
+
+    @Test
+    public void testReplicationDocWithEmptyId() throws Exception {
+        CouchDB mockRemoteDb = mock(CouchDB.class);
+        when(mockRemoteDb.changes(null, null, 1000)).then(new Answer<Object>() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                JSONHelper jsonHelper = new JSONHelper();
+                FileReader fr = new FileReader(TestUtils.loadFixture("fixture/testReplicationDocWithEmptyId_changes.json"));
+                return jsonHelper.fromJson(fr, ChangesResult.class);
+            }
+        });
+        when(mockRemoteDb.exists()).thenReturn(true);
+        Collection<String> revs = new ArrayList<String>();
+        revs.add("1-bd42b942b8b672f0289cf3cd1f67044c");
+        when(mockRemoteDb.getRevisions("", revs, new HashSet<String>(), false)).then(new Answer<Object>() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+
+                return loadOpenRevsResponseFromFixture("testReplicationDocWithEmptyId_open_revs_1.json");
+
+            }
+        });
+        revs = new ArrayList<String>();
+        revs.add("1-13d33701a0954729ad029adf8fdc5a04");
+        when(mockRemoteDb.getRevisions("4d3b3f01362649d79b31d9092799a7e0", revs, new HashSet<String>(),false)).then(new Answer<Object>() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+
+                return loadOpenRevsResponseFromFixture("fixture/testReplicationDocWithEmptyId_open_revs_2.json");
+
+            }
+        });
+
+        StrategyListener mockListener = mock(StrategyListener.class);
+        final BasicPullStrategy pullStrategy = new BasicPullStrategy(createPullReplication());
+        pullStrategy.sourceDb = mockRemoteDb;
+        pullStrategy.getEventBus().register(mockListener);
+        pullStrategy.run();
+
+        //should have 1 document
+        Assert.assertEquals(this.datastore.getDocumentCount(), 1);
+        //make sure the correct events were fired
+        verify(mockListener).complete(any(ReplicationStrategyCompleted.class));
+        verify(mockListener,never()).error(any(ReplicationStrategyErrored.class));
+    }
     
     public class StrategyListener {
 
@@ -157,6 +218,24 @@ public class BasicPullStrategyMockTest extends ReplicationTestBase {
         @Subscribe
         public void error(ReplicationStrategyErrored re) {
         }
+    }
+
+    private List<DocumentRevs> loadOpenRevsResponseFromFixture(String fixturePath) throws Exception{
+        JSONHelper helper = new JSONHelper();
+        FileReader fileReader = new FileReader(TestUtils.loadFixture(fixturePath));
+        List<OpenRevision> openRevs = helper.fromJson(fileReader,
+                new TypeReference<List<OpenRevision>>() {
+                });
+
+        List<DocumentRevs> documentRevs = new ArrayList<DocumentRevs>();
+
+        for (OpenRevision openRev : openRevs) {
+            if (openRev instanceof OkOpenRevision) {
+                documentRevs.add(((OkOpenRevision) openRev).getDocumentRevs());
+            }
+        }
+
+        return documentRevs;
     }
 
 }


### PR DESCRIPTION
Ignore documents with an empty id in the changes feed. This
allows replication with databases which contain documents
with empty id fields as a result in a bug in CouchDB.

BugzID 24255


reviewer @mikerhodes 
reviewer @alfinkel 