### PR TITLE
Fix FTS enabled check

### DIFF
--- a/sync-core/src/test/java/com/cloudant/sync/query/IndexManagerTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/IndexManagerTest.java
@@ -147,9 +147,6 @@ public class IndexManagerTest extends AbstractIndexTestBase {
 
     @Test
     public void validateTextSearchIsAvailable() throws Exception {
-        Set<String> compileOptions = SQLDatabaseTestUtils.getCompileOptions(db);
-        assertThat(compileOptions, hasItems("ENABLE_FTS3", "ENABLE_FTS3_PARENTHESIS"));
-
         assertThat(im.isTextSearchEnabled(), is(true));
     }
 

--- a/sync-core/src/test/java/com/cloudant/sync/query/QueryTextSearchTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/QueryTextSearchTest.java
@@ -34,6 +34,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class QueryTextSearchTest extends AbstractQueryTestBase {
 
@@ -302,36 +303,44 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
     }
 
     @Test
-    public void canQueryUsingEnhancedQuerySyntaxNOT() {
-        List<Object> fields = Collections.<Object>singletonList("comment");
-        assertThat(im.ensureIndexed(fields, "basic_text", "text"), is("basic_text"));
+    public void canQueryUsingEnhancedQuerySyntaxNOT() throws Exception{
+        // Only execute this test if SQLite enhanced query syntax is enabled
+        Set<String> compileOptions = SQLDatabaseTestUtils.getCompileOptions(db);
+        if (compileOptions.containsAll(Arrays.asList("ENABLE_FTS3", "ENABLE_FTS3_PARENTHESIS"))) {
+            List<Object> fields = Collections.<Object>singletonList("comment");
+            assertThat(im.ensureIndexed(fields, "basic_text", "text"), is("basic_text"));
 
-        // query - { "$text" : { "$search" : "Remus NOT Romulus" } }
-        // - Enhanced Query Syntax - logical operators must be uppercase otherwise they will
-        //   be treated as a search token
-        // - NOT operator only works between tokens as in (token1 NOT token2)
-        Map<String, Object> search = new HashMap<String, Object>();
-        search.put("$search", "Remus NOT Romulus");
-        Map<String, Object> query = new HashMap<String, Object>();
-        query.put("$text", search);
-        QueryResult queryResult = im.find(query);
-        assertThat(queryResult.documentIds(), contains("mike72"));
+            // query - { "$text" : { "$search" : "Remus NOT Romulus" } }
+            // - Enhanced Query Syntax - logical operators must be uppercase otherwise they will
+            //   be treated as a search token
+            // - NOT operator only works between tokens as in (token1 NOT token2)
+            Map<String, Object> search = new HashMap<String, Object>();
+            search.put("$search", "Remus NOT Romulus");
+            Map<String, Object> query = new HashMap<String, Object>();
+            query.put("$text", search);
+            QueryResult queryResult = im.find(query);
+            assertThat(queryResult.documentIds(), contains("mike72"));
+        }
     }
 
     @Test
-    public void canQueryUsingEnhancedQuerySyntaxParentheses() {
-        List<Object> fields = Collections.<Object>singletonList("comment");
-        assertThat(im.ensureIndexed(fields, "basic_text", "text"), is("basic_text"));
+    public void canQueryUsingEnhancedQuerySyntaxParentheses() throws Exception{
+        // Only execute this test if SQLite enhanced query syntax is enabled
+        Set<String> compileOptions = SQLDatabaseTestUtils.getCompileOptions(db);
+        if (compileOptions.containsAll(Arrays.asList("ENABLE_FTS3", "ENABLE_FTS3_PARENTHESIS"))) {
+            List<Object> fields = Collections.<Object>singletonList("comment");
+            assertThat(im.ensureIndexed(fields, "basic_text", "text"), is("basic_text"));
 
-        // query - { "$text" : { "$search" : "(Remus OR Romulus) AND \"lives next door\"" } }
-        // - Parentheses are used to override SQLite enhanced query syntax operator precedence
-        // - Operator precedence is NOT -> AND -> OR
-        Map<String, Object> search = new HashMap<String, Object>();
-        search.put("$search", "(Remus OR Romulus) AND \"lives next door\"");
-        Map<String, Object> query = new HashMap<String, Object>();
-        query.put("$text", search);
-        QueryResult queryResult = im.find(query);
-        assertThat(queryResult.documentIds(), contains("fred34"));
+            // query - { "$text" : { "$search" : "(Remus OR Romulus) AND \"lives next door\"" } }
+            // - Parentheses are used to override SQLite enhanced query syntax operator precedence
+            // - Operator precedence is NOT -> AND -> OR
+            Map<String, Object> search = new HashMap<String, Object>();
+            search.put("$search", "(Remus OR Romulus) AND \"lives next door\"");
+            Map<String, Object> query = new HashMap<String, Object>();
+            query.put("$text", search);
+            QueryResult queryResult = im.find(query);
+            assertThat(queryResult.documentIds(), contains("fred34"));
+        }
     }
 
     @Test


### PR DESCRIPTION
_What_

Text search tests fail during Android testing because of SQLite idiosyncrasies on Android.

_Why_

We need to ensure that text search will work on Android mobile devices as well as we need to ensure that our build tests pass without failures.

_How_

Since the problem is that the `PRAGMA compile_options` command is returning an empty cursor when executed on Android, change the FTS availability check to instead create a SQL FTS virtual table.  Successful table creation means that FTS is available whereas a failed table create means that FTS is not enabled.

_Tests_

- IndexManagerTest: removed the check for `ENABLE_FTS3` and `ENABLE_FTS3_PARENTHESIS` compile options in `validateTextSearchIsAvailable()`, since this check will fail in Android.
- Add conditional logic to two enhanced query syntax tests to check for `ENABLE_FTS3` and `ENABLE_FTS3_PARENTHESIS` and only execute the content of the tests if enhanced query syntax is available.  This conditional logic allows us to still run the enhanced query syntax tests during Java SE testing.

reviewer @mikerhodes 
reviewer @rhyshort 

BugId: 46093