### PR TITLE
Remove Thread Local code from AndroidSQLite

### DIFF
--- a/sync-android/src/main/java/com/cloudant/sync/sqlite/android/AndroidSQLite.java
+++ b/sync-android/src/main/java/com/cloudant/sync/sqlite/android/AndroidSQLite.java
@@ -27,8 +27,7 @@ import java.sql.SQLException;
 public class AndroidSQLite extends SQLDatabase {
 
     android.database.sqlite.SQLiteDatabase database = null;
-    private Thread threadWhichOpened = null;
-    private ThreadLocal<Boolean> appearsOpen = null;
+
 
     public static AndroidSQLite createAndroidSQLite(String path) {
         SQLiteDatabase db = SQLiteDatabase.openDatabase(path, null, SQLiteDatabase.CREATE_IF_NECESSARY);
@@ -37,13 +36,7 @@ public class AndroidSQLite extends SQLDatabase {
 
     public AndroidSQLite(final android.database.sqlite.SQLiteDatabase database) {
         this.database = database;
-        this.threadWhichOpened = Thread.currentThread();
-        this.appearsOpen = new ThreadLocal<Boolean>(){
-            @Override
-            protected Boolean initialValue() {
-                return database.isOpen();
-            }
-        };
+
     }
 
     @Override
@@ -58,14 +51,7 @@ public class AndroidSQLite extends SQLDatabase {
 
     @Override
     public void close() {
-        // Since the JavaSE version of this needs to have each thread that operated on the db
-        // close its connection to the db. Since android does not have ThreadLocal connections
-        // the connection only needs to be closed once.
-        // To maintain compatibility with JavaSE unless the current thread opened the connection,
-        // the db only appears closed to the thread that called close
-        if(threadWhichOpened == Thread.currentThread())
-            this.database.close();
-        appearsOpen.set(Boolean.FALSE);
+        this.database.close();
     }
 
     // This implementation of isOpen will only return true if the database is open AND the current
@@ -73,7 +59,7 @@ public class AndroidSQLite extends SQLDatabase {
     // with the JavaSE SQLiteWrapper, where each thread closes its own connection.
     @Override
     public boolean isOpen() {
-        return this.database.isOpen() && this.appearsOpen.get();
+        return this.database.isOpen();
     }
 
     @Override


### PR DESCRIPTION
Removed thread local code from AndroidSQLite, it is no longer
needed to match the behaviour of the JavaSE implementation.

BugzID: 47161


reviewer @tomblench 
reviewer @brynh 