### PR TITLE
Add EndToEndEncryptionTest to test files encrypted on disk

### DIFF
--- a/sync-android/src/test/java/com/cloudant/sync/datastore/encryption/EndToEndEncryptionTest.java
+++ b/sync-android/src/test/java/com/cloudant/sync/datastore/encryption/EndToEndEncryptionTest.java
@@ -186,7 +186,7 @@ public class EndToEndEncryptionTest {
             byte[] actualContent = new byte[expectedFirstAttachmentByte.length];
             int readLength = in.read(actualContent);
             assertEquals("Didn't read full buffer", actualContent.length, readLength);
-            assertArrayEquals("First byte not version byte", actualContent, expectedFirstAttachmentByte);
+            assertArrayEquals("First byte not version byte", expectedFirstAttachmentByte, actualContent);
 
         } else {
             assertTrue(IOUtils.contentEquals(new FileInputStream(expectedPlainText), in));

--- a/sync-android/src/test/java/com/cloudant/sync/datastore/encryption/EndToEndEncryptionTest.java
+++ b/sync-android/src/test/java/com/cloudant/sync/datastore/encryption/EndToEndEncryptionTest.java
@@ -72,7 +72,7 @@ public class EndToEndEncryptionTest {
     @Parameterized.Parameter
     public boolean dataShouldBeEncrypted;
 
-    String datastore_manager_dir;
+    String datastoreManagerDir;
     DatastoreManager datastoreManager;
     Datastore datastore = null;
 
@@ -82,8 +82,8 @@ public class EndToEndEncryptionTest {
 
     @Before
     public void setUp() throws DatastoreNotCreatedException {
-        datastore_manager_dir = TestUtils.createTempTestingDir(this.getClass().getName());
-        datastoreManager = new DatastoreManager(this.datastore_manager_dir);
+        datastoreManagerDir = TestUtils.createTempTestingDir(this.getClass().getName());
+        datastoreManager = new DatastoreManager(this.datastoreManagerDir);
 
         if(dataShouldBeEncrypted) {
             this.datastore = this.datastoreManager.openDatastore(getClass().getSimpleName(),
@@ -97,12 +97,12 @@ public class EndToEndEncryptionTest {
 
     @After
     public void tearDown() {
-        TestUtils.deleteTempTestingDir(datastore_manager_dir);
+        TestUtils.deleteTempTestingDir(datastoreManagerDir);
     }
 
     @Test
     public void jsonDataEncrypted() throws IOException {
-        File jsonDatabase = new File(datastore_manager_dir
+        File jsonDatabase = new File(datastoreManagerDir
                 + File.separator + "EndToEndEncryptionTest"
                 + File.separator + "db.sync");
 
@@ -135,7 +135,7 @@ public class EndToEndEncryptionTest {
         IndexManager im = new IndexManager(this.datastore);
         im.ensureIndexed(Arrays.<Object>asList("name", "age"));
 
-        File jsonDatabase = new File(datastore_manager_dir
+        File jsonDatabase = new File(datastoreManagerDir
                 + File.separator + "EndToEndEncryptionTest"
                 + File.separator + "extensions"
                 + File.separator + "com.cloudant.sync.query"
@@ -171,7 +171,7 @@ public class EndToEndEncryptionTest {
 
         datastore.createDocumentFromRevision(rev);
 
-        File attachmentsFolder = new File(datastore_manager_dir
+        File attachmentsFolder = new File(datastoreManagerDir
                 + File.separator + "EndToEndEncryptionTest"
                 + File.separator + "extensions"
                 + File.separator + "com.cloudant.attachments");

--- a/sync-android/src/test/java/com/cloudant/sync/datastore/encryption/EndToEndEncryptionTest.java
+++ b/sync-android/src/test/java/com/cloudant/sync/datastore/encryption/EndToEndEncryptionTest.java
@@ -15,7 +15,6 @@
 package com.cloudant.sync.datastore.encryption;
 
 import com.cloudant.sync.datastore.Attachment;
-import com.cloudant.sync.datastore.AttachmentException;
 import com.cloudant.sync.datastore.BasicDocumentRevision;
 import com.cloudant.sync.datastore.ConflictException;
 import com.cloudant.sync.datastore.Datastore;
@@ -43,12 +42,8 @@ import org.junit.runners.Parameterized;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.StringBufferInputStream;
-import java.io.StringReader;
-import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.util.Arrays;
 import java.util.Collection;

--- a/sync-android/src/test/java/com/cloudant/sync/datastore/encryption/EndToEndEncryptionTest.java
+++ b/sync-android/src/test/java/com/cloudant/sync/datastore/encryption/EndToEndEncryptionTest.java
@@ -1,0 +1,205 @@
+/**
+ * Copyright (c) 2015 IBM Cloudant. All rights reserved.
+ * <p/>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.datastore.encryption;
+
+import com.cloudant.sync.datastore.Datastore;
+import com.cloudant.sync.datastore.DatastoreManager;
+import com.cloudant.sync.datastore.DatastoreNotCreatedException;
+import com.cloudant.sync.datastore.DocumentBodyFactory;
+import com.cloudant.sync.datastore.DocumentException;
+import com.cloudant.sync.datastore.MutableDocumentRevision;
+import com.cloudant.sync.datastore.UnsavedFileAttachment;
+import com.cloudant.sync.query.IndexManager;
+
+import net.sqlcipher.database.SQLiteDatabase;
+import org.apache.commons.codec.DecoderException;
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.io.IOUtils;
+import org.hamcrest.core.IsEqual;
+import org.hamcrest.core.IsNot;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Test that when you open a database with an encryption key, the content on disk
+ * is all encrypted.
+ */
+@RunWith(Parameterized.class)
+public class EndToEndEncryptionTest {
+
+    static {
+        // Load SQLCipher libraries
+        SQLiteDatabase.loadLibs(ProviderTestUtil.getContext());
+    }
+
+    @Parameterized.Parameters(name = "{index}: encryption={0}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {false}, {true},
+        });
+    }
+
+    @Parameterized.Parameter
+    public boolean dataShouldBeEncrypted;
+
+    String datastore_manager_dir;
+    DatastoreManager datastoreManager;
+    Datastore datastore = null;
+
+    // Magic bytes are "SQLite format 3" + null-terminator
+    byte[] sqlCipherMagicBytes = hexStringToByteArray("53514c69746520666f726d6174203300");
+    byte[] expectedFirstAttachmentByte = new byte[]{ 1 };
+
+    @Before
+    public void setUp() throws DatastoreNotCreatedException {
+        datastore_manager_dir = TestUtils.createTempTestingDir(this.getClass().getName());
+        datastoreManager = new DatastoreManager(this.datastore_manager_dir);
+
+        if(dataShouldBeEncrypted) {
+            this.datastore = this.datastoreManager.openDatastore(getClass().getSimpleName(),
+                    new SimpleKeyProvider(new byte[] { -123, 53, -22, -15, -123, 53, -22, -15, 53, -22, -15,
+                            -123, -22, -15, 53, -22, -123, 53, -22, -15, -123, 53, -22, -15, 53, -22,
+                            -15, -123, -22, -15, 53, -22 }));
+        } else {
+            this.datastore = this.datastoreManager.openDatastore(getClass().getSimpleName());
+        }
+    }
+
+    @After
+    public void tearDown() {
+        TestUtils.deleteTempTestingDir(datastore_manager_dir);
+    }
+
+    @Test
+    public void jsonDataEncrypted() throws IOException {
+        File jsonDatabase = new File(datastore_manager_dir
+                + File.separator + "EndToEndEncryptionTest"
+                + File.separator + "db.sync");
+
+        // Database creation happens in the background, so we need to call a blocking
+        // database operation to ensure the database exists on disk before we look at
+        // it.
+
+        IndexManager im = new IndexManager(this.datastore);
+        im.ensureIndexed(Arrays.<Object>asList("name", "age"));
+
+
+        InputStream in = new FileInputStream(jsonDatabase);
+        byte[] magicBytesBuffer = new byte[sqlCipherMagicBytes.length];
+        int readLength = in.read(magicBytesBuffer);
+
+        assertEquals("Didn't read full buffer", magicBytesBuffer.length, readLength);
+
+        if(dataShouldBeEncrypted) {
+            assertThat("SQLite magic bytes found in file that should be encrypted",
+                    sqlCipherMagicBytes, IsNot.not(IsEqual.equalTo(magicBytesBuffer)));
+        } else {
+            assertThat("SQLite magic bytes not found in file that should not be encrypted",
+                    sqlCipherMagicBytes, IsEqual.equalTo(magicBytesBuffer));
+        }
+    }
+
+    @Test
+    public void indexDataEncrypted() throws IOException {
+
+        IndexManager im = new IndexManager(this.datastore);
+        im.ensureIndexed(Arrays.<Object>asList("name", "age"));
+
+        File jsonDatabase = new File(datastore_manager_dir
+                + File.separator + "EndToEndEncryptionTest"
+                + File.separator + "extensions"
+                + File.separator + "com.cloudant.sync.query"
+                + File.separator + "indexes.sqlite");
+
+        InputStream in = new FileInputStream(jsonDatabase);
+        byte[] magicBytesBuffer = new byte[sqlCipherMagicBytes.length];
+        int readLength = in.read(magicBytesBuffer);
+
+        assertEquals("Didn't read full buffer", magicBytesBuffer.length, readLength);
+
+        if(dataShouldBeEncrypted) {
+            assertThat("SQLite magic bytes found in file that should be encrypted",
+                    sqlCipherMagicBytes, IsNot.not(IsEqual.equalTo(magicBytesBuffer)));
+        } else {
+            assertThat("SQLite magic bytes not found in file that should not be encrypted",
+                    sqlCipherMagicBytes, IsEqual.equalTo(magicBytesBuffer));
+        }
+    }
+
+    @Test
+    public void attachmentsDataEncrypted() throws IOException, DocumentException {
+
+        MutableDocumentRevision rev = new MutableDocumentRevision();
+        rev.body = DocumentBodyFactory.create(new HashMap<String, String>());
+
+        File expectedPlainText = TestUtils.loadFixture("fixture/EncryptedAttachmentTest_plainText");
+        assertNotNull(expectedPlainText);
+
+        UnsavedFileAttachment attachment = new UnsavedFileAttachment(
+                expectedPlainText, "text/plain");
+        rev.attachments.put("EncryptedAttachmentTest_plainText", attachment);
+
+        datastore.createDocumentFromRevision(rev);
+
+        File attachmentsFolder = new File(datastore_manager_dir
+                + File.separator + "EndToEndEncryptionTest"
+                + File.separator + "extensions"
+                + File.separator + "com.cloudant.attachments");
+
+        File[] contents = attachmentsFolder.listFiles();
+        assertNotNull("Didn't find expected attachments folder", contents);
+        assertThat("Didn't find expected file in attachments", contents.length, IsEqual.equalTo(1));
+        InputStream in = new FileInputStream(contents[0]);
+
+        if(dataShouldBeEncrypted) {
+
+            byte[] actualContent = new byte[expectedFirstAttachmentByte.length];
+            int readLength = in.read(actualContent);
+            assertEquals("Didn't read full buffer", actualContent.length, readLength);
+            assertArrayEquals("First byte not version byte", actualContent, expectedFirstAttachmentByte);
+
+        } else {
+            assertTrue(IOUtils.contentEquals(new FileInputStream(expectedPlainText), in));
+        }
+    }
+
+    public static byte[] hexStringToByteArray(String s) {
+        try {
+            return Hex.decodeHex(s.toCharArray());
+        } catch (DecoderException ex) {
+            // Crash the tests at this point, we've input bad data in our hard-coded values
+            throw new RuntimeException("Error decoding hex data: " + s);
+        }
+    }
+
+}

--- a/sync-android/src/test/java/com/cloudant/sync/datastore/encryption/EndToEndEncryptionTest.java
+++ b/sync-android/src/test/java/com/cloudant/sync/datastore/encryption/EndToEndEncryptionTest.java
@@ -74,7 +74,7 @@ public class EndToEndEncryptionTest {
 
     String datastoreManagerDir;
     DatastoreManager datastoreManager;
-    Datastore datastore = null;
+    Datastore datastore;
 
     // Magic bytes are "SQLite format 3" + null-terminator
     byte[] sqlCipherMagicBytes = hexStringToByteArray("53514c69746520666f726d6174203300");

--- a/sync-android/src/test/java/com/cloudant/sync/datastore/encryption/TestUtils.java
+++ b/sync-android/src/test/java/com/cloudant/sync/datastore/encryption/TestUtils.java
@@ -1,0 +1,178 @@
+/**
+ * Copyright (c) 2013 Cloudant, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.datastore.encryption;
+
+import com.cloudant.sync.datastore.DatastoreExtended;
+import com.cloudant.sync.datastore.DocumentBody;
+import com.cloudant.sync.datastore.DocumentBodyFactory;
+import com.cloudant.sync.datastore.encryption.NullKeyProvider;
+import com.cloudant.sync.sqlite.SQLDatabase;
+import com.cloudant.sync.sqlite.SQLDatabaseFactory;
+
+import com.cloudant.sync.util.Misc;
+import org.apache.commons.io.FileUtils;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.sql.SQLData;
+import java.sql.SQLException;
+import java.util.UUID;
+
+public class TestUtils {
+
+    private final static String DATABASE_FILE_EXT = ".sqlite4java";
+
+    public static DocumentBody createBDBody(String filePath) throws IOException {
+        byte[] data = FileUtils.readFileToByteArray(TestUtils.loadFixture(filePath));
+        return DocumentBodyFactory.create(data);
+
+    }
+
+    public static SQLDatabase createEmptyDatabase(String database_dir, String database_file) throws IOException, SQLException {
+        File dbFile = new File(database_dir + File.separator + database_file + DATABASE_FILE_EXT);
+        FileUtils.touch(dbFile);
+        SQLDatabase database = SQLDatabaseFactory.openSqlDatabase(dbFile.getAbsolutePath(),
+                new NullKeyProvider());
+        return database;
+    }
+
+    public static void deleteDatabaseQuietly(SQLDatabase database) {
+        try {
+            if (database != null) {
+                FileUtils.deleteQuietly(new File(database.filename));
+            }
+        } catch (Exception e) {
+        }
+    }
+
+    public static String createTempTestingDir(String dirPrefix) {
+        String tempPath = String.format(
+                "%s_%s",
+                dirPrefix,
+                UUID.randomUUID().toString()
+        );
+        File f = new File(
+                FileUtils.getTempDirectory().getAbsolutePath(),
+                tempPath);
+        f.mkdirs();
+        return f.getAbsolutePath();
+    }
+
+    public static void deleteTempTestingDir(String path) {
+        FileUtils.deleteQuietly(new File(path));
+    }
+
+    public static String createTempFile(String dir, String file) throws IOException {
+        File f = new File(dir + File.separator + file);
+        FileUtils.touch(f);
+        return f.getAbsolutePath();
+    }
+
+    // iterate through both streams byte-for-byte and check they are equal
+    // exit false if we get to the end of one stream before the other (they are different lengths)
+    // or if two bytes at the same point in the streams aren't equal
+    public static boolean streamsEqual(InputStream is1, InputStream is2){
+        int c1, c2;
+        boolean equal = true;
+        try {
+            while ((c1 = is1.read()) != -1) {
+                c2 = is2.read();
+                // % is 'any' metacharacter
+                if (c1 == '%') {
+                    continue;
+                }
+                if (c1 != c2) {
+                    equal = false;
+                    break;
+                }
+            }
+            if (is2.read() != -1) {
+                // more bytes in the 2nd stream
+                return false;
+            }
+        } catch (IOException ioe) {
+            return false;
+        }
+        return equal;
+    }
+
+    /**
+     * Load a test fixture, by either suffixing a path to the external storage directory for an android
+     * emulator or device, or directly going to the fixture directory in the working directory to
+     * create a file object from which to read a fixture.
+     * @param fileName the name of a fixture to read
+     * @return {@link File} object An file object representing a fixture on disk
+     */
+   public static File loadFixture(String fileName){
+       if(Misc.isRunningOnAndroid()){
+           //yay more reflection goes here
+
+           try {
+               Class env = Class.forName("android.os.Environment");
+               Method externalStorageMethod = env.getMethod("getExternalStorageDirectory");
+
+               File sdcard = (File) externalStorageMethod.invoke(null);
+               return new File(sdcard, fileName);
+           } catch (ClassNotFoundException e){
+               //couldn't find the needed classed
+               e.printStackTrace();
+               return null;
+           } catch (NoSuchMethodException e){
+               e.printStackTrace();
+               return null;
+           } catch (IllegalAccessException e){
+               e.printStackTrace();
+               return null;
+           } catch (InvocationTargetException e){
+               e.printStackTrace();
+               return null;
+           }
+
+       }else {
+           //just return the new File object
+           return new File(fileName);
+
+       }
+   }
+
+   public static SQLDatabase getDatabaseConnectionToExistingDb(SQLDatabase db){
+       if(Misc.isRunningOnAndroid())
+           return db;
+
+       try {
+           String filePath = (String) db.getClass()
+                   .getMethod("getDatabaseFile")
+                   .invoke(db);
+           return SQLDatabaseFactory.openSqlDatabase(filePath,
+                   new NullKeyProvider());
+       } catch (IllegalAccessException e) {
+           e.printStackTrace();
+       } catch (InvocationTargetException e) {
+           e.printStackTrace();
+       } catch (NoSuchMethodException e) {
+           e.printStackTrace();
+       } catch (IOException e) {
+           e.printStackTrace();
+       }
+
+       return null;
+   }
+
+
+}


### PR DESCRIPTION
This test creates a database with a key using the DatastoreManager.
It then looks at the JSON database, the indexes database and the
attachment file created to check they are encrypted or not, using
parameterisation to check both encrypted and non-encrypted
datastores.

End to end tests are in sync-android project so they are only
tested on Android as JavaSE doesn't support encryption yet.

It also parameterises the test so we _always_ test both the
encrypted and non-encrypted case when running on Android for
the EndToEndEncryptionTest case.

I copied TestUtils into the sync-android library to avoid
dependency issues with the non-Android build where the class
wasn't available to the sync-android sub-project compilation.

reviewer @tomblench 
reviewer @brynh 