### PR TITLE
Add fts availability check to API

### DIFF
--- a/sync-core/src/main/java/com/cloudant/sync/query/IndexCreator.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/IndexCreator.java
@@ -58,7 +58,8 @@ class IndexCreator {
     }
 
     /**
-     *  Add a single, possibly compound, possibly text index for the given field names.
+     *  Add a single, possibly compound index for the given field names and ensure all indexing
+     *  constraints are met.
      *
      *  This function generates a name for the new index.
      *
@@ -69,6 +70,14 @@ class IndexCreator {
     private String ensureIndexed(final Index index) {
         if (index == null) {
             return null;
+        }
+
+        if (index.indexType.equalsIgnoreCase("text")) {
+            if (!IndexManager.ftsAvailable(queue, database)) {
+                logger.log(Level.SEVERE, "Text search not supported.  To add support for text " +
+                                         "search, enable FTS compile options in SQLite.");
+                return null;
+            }
         }
 
         final List<String> fieldNamesList = removeDirectionsFromFields(index.fieldNames);

--- a/sync-core/src/test/java/com/cloudant/sync/query/IndexManagerTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/IndexManagerTest.java
@@ -15,17 +15,20 @@ package com.cloudant.sync.query;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
 import com.cloudant.sync.datastore.DocumentBodyFactory;
 import com.cloudant.sync.datastore.MutableDocumentRevision;
+import com.cloudant.sync.util.SQLDatabaseTestUtils;
 
 import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 public class IndexManagerTest extends AbstractIndexTestBase {
 
@@ -140,6 +143,14 @@ public class IndexManagerTest extends AbstractIndexTestBase {
 
         assertThat(im.deleteIndexNamed("basic"), is(true));
         assertThat(im.listIndexes().isEmpty(), is(true));
+    }
+
+    @Test
+    public void validateTextSearchIsAvailable() throws Exception {
+        Set<String> compileOptions = SQLDatabaseTestUtils.getCompileOptions(db);
+        assertThat(compileOptions, hasItems("ENABLE_FTS3", "ENABLE_FTS3_PARENTHESIS"));
+
+        assertThat(im.isTextSearchEnabled(), is(true));
     }
 
 }

--- a/sync-core/src/test/java/com/cloudant/sync/util/SQLDatabaseTestUtils.java
+++ b/sync-core/src/test/java/com/cloudant/sync/util/SQLDatabaseTestUtils.java
@@ -55,4 +55,20 @@ public class SQLDatabaseTestUtils {
         }
     }
 
+    public static Set<String> getCompileOptions(SQLDatabase db) throws SQLException {
+        Cursor cursor = null;
+        Set<String> compileOptions = new HashSet<String>();
+        try {
+            cursor = db.rawQuery("PRAGMA compile_options", new String[]{});
+            while(cursor.moveToNext()) {
+                compileOptions.add(cursor.getString(0));
+            }
+        } finally {
+            if (cursor != null) {
+                cursor.close();
+            }
+        }
+        return compileOptions;
+    }
+
 }


### PR DESCRIPTION
_What_

Add a public method to the IndexManager that allows users of the library to check whether full text search is enabled in SQLite.

_Why_

Since Cloudant Query - mobile text search leverages SQLite FTS functionality and FTS is a compile option for SQLite, it is conceivable that FTS may not be enabled in SQLite.  This method provides a check regarding SQLite FTS availability.

_How_

- Add a static method to the IndexManager to check the SQLite PRAGMA compile options for ENABLE_FTS3 and ENABLE_FTS3_PARENTHESIS.
- Add a public method to the IndexManager to return text search status.
- Add logic to the index creator to halt any text index creation if FTS is not available in SQLite.

reviewer @mikerhodes 
reviewer @rhyshort

BugId: 46093