### PR TITLE
Make SQLDatabaseQueue less susceptible to Race Conditions

### DIFF
--- a/sync-core/src/main/java/com/cloudant/sync/sqlite/SQLQueueCallable.java
+++ b/sync-core/src/main/java/com/cloudant/sync/sqlite/SQLQueueCallable.java
@@ -44,7 +44,7 @@ public abstract class SQLQueueCallable<T> implements Callable<T> {
 
     /**
      * Called either within a transaction or not depending on if
-     * @{link com.cloudant.sync.sqlite.SQLDatabaseQueue#setRunInTransaction(SQLQueueCallable} or
+     * {@link com.cloudant.sync.sqlite.SQLDatabaseQueue#submitTransaction(SQLQueueCallable)} or
      * {@link com.cloudant.sync.sqlite.SQLDatabaseQueue#submit(SQLQueueCallable)} is called
      *
      * When called within a transaction, to mark the transaction as successful


### PR DESCRIPTION
What:

Reduce the possible window for a task to be added to the SQLiteDatabaseQueue after shutdown has been called.

How:

Introduce a flag which enables SQLDatabase Queue to reject tasks, as soon as shutdown is called.
When the the queue can no longer accept jobs, RejectedExecutionException is thrown. During the shutdown method, will wait 2 seconds to allow other jobs to finish.

Things to look at:

I'm not sure of waiting two seconds is appropriate, but having the ExecutorService thread killed before the job is complete is a bit of a risk, any thoughts on this? 


BugzId: 47164

reviewer @tomblench 
reviewer @mikerhodes 