### PR TITLE
Stop Base64 encoded strings containing new lines

### DIFF
--- a/sync-android/src/test/java/com/cloudant/android/Base64OutputStreamFactoryTest.java
+++ b/sync-android/src/test/java/com/cloudant/android/Base64OutputStreamFactoryTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2015 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.android;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+
+/**
+ * Created by Rhys Short on 12/06/15.
+ */
+public class Base64OutputStreamFactoryTest extends Object {
+
+    private final String password="k8b:2KcU2re:BSTeyYg:4hUsu+zWgg#85+!22VUuf:22@2ESzQKZwwv+:/S3Qd79";
+
+    @Test
+    public void testInputStreamContainsNoNewLines() throws Exception {
+
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        OutputStream outputStream = Base64OutputStreamFactory.get(byteArrayOutputStream);
+        outputStream.write(password.getBytes());
+        Assert.assertFalse(byteArrayOutputStream.toString().contains("\n"));
+    }
+}

--- a/sync-core/src/main/java/com/cloudant/android/Base64OutputStreamFactory.java
+++ b/sync-core/src/main/java/com/cloudant/android/Base64OutputStreamFactory.java
@@ -28,7 +28,8 @@ public class Base64OutputStreamFactory {
             if (Misc.isRunningOnAndroid()) {
                 Class c = Class.forName("android.util.Base64OutputStream");
                 Constructor ctor = c.getDeclaredConstructor(OutputStream.class, int.class);
-                return (OutputStream)ctor.newInstance(os, 0);
+                // 2 = android.util.BASE64.NO_WRAP http://developer.android.com/reference/android/util/Base64.html#NO_WRAP
+                return (OutputStream)ctor.newInstance(os, 2);
             } else {
                 Class c = Class.forName("org.apache.commons.codec.binary.Base64OutputStream");
                 Constructor ctor = c.getDeclaredConstructor(OutputStream.class, boolean.class, int.class, byte[].class);


### PR DESCRIPTION
Stop Base64 encoding on android adding new lines to large strings when encoding.

reviewer @mikerhodes 
reviewer @tomblench 