### PR TITLE
Add $mod operator support to Query

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- [NEW] Added query support for the `$mod` operator.
+
 # 0.12.1 (2015-06-12)
 
 - [FIX] Fixed issue where Base64 encoded strings for HTTP basic authentication
@@ -23,6 +27,7 @@
   should use the method described in the
   [replication documentation](https://github.com/cloudant/sync-android/blob/master/doc/replication.md)
   instead.
+- [NEW] Added query support for the `$mod` operator.
 
 # 0.11.0 (2015-04-22)
 

--- a/doc/query.md
+++ b/doc/query.md
@@ -204,6 +204,23 @@ query.put("age", gt12);
 
 See below for supported operators (Selections -> Conditions).
 
+#### Modulo operation in queries
+
+Using the `$mod` operator in queries allows you to select documents based on the value of a field divided by an integer yielding a specific remainder.
+
+To query for documents where `age` divided by 5 has a remainder of  4, do the following:
+
+```java
+{ "age": { "$mod": [ 5, 4 ] } }
+```
+
+A few things to keep in mind when using `$mod` are:
+
+- The list argument to the `$mod` operator must contain two number elements. The first element is the divisor and the second element is the remainder.
+- Division by zero is not allowed so the divisor cannot be zero.
+- The dividend (field value), divisor, and the remainder can be positive or negative.
+- The dividend, divisor, and the remainder can be represented as whole numbers or by using decimal notation.  However internally, prior to performing the modulo arithmetic operation, all three are truncated to their logical whole number representations.  So, for example, the query `{ "age": { "$mod": [ 5.6, 4.2 ] } }` will provide the same result as the query `{ "age": { "$mod": [ 5, 4 ] } }`.
+
 #### Text search
 
 After creating a text index, a text clause may be used as part of a query to perform full text search term matching, phrase matching, and prefix matching.  A text clause can stand on its own as a query or can be part of a compound query (see below).  Text search supports either SQLite [Standard Query Syntax][ftsStandard] or [Enhanced Query Syntax][ftsEnhanced].  This is dependent on which syntax is enabled as part of SQLite FTS.  Typically SQLite FTS on Android comes configured with the SQLite Standard Query Syntax (confirmed during testing on Android API levels 19, 20, and 21).  See [SQLite full text query][ftsQuery] for more details on syntax that is possible with text search.
@@ -557,6 +574,7 @@ Selectors -> Condition -> Objects
 Selectors -> Condition -> Misc
 
 - `$text` in combination with `$search`
+- `$mod`
 
 Selectors -> Condition -> Array
 
@@ -610,7 +628,6 @@ Selectors -> Condition -> Array
 
 Selectors -> Condition -> Misc
 
-- `$mod` (planned)
 - `$regex` (unplanned, waiting on filtering)
 
 
@@ -665,19 +682,19 @@ Here:
     <em>negation-expression</em>
     <strong>{</strong> <em>operator</em> <strong>:</strong> <em>simple-value</em> <strong>}</strong>
     <strong>{</strong> &quot;$regex&quot; <strong>:</strong> <em>Pattern</em> <strong>}</strong>  // not implemented
-    <strong>{</strong> &quot;$mod&quot; <strong>:</strong> <strong>[</strong> <em>divisor, remainder</em> <strong>] }</strong>  // not implemented
+    <strong>{</strong> &quot;$mod&quot; <strong>:</strong> <strong>[</strong> <em>non-zero-number, number</em> <strong>] }</strong>
     <strong>{</strong> &quot;$elemMatch&quot; <strong>: {</strong> <em>many-expressions</em> <strong>} }</strong>  // not implemented
     <strong>{</strong> &quot;$size&quot; <strong>:</strong> <em>positive-integer</em> <strong>}</strong>  // not implemented
     <strong>{</strong> &quot;$all&quot; <strong>:</strong> <em>array-value</em> <strong>}</strong>  // not implemented
-    <strong>{</strong> &quot;$in&quot; <strong>:</strong> <em>array-value</em> <strong>}</strong>  // not implemented
-    <strong>{</strong> &quot;$nin&quot; <strong>:</strong> <em>array-value</em> <strong>}</strong>  // not implemented
+    <strong>{</strong> &quot;$in&quot; <strong>:</strong> <em>array-value</em> <strong>}</strong>
+    <strong>{</strong> &quot;$nin&quot; <strong>:</strong> <em>array-value</em> <strong>}</strong>
     <strong>{</strong> &quot;$exists&quot; <strong>:</strong> <em>boolean</em> <strong>}</strong>
     <strong>{</strong> &quot;$type&quot; <strong>:</strong> <em>type</em> <strong>}</strong>  // not implemented
 
 <em>text-search-expression</em> :=     
     <strong>{</strong> &quot;$text&quot; <strong>:</strong><strong> {</strong> &quot;$search&quot; <strong>:</strong> <em>string-value</em> <strong>}</strong> <strong>}</strong>
 
-<em>operator</em> := &quot;$gt&quot; | &quot;$gte&quot; | &quot;$lt&quot; | &quot;$lte&quot; | &quot;$eq&quot; | &quot;$neq&quot;
+<em>operator</em> := &quot;$gt&quot; | &quot;$gte&quot; | &quot;$lt&quot; | &quot;$lte&quot; | &quot;$eq&quot; | &quot;$ne&quot;
 
 // Obviously List, but easier to express like this
 <em>array-value</em> := <strong>[</strong> simple-value (&quot;,&quot; simple-value)+ <strong>]</strong>
@@ -689,6 +706,10 @@ Here:
 <em>simple-value</em> := <em>String</em> | <em>Number</em>
 
 <em>string-value</em> := <em>String</em>
+
+<em>number</em> := <em>NSNumber</em>
+
+<em>non-zero-number</em> := <em>NSNumber</em>
 
 <em>positive-integer</em> := <em>Integer</em>
 

--- a/sync-core/src/main/java/com/cloudant/sync/query/QueryConstants.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/QueryConstants.java
@@ -42,6 +42,8 @@ final class QueryConstants {
 
     public static final String SEARCH = "$search";
 
+    public static final String MOD = "$mod";
+
     private QueryConstants() {
         throw new AssertionError();
     }

--- a/sync-core/src/main/java/com/cloudant/sync/query/QuerySqlTranslator.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/QuerySqlTranslator.java
@@ -469,6 +469,7 @@ class QuerySqlTranslator {
         operatorMap.put(LT, "<");
         operatorMap.put(LTE, "<=");
         operatorMap.put(IN, "IN");
+        operatorMap.put(MOD, "%");
 
         for (Object rawComponent: clause) {
             Map<String, Object> component = (Map<String, Object>) rawComponent;
@@ -522,6 +523,15 @@ class QuerySqlTranslator {
                         // This was validated during normalization.
                         List<Object> inList = (List<Object>) negatedPredicate.get(operator);
                         placeholder = placeholdersForInList(inList, sqlParameters);
+                    } else if (operator.equals(MOD)) {
+                        // The predicate map value must be a two element list containing integers
+                        // here.  This was validated during normalization.
+                        List<Integer> modulus = (List<Integer>) negatedPredicate.get(operator);
+                        // Casting the remainder as integer ensures proper processing of the modulo
+                        // operation by SQLite.  If left un-cast, unexpected results occur.
+                        placeholder = String.format("? %s CAST(? AS INTEGER)", operatorMap.get(EQ));
+                        sqlParameters.add(modulus.get(0));
+                        sqlParameters.add(modulus.get(1));
                     } else {
                         // The predicate map value must be either a
                         // String or a non-Float Number here.
@@ -547,6 +557,15 @@ class QuerySqlTranslator {
                         // This was validated during normalization.
                         List<Object> inList = (List<Object>) predicate.get(operator);
                         placeholder = placeholdersForInList(inList, sqlParameters);
+                    } else if (operator.equals(MOD)) {
+                        // The predicate map value must be a two element list containing integers
+                        // here.  This was validated during normalization.
+                        List<Integer> modulus = (List<Integer>) predicate.get(operator);
+                        // Casting the remainder as integer ensures proper processing of the modulo
+                        // operation by SQLite.  If left un-cast, unexpected results occur.
+                        placeholder = String.format("? %s CAST(? AS INTEGER)", operatorMap.get(EQ));
+                        sqlParameters.add(modulus.get(0));
+                        sqlParameters.add(modulus.get(1));
                     } else {
                         // The predicate map value must be either a
                         // String or a non-Float Number here.

--- a/sync-core/src/test/java/com/cloudant/sync/query/AbstractQueryTestBase.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/AbstractQueryTestBase.java
@@ -327,6 +327,84 @@ public abstract class AbstractQueryTestBase {
                 is("pet"));
     }
 
+    // Used to setup document data testing for queries with mathematical operations.
+    // - When querying using $mod operator
+    public void setUpNumericOperationsQueryData() throws Exception {
+        MutableDocumentRevision rev = new MutableDocumentRevision();
+        rev.docId = "mike31";
+        Map<String, Object> bodyMap = new HashMap<String, Object>();
+        bodyMap.put("name", "mike");
+        bodyMap.put("score", 31);
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        ds.createDocumentFromRevision(rev);
+
+        rev.docId = "fred11";
+        bodyMap.clear();
+        bodyMap.put("name", "fred");
+        bodyMap.put("score", 11);
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        ds.createDocumentFromRevision(rev);
+
+        rev.docId = "john15";
+        bodyMap.clear();
+        bodyMap.put("name", "john");
+        bodyMap.put("score", 15);
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        ds.createDocumentFromRevision(rev);
+
+        rev.docId = "john-15";
+        bodyMap.clear();
+        bodyMap.put("name", "john");
+        bodyMap.put("score", -15);
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        ds.createDocumentFromRevision(rev);
+
+        rev.docId = "john15.2";
+        bodyMap.clear();
+        bodyMap.put("name", "john");
+        bodyMap.put("score", 15.2);
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        ds.createDocumentFromRevision(rev);
+
+        rev.docId = "john15.6";
+        bodyMap.clear();
+        bodyMap.put("name", "john");
+        bodyMap.put("score", 15.6);
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        ds.createDocumentFromRevision(rev);
+
+        rev.docId = "john0";
+        bodyMap.clear();
+        bodyMap.put("name", "john");
+        bodyMap.put("score", 0);
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        ds.createDocumentFromRevision(rev);
+
+        rev.docId = "john0.0";
+        bodyMap.clear();
+        bodyMap.put("name", "john");
+        bodyMap.put("score", 0.0);
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        ds.createDocumentFromRevision(rev);
+
+        rev.docId = "john0.6";
+        bodyMap.clear();
+        bodyMap.put("name", "john");
+        bodyMap.put("score", 0.6);
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        ds.createDocumentFromRevision(rev);
+
+        rev.docId = "john-0.6";
+        bodyMap.clear();
+        bodyMap.put("name", "john");
+        bodyMap.put("score", -0.6);
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        ds.createDocumentFromRevision(rev);
+
+        assertThat(im.ensureIndexed(Arrays.<Object>asList("name", "score"), "name_score"),
+                                    is("name_score"));
+    }
+
     // Used to setup document data testing:
     // - When there is a large result set
     public void setUpLargeResultSetQueryData() throws Exception {


### PR DESCRIPTION
_What:_

This PR adds support for the `$mod` operator for use in Query.  It is the port of `$mod` operator functionality already delivered to the CDTDatastore repository in https://github.com/cloudant/CDTDatastore/pull/152.

Due to PR size, there will be a follow up PR that will contain Query Executor tests for `$mod` and the `$mod` documentation.

_Why:_

In an effort to provide as much functionality to Query as is available elsewhere (such as MongoDB), we are adding support to the $mod operator so that users can write queries containing modulo arithmetic.

_How:_

Add logic to the validator code, the SQLtranslator code, and the unindexed matcher code to support the safe use of `$mod` in queries.

_Tests:_

- Validation tests have been added to QueryValidatorTest exercise argument validation and query normalization for queries containing the $mod operator.
- SQL WHERE clause generation tests have been added to QuerySqlTranslatorTest for queries containing the `$mod` operator.
- Tests have been added to UnindexedMatcherTest to exercise the unindexed matcher engine for queries containing the `$mod` operator.

reviewer @mikerhodes 
reviewer @gadamc

BugId: 44631