### PR TITLE
47252 public keyprovider

### DIFF
--- a/sync-core/src/main/java/com/cloudant/sync/datastore/BasicDatastore.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/BasicDatastore.java
@@ -92,7 +92,9 @@ class BasicDatastore implements Datastore, DatastoreExtended {
 
     private static final String DB_FILE_NAME = "db.sync";
 
-    //Single thread executor to esnure only one tread accesses the db
+    /**
+     * Queue for all database tasks.
+     */
     private final SQLDatabaseQueue queue;
 
     public BasicDatastore(String dir, String name) throws SQLException, IOException, DatastoreException {

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/BasicDatastore.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/BasicDatastore.java
@@ -93,6 +93,12 @@ class BasicDatastore implements Datastore, DatastoreExtended {
     private static final String DB_FILE_NAME = "db.sync";
 
     /**
+     * Stores a reference to the encryption key provider so
+     * it can be passed to extensions.
+     */
+    private final KeyProvider keyProvider;
+
+    /**
      * Queue for all database tasks.
      */
     private final SQLDatabaseQueue queue;
@@ -112,7 +118,9 @@ class BasicDatastore implements Datastore, DatastoreExtended {
     public BasicDatastore(String dir, String name, KeyProvider provider) throws SQLException, IOException, DatastoreException {
         Preconditions.checkNotNull(dir);
         Preconditions.checkNotNull(name);
+        Preconditions.checkNotNull(provider);
 
+        this.keyProvider = provider;
         this.datastoreDir = dir;
         this.datastoreName = name;
         this.extensionsDir = FilenameUtils.concat(this.datastoreDir, "extensions");
@@ -136,6 +144,11 @@ class BasicDatastore implements Datastore, DatastoreExtended {
     public String getDatastoreName() {
         Preconditions.checkState(this.isOpen(), "Database is closed");
         return this.datastoreName;
+    }
+
+    @Override
+    public KeyProvider getKeyProvider() {
+        return this.keyProvider;
     }
 
     @Override

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/Datastore.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/Datastore.java
@@ -17,6 +17,7 @@
 
 package com.cloudant.sync.datastore;
 
+import com.cloudant.sync.datastore.encryption.KeyProvider;
 import com.google.common.eventbus.EventBus;
 
 import java.io.IOException;
@@ -67,6 +68,16 @@ public interface Datastore {
      * @return the name of this datastore
      */
     public String getDatastoreName();
+
+    /**
+     * <p>Returns the encryption KeyProvider of this datastore.</p>
+     *
+     * <p>Note the key provider could return null for the key,
+     * in which case encryption isn't used on this datastore.</p>
+     *
+     * @return the key provider used by this datastore.
+     */
+    public KeyProvider getKeyProvider();
 
     /**
      * <p>Returns the current winning revision of a document.</p>


### PR DESCRIPTION
This PR simply exposes a Datastore's key provider to the outside world. This is primarily intended so that the Query index code and the Attachments code can get access to the key provider.

reviewer @emlaver 
reviewer @tomblench 