### PR TITLE
Fix Issues in SavedHTTPAttachment

### DIFF
--- a/sync-core/src/main/java/com/cloudant/sync/datastore/DocumentRevisionBuilder.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/DocumentRevisionBuilder.java
@@ -267,7 +267,9 @@ public class DocumentRevisionBuilder {
                 URI attachmentURI= null;
                 try {
                     attachmentURI = new URI(documentURI.getScheme(),
-                            documentURI.getAuthority(),
+                            documentURI.getUserInfo(),
+                            documentURI.getHost(),
+                            documentURI.getPort(),
                             attachmentURIPath,
                             documentURI.getQuery(),
                             documentURI.getFragment());

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/SavedHttpAttachment.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/SavedHttpAttachment.java
@@ -34,9 +34,8 @@ public class SavedHttpAttachment extends Attachment {
 
 
     private URI attachmentURI;
-    private int size;
+    private long size;
     private byte[] data;
-    private Encoding encoding;
 
 
     /**
@@ -49,23 +48,26 @@ public class SavedHttpAttachment extends Attachment {
      */
     public SavedHttpAttachment(String name, Map<String,Object> attachmentData, URI attachmentURI)
            throws IOException {
-         super(name, (String)attachmentData.get("content_type"), Encoding.Plain);
-         Boolean stub = (Boolean) attachmentData.get("stub");
-         Number length = (Number)attachmentData.get("length");
+         super(name,
+                 (String)attachmentData.get("content_type"),
+                 Attachment.getEncodingFromString((String)attachmentData.get("encoding")));
+
+         Number length;
          String data = (String)attachmentData.get("data");
-         String encoding =  (String)attachmentData.get("encoding");
-         this.encoding = Attachment.getEncodingFromString(encoding);
-         if(!stub){
+         if(data != null){
             byte[] dataArray =  data.getBytes();
             InputStream is = Base64InputStreamFactory.get(new ByteArrayInputStream(dataArray));
             this.data = IOUtils.toByteArray(is);
+            length = this.data.length;
+         } else {
+            length = (Number)attachmentData.get("length");
          }
 
          this.attachmentURI = attachmentURI;
-         this.size = length.intValue();
-
+         this.size = length.longValue();
 
     }
+
     @Override
     public long getSize() {
         return size;

--- a/sync-core/src/test/java/com/cloudant/sync/datastore/DocumentRevisionBuilderAttachmentsTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/datastore/DocumentRevisionBuilderAttachmentsTest.java
@@ -108,14 +108,12 @@ public class DocumentRevisionBuilderAttachmentsTest extends ReplicationTestBase 
         byte[] unencodedAttachment = FileUtils.readFileToByteArray(file);
         byte[] encodedAttachment = this.encodeAttachment(unencodedAttachment);
 
-        String encodedAttachmentString = new String(encodedAttachment);
-
         //create a revision on a couchDB instance so we can test the download
         //of attachments
         Map<String,Object> remoteDoc = new HashMap<String,Object>();
         remoteDoc.put("_id","someIdHere");
         Map<String,Map<String,Object>> remoteAttachments = new HashMap<String,Map<String,Object>>();
-        Map<String,Object> remoteBonsai = createAttachmentMap(encodedAttachment,"image/jpeg",false);//new HashMap<String,Object>();
+        Map<String,Object> remoteBonsai = createAttachmentMap(encodedAttachment,"image/jpeg",false);
 
         remoteAttachments.put("bonsai-boston.jpg",remoteBonsai);
         remoteDoc.put("_attachments",remoteAttachments);
@@ -254,14 +252,15 @@ public class DocumentRevisionBuilderAttachmentsTest extends ReplicationTestBase 
     private Map<String,Object> createAttachmentMap(byte[] encodedAttachment,String contentType,boolean stub){
         String encodedAttachmentString = new String(encodedAttachment);
 
-
         Map<String,Object> remoteBonsai = new HashMap<String,Object>();
-        remoteBonsai.put("length",encodedAttachmentString.length());
         remoteBonsai.put("digest","thisisahasiswear");
         remoteBonsai.put("revpos",1);
         remoteBonsai.put("content_type",contentType);
-        remoteBonsai.put("stub",stub);
-        if(!stub) {
+        if(stub) {
+            remoteBonsai.put("stub", stub);
+            remoteBonsai.put("length",encodedAttachmentString.length());
+
+        } else  {
             remoteBonsai.put("data", encodedAttachmentString);
         }
 


### PR DESCRIPTION
## What

Correct SavedHTTPAttachment's expectations of what is present in a JSON object for attachments from couch.

## How
Instead of the code path being based on `stub` being present, it is now based on the presence of `data`. `length` is correctly worked out based on the information provided in the `data` field if present or by
using the `length` field of the attachment objects.

reviewer @tomblench 
reviewer @brynh  

