### PR TITLE
Fix compaction by setting json bodies of old revisions to {}

### DIFF
--- a/sync-core/src/main/java/com/cloudant/sync/datastore/BasicDocumentBody.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/BasicDocumentBody.java
@@ -30,7 +30,10 @@ final class BasicDocumentBody implements DocumentBody {
     private Map<String, Object> map;
 
     protected BasicDocumentBody(byte[] bytes) {
-        assert bytes != null;
+        // compacted revisions have their bodies set to null, so return an empty body
+        if (bytes == null) {
+            bytes = JSONUtils.EMPTY_JSON;
+        }
         if(JSONUtils.isValidJSON(bytes)) {
             this.bytes = bytes;
         } else {

--- a/sync-core/src/test/java/com/cloudant/sync/replication/BasicPushStrategyTest2.java
+++ b/sync-core/src/test/java/com/cloudant/sync/replication/BasicPushStrategyTest2.java
@@ -78,6 +78,20 @@ public class BasicPushStrategyTest2 extends ReplicationTestBase {
         return datastore.updateDocumentFromRevision(rev).getId();
     }
 
+    // check that we can correctly push after compaction
+    @Test
+    public void replicate_compactedTest() throws Exception {
+        BasicPushStrategy push = push();
+
+        populateSomeDataInLocalDatastore();
+        waitForPushToFinish(push);
+
+        datastore.deleteDocument(id1);
+        datastore.compact();
+
+        waitForPushToFinish(push);
+    }
+
     @Test
     public void replicate_fullTest() throws Exception {
 


### PR DESCRIPTION
FB ticket: 47582

- What: fix compaction which was causing subsequent push replication to fail
- How: by setting old json bodies to EMPTY_JSON (`{}`) instead of null, which triggered an assertion causing replication to fail
- Testing: Unit test `BasicPushStrategyTest2.replicate_compactedTest`

reviewer: @rhyshort 
reviewer: @ricellis 