### PR TITLE
Encode + characters in query strings

### DIFF
--- a/sync-core/src/main/java/com/cloudant/mazha/CouchURIHelper.java
+++ b/sync-core/src/main/java/com/cloudant/mazha/CouchURIHelper.java
@@ -236,7 +236,9 @@ public class CouchURIHelper {
                     null // fragment
             );
             return uri.toASCIIString()
-                    .replace("&", "%26").replace("=", "%3D")  // encode qs separators
+                    .replace("&", "%26")
+                    .replace("=", "%3D")  // encode qs separators
+                    .replace("+", "%2B")
                     .substring(1);  // remove leading ?
         } catch (URISyntaxException e) {
             throw new RuntimeException(

--- a/sync-core/src/test/java/com/cloudant/mazha/CouchURIHelperTest.java
+++ b/sync-core/src/test/java/com/cloudant/mazha/CouchURIHelperTest.java
@@ -155,6 +155,17 @@ public class CouchURIHelperTest {
         Assert.assertEquals(expected, actual);
     }
 
+    @Test
+    public void buildDocumentUri_options_hasPlus() throws Exception {
+        URI expected = new URI(uriBase + "/test/path1%2Fpath2?q=class:mammal%2Bwith%2Bplusses");
+
+        TreeMap<String, Object> options = new TreeMap<String, Object>();
+        options.put("q", "class:mammal+with+plusses");
+        URI actual = helper(path+"/test").documentUri("path1/path2", options);
+        Assert.assertEquals(expected, actual);
+    }
+
+
     // this test shows that non-ascii characters will be represented correctly
     // in the url but that we don't escape characters like / in the root url, but that they are
     // correctly escaped in the document part of the url


### PR DESCRIPTION
FB ticket 47061:

* *What:* Correctly percent-encode plus characters (`+`) in the query part of the URL
* *Why:* Lucene queries etc need to use this character. If it isn't encoded then the `+` character is interpreted as a space by CouchDB
* *How:* Replace `+` with `%2B` in `encodeQueryParameter`
* *Testing:* Added unit test `buildDocumentUri_options_hasPlus` and tested end-to-end with `curl` (see related ticket 46986)

reviewer @mikerhodes 
reviewer @brynh 