### PR TITLE
47172 close attachment streams

### DIFF
--- a/sync-core/src/main/java/com/cloudant/sync/datastore/PreparedAttachment.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/PreparedAttachment.java
@@ -17,6 +17,7 @@ package com.cloudant.sync.datastore;
 import com.cloudant.sync.util.Misc;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -42,11 +43,15 @@ public class PreparedAttachment {
                               String attachmentsDir) throws AttachmentException {
         this.attachment = attachment;
         this.tempFile = new File(attachmentsDir, "temp" + UUID.randomUUID());
+        FileInputStream tempFileIS = null;
         try {
             FileUtils.copyInputStreamToFile(attachment.getInputStream(), tempFile);
-            this.sha1 = Misc.getSha1(new FileInputStream(tempFile));
-        } catch (IOException e){
+            this.sha1 = Misc.getSha1((tempFileIS = new FileInputStream(tempFile)));
+        } catch (IOException e) {
             throw new AttachmentNotSavedException(e);
+        } finally {
+            //ensure the temp file is closed after calculating the hash
+            IOUtils.closeQuietly(tempFileIS);
         }
     }
 

--- a/sync-core/src/test/java/com/cloudant/sync/datastore/AttachmentTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/datastore/AttachmentTest.java
@@ -21,6 +21,8 @@ import com.cloudant.sync.util.Misc;
 import com.cloudant.sync.util.TestUtils;
 
 import static org.hamcrest.CoreMatchers.is;
+
+import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -53,16 +55,21 @@ public class AttachmentTest extends BasicDatastoreTestBase {
             Assert.fail("ConflictException thrown: "+ce);
         }
         // get attachment...
+        FileInputStream fis = null;
         try {
-            byte[] expectedSha1 = Misc.getSha1(new FileInputStream(f));
+            byte[] expectedSha1 = Misc.getSha1((fis = new FileInputStream(f)));
 
-            SavedAttachment savedAtt = (SavedAttachment) datastore.getAttachment(newRevision, attachmentName);
+            SavedAttachment savedAtt = (SavedAttachment) datastore.getAttachment(newRevision,
+                    attachmentName);
             Assert.assertArrayEquals(expectedSha1, savedAtt.key);
 
-            SavedAttachment savedAtt2 = (SavedAttachment) datastore.attachmentsForRevision(newRevision).get(0);
+            SavedAttachment savedAtt2 = (SavedAttachment) datastore.attachmentsForRevision
+                    (newRevision).get(0);
             Assert.assertArrayEquals(expectedSha1, savedAtt2.key);
         } catch (FileNotFoundException fnfe) {
-            Assert.fail("FileNotFoundException thrown "+fnfe);
+            Assert.fail("FileNotFoundException thrown " + fnfe);
+        } finally {
+            IOUtils.closeQuietly(fis);
         }
     }
 


### PR DESCRIPTION
*What*
Close attachment streams after calculating sha1 hash

*Why*
If the file streams are not closed it causes AttachmentNotSavedExceptions on Windows when deletion of the temporary copy is attempted.

*How*
Add finally blocks to close the streams.

*Testing*
Exercised by existing attachment tests.

reviewer @rhyshort 
reviewer @tomblench 