### PR TITLE
47761 use db for blob fnames

### DIFF
--- a/sync-core/src/main/java/com/cloudant/sync/datastore/AttachmentManager.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/AttachmentManager.java
@@ -141,7 +141,7 @@ class AttachmentManager {
         // move file to blob store, with file name based on sha1
         File newFile = null;
         try {
-            newFile = fileFromKey(db, sha1, true);
+            newFile = fileFromKey(db, sha1, attachmentsDir, true);
         } catch (AttachmentException ex) {
             // As we couldn't generate a filename, we can't save the attachment. Clean up
             // temporary file and throw an exception.
@@ -267,7 +267,7 @@ class AttachmentManager {
                 String type = c.getString(3);
                 int encoding = c.getInt(4);
                 int revpos = c.getInt(7);
-                File file = fileFromKey(db, key, false);
+                File file = fileFromKey(db, key, attachmentsDir, false);
                 return new SavedAttachment(attachmentName, revpos, sequence, key, type, file,
                         Attachment.Encoding.values()[encoding], this.attachmentStreamFactory);
             }
@@ -295,7 +295,7 @@ class AttachmentManager {
                 String type = c.getString(3);
                 int encoding = c.getInt(4);
                 int revpos = c.getInt(7);
-                File file = fileFromKey(db, key, false);
+                File file = fileFromKey(db, key, attachmentsDir, false);
                 atts.add(new SavedAttachment(name, revpos, sequence, key, type, file,
                         Attachment.Encoding.values()[encoding], this.attachmentStreamFactory));
             }
@@ -449,6 +449,7 @@ class AttachmentManager {
      *
      * @param db database to use.
      * @param key key to lookup filename for.
+     * @param attachmentsDir Root directory for attachment blobs.
      * @param allowCreateName if the is no existing mapping, whether one should be created
      *                        and returned. If false, and no existing mapping, AttachmentException
      *                        is thrown.
@@ -456,7 +457,8 @@ class AttachmentManager {
      * @throws AttachmentException if a mapping doesn't exist and {@code allowCreateName} is
      *          false or if the name generation process fails.
      */
-    File fileFromKey(SQLDatabase db, byte[] key, boolean allowCreateName) throws AttachmentException {
+    static File fileFromKey(SQLDatabase db, byte[] key, String attachmentsDir, boolean allowCreateName)
+            throws AttachmentException {
 
         String keyString = keyToString(key);
         String filename = null;

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/AttachmentManager.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/AttachmentManager.java
@@ -416,7 +416,7 @@ class AttachmentManager {
 
         } catch (SQLException e) {
             logger.log(Level.SEVERE, "Problem in purgeAttachments, executing SQL to fetch all attachment keys ", e);
-        }finally {
+        } finally {
             DatabaseUtils.closeCursorQuietly(c);
         }
     }
@@ -454,15 +454,15 @@ class AttachmentManager {
             Cursor c = db.rawQuery(SQL_FILENAME_LOOKUP_QUERY, new String[]{ keyString });
             if (c.moveToFirst()) {
                 filename = c.getString(0);
-                System.out.println(String.format("FOUND filename %1$s for key %2$s", filename, keyString));
+                logger.finest(String.format("Found filename %s for key %s", filename, keyString));
             } else if (allowCreateName) {
                 filename = generateFilenameForKey(db, keyString);
-                System.out.println(String.format("ADDED filename %1$s for key %2$s", filename, keyString));
+                logger.finest(String.format("Added filename %s for key %s", filename, keyString));
             }
             c.close();
             db.setTransactionSuccessful();
         } catch (SQLException e) {
-            e.printStackTrace();
+            logger.log(Level.WARNING, "Couldn't read key,filename mapping database", e);
             filename = null;
         } finally {
             db.endTransaction();
@@ -494,9 +494,10 @@ class AttachmentManager {
      * loop forever.
      *
      * @param db database to use
-     * @param keyString blobs key
+     * @param keyString blob's key
      */
-    static String generateFilenameForKey(SQLDatabase db, String keyString) throws NameGenerationException {
+    static String generateFilenameForKey(SQLDatabase db, String keyString)
+            throws NameGenerationException {
 
         String filename = null;
 
@@ -522,7 +523,8 @@ class AttachmentManager {
         if (filename != null) {
             return filename;
         } else {
-            throw new NameGenerationException("Couldn't generate unique filename for attachment");
+            throw new NameGenerationException(String.format(
+                    "Couldn't generate unique filename for attachment with key %s", keyString));
         }
     }
 

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/AttachmentManager.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/AttachmentManager.java
@@ -455,10 +455,12 @@ class AttachmentManager {
                 // Iterate candidate filenames generated from the filenameRandom generator
                 // until we find one which doesn't already exist (filename is declared
                 // UNIQUE in the attachments_key_filename table).
+                // 200 iterations should give us many millions of files before a name
+                // fails to be generated.
 
                 long result = -1;  // -1 is error for insert call
                 int tries = 0;
-                while (result == -1 && tries < 100) {
+                while (result == -1 && tries < 200) {
                     byte[] randomBytes = new byte[20];
                     filenameRandom.nextBytes(randomBytes);
                     String candidate = keyToString(randomBytes);

--- a/sync-core/src/test/java/com/cloudant/sync/datastore/AttachmentManagerTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/datastore/AttachmentManagerTest.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) 2015 IBM Cloudant, Inc. All rights reserved.
+ * <p/>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.datastore;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.anyVararg;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.cloudant.sync.datastore.encryption.NullKeyProvider;
+import com.cloudant.sync.sqlite.ContentValues;
+import com.cloudant.sync.sqlite.Cursor;
+import com.cloudant.sync.sqlite.SQLDatabase;
+
+import org.junit.Assert;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.sql.SQLException;
+
+/**
+ * Test AttachmentManager classes
+ */
+public class AttachmentManagerTest {
+
+    /**
+     * Test that name read from database is returned
+     */
+    @Test
+    public void testFileForNameFindsName() throws AttachmentException, SQLException {
+
+        final String my_filename = "my_filename";
+
+        // Force returning my_filename
+        Cursor c = mock(Cursor.class);
+        when(c.moveToFirst()).thenReturn(true);
+        when(c.getString(anyInt())).thenReturn(my_filename);  // make cursor returning my_filename
+        SQLDatabase db = mock(SQLDatabase.class);
+        when(db.rawQuery(anyString(), any(String[].class))).thenReturn(c);  // use that cursor
+
+        // Mock enough datastore for AttachmentManager
+        BasicDatastore ds = mock(BasicDatastore.class);
+        when(ds.extensionDataFolder(anyString())).thenReturn("blah");
+        when(ds.getKeyProvider()).thenReturn(new NullKeyProvider());
+
+        File expected = new File("blah", my_filename);
+
+        // Test
+        AttachmentManager attachmentManager = new AttachmentManager(ds);
+        Assert.assertEquals(expected, attachmentManager.fileFromKey(db, new byte[]{-1, 23}));
+
+    }
+
+    /**
+     * Test that name is generated when it cannot be read from the database.
+     */
+    @Test
+    public void testFileForNameGeneratesName() throws AttachmentException, SQLException {
+
+        final String my_filename = "my_filename";
+
+        // Force returning my_filename
+        Cursor c = mock(Cursor.class);
+        when(c.moveToFirst()).thenReturn(false);  // no existing filename
+        SQLDatabase db = mock(SQLDatabase.class);
+        when(db.rawQuery(anyString(), any(String[].class))).thenReturn(c);  // no existing filename
+        when(db.insert(anyString(), any(ContentValues.class))).thenReturn(10l);  // 10 => success
+
+        // Mock enough datastore for AttachmentManager
+        BasicDatastore ds = mock(BasicDatastore.class);
+        when(ds.extensionDataFolder(anyString())).thenReturn("blah");
+        when(ds.getKeyProvider()).thenReturn(new NullKeyProvider());
+
+        // Test
+        AttachmentManager attachmentManager = new AttachmentManager(ds);
+        final File fileFromKey = attachmentManager.fileFromKey(db, new byte[]{-1, 23});
+        Assert.assertEquals(new File("blah"), fileFromKey.getParentFile());
+        Assert.assertNotNull(fileFromKey.getName());
+        Assert.assertTrue(fileFromKey.getName().length() == 40);
+    }
+
+    /**
+     * Tests that generateFilenameForKey returns a filename when
+     * inserting into the database succeeds.
+     */
+    @Test
+    public void testNameGeneration() throws AttachmentManager.NameGenerationException {
+        SQLDatabase db = mock(SQLDatabase.class);
+        when(db.insert(anyString(), any(ContentValues.class))).thenReturn(10l);  // 10 => success
+        Assert.assertNotNull(AttachmentManager.generateFilenameForKey(db, "blah"));
+    }
+
+    /**
+     * Tests that generateFilenameForKey throws an exception when it is never
+     * able to find a suitable filename (i.e., insert always fails).
+     */
+    @Test
+    public void testNameGenerationFailure() throws AttachmentManager.NameGenerationException {
+        SQLDatabase db = mock(SQLDatabase.class);
+        when(db.insert(anyString(), any(ContentValues.class))).thenReturn(-1l);  // -1 => failure
+
+        // Catch exception so we can verify number of insert calls
+        try {
+            AttachmentManager.generateFilenameForKey(db, "blah");
+            Assert.fail("Exception not thrown when name not generated");
+        } catch (AttachmentManager.NameGenerationException ex) {
+            verify(db, times(200)).insert(anyString(), any(ContentValues.class));
+        }
+
+    }
+
+}


### PR DESCRIPTION
This PR updates AttachmentManager to use the `attachments_key_filename` mapping table from PR https://github.com/cloudant/sync-android/pull/153.

We update:
1. `fileFromKey` to look up a key in the `attachments_key_filename` table, generating a key if required.
2. `purgeAttachments` to also clean up entries in the `attachments_key_filename` table as well as files on disk.

Questions:
- Should `fileFromKey` take a `create` parameter, and only generate a file if it's set to true (to avoid the `get` methods generating filenames for keys that don't exist?
   - I decided YES here.
- How's the exception and error handling?
- Is there a better purge implementation?
   - Not sure the whole delete row in thing is very performant, but couldn't see a better way (does this make the whole `attachments_key_filename` idea bad?)

reviewer @rhyshort 
reviewer @brynh 