### PR TITLE
44538 filter pipeline and cookie filter.

### DIFF
--- a/sync-core/src/main/java/com/cloudant/http/CookieFilter.java
+++ b/sync-core/src/main/java/com/cloudant/http/CookieFilter.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2015 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.http;
+
+import com.cloudant.mazha.json.JSONHelper;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ *
+ * Adds cookie authentication support to http requests.
+ *
+ * It does this by adding the cookie header for CouchDB
+ * using request filtering pipeline in {@link HttpConnection}.
+ *
+ * If a response has a response code of 401, it will fetch a cookie from
+ * the server using provided credentials and tell {@link HttpConnection} to reply
+ * the request by setting {@link HttpConnectionFilterContext#replayRequest} property to true.
+ *
+ * If the request to get the cookie for use in future request fails with a 401 status code
+ * (or any status that indicates client error) cookie authentication will not be attempted again.
+ *
+ *
+ */
+public  class CookieFilter implements HttpConnectionRequestFilter, HttpConnectionResponseFilter {
+
+    private final static Logger logger = Logger.getLogger(CookieFilter.class.getCanonicalName());
+    final String sessionRequestBody;
+    private String cookie = null;
+    private boolean shouldAttemptCookieRequest = true;
+    private final String username;
+
+    /**
+     * Constructs a cookie filter.
+     * @param username The username to use when getting the cookie
+     * @param password The password to use when getting the cookie
+     */
+    public CookieFilter(String username, String password){
+        this.sessionRequestBody = String.format("name=%s&password=%s",username,password);
+        this.username = username;
+    }
+
+    @Override
+    public HttpConnectionFilterContext filterRequest(HttpConnectionFilterContext context) {
+
+        HttpURLConnection connection = context.connection.getConnection();
+
+        if(shouldAttemptCookieRequest) {
+            if (cookie == null) {
+                cookie = getCookie(connection.getURL());
+            }
+            connection.setRequestProperty("Cookie", cookie);
+        }
+
+        return context;
+    }
+
+    @Override
+    public HttpConnectionFilterContext filterResponse(HttpConnectionFilterContext context) {
+        HttpURLConnection connection = context.connection.getConnection();
+        try {
+            if (context.connection.getConnection().getResponseCode() == 401) {
+                //we need to get a new cookie
+                cookie = getCookie(connection.getURL());
+                //don't resend request, failed to get cookie
+                if(cookie != null) {
+                    context.replayRequest = true;
+                } else {
+                    context.replayRequest = false;
+                }
+            }
+        } catch (IOException e) {
+            logger.log(Level.SEVERE, "Failed to get response code from request",e);
+        }
+        return context;
+
+    }
+
+     private String getCookie(URL url){
+        try {
+            URL sessionURL = new URL(String.format("%s://%s:%d/_session",
+                    url.getProtocol(),
+                    url.getHost(),
+                    url.getPort()));
+
+            HttpConnection conn = Http.POST(sessionURL, "application/x-www-form-urlencoded");
+            conn.setRequestBody(sessionRequestBody);
+            HttpURLConnection connection = conn.execute().getConnection();
+            String cookieHeader = connection.getHeaderField("Set-Cookie");
+            int responseCode = connection.getResponseCode();
+
+            if(responseCode / 100 == 2){
+
+                if(sessionHasStarted(connection.getInputStream())) {
+                    return cookieHeader.substring(0, cookieHeader.indexOf(";"));
+                } else {
+                    return null;
+                }
+
+            } else if(responseCode == 401){
+                shouldAttemptCookieRequest  = false;
+                logger.severe("Credentials are incorrect, cookie authentication will not be" +
+                        " attempted again by this filter object");
+            } else if (responseCode / 100 == 5){
+                logger.log(Level.SEVERE,
+                        "Failed to get cookie from server, response code %s, cookie auth",
+                        responseCode);
+            }  else {
+                // catch any other response code
+                logger.log(Level.SEVERE,
+                        "Failed to get cookie from server, response code %s, " +
+                                "cookie authentication will not be attempted again",
+                        responseCode);
+                shouldAttemptCookieRequest = false;
+            }
+
+        } catch (MalformedURLException e) {
+            logger.log(Level.SEVERE,"Failed to create URL for _session endpoint",e);
+        } catch (UnsupportedEncodingException e) {
+            logger.log(Level.SEVERE, "Failed to encode cookieRequest body", e);
+        } catch (IOException e) {
+            logger.log(Level.SEVERE, "Failed to read cookie response header", e);
+        }
+        return null;
+    }
+
+    private boolean sessionHasStarted(InputStream responseStream){
+        //check the response body
+        JSONHelper jsonHelper = new JSONHelper();
+        Map<String,Object> jsonResponse = jsonHelper.fromJson(new InputStreamReader(responseStream));
+
+        // only check for ok:true, https://issues.apache.org/jira/browse/COUCHDB-1356
+        // means we cannot check that the name returned is the one we sent.
+       return jsonResponse.containsKey("ok") && (Boolean) jsonResponse.get("ok");
+
+    }
+}

--- a/sync-core/src/main/java/com/cloudant/http/Http.java
+++ b/sync-core/src/main/java/com/cloudant/http/Http.java
@@ -12,7 +12,6 @@ package com.cloudant.http;
 
 import java.net.MalformedURLException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URL;
 
 /**

--- a/sync-core/src/main/java/com/cloudant/http/HttpConnectionFilterContext.java
+++ b/sync-core/src/main/java/com/cloudant/http/HttpConnectionFilterContext.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2015 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package com.cloudant.http;
+
+/**
+ * Created by tomblench on 30/03/15.
+ */
+public class HttpConnectionFilterContext {
+
+    public boolean replayRequest;
+    public final HttpConnection connection;
+
+    /**
+     * Constructor
+     * @param connection HttpConnection
+     */
+    public HttpConnectionFilterContext (HttpConnection connection) {
+        this.replayRequest = false;
+        this.connection = connection;
+    }
+
+    /**
+     * Shallow copy constructor
+     * @param other Context to copy
+     */
+    public HttpConnectionFilterContext (HttpConnectionFilterContext other) {
+        this.replayRequest = other.replayRequest;
+        this.connection = other.connection;
+
+    }
+
+}

--- a/sync-core/src/main/java/com/cloudant/http/HttpConnectionRequestFilter.java
+++ b/sync-core/src/main/java/com/cloudant/http/HttpConnectionRequestFilter.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2015 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package com.cloudant.http;
+
+/**
+ * Created by tomblench on 30/03/15.
+ */
+
+import java.net.HttpURLConnection;
+
+/**
+
+ A Request Filter is run before the request is made to the server. It can use headers to add support
+ for other authentication methods, for example cookie authentication. See
+ {@link CookieFilter#filterRequest(HttpConnectionFilterContext)} for an example.
+
+
+ Filters are executed in a pipeline and modify the context in a serial fashion.
+ */
+
+
+public interface HttpConnectionRequestFilter {
+
+    /**
+     * Filter the request.
+     * This method <strong>must not</strong> do any of the following:
+     * <ul>
+     *     <li>Return null</li>
+     *     <li>Call methods on the underlying {@link java.net.HttpURLConnection} which
+     *     initiate a request such as {@link HttpURLConnection#getResponseCode()}</li>
+     * </ul>
+     * @param context Input context
+     * @return Output context
+     */
+    HttpConnectionFilterContext filterRequest(HttpConnectionFilterContext context);
+
+}

--- a/sync-core/src/main/java/com/cloudant/http/HttpConnectionResponseFilter.java
+++ b/sync-core/src/main/java/com/cloudant/http/HttpConnectionResponseFilter.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2015 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.http;
+
+/**
+ A Response Filter is run after the response is obtained from the
+ server but before the output stream is returned to the original client. The Response
+ Filter enables two main behaviours:
+<ul>
+  <li>Modifying the response for every request</li>
+
+ <li> Replaying a (potentially modified) request by reacting to the
+ response.</li>
+ </ul>
+
+ Filters are executed in a pipeline and modify the context in a serial fashion.
+ */
+public interface HttpConnectionResponseFilter {
+
+    /**
+     * Filter the response
+     *
+     * This method <strong>must not</strong> do any of the following
+     * <ul>
+     *     <li>Return null</li>
+     *     <li>Read the response stream</li>
+     * </ul>
+     * @param context Input context
+     * @return Output context
+     */
+    HttpConnectionFilterContext filterResponse(HttpConnectionFilterContext context);
+}

--- a/sync-core/src/test/java/com/cloudant/common/CouchTestBase.java
+++ b/sync-core/src/test/java/com/cloudant/common/CouchTestBase.java
@@ -57,7 +57,7 @@ public abstract class CouchTestBase {
             System.getProperty("test.couch.ignore.compaction",Boolean.FALSE.toString()));
 
     public static final Boolean IGNORE_AUTH_HEADERS = Boolean.valueOf(
-            System.getProperty("test.couch.ignore.auth.headers",Boolean.FALSE.toString()));
+            System.getProperty("test.couch.ignore.auth.headers",Boolean.TRUE.toString()));
 
     public CouchConfig getCouchConfig(String db) {
 


### PR DESCRIPTION
What:

Introduce filter pipeline for modifying requests and replaying requests based on responses. Also add a cookie filter to make use of the filtering mechanism.

Why:

Enables developers to add information to http request their system may need, for example tokens for 
their proxy set up. The most asked for authentication method is cookie, as a result I have directly
implemented the filter for their use and as a way of "dog fooding" our filter API.

How:

Two interfaces, one for interacting with requests and one for responses. Request filters
implement the `HttpConnectionRequestFilter` interface, response filters should implement `HttpConnectionResponseFilter` interface. A class can implement both interfaces without 
collision, the methods to implement are called `filterRequest` and `filterResponse` respectively.  

Cookie filter interacts with both requests and responses to correctly get and set the 
cookie for requests with couch/cloudant. It will instruct the HttpConnection to replay requests in the event of a 401 error.

Testing:

Set up a local couch server with an admin, along with a protected database called "cookie_test". Test should be able to add a document containing "hello:world" into the database.


reviewer @mikerhodes 
reviewer @tomblench 