### PR TITLE
Fix failing validator test due to clause order

### DIFF
--- a/sync-core/src/test/java/com/cloudant/sync/query/QueryValidatorTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/QueryValidatorTest.java
@@ -431,7 +431,7 @@ public class QueryValidatorTest {
 
     @Test
     public void normalizesMultiFieldQueryWithTextSearch() {
-        Map<String, Object> query = new HashMap<String, Object>();
+        Map<String, Object> query = new LinkedHashMap<String, Object>();
         // query - { "name" : "mike", "$text" : { "$search" : "foo bar baz" } }
         query.put("name", "mike");
         Map<String, Object> search = new HashMap<String, Object>();


### PR DESCRIPTION
_What_

When a test runs under certain versions of Java, the test fails due to the order of the actual normalized query object and the expected query object not matching due to query clause ordering.

_Why_

In reality the query objects should be considered as a match regardless of clause order and the test should succeed.

_How_

Change the QueryValidatorTest.normalizesMultiFieldQueryWithTextSearch test to instantiate the query object as a LinkedHashMap<String, Object> rather than a HashMap<String, Object>.  This will impose an order and will allow the comparison to the expected query which also is a LinkedHashMap to be successful.

reviewer @rhyshort 
reviewer @emlaver 

BugId: 47177