### PR TITLE
47251 encrypt query indexes

### DIFF
--- a/sync-core/src/main/java/com/cloudant/sync/query/IndexManager.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/IndexManager.java
@@ -37,6 +37,7 @@
 package com.cloudant.sync.query;
 
 import com.cloudant.sync.datastore.Datastore;
+import com.cloudant.sync.datastore.encryption.KeyProvider;
 import com.cloudant.sync.sqlite.Cursor;
 import com.cloudant.sync.sqlite.SQLDatabase;
 import com.cloudant.sync.sqlite.SQLDatabaseFactory;
@@ -94,16 +95,23 @@ public class IndexManager {
         validFieldName = Pattern.compile(INDEX_FIELD_NAME_PATTERN);
         queue = Executors.newSingleThreadExecutor();
 
-        final String filename = datastore.extensionDataFolder(EXTENSION_NAME) + File.separator
-                                                                              + "indexes.sqlite";
+        final String filename = datastore.extensionDataFolder(EXTENSION_NAME)
+                + File.separator
+                + "indexes.sqlite";
+        final KeyProvider keyProvider = datastore.getKeyProvider();
+
         SQLDatabase sqlDatabase = null;
         try {
             sqlDatabase = queue.submit(new Callable<SQLDatabase>() {
                 @Override
                 public SQLDatabase call() throws Exception {
-                    SQLDatabase db = SQLDatabaseFactory.openSqlDatabase(filename);
-                    SQLDatabaseFactory.updateSchema(db, QueryConstants.getSchemaVersion1(), 1);
-                    SQLDatabaseFactory.updateSchema(db, QueryConstants.getSchemaVersion2(), 2);
+                    SQLDatabase db = SQLDatabaseFactory.openSqlDatabase(filename, keyProvider);
+
+                    if (db != null) {
+                        SQLDatabaseFactory.updateSchema(db, QueryConstants.getSchemaVersion1(), 1);
+                        SQLDatabaseFactory.updateSchema(db, QueryConstants.getSchemaVersion2(), 2);
+                    }
+
                     return db;
                 }
             }).get();

--- a/sync-core/src/main/java/com/cloudant/sync/query/IndexManager.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/IndexManager.java
@@ -95,9 +95,8 @@ public class IndexManager {
         validFieldName = Pattern.compile(INDEX_FIELD_NAME_PATTERN);
         queue = Executors.newSingleThreadExecutor();
 
-        final String filename = datastore.extensionDataFolder(EXTENSION_NAME)
-                + File.separator
-                + "indexes.sqlite";
+        final String filename = datastore.extensionDataFolder(EXTENSION_NAME) + File.separator
+                                                                              + "indexes.sqlite";
         final KeyProvider keyProvider = datastore.getKeyProvider();
 
         SQLDatabase sqlDatabase = null;

--- a/sync-core/src/main/java/com/cloudant/sync/sqlite/SQLDatabaseFactory.java
+++ b/sync-core/src/main/java/com/cloudant/sync/sqlite/SQLDatabaseFactory.java
@@ -83,18 +83,6 @@ public class SQLDatabaseFactory {
     }
 
     /**
-     * Return {@code SQLDatabase} for the given dbFilename
-     *
-     * @param dbFilename full file path of the db file
-     * @return {@code SQLDatabase} for the give filename
-     * @throws IOException if the file does not exists, and also
-     *         can not be created
-     */
-    public static SQLDatabase openSqlDatabase(String dbFilename) throws IOException {
-        return openSqlDatabase(dbFilename, new NullKeyProvider());
-    }
-
-    /**
      * SQLCipher-based implementation for opening database.
      * @param dbFilename full file path of the db file
      * @param provider Key provider object storing the SQLCipher key

--- a/sync-core/src/test/java/com/cloudant/sync/datastore/DatastoreTestUtils.java
+++ b/sync-core/src/test/java/com/cloudant/sync/datastore/DatastoreTestUtils.java
@@ -14,6 +14,7 @@
 
 package com.cloudant.sync.datastore;
 
+import com.cloudant.sync.datastore.encryption.NullKeyProvider;
 import com.cloudant.sync.sqlite.SQLDatabaseFactory;
 import com.cloudant.sync.sqlite.SQLDatabase;
 import org.apache.commons.io.FileUtils;
@@ -34,7 +35,8 @@ public class DatastoreTestUtils {
         String path = database_dir + File.separator + database_file + DATABASE_FILE_EXT;
         File dbFile = new File(path);
         FileUtils.touch(dbFile);
-        SQLDatabase database = SQLDatabaseFactory.openSqlDatabase(dbFile.getAbsolutePath());
+        SQLDatabase database = SQLDatabaseFactory.openSqlDatabase(dbFile.getAbsolutePath(),
+                new NullKeyProvider());
         SQLDatabaseFactory.updateSchema(database, DatastoreConstants.getSchemaVersion3(), 3);
         SQLDatabaseFactory.updateSchema(database, DatastoreConstants.getSchemaVersion4(), 4);
         SQLDatabaseFactory.updateSchema(database, DatastoreConstants.getSchemaVersion5(), 5);

--- a/sync-core/src/test/java/com/cloudant/sync/util/TestUtils.java
+++ b/sync-core/src/test/java/com/cloudant/sync/util/TestUtils.java
@@ -17,6 +17,7 @@ package com.cloudant.sync.util;
 import com.cloudant.sync.datastore.DatastoreExtended;
 import com.cloudant.sync.datastore.DocumentBody;
 import com.cloudant.sync.datastore.DocumentBodyFactory;
+import com.cloudant.sync.datastore.encryption.NullKeyProvider;
 import com.cloudant.sync.sqlite.SQLDatabase;
 import com.cloudant.sync.sqlite.SQLDatabaseFactory;
 
@@ -45,7 +46,8 @@ public class TestUtils {
     public static SQLDatabase createEmptyDatabase(String database_dir, String database_file) throws IOException, SQLException {
         File dbFile = new File(database_dir + File.separator + database_file + DATABASE_FILE_EXT);
         FileUtils.touch(dbFile);
-        SQLDatabase database = SQLDatabaseFactory.openSqlDatabase(dbFile.getAbsolutePath());
+        SQLDatabase database = SQLDatabaseFactory.openSqlDatabase(dbFile.getAbsolutePath(),
+                new NullKeyProvider());
         return database;
     }
 
@@ -156,7 +158,8 @@ public class TestUtils {
            String filePath = (String) db.getClass()
                    .getMethod("getDatabaseFile")
                    .invoke(db);
-           return SQLDatabaseFactory.openSqlDatabase(filePath);
+           return SQLDatabaseFactory.openSqlDatabase(filePath,
+                   new NullKeyProvider());
        } catch (IllegalAccessException e) {
            e.printStackTrace();
        } catch (InvocationTargetException e) {


### PR DESCRIPTION
What:
Open the database using the KeyProvider given by the datastore.

Why:
So Query indexes are encrypted.

How:
Access KeyProvider for datastore from Query code, pass to database opening code. Remove the openDatastore method which doesn't take a key provider to force future users to use key provider appropriately and automatically get an appropriately encrypted database.

Tests:
I'm a little worried to not add any tests. But I think these belong to a future when we properly check for databases being encrypted in the main JSON data too.

reviewer @emlaver 
reviewer @alfinkel 