### PR TITLE
Read file manually in PreparedAttachment while calculating SHA1 and length

### DIFF
--- a/sync-core/src/main/java/com/cloudant/sync/datastore/AttachmentManager.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/AttachmentManager.java
@@ -95,7 +95,7 @@ class AttachmentManager {
         byte[] sha1 = a.sha1;
         String type = a.attachment.type;
         int encoding = a.attachment.encoding.ordinal();
-        long length = a.tempFile.length();
+        long length = a.length;
         long revpos = CouchUtils.generationFromRevId(rev.getRevision());
 
         values.put("sequence", sequence);

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/PreparedAttachment.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/PreparedAttachment.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014 Cloudant, Inc. All rights reserved.
+ * Copyright (c) 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -14,15 +14,18 @@
 
 package com.cloudant.sync.datastore;
 
-import com.cloudant.sync.util.Misc;
-
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * An attachment which has been been copied to a temporary location and had its sha1 calculated,
@@ -32,6 +35,7 @@ import java.util.UUID;
  */
 public class PreparedAttachment {
 
+    private Logger logger = Logger.getLogger(PreparedAttachment.class.getCanonicalName());
     /**
      * Prepare an attachment by copying it to a temp location and calculating its sha1.
      *
@@ -43,20 +47,46 @@ public class PreparedAttachment {
                               String attachmentsDir) throws AttachmentException {
         this.attachment = attachment;
         this.tempFile = new File(attachmentsDir, "temp" + UUID.randomUUID());
-        FileInputStream tempFileIS = null;
+        InputStream attachmentInStream = null;
+        OutputStream tempFileOutStream = null;
+        MessageDigest calculateSha1 = null;
+        int totalRead = 0;
         try {
-            FileUtils.copyInputStreamToFile(attachment.getInputStream(), tempFile);
-            this.sha1 = Misc.getSha1((tempFileIS = new FileInputStream(tempFile)));
+            attachmentInStream = attachment.getInputStream();
+
+            //Use FileUtils to create folder structure and file if necessary for output stream
+            tempFileOutStream = FileUtils.openOutputStream(this.tempFile);
+
+            calculateSha1 = MessageDigest.getInstance("SHA-1");
+            int bufferSize = 1024;
+            byte[] buffer = new byte[bufferSize];
+            int bytesRead;
+            while ((bytesRead = attachmentInStream.read(buffer)) != -1) {
+                calculateSha1.update(buffer, 0, bytesRead);
+                tempFileOutStream.write(buffer, 0, bytesRead);
+                totalRead += bytesRead;
+            }
         } catch (IOException e) {
+            logger.log(Level.WARNING, "Problem reading from input or writing to output stream ", e);
+            throw new AttachmentNotSavedException(e);
+        } catch (NoSuchAlgorithmException e) {
+            logger.log(Level.WARNING, "Problem calculating SHA1 for attachment stream ", e);
             throw new AttachmentNotSavedException(e);
         } finally {
-            //ensure the temp file is closed after calculating the hash
-            IOUtils.closeQuietly(tempFileIS);
+            //Ensure the attachment input stream and file output stream is closed after calculating the hash
+            IOUtils.closeQuietly(attachmentInStream);
+            IOUtils.closeQuietly(tempFileOutStream);
         }
+        //Set attachment length from bytes read in input stream
+        this.length = totalRead;
+        this.sha1 = calculateSha1.digest();
     }
 
     public final Attachment attachment;
     public final File tempFile;
     public final byte[] sha1;
+    public final long length;
 }
+
+
 

--- a/sync-core/src/test/java/com/cloudant/sync/datastore/AttachmentTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/datastore/AttachmentTest.java
@@ -20,8 +20,6 @@ import com.cloudant.sync.sqlite.SQLQueueCallable;
 import com.cloudant.sync.util.Misc;
 import com.cloudant.sync.util.TestUtils;
 
-import static org.hamcrest.CoreMatchers.is;
-
 import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -29,9 +27,10 @@ import org.junit.Test;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.sql.SQLException;
 import java.util.List;
+
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.equalTo;
 
 /**
  * Created by tomblench on 12/03/2014.
@@ -271,4 +270,71 @@ public class AttachmentTest extends BasicDatastoreTestBase {
         }
     }
 
+    @Test
+    public void testLengthPreparedAttachmentsTest() throws Exception {
+        String textAttachmentName = "attachment_1.txt";
+        File textFile = TestUtils.loadFixture("fixture/" + textAttachmentName);
+        long expectedTextFileLength = textFile.length();
+
+        String imageAttachmentName = "bonsai-boston.jpg";
+        File imageFile = TestUtils.loadFixture("fixture/" + imageAttachmentName);
+        long expectedImageFileLength = imageFile.length();
+
+        Attachment att = new UnsavedFileAttachment(textFile, "text/plain");
+        PreparedAttachment textPatt = new PreparedAttachment(att, datastore_manager_dir);
+        //Assert that the original file length is equal to the prepared attachment length
+        Assert.assertEquals(expectedTextFileLength, textPatt.length);
+
+        Attachment att2 = new UnsavedFileAttachment(imageFile, "image/jpeg");
+        PreparedAttachment imagePatt = new PreparedAttachment(att2, datastore_manager_dir);
+        Assert.assertEquals(expectedImageFileLength, imagePatt.length);
+    }
+
+    @Test(expected = AttachmentNotSavedException.class)
+    public void testNonexistentPreparedAttachmentsTest() throws Exception {
+        String nonexistentFileName = "nonexistentfile";
+        File nonExistentFile = TestUtils.loadFixture("fixture/" + nonexistentFileName);
+
+        Attachment nonexistentAtt = new UnsavedFileAttachment(nonExistentFile, "text/plain");
+
+        PreparedAttachment nonexistentPatt = new PreparedAttachment(nonexistentAtt, datastore_manager_dir);
+    }
+
+    @Test
+    public void testSha1PreparedAttachmentsTest() throws Exception {
+        String textAttachmentName = "attachment_1.txt";
+        File textFile = TestUtils.loadFixture("fixture/" + textAttachmentName);
+
+        String imageAttachmentName = "bonsai-boston.jpg";
+        File imageFile = TestUtils.loadFixture("fixture/" + imageAttachmentName);
+
+        Attachment att = new UnsavedFileAttachment(textFile, "text/plain");
+        PreparedAttachment textPatt = new PreparedAttachment(att, datastore_manager_dir);
+
+        byte[] textExpectedSha1 = Misc.getSha1((new FileInputStream(textFile)));
+        //Assert that the expected sha1 is equal to the prepared attachment sha1
+        Assert.assertArrayEquals(textExpectedSha1, textPatt.sha1);
+
+        Attachment att2 = new UnsavedFileAttachment(imageFile, "image/jpeg");
+        PreparedAttachment imagePatt = new PreparedAttachment(att2, datastore_manager_dir);
+
+        byte[] imageExpectedSha1 = Misc.getSha1((new FileInputStream(imageFile)));
+        Assert.assertArrayEquals(imageExpectedSha1, imagePatt.sha1);
+
+        //Assert that the text file expected sha1 is NOT equal to the prepared attachment image sha1
+        Assert.assertThat(textExpectedSha1, not(equalTo(imagePatt.sha1)));
+    }
+
+    @Test
+    public void testContentPreparedAttachmentsTest() throws Exception {
+        String imageAttachmentName = "bonsai-boston.jpg";
+        File imageFile = TestUtils.loadFixture("fixture/" + imageAttachmentName);
+
+        Attachment att2 = new UnsavedFileAttachment(imageFile, "image/jpeg");
+        PreparedAttachment imagePatt = new PreparedAttachment(att2, datastore_manager_dir);
+
+        IOUtils.contentEquals(
+                new FileInputStream(imageFile),
+                new FileInputStream(imagePatt.tempFile));
+    }
 }


### PR DESCRIPTION
*What*
Change the current method of saving the temporary file, length, and calculating the SHA1 in PreparedAttachment.
*Why* 
To prepare for encrypting attachments, we need the stream to be read once and the SHA1 digest calculated as we go.
*How*
Using a manual method that includes a while loop that reads the input stream and writes to the temporary file using an output stream. Within the loop, we calculate the SHA1 and the total length.
*Testing* 
setAndGetAttachmentsTest includes a test for asserting the expected SHA1 and saved attachment SHA1.  Also added in the same method a test to compare file length and saved attachment length.

reviewer @mikerhodes 
reviewer @tomblench 

BugId: 47455