### PR TITLE
Add query text search documentation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 - [REMOVED] Removed oneway methods from ReplicatorFactory. Users should 
   use the method described in the [replication documentation](https://github.com/cloudant/sync-android/blob/master/doc/replication.md) 
   instead
+- [NEW] Added query text search support.  See [query documentation](https://github.com/cloudant/sync-android/blob/master/doc/query.md) for details.
 
 # 0.11.0 (2015-04-22)
 


### PR DESCRIPTION
_What_

Update query documentation to include details for text search support.

_Why_

Text search support was recently added to Query.  We need to provide developers with documentation that assists them in using Query Text Search.

_How_

Add text search content to query.md

reviewer @mikerhodes 
reviewer @gadamc 

BugID: 46163 