### PR TITLE
47368 android keychainprovider 02

### DIFF
--- a/AndroidTest/app/src/main/java/cloudant/com/androidtest/AndroidTestUtil.java
+++ b/AndroidTest/app/src/main/java/cloudant/com/androidtest/AndroidTestUtil.java
@@ -1,0 +1,8 @@
+package cloudant.com.androidtest;
+
+import android.content.Context;
+
+public class AndroidTestUtil {
+    public static Context context;
+}
+

--- a/sync-android/build.gradle
+++ b/sync-android/build.gradle
@@ -8,7 +8,6 @@ dependencies {
     // for unit tests
     testCompile group: 'org.hamcrest', name: 'hamcrest-all', version:'1.3'
     testCompile group: 'junit', name: 'junit', version:'4.11'
-    testCompile group: 'org.mockito', name: 'mockito-all', version:'1.9.5'    
 }
 
 //
@@ -27,24 +26,24 @@ test {
 publishing {
     publications {
         mavenJava(MavenPublication) {
-            
+
             from components.java
-            
+
             groupId 'com.cloudant'
             artifactId 'cloudant-sync-datastore-android'
-            
+
             pom.withXml {
                 Node rootNode = asNode()
-                
+
                 rootNode.appendNode('name', 'Cloudant Sync Datastore Android: Android components')
                 rootNode.appendNode('description', 'A JSON document datastore that syncs')
                 rootNode.appendNode('url', 'https://cloudant.com/')
                 rootNode.appendNode('packaging', 'jar')
-                
+
                 Node scmNode = rootNode.appendNode('scm')
                 scmNode.appendNode('url', 'https://github.com/cloudant/sync-android')
                 scmNode.appendNode('connection', 'https://github.com/cloudant/sync-android.git')
-                
+
                 Node licencesNode = rootNode.appendNode('licenses')
                 Node licenceNode = licencesNode.appendNode('license')
                 licenceNode.appendNode('name', 'The Apache Software License, Version 2.0')

--- a/sync-android/src/main/java/com/cloudant/sync/datastore/encryption/AndroidKeyProvider.java
+++ b/sync-android/src/main/java/com/cloudant/sync/datastore/encryption/AndroidKeyProvider.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2015 IBM Cloudant, Inc. All rights reserved.
+ * <p/>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * <p/>
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.datastore.encryption;
+
+import android.content.Context;
+
+import java.util.logging.Logger;
+
+/**
+ * This class implements the interface {@link KeyProvider} and it can be used to create an
+ * encrypted datastore.
+ *
+ * Given an user-provided password and an identifier, it generates a strong key and store it safely
+ * in the application's {@link android.content.SharedPreferences}, so the same key can be retrieved
+ * later provided that the user supplies the same password and id.
+ *
+ * The password is used to protect the key before saving it to the {@link android.content
+ * .SharedPreferences}. The identifier is an
+ * easy way to have more than one encryption key in the same app, the only condition is to provide
+ * different ids for each of them.
+ *
+ * @see KeyProvider
+ * @see KeyManager
+ * @see KeyStorage
+ */
+public class AndroidKeyProvider implements KeyProvider {
+    private static final Logger LOGGER = Logger.getLogger(AndroidKeyProvider.class
+            .getCanonicalName());
+    private String password;
+    private KeyManager manager;
+
+
+    /**
+     * Creates a {@link AndroidKeyProvider} containing a {@link KeyManager} associated with the
+     * provided identifier.
+     *
+     * @param context    The application's {@link Context}
+     * @param password   An user-provided password
+     * @param identifier The data saved in the {@link android.content.SharedPreferences} will be
+     *                   accessed with this identifier
+     * @see KeyManager
+     */
+    public AndroidKeyProvider(Context context, String password, String identifier) {
+        if (context != null && password != null && identifier != null && !password.equals("") &&
+                !identifier.equals("")) {
+            this.password = password;
+            KeyStorage storage = new KeyStorage(context, identifier);
+            this.manager = new KeyManager(storage);
+        } else {
+            LOGGER.severe("All parameters are mandatory");
+            throw new IllegalArgumentException("All parameters are mandatory");
+        }
+    }
+
+    @Override
+    public synchronized EncryptionKey getEncryptionKey() {
+        EncryptionKey key = null;
+        if (this.manager.keyExists()) {
+            key = this.manager.loadKeyUsingPassword(this.password);
+        } else {
+            key = this.manager.generateAndSaveKeyProtectedByPassword(this.password);
+        }
+
+        return key;
+    }
+
+    KeyManager getManager() {
+        return this.manager;
+    }
+}

--- a/sync-android/src/main/java/com/cloudant/sync/datastore/encryption/DPKEncryptionUtil.java
+++ b/sync-android/src/main/java/com/cloudant/sync/datastore/encryption/DPKEncryptionUtil.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2015 IBM Cloudant, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.datastore.encryption;
+
+import android.os.Build;
+
+import org.apache.commons.codec.DecoderException;
+import org.apache.commons.codec.binary.Hex;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Formatter;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.PBEKeySpec;
+
+/**
+ * A utility to aid in encrypting/decrypting the DPK
+ */
+class DPKEncryptionUtil {
+
+    /**
+     * Convert a String to a hex byte array
+     *
+     * @param s The string
+     * @return The hex byte array
+     */
+    public static final byte[] hexStringToByteArray(String s) throws DecoderException {
+        return Hex.decodeHex(s.toCharArray());
+    }
+
+    /**
+     * Convert a hex byte array back to a String
+     *
+     * @param bytes The hex byte array
+     * @return The string
+     */
+    public static final String byteArrayToHexString(byte[] bytes) {
+        return new String(new Hex().encode(bytes));
+    }
+
+    /**
+     * AES Encrypt a byte array
+     *
+     * @param key              The encryption key
+     * @param iv               The iv
+     * @param unencryptedBytes The data to encrypt
+     * @return The encrypted data
+     * @throws NoSuchPaddingException
+     * @throws NoSuchAlgorithmException
+     * @throws InvalidAlgorithmParameterException
+     * @throws InvalidKeyException
+     * @throws BadPaddingException
+     * @throws IllegalBlockSizeException
+     */
+    public static byte[] encryptAES(SecretKey key, byte[] iv, byte[] unencryptedBytes) throws
+            NoSuchPaddingException, NoSuchAlgorithmException, InvalidAlgorithmParameterException,
+            InvalidKeyException, BadPaddingException, IllegalBlockSizeException {
+        Cipher aesCipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+        IvParameterSpec ivParameter = new IvParameterSpec(iv);
+        aesCipher.init(Cipher.ENCRYPT_MODE, key, ivParameter);
+        return aesCipher.doFinal(unencryptedBytes);
+    }
+
+    /**
+     * Decrypt an AES encrypted byte array
+     *
+     * @param key            The encryption key
+     * @param iv             The iv
+     * @param encryptedBytes The data to decrypt
+     * @return The decrypted data
+     * @throws NoSuchPaddingException
+     * @throws NoSuchAlgorithmException
+     * @throws InvalidAlgorithmParameterException
+     * @throws InvalidKeyException
+     * @throws BadPaddingException
+     * @throws IllegalBlockSizeException
+     */
+    public static byte[] decryptAES(SecretKey key, byte[] iv, byte[] encryptedBytes) throws
+            NoSuchPaddingException, NoSuchAlgorithmException, InvalidAlgorithmParameterException,
+            InvalidKeyException, BadPaddingException, IllegalBlockSizeException {
+        Cipher aesCipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+        IvParameterSpec ivParameter = new IvParameterSpec(iv);
+        aesCipher.init(Cipher.DECRYPT_MODE, key, ivParameter);
+        return aesCipher.doFinal(encryptedBytes);
+    }
+}

--- a/sync-android/src/main/java/com/cloudant/sync/datastore/encryption/DPKException.java
+++ b/sync-android/src/main/java/com/cloudant/sync/datastore/encryption/DPKException.java
@@ -1,0 +1,15 @@
+package com.cloudant.sync.datastore.encryption;
+
+/**
+ * Exception thrown when encryption or decryption of Data Protect Key fails.
+ */
+class DPKException extends RuntimeException {
+
+    /**
+     * @param description Context of failure
+     * @param cause       Root cause of failure
+     */
+    public DPKException(String description, Throwable cause) {
+        super(description, cause);
+    }
+}

--- a/sync-android/src/main/java/com/cloudant/sync/datastore/encryption/KeyData.java
+++ b/sync-android/src/main/java/com/cloudant/sync/datastore/encryption/KeyData.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2015 IBM Cloudant, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under thegregree
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.datastore.encryption;
+
+/**
+ * This class defines all the values required to store an encrypted DPK and decipher it later on.
+ *
+ * @see KeyStorage
+ */
+class KeyData {
+
+    private final byte[] encryptedDPK;
+    private final byte[] salt;
+    private final byte[] iv;
+    public final int iterations;
+    public final String version;
+
+    /**
+     * Contains the encrypted DPK and all the values required to decrypt it.
+     *
+     * @param encryptedDPK The encrypted Data Protection Key (DPK)
+     * @param salt         The salt used for encryption
+     * @param iv           The initialization vector
+     * @param iterations   The number of iterations
+     * @param version      The version
+     */
+    public KeyData(byte[] encryptedDPK, byte[] salt, byte[] iv, int iterations, String version) {
+        if (encryptedDPK != null && salt != null && iv != null && iterations > 0 && version !=
+                null && encryptedDPK.length > 0 && salt.length > 0 && iv.length > 0 && !version
+                .equals("")) {
+            this.encryptedDPK = encryptedDPK;
+            this.salt = salt;
+            this.iv = iv;
+            this.iterations = iterations;
+            this.version = version;
+        } else {
+            throw new IllegalArgumentException("All parameters are required to be " +
+                    "non-null/non-empty values");
+        }
+    }
+
+    /**
+     * @return A byte array containing the encrypted DPK
+     */
+    public byte[] getEncryptedDPK() {
+        return encryptedDPK;
+    }
+
+    /**
+     * @return A byte array containing the salt
+     */
+    public byte[] getSalt() {
+        return salt;
+    }
+
+    /**
+     * @return A byte array containing the iv
+     */
+    public byte[] getIv() {
+        return iv;
+    }
+}

--- a/sync-android/src/main/java/com/cloudant/sync/datastore/encryption/KeyManager.java
+++ b/sync-android/src/main/java/com/cloudant/sync/datastore/encryption/KeyManager.java
@@ -1,0 +1,249 @@
+/**
+ * Copyright (c) 2015 IBM Cloudant, Inc. All rights reserved.
+ * <p/>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.datastore.encryption;
+
+import android.os.Build;
+
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.spec.InvalidKeySpecException;
+import java.util.logging.Logger;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+
+import android.content.SharedPreferences;
+
+/**
+ * Use this class to generate a Data Protection Key (DPK), i.e. a strong password that can be used
+ * later on for other purposes like encrypting a database.
+ *
+ * The generated DPK is automatically encrypted and saved to the {@link android.content
+ * .SharedPreferences}, for this reason, it is
+ * necessary to provide a password to generate and retrieve the DPK. On a high level, this is
+ * done as
+ * follow:
+ * - Generate a DPK as a 32 bytes buffer with secure random values.
+ * - Generate a salt as a 32 bytes buffer with secure random values.
+ * - Use PBKDF2 to derive a key based on the user-provided password and the salt.
+ * - Generate an initialization vector (IV) as a 16 bytes buffer with secure random values.
+ * - Use AES to cipher the DPK with the key and the IV.
+ * - Return the DPK and save the encrypted version to the {@link SharedPreferences}.
+ */
+class KeyManager {
+    private static final int BYTES_TO_BITS = 8;
+
+    static final int ENCRYPTION_KEYCHAIN_AES_KEY_SIZE = 32;
+    static final int ENCRYPTION_KEYCHAIN_ENCRYPTIONKEY_SIZE = 32;
+    static final int ENCRYPTION_KEYCHAIN_PBKDF2_SALT_SIZE = 32;
+    static final int ENCRYPTION_KEYCHAIN_PBKDF2_ITERATIONS = 10000;
+    static final String ENCRYPTION_KEYCHAIN_VERSION = "1.0";
+    static final int ENCRYPTIONKEYCHAINMANAGER_AES_IV_SIZE = 16;
+
+    private static final Logger LOGGER = Logger.getLogger(KeyManager.class.getCanonicalName());
+    private KeyStorage storage;
+    private SecureRandom secureRandom;
+
+    /**
+     * Initialise a manager with a CDTEncryptionKeychainStorage instance.
+     *
+     * A {@link KeyStorage} binds an entry in the {@link SharedPreferences} to an identifier. The
+     * data protection key (DPK) saved to the {@link SharedPreferences} by this class will
+     * therefore be bound to the storage's identifier. To save different DPKs (say for different
+     * users of your application), create multiple managers using storages initialised with
+     * different identifiers.
+     *
+     * @param storage Storage instance to save DPKs to the {@link SharedPreferences}
+     * @see KeyStorage
+     */
+    public KeyManager(KeyStorage storage) {
+        if (storage != null) {
+            this.storage = storage;
+            this.secureRandom = new SecureRandom();
+        } else {
+            LOGGER.severe("Storage is mandatory");
+            throw new IllegalArgumentException("Storage is mandatory");
+        }
+    }
+
+    /**
+     * Returns the decrypted Data Protection Key (DPK) from the {@link SharedPreferences}.
+     *
+     * @param password Password used to decrypt the DPK
+     * @return The DPK
+     */
+    public EncryptionKey loadKeyUsingPassword(String password) {
+        if (password == null || password.equals("")) {
+            throw new IllegalArgumentException("password is required to be a non-null/non-empty " +
+                    "string");
+        }
+        KeyData data = this.storage.getEncryptionKeyData();
+        if (data == null || !validateEncryptionKeyData(data)) {
+            return null;
+        }
+
+        EncryptionKey dpk = null;
+        SecretKey aesKey = null;
+        try {
+            aesKey = pbkdf2DerivedKeyForPassword(password, data.getSalt(), data.iterations,
+                    ENCRYPTION_KEYCHAIN_AES_KEY_SIZE);
+            byte[] dpkBytes = DPKEncryptionUtil.decryptAES(aesKey, data.getIv(), data
+                    .getEncryptedDPK());
+            dpk = new EncryptionKey(dpkBytes);
+        } catch (NoSuchAlgorithmException e) {
+            throw new DPKException("Failed to decrypt DPK", e);
+        } catch (InvalidKeySpecException e) {
+            throw new DPKException("Failed to decrypt DPK", e);
+        } catch (IllegalBlockSizeException e) {
+            throw new DPKException("Failed to decrypt DPK", e);
+        } catch (InvalidKeyException e) {
+            throw new DPKException("Failed to decrypt DPK", e);
+        } catch (BadPaddingException e) {
+            throw new DPKException("Failed to decrypt DPK", e);
+        } catch (InvalidAlgorithmParameterException e) {
+            throw new DPKException("Failed to decrypt DPK", e);
+        } catch (NoSuchPaddingException e) {
+            throw new DPKException("Failed to decrypt DPK", e);
+        }
+
+        return dpk;
+    }
+
+    /**
+     * Generates a Data Protection Key (DPK), encrypts it, and stores it inside the {@link
+     * SharedPreferences}.
+     *
+     * @param password Password used to encrypt the DPK
+     * @return The DPK
+     */
+    public EncryptionKey generateAndSaveKeyProtectedByPassword(String password) {
+        EncryptionKey dpk = null;
+        if (password == null || password.equals("")) {
+            throw new IllegalArgumentException("password is required to be a non-null/non-empty " +
+                    "string");
+        }
+        try {
+            if (!keyExists()) {
+                byte[] dpkBytes = generateSecureRandomBytesWithLength
+                        (ENCRYPTION_KEYCHAIN_ENCRYPTIONKEY_SIZE);
+                byte[] salt = generateSecureRandomBytesWithLength
+                        (ENCRYPTION_KEYCHAIN_PBKDF2_SALT_SIZE);
+                byte[] iv = generateSecureRandomBytesWithLength
+                        (ENCRYPTIONKEYCHAINMANAGER_AES_IV_SIZE);
+                SecretKey aesKey = pbkdf2DerivedKeyForPassword(password, salt,
+                        ENCRYPTION_KEYCHAIN_PBKDF2_ITERATIONS,
+                        ENCRYPTION_KEYCHAIN_AES_KEY_SIZE);
+
+                byte[] encryptedDpkBytes = DPKEncryptionUtil.encryptAES(aesKey, iv, dpkBytes);
+
+                KeyData keyData = new KeyData(encryptedDpkBytes, salt, iv,
+                        ENCRYPTION_KEYCHAIN_PBKDF2_ITERATIONS, ENCRYPTION_KEYCHAIN_VERSION);
+
+                if (this.storage.saveEncryptionKeyData(keyData)) {
+                    dpk = new EncryptionKey(dpkBytes);
+                }
+            }
+        } catch (InvalidKeyException e) {
+            throw new DPKException("Failed to encrypt DPK", e);
+        } catch (NoSuchPaddingException e) {
+            throw new DPKException("Failed to encrypt DPK", e);
+        } catch (NoSuchAlgorithmException e) {
+            throw new DPKException("Failed to encrypt DPK", e);
+        } catch (IllegalBlockSizeException e) {
+            throw new DPKException("Failed to encrypt DPK", e);
+        } catch (BadPaddingException e) {
+            throw new DPKException("Failed to encrypt DPK", e);
+        } catch (InvalidAlgorithmParameterException e) {
+            throw new DPKException("Failed to encrypt DPK", e);
+        } catch (InvalidKeySpecException e) {
+            throw new DPKException("Failed to encrypt DPK", e);
+        }
+        return dpk;
+    }
+
+    /**
+     * Checks if the encrypted Data Protection Key (DPK) is inside the {@link SharedPreferences}.
+     *
+     * @return true if the encrypted DPK is inside the {@link SharedPreferences}, false otherwise
+     */
+    public boolean keyExists() {
+        return this.storage.encryptionKeyDataExists();
+    }
+
+    /**
+     * Clears security metadata from the {@link SharedPreferences}.
+     *
+     * @return Success (true) or failure (false)
+     */
+    public boolean clearKey() {
+        return this.storage.clearEncryptionKeyData();
+    }
+
+    // PRIVATE HELPER METHODS
+    private boolean validateEncryptionKeyData(KeyData data) {
+        if (data.getIv().length != ENCRYPTIONKEYCHAINMANAGER_AES_IV_SIZE) {
+            LOGGER.warning("IV does not have the expected size: " +
+                    ENCRYPTIONKEYCHAINMANAGER_AES_IV_SIZE + " bytes");
+            return false;
+        }
+        return true;
+    }
+
+    private SecretKey pbkdf2DerivedKeyForPassword(String password, byte[] salt, int
+            iterations, int length) throws NoSuchAlgorithmException, InvalidKeySpecException {
+        if (length < 1) {
+            throw new IllegalArgumentException("length must greater than 0");
+        }
+
+        if (password == null || password.length() < 1) {
+            throw new IllegalArgumentException("password must not be null or empty String");
+        }
+
+        if (salt == null || salt.length < 1) {
+            throw new IllegalArgumentException("salt must not be null or empty byte array");
+        }
+
+        if (iterations < 1) {
+            throw new IllegalArgumentException("iterations must greater than 0");
+        }
+
+        SecretKeyFactory pbkdf2Factory;
+
+        // Handle Android 4.4 changes to SecretKeyFactory API.
+        if (Build.VERSION.SDK_INT >= 19) {
+            // Use compatibility key factory required for backwards compatibility in API 19 and up.
+            pbkdf2Factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA1And8bit"); //$NON-NLS-1$
+        } else {
+            // Traditional key factory.
+            pbkdf2Factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA1"); //$NON-NLS-1$
+        }
+
+        PBEKeySpec keySpec = new PBEKeySpec(password.toCharArray(), salt, iterations, length *
+                BYTES_TO_BITS); //$NON-NLS-1$
+        return pbkdf2Factory.generateSecret(keySpec);
+    }
+
+    private byte[] generateSecureRandomBytesWithLength(int length) {
+        byte[] randBytes = new byte[length];
+        secureRandom.nextBytes(randBytes);
+        return randBytes;
+    }
+}

--- a/sync-android/src/main/java/com/cloudant/sync/datastore/encryption/KeyManager.java
+++ b/sync-android/src/main/java/com/cloudant/sync/datastore/encryption/KeyManager.java
@@ -162,19 +162,19 @@ class KeyManager {
                 }
             }
         } catch (InvalidKeyException e) {
-            throw new DPKException("Failed to encrypt DPK", e);
+            throw new DPKException("Failed to encrypt DPK.  Cause: " + e.getLocalizedMessage(), e);
         } catch (NoSuchPaddingException e) {
-            throw new DPKException("Failed to encrypt DPK", e);
+            throw new DPKException("Failed to encrypt DPK.  Cause: " + e.getLocalizedMessage(), e);
         } catch (NoSuchAlgorithmException e) {
-            throw new DPKException("Failed to encrypt DPK", e);
+            throw new DPKException("Failed to encrypt DPK.  Cause: " + e.getLocalizedMessage(), e);
         } catch (IllegalBlockSizeException e) {
-            throw new DPKException("Failed to encrypt DPK", e);
+            throw new DPKException("Failed to encrypt DPK.  Cause: " + e.getLocalizedMessage(), e);
         } catch (BadPaddingException e) {
-            throw new DPKException("Failed to encrypt DPK", e);
+            throw new DPKException("Failed to encrypt DPK.  Cause: " + e.getLocalizedMessage(), e);
         } catch (InvalidAlgorithmParameterException e) {
-            throw new DPKException("Failed to encrypt DPK", e);
+            throw new DPKException("Failed to encrypt DPK.  Cause: " + e.getLocalizedMessage(), e);
         } catch (InvalidKeySpecException e) {
-            throw new DPKException("Failed to encrypt DPK", e);
+            throw new DPKException("Failed to encrypt DPK.  Cause: " + e.getLocalizedMessage(), e);
         }
         return dpk;
     }

--- a/sync-android/src/main/java/com/cloudant/sync/datastore/encryption/KeyStorage.java
+++ b/sync-android/src/main/java/com/cloudant/sync/datastore/encryption/KeyStorage.java
@@ -1,0 +1,172 @@
+/**
+ * Copyright (c) 2015 IBM Cloudant, Inc. All rights reserved.
+ * <p/>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.datastore.encryption;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import org.apache.commons.codec.DecoderException;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Use this class to store a {@link KeyData} instance in the {@link SharedPreferences} associated
+ * to an
+ * identifier. To say in another way, it is possible to store multiple {@link KeyData}
+ * instances as long as you use a {@link KeyStorage} with a different identifier for each
+ * one.
+ *
+ * Each {@link KeyData} is bound to a specific identifier and all of them are grouped in
+ * the keychain by service (service name defined with CDTENCRYPTION_KEYCHAINSTORAGE_SERVICE_VALUE).
+ * This means that if you use the same identifier to store other data in the {@link
+ * SharedPreferences} it will not
+ * conflict with these values.
+ *
+ * @see KeyData
+ */
+class KeyStorage {
+    private static final Logger LOGGER = Logger.getLogger(KeyStorage.class.getCanonicalName());
+    private static final String CDTENCRYPTION_KEYCHAINSTORAGE_SERVICE_VALUE =
+            "com.cloudant.sync.CDTEncryptionKeychainStorage.keychain.service";
+
+    private static final String PREF_NAME_DPK = "dpk"; //$NON-NLS-1$
+
+    private static final String KEY_DPK = "dpk"; //$NON-NLS-1$
+    private static final String KEY_ITERATIONS = "iterations"; //$NON-NLS-1$
+    private static final String KEY_IV = "iv"; //$NON-NLS-1$
+    private static final String KEY_SALT = "salt"; //$NON-NLS-1$
+    private static final String KEY_VERSION = "version"; //$NON-NLS-1$
+    private final String preferenceKey;
+
+    private String service;
+    private String account;
+    private SharedPreferences prefs;
+
+    /**
+     * Create a storage with an identifier. A {@link KeyData} saved to the {@link
+     * SharedPreferences} using this storage will be bound to the identifier specified here.
+     *
+     * @param context    The applications {@link Context}
+     * @param identifier A string
+     */
+    public KeyStorage(Context context, String identifier) {
+        if (identifier != null && context != null && !identifier.equals("")) {
+            this.service = CDTENCRYPTION_KEYCHAINSTORAGE_SERVICE_VALUE;
+            this.account = identifier;
+            this.prefs = context.getSharedPreferences(this.service, Context.MODE_PRIVATE);
+            this.preferenceKey = PREF_NAME_DPK + "-" + this.account;
+        } else {
+            throw new IllegalArgumentException("All parameters are required");
+        }
+    }
+
+    /**
+     * A {@link KeyData} previously saved with this storage (or other storage created before
+     * with the same identifier).
+     *
+     * @return A {@link KeyData} saved before or null
+     */
+    public KeyData getEncryptionKeyData() {
+        KeyData encryptionData = null;
+
+        String savedValue = this.prefs.getString(preferenceKey, null);
+        if (savedValue != null) {
+            JSONObject savedObject = null;
+            try {
+                savedObject = new JSONObject(savedValue);
+                encryptionData = new KeyData(DPKEncryptionUtil.hexStringToByteArray(savedObject
+                        .getString(KEY_DPK)), DPKEncryptionUtil.hexStringToByteArray
+                        (savedObject.getString(KEY_SALT)), DPKEncryptionUtil
+                        .hexStringToByteArray(savedObject.getString(KEY_IV)), savedObject.getInt
+                        (KEY_ITERATIONS), savedObject.getString(KEY_VERSION));
+            } catch (JSONException e) {
+                LOGGER.log(Level.SEVERE, e.getLocalizedMessage(), e);
+                return null;
+            } catch (DecoderException e) {
+                LOGGER.log(Level.SEVERE, e.getLocalizedMessage(), e);
+                return null;
+            }
+        }
+        return encryptionData;
+    }
+
+    /**
+     * Save to the {@link SharedPreferences} a {@link KeyData}.
+     * <p/>
+     * Notice that if there is already data in the {@link SharedPreferences} bound to the same
+     * identifier used to create
+     * this storage, the operation will fail.
+     *
+     * @param data {@link KeyData} to save to the {@link SharedPreferences}
+     * @return true (success) or false (fail)
+     */
+    public boolean saveEncryptionKeyData(KeyData data) {
+        JSONObject objectToSave = new JSONObject();
+        try {
+            objectToSave.put(KEY_DPK, DPKEncryptionUtil.byteArrayToHexString(data
+                    .getEncryptedDPK()));
+            objectToSave.put(KEY_IV, DPKEncryptionUtil.byteArrayToHexString(data.getIv()));
+            objectToSave.put(KEY_SALT, DPKEncryptionUtil.byteArrayToHexString(data.getSalt()));
+            objectToSave.put(KEY_ITERATIONS, data.iterations);
+            objectToSave.put(KEY_VERSION, data.version);
+
+            String valueToSave = objectToSave.toString();
+
+            SharedPreferences.Editor editor = this.prefs.edit();
+            editor.putString(preferenceKey, valueToSave);
+            editor.commit();
+
+        } catch (JSONException e) {
+            LOGGER.log(Level.SEVERE, e.getLocalizedMessage(), e);
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Remove from the {@link SharedPreferences} a {@link KeyData} associated to the same
+     * identifier used to
+     * create this storage.
+     * <p/>
+     * It will succeed if the data is deleted or if there is no data at all.
+     *
+     * @return true (success) or false (fail)
+     */
+    public boolean clearEncryptionKeyData() {
+        try {
+            SharedPreferences.Editor editor = this.prefs.edit();
+            editor.remove(preferenceKey);
+            editor.commit();
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, e.getLocalizedMessage(), e);
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Look for data saved in the {@link SharedPreferences} with the same identifier used to
+     * create this storage instance.
+     *
+     * @return true (data found) or false (data not found)
+     */
+    public boolean encryptionKeyDataExists() {
+        return this.prefs.contains(preferenceKey);
+    }
+}

--- a/sync-android/src/test/java/com/cloudant/sync/datastore/encryption/AndroidKeyProviderTests.java
+++ b/sync-android/src/test/java/com/cloudant/sync/datastore/encryption/AndroidKeyProviderTests.java
@@ -1,0 +1,125 @@
+package com.cloudant.sync.datastore.encryption;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class AndroidKeyProviderTests {
+
+    @Test
+    public void testCreateProviderWithIdentifier() {
+        AndroidKeyProvider provider = new AndroidKeyProvider(ProviderTestUtil.getContext(),
+                ProviderTestUtil.password, ProviderTestUtil.getUniqueIdentifier());
+
+        // This will cause the provider to generate a key.  The key will be encrypted and persisted.
+        EncryptionKey createdKey = provider.getEncryptionKey();
+        assertNotNull("EncryptionKey was not created", createdKey);
+
+        // This will cause the provider to decrypt and load a key that was persisted.
+        EncryptionKey loadedKey = provider.getEncryptionKey();
+        assertNotNull("EncryptionKey was not loaded", loadedKey);
+
+        // Compare the decrypted persisted key to the original generated key.
+        assertTrue("loadedKey did not match createdKey", Arrays.equals(createdKey.getKey(),
+                loadedKey.getKey()));
+
+        provider.getManager().clearKey();
+    }
+
+    @Test
+    public void testCreateTwoProvidersWithSameIdentifier() {
+        String identifier = ProviderTestUtil.getUniqueIdentifier();
+        AndroidKeyProvider provider1 = new AndroidKeyProvider(ProviderTestUtil.getContext(),
+                ProviderTestUtil.password, identifier);
+        AndroidKeyProvider provider2 = new AndroidKeyProvider(ProviderTestUtil.getContext(),
+                ProviderTestUtil.password, identifier);
+
+        EncryptionKey provider1Key = provider1.getEncryptionKey();
+        assertNotNull("provider1 EncryptionKey was not created", provider1Key);
+
+        EncryptionKey provider2Key = provider2.getEncryptionKey();
+        assertNotNull("provider2 EncryptionKey was not created", provider2Key);
+
+        assertTrue("provider1 key and provider2 key should be equal", Arrays.equals(provider1Key
+                .getKey(), provider2Key.getKey()));
+
+        provider1.getManager().clearKey();
+        provider2.getManager().clearKey();
+    }
+
+    @Test
+    public void testCreateTwoProvidersWithDifferentIdentifier() {
+        AndroidKeyProvider provider1 = new AndroidKeyProvider(ProviderTestUtil.getContext(),
+                ProviderTestUtil.password, ProviderTestUtil.getUniqueIdentifier());
+        AndroidKeyProvider provider2 = new AndroidKeyProvider(ProviderTestUtil.getContext(),
+                ProviderTestUtil.password, ProviderTestUtil.getUniqueIdentifier());
+
+        EncryptionKey provider1Key = provider1.getEncryptionKey();
+        assertNotNull("provider1 EncryptionKey was not created", provider1Key);
+
+        EncryptionKey provider2Key = provider2.getEncryptionKey();
+        assertNotNull("provider2 EncryptionKey was not created", provider2Key);
+
+        assertFalse("provider1 key and provider2 key should not be equal", Arrays.equals
+                (provider1Key.getKey(), provider2Key.getKey()));
+
+        provider1.getManager().clearKey();
+        provider2.getManager().clearKey();
+    }
+
+    // Negative tests
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreateProviderWithNullContext() {
+        new AndroidKeyProvider(null, ProviderTestUtil.password, ProviderTestUtil
+                .getUniqueIdentifier());
+        fail("AndroidKeyProvider constructor should fail if context is null");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreateProviderWithNullPassword() {
+        new AndroidKeyProvider(ProviderTestUtil.getContext(), null, ProviderTestUtil
+                .getUniqueIdentifier());
+        fail("AndroidKeyProvider constructor should fail if password is null");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreateProviderWithEmptyPassword() {
+        new AndroidKeyProvider(ProviderTestUtil.getContext(), "", ProviderTestUtil.getUniqueIdentifier());
+        fail("AndroidKeyProvider constructor should fail if password is empty string");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreateProviderWithNullIdentifier() {
+        new AndroidKeyProvider(ProviderTestUtil.getContext(), ProviderTestUtil.password, null);
+        fail("AndroidKeyProvider constructor should fail if identifier is null");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreateProviderWithEmptyIdentifier() {
+        new AndroidKeyProvider(ProviderTestUtil.getContext(), ProviderTestUtil.password, "");
+        fail("AndroidKeyProvider constructor should fail if identifier is empty string");
+    }
+
+    @Test(expected = DPKException.class)
+    public void testLoadWithWrongPassword() {
+        String identifier = ProviderTestUtil.getUniqueIdentifier();
+        AndroidKeyProvider provider1 = new AndroidKeyProvider(ProviderTestUtil.getContext(),
+                ProviderTestUtil.password, identifier);
+        AndroidKeyProvider provider2 = new AndroidKeyProvider(ProviderTestUtil.getContext(),
+                "wrongpassword", identifier);
+
+        EncryptionKey provider1Key = provider1.getEncryptionKey();
+        assertNotNull("provider1 EncryptionKey was not created", provider1Key);
+
+        provider2.getEncryptionKey();
+        fail("AndroidKeyProvider getEncryptionKey should fail if password is not correct");
+
+        provider1.getManager().clearKey();
+        provider2.getManager().clearKey();
+    }
+}

--- a/sync-android/src/test/java/com/cloudant/sync/datastore/encryption/AndroidKeyProviderTests.java
+++ b/sync-android/src/test/java/com/cloudant/sync/datastore/encryption/AndroidKeyProviderTests.java
@@ -1,5 +1,6 @@
 package com.cloudant.sync.datastore.encryption;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -8,8 +9,13 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeNotNull;
 
 public class AndroidKeyProviderTests {
+    @Before
+    public void beforeMethod(){
+        assumeNotNull(ProviderTestUtil.getContext());
+    }
 
     @Test
     public void testCreateProviderWithIdentifier() {

--- a/sync-android/src/test/java/com/cloudant/sync/datastore/encryption/KeyDataTests.java
+++ b/sync-android/src/test/java/com/cloudant/sync/datastore/encryption/KeyDataTests.java
@@ -1,0 +1,101 @@
+package com.cloudant.sync.datastore.encryption;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+
+public class KeyDataTests {
+
+    private KeyData original;
+
+    @Before
+    public void setUp() {
+        original = ProviderTestUtil.createKeyData();
+    }
+
+    @Test
+    public void testConstructorGreenPath() {
+        KeyData newData = new KeyData(original.getEncryptedDPK(), original.getSalt(), original
+                .getIv(), original.iterations, original.version);
+
+        assertTrue("newData encryptedDPK didn't match original", Arrays.equals(original
+                .getEncryptedDPK(), newData.getEncryptedDPK()));
+        assertTrue("newData iv didn't match original", Arrays.equals(original
+                .getIv(), newData.getIv()));
+        assertTrue("newData salt didn't match original", Arrays.equals(original
+                .getSalt(), newData.getSalt()));
+        assertTrue("newData iterations didn't match original", original.iterations == newData
+                .iterations);
+        assertTrue("newData versions didn't match original", original.version.equals(newData
+                .version));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructorNullDPK() {
+        new KeyData(null, original.getSalt(), original.getIv(), original
+                .iterations, original.version);
+        fail("KeyData constructor should throw IllegalArgumentException if DPK is null");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructorEmptyDPK() {
+        new KeyData(new byte[0], original.getSalt(), original.getIv(),
+                original.iterations, original.version);
+        fail("KeyData constructor should throw IllegalArgumentException if DPK is empty");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructorNullSalt() {
+        new KeyData(original.getEncryptedDPK(), null, original.getIv(),
+                original.iterations, original.version);
+        fail("KeyData constructor should throw IllegalArgumentException if Salt is null");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructorEmptySalt() {
+        new KeyData(original.getEncryptedDPK(), new byte[0], original.getIv(),
+                original.iterations, original.version);
+        fail("KeyData constructor should throw IllegalArgumentException if Salt is empty");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructorNullIV() {
+        new KeyData(original.getEncryptedDPK(), original.getSalt(), null,
+                original.iterations, original.version);
+        fail("KeyData constructor should throw IllegalArgumentException if iv is null");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructorEmptyIV() {
+        new KeyData(original.getEncryptedDPK(), original.getSalt(), null,
+                original.iterations, original.version);
+        fail("KeyData constructor should throw IllegalArgumentException if iv is empty");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructorNegativeIterations() {
+        new KeyData(original.getEncryptedDPK(), original.getSalt(), original.getIv(),
+                -1, original.version);
+        fail("KeyData constructor should throw IllegalArgumentException if iterations is " +
+                "negative");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructorNullVersion() {
+        new KeyData(original.getEncryptedDPK(), original.getSalt(), original.getIv(),
+                original.iterations, null);
+        fail("KeyData constructor should throw IllegalArgumentException if version is null");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructorEmptyVersion() {
+        new KeyData(original.getEncryptedDPK(), original.getSalt(), original.getIv(),
+                original.iterations, "");
+        fail("KeyData constructor should throw IllegalArgumentException if version is null");
+    }
+}

--- a/sync-android/src/test/java/com/cloudant/sync/datastore/encryption/KeyManagerTests.java
+++ b/sync-android/src/test/java/com/cloudant/sync/datastore/encryption/KeyManagerTests.java
@@ -1,0 +1,155 @@
+package com.cloudant.sync.datastore.encryption;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class KeyManagerTests {
+    private KeyManager manager;
+    private KeyStorage storage;
+
+    @Before
+    protected void setUp() throws Exception {
+        storage = new KeyStorage(ProviderTestUtil.getContext(), ProviderTestUtil.getUniqueIdentifier());
+        manager = new KeyManager(storage);
+    }
+
+    @After
+    protected void tearDown() throws Exception {
+        manager.clearKey();
+    }
+
+    @Test
+    public void testGenerateDPK() {
+        EncryptionKey dpk = manager.generateAndSaveKeyProtectedByPassword(ProviderTestUtil
+                .password);
+        assertNotNull("DPK should not be null", dpk);
+        assertNotNull("byte[] of DPK should not be null", dpk.getKey());
+    }
+
+    @Test
+    public void testLoadDPK() {
+        EncryptionKey dpk = manager.generateAndSaveKeyProtectedByPassword(ProviderTestUtil
+                .password);
+        assertNotNull("DPK should not be null", dpk);
+        assertNotNull("byte[] of DPK should not be null", dpk.getKey());
+
+        EncryptionKey storedDPK = manager.loadKeyUsingPassword(ProviderTestUtil.password);
+        assertNotNull("DPK should not be null", storedDPK);
+        assertNotNull("byte[] of DPK should not be null", storedDPK.getKey());
+
+        assertTrue(Arrays.equals(dpk.getKey(), storedDPK.getKey()));
+    }
+
+    @Test
+    public void testLoadBeforeGenerateDPK() {
+        EncryptionKey storedDPK = manager.loadKeyUsingPassword(ProviderTestUtil.password);
+        assertNull("DPK should not be null", storedDPK);
+    }
+
+    @Test
+    public void testDPKExists() {
+        EncryptionKey dpk = manager.generateAndSaveKeyProtectedByPassword(ProviderTestUtil
+                .password);
+        assertNotNull("DPK should not be null", dpk);
+        assertNotNull("byte[] of DPK should not be null", dpk.getKey());
+
+        boolean keyExists = manager.keyExists();
+        assertTrue("DPK should exist but does not exist", keyExists);
+    }
+
+    @Test
+    public void testDPKClear() {
+        EncryptionKey dpk = manager.generateAndSaveKeyProtectedByPassword(ProviderTestUtil
+                .password);
+        assertNotNull("DPK should not be null", dpk);
+        assertNotNull("byte[] of DPK should not be null", dpk.getKey());
+
+        boolean keyExists = manager.keyExists();
+        assertTrue("DPK should exist but does not exist", keyExists);
+
+        EncryptionKey storedDPK = manager.loadKeyUsingPassword(ProviderTestUtil.password);
+        assertNotNull("DPK should not be null", storedDPK);
+        assertNotNull("byte[] of DPK should not be null", storedDPK.getKey());
+
+        boolean clearSuccess = manager.clearKey();
+        assertTrue("clear key failed", clearSuccess);
+
+        storedDPK = manager.loadKeyUsingPassword(ProviderTestUtil.password);
+        assertNull("DPK should be null", storedDPK);
+
+        keyExists = manager.keyExists();
+        assertFalse("DPK should not exist but does not exist", keyExists);
+    }
+
+    @Test
+    public void testDPKRecreateAfterClear() {
+        EncryptionKey dpk = manager.generateAndSaveKeyProtectedByPassword(ProviderTestUtil
+                .password);
+        assertNotNull("DPK should not be null", dpk);
+        assertNotNull("byte[] of DPK should not be null", dpk.getKey());
+
+        boolean keyExists = manager.keyExists();
+        assertTrue("DPK should exist but does not exist", keyExists);
+
+        boolean clearSuccess = manager.clearKey();
+        assertTrue("clear key failed", clearSuccess);
+
+        keyExists = manager.keyExists();
+        assertFalse("DPK should not exist but does not exist", keyExists);
+
+        EncryptionKey newDPK = manager.generateAndSaveKeyProtectedByPassword(ProviderTestUtil
+                .password);
+        assertNotNull("DPK should not be null", newDPK);
+        assertNotNull("byte[] of DPK should not be null", newDPK.getKey());
+
+        assertFalse("newKey should not be the same as the original deleted key", Arrays.equals
+                (dpk.getKey(), newDPK.getKey()));
+    }
+
+    // Negative tests
+    @Test(expected = IllegalArgumentException.class)
+    public void testGenerateDPKWithNullPassword() {
+        manager.generateAndSaveKeyProtectedByPassword(null);
+        fail("KeyManager generateAndSaveKeyProtectedByPassword should fail if password is " +
+                "null");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGenerateDPKWithEmptyPassword() {
+        manager.generateAndSaveKeyProtectedByPassword("");
+        fail("KeyManager generateAndSaveKeyProtectedByPassword should fail if password is " +
+                "empty string");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testLoadDPKWithNullPassword() {
+        manager.loadKeyUsingPassword(null);
+        fail("KeyManager loadKeyUsingPassword should fail if password is null");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testLoadDPKWithEmptyPassword() {
+        manager.loadKeyUsingPassword("");
+        fail("KeyManager loadKeyUsingPassword should fail if password is empty string");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testLoadWithWrongPassword() {
+        EncryptionKey dpk = manager.generateAndSaveKeyProtectedByPassword(ProviderTestUtil
+                .password);
+        assertNotNull("DPK should not be null", dpk);
+        assertNotNull("byte[] of DPK should not be null", dpk.getKey());
+
+        manager.loadKeyUsingPassword("wrongpass");
+        fail("KeyManager loadKeyUsingPassword should fail if password is not correct");
+    }
+}

--- a/sync-android/src/test/java/com/cloudant/sync/datastore/encryption/KeyManagerTests.java
+++ b/sync-android/src/test/java/com/cloudant/sync/datastore/encryption/KeyManagerTests.java
@@ -11,20 +11,23 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeNotNull;
 
 public class KeyManagerTests {
     private KeyManager manager;
     private KeyStorage storage;
 
     @Before
-    protected void setUp() throws Exception {
+    public void beforeMethod() {
+        assumeNotNull(ProviderTestUtil.getContext());
         storage = new KeyStorage(ProviderTestUtil.getContext(), ProviderTestUtil.getUniqueIdentifier());
         manager = new KeyManager(storage);
     }
 
     @After
-    protected void tearDown() throws Exception {
-        manager.clearKey();
+    public void afterMethod() throws Exception {
+        if(manager != null)
+            manager.clearKey();
     }
 
     @Test
@@ -142,7 +145,7 @@ public class KeyManagerTests {
         fail("KeyManager loadKeyUsingPassword should fail if password is empty string");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = DPKException.class)
     public void testLoadWithWrongPassword() {
         EncryptionKey dpk = manager.generateAndSaveKeyProtectedByPassword(ProviderTestUtil
                 .password);

--- a/sync-android/src/test/java/com/cloudant/sync/datastore/encryption/KeyStorageTests.java
+++ b/sync-android/src/test/java/com/cloudant/sync/datastore/encryption/KeyStorageTests.java
@@ -1,0 +1,104 @@
+package com.cloudant.sync.datastore.encryption;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class KeyStorageTests {
+
+    // Green Path Tests
+    @Test
+    public void testKeyDataSaveAndRetrieve() {
+        KeyStorage storage = new KeyStorage(ProviderTestUtil.getContext(), ProviderTestUtil
+                .getUniqueIdentifier());
+        KeyData original = ProviderTestUtil.createKeyData();
+
+        boolean saveSuccess = storage.saveEncryptionKeyData(original);
+        assertTrue("saveEncryptionKeyData failed", saveSuccess);
+
+        KeyData savedData = storage.getEncryptionKeyData();
+
+        assertTrue("saved KeyData should be equal to original", keyDataEquals(original, savedData));
+
+        storage.clearEncryptionKeyData();
+    }
+
+    @Test
+    public void testKeyDataExists() {
+        KeyStorage storage = new KeyStorage(ProviderTestUtil.getContext(), ProviderTestUtil
+                .getUniqueIdentifier());
+        KeyData original = ProviderTestUtil.createKeyData();
+
+        boolean keyDataExists = storage.encryptionKeyDataExists();
+        assertFalse("KeyData should not exist", keyDataExists);
+
+        boolean saveSuccess = storage.saveEncryptionKeyData(original);
+        assertTrue("saveEncryptionKeyData failed", saveSuccess);
+
+        keyDataExists = storage.encryptionKeyDataExists();
+        assertTrue("KeyData should exist", keyDataExists);
+
+        storage.clearEncryptionKeyData();
+    }
+
+    @Test
+    public void testKeyDataClear() {
+        KeyStorage storage = new KeyStorage(ProviderTestUtil.getContext(), ProviderTestUtil
+                .getUniqueIdentifier());
+        KeyData original = ProviderTestUtil.createKeyData();
+
+        boolean saveSuccess = storage.saveEncryptionKeyData(original);
+        assertTrue("saveEncryptionKeyData failed", saveSuccess);
+
+        boolean keyDataExists = storage.encryptionKeyDataExists();
+        assertTrue("KeyData should exist", keyDataExists);
+
+        boolean dataCleared = storage.clearEncryptionKeyData();
+        assertTrue("KeyData should not exist", dataCleared);
+
+        KeyData savedKeyData = storage.getEncryptionKeyData();
+        assertNull("KeyData should not exist", savedKeyData);
+
+        keyDataExists = storage.encryptionKeyDataExists();
+        assertFalse("KeyData should exist", keyDataExists);
+
+        storage.clearEncryptionKeyData();
+    }
+
+    // Negative Tests
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructorNullContext() {
+        new KeyStorage(null, ProviderTestUtil.getUniqueIdentifier());
+        fail("KeyStorage constructor should fail if Context is null");
+
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructorNullIdentifier() {
+        new KeyStorage(ProviderTestUtil.getContext(), null);
+        fail("KeyStorage constructor should fail if identifer is null");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructorEmptyStringIdentifier() {
+        new KeyStorage(ProviderTestUtil.getContext(), "");
+        fail("KeyStorage constructor should fail if identifer is empty string");
+    }
+
+    // Helper methods
+    private boolean keyDataEquals(KeyData data1, KeyData data2) {
+        if (data1 == null || data2 == null) {
+            return false;
+        }
+        return Arrays.equals(data1.getEncryptedDPK(), data2.getEncryptedDPK()) && Arrays.equals
+                (data1.getSalt(), data2.getSalt()) && Arrays.equals(data1.getIv(),
+                data2.getIv()) && data1.iterations == data2.iterations && data1
+                .version.equals(data2.version);
+    }
+
+}

--- a/sync-android/src/test/java/com/cloudant/sync/datastore/encryption/KeyStorageTests.java
+++ b/sync-android/src/test/java/com/cloudant/sync/datastore/encryption/KeyStorageTests.java
@@ -1,5 +1,6 @@
 package com.cloudant.sync.datastore.encryption;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -8,8 +9,14 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeNotNull;
 
 public class KeyStorageTests {
+
+    @Before
+    public void beforeMethod(){
+        assumeNotNull(ProviderTestUtil.getContext());
+    }
 
     // Green Path Tests
     @Test

--- a/sync-android/src/test/java/com/cloudant/sync/datastore/encryption/ProviderTestUtil.java
+++ b/sync-android/src/test/java/com/cloudant/sync/datastore/encryption/ProviderTestUtil.java
@@ -1,0 +1,59 @@
+package com.cloudant.sync.datastore.encryption;
+
+import android.content.Context;
+
+import com.cloudant.sync.util.Misc;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.security.SecureRandom;
+import java.util.Random;
+import java.util.UUID;
+
+public class ProviderTestUtil {
+    public static final String password = "provider1password";
+    private static Context context = null;
+
+    public static String getUniqueIdentifier() {
+        return "test-id-" + UUID.randomUUID();
+    }
+
+    public static KeyData createKeyData() {
+        byte[] encryptedDPK = new byte[KeyManager.ENCRYPTION_KEYCHAIN_AES_KEY_SIZE];
+        byte[] salt = new byte[KeyManager.ENCRYPTION_KEYCHAIN_PBKDF2_SALT_SIZE];
+        byte[] iv = new byte[KeyManager.ENCRYPTIONKEYCHAINMANAGER_AES_IV_SIZE];
+        int iterations = new Random().nextInt(100000);
+        String version = "1." + System.currentTimeMillis();
+
+        SecureRandom secureRandom = new SecureRandom();
+        secureRandom.nextBytes(encryptedDPK);
+        secureRandom.nextBytes(salt);
+        secureRandom.nextBytes(iv);
+
+        return new KeyData(encryptedDPK, salt, iv, iterations, version);
+    }
+
+    public static synchronized Context getContext(){
+        if(context == null) {
+            if (Misc.isRunningOnAndroid()) {
+                try {
+                    Class<?> androidTestUtilClazz = Class.forName("cloudant.com.androidtest.AndroidTestUtil");
+                    if (androidTestUtilClazz != null) {
+                        Field contextField = androidTestUtilClazz.getField("context");
+                        if (contextField != null) {
+                            Object contextObj = contextField.get(null);
+                            if (contextObj instanceof Context)
+                                context = (Context) contextObj;
+                        }
+
+                    }
+
+                } catch (Exception e) {
+                    // do nothing
+                    context = null;
+                }
+            }
+        }
+        return context;
+    }
+}

--- a/sync-android/src/test/java/com/cloudant/sync/datastore/encryption/ProviderTestUtil.java
+++ b/sync-android/src/test/java/com/cloudant/sync/datastore/encryption/ProviderTestUtil.java
@@ -5,7 +5,6 @@ import android.content.Context;
 import com.cloudant.sync.util.Misc;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.security.SecureRandom;
 import java.util.Random;
 import java.util.UUID;

--- a/sync-android/src/test/java/com/cloudant/sync/datastore/encryption/ProviderTestUtil.java
+++ b/sync-android/src/test/java/com/cloudant/sync/datastore/encryption/ProviderTestUtil.java
@@ -4,7 +4,8 @@ import android.content.Context;
 
 import com.cloudant.sync.util.Misc;
 
-import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.security.SecureRandom;
 import java.util.Random;
 import java.util.UUID;
@@ -33,26 +34,24 @@ public class ProviderTestUtil {
     }
 
     public static synchronized Context getContext(){
-        if(context == null) {
             if (Misc.isRunningOnAndroid()) {
+
                 try {
-                    Class<?> androidTestUtilClazz = Class.forName("cloudant.com.androidtest.AndroidTestUtil");
-                    if (androidTestUtilClazz != null) {
-                        Field contextField = androidTestUtilClazz.getField("context");
-                        if (contextField != null) {
-                            Object contextObj = contextField.get(null);
-                            if (contextObj instanceof Context)
-                                context = (Context) contextObj;
-                        }
+                    Class klass = Class.forName("android.support.test.InstrumentationRegistry");
+                    Method method = klass.getMethod("getTargetContext");
+                    return (Context) method.invoke(null);
+                } catch (ClassNotFoundException e){
 
-                    }
+                } catch (NoSuchMethodException e){
 
-                } catch (Exception e) {
-                    // do nothing
-                    context = null;
+                } catch (InvocationTargetException e) {
+                    e.printStackTrace();
+                } catch (IllegalAccessException e) {
+                    e.printStackTrace();
                 }
+
+
             }
-        }
         return context;
     }
 }

--- a/sync-core/src/test/java/com/cloudant/sync/datastore/DatastoreTestBase.java
+++ b/sync-core/src/test/java/com/cloudant/sync/datastore/DatastoreTestBase.java
@@ -14,7 +14,6 @@
 
 package com.cloudant.sync.datastore;
 
-import com.cloudant.sync.datastore.encryption.HelperSimpleKeyProvider;
 import com.cloudant.sync.util.TestUtils;
 
 import org.junit.After;
@@ -34,13 +33,8 @@ public abstract class DatastoreTestBase {
     public void setUp() throws Exception {
         datastore_manager_dir = TestUtils.createTempTestingDir(this.getClass().getName());
         datastoreManager = new DatastoreManager(this.datastore_manager_dir);
+        this.datastore = (BasicDatastore) (this.datastoreManager.openDatastore(getClass().getSimpleName()));
 
-        //Open SQLCipher-based datastore if SQLCipher parameter is 'true'
-        if(Boolean.valueOf(System.getProperty("test.sqlcipher.passphrase"))) {
-            this.datastore = (BasicDatastore) (this.datastoreManager.openDatastore(getClass().getSimpleName(), new HelperSimpleKeyProvider()));
-        } else {
-            this.datastore = (BasicDatastore) (this.datastoreManager.openDatastore(getClass().getSimpleName()));
-        }
     }
 
     @After


### PR DESCRIPTION
See https://github.com/cloudant/sync-android/pull/146.

This is a version of the above, rebased onto feature-encryption.

It also removes use of the `test.sqlcipher.passphrase` variable, which means we don't test encryption after this PR (planning to bring back specific testing on branch https://github.com/cloudant/sync-android/tree/47619-endtoend-encryption).