### PR TITLE
Correctly persist and send length & encoded_length values (3rd attempt)

### DIFF
--- a/sync-core/src/main/java/com/cloudant/sync/datastore/Attachment.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/Attachment.java
@@ -46,11 +46,6 @@ public abstract class Attachment implements Comparable<Attachment>{
      * Encoding - Plain or GZIP
      */
     public final Encoding encoding;
-
-    /**
-     * @return Size in bytes, may be -1 if not known (e.g., HTTP URL for new attachment)
-     */
-    public abstract long getSize();
     
     /**
      * Gets contents of attachments as a stream.

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/AttachmentManager.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/AttachmentManager.java
@@ -103,7 +103,7 @@ class AttachmentManager {
         this.attachmentStreamFactory = new AttachmentStreamFactory(datastore.getKeyProvider());
     }
 
-    public void addAttachment(SQLDatabase db,PreparedAttachment a, BasicDocumentRevision rev) throws  AttachmentNotSavedException {
+    public void addAttachment(SQLDatabase db, PreparedAttachment a, BasicDocumentRevision rev) throws  AttachmentNotSavedException {
 
         // do it this way to only go thru inputstream once
         // * write to temp location using copyinputstreamtofile
@@ -118,6 +118,7 @@ class AttachmentManager {
         String type = a.attachment.type;
         int encoding = a.attachment.encoding.ordinal();
         long length = a.length;
+        long encodedLength = a.encodedLength;
         long revpos = CouchUtils.generationFromRevId(rev.getRevision());
 
         values.put("sequence", sequence);
@@ -126,7 +127,7 @@ class AttachmentManager {
         values.put("type", type);
         values.put("encoding", encoding);
         values.put("length", length);
-        values.put("encoded_length", length);
+        values.put("encoded_length", encodedLength);
         values.put("revpos", revpos);
 
         // delete and insert in case there is already an attachment at this seq (eg copied over from a previous rev)
@@ -178,21 +179,6 @@ class AttachmentManager {
 
     }
 
-    /**
-     * Creates a PreparedAttachment from {@code att}, preparing it for insertion into
-     * the datastore.
-     *
-     * @param att Attachment to prepare for insertion into datastore
-     * @return PreparedAttachment, which can be used in addAttachment methods
-     * @throws AttachmentException if there was an error preparing the attachment, e.g., reading
-     *                  attachment data.
-     */
-    public PreparedAttachment prepareAttachment(Attachment att)
-            throws AttachmentException {
-        return new PreparedAttachment(
-                att, this.attachmentsDir, this.attachmentStreamFactory);
-    }
-
     class PreparedAndSavedAttachments
     {
         List<SavedAttachment> savedAttachments = new ArrayList<SavedAttachment>();
@@ -201,6 +187,39 @@ class AttachmentManager {
         public boolean isEmpty() {
             return savedAttachments.isEmpty() && preparedAttachments.isEmpty();
         }
+    }
+
+    /**
+     * Creates a PreparedAttachment from {@code attachment}, preparing it for insertion into
+     * the datastore.
+     *
+     * @param attachment Attachment to prepare for insertion into datastore
+     * @return PreparedAttachment, which can be used in addAttachment methods
+     * @throws AttachmentException if there was an error preparing the attachment, e.g., reading
+     *                  attachment data.
+     */    protected PreparedAttachment prepareAttachment(Attachment attachment) throws AttachmentException {
+        if (attachment.encoding != Attachment.Encoding.Plain) {
+            throw new AttachmentNotSavedException("Encoded attachments can only be prepared if the value of \"length\" is known");
+        }
+        return new PreparedAttachment(attachment, this.attachmentsDir, 0, attachmentStreamFactory);
+    }
+
+    // prepare an attachment and check validity of length and encodedLength metadata
+    protected PreparedAttachment prepareAttachment(Attachment attachment, long length, long encodedLength) throws AttachmentException {
+        PreparedAttachment pa = new PreparedAttachment(attachment, this.attachmentsDir, length, attachmentStreamFactory);
+        // check the length on disk is correct:
+        // - plain encoding, length on disk is signalled by the "length" metadata property
+        // - all other encodings, length on disk is signalled by the "encoded_length" metadata property
+        if (pa.attachment.encoding == Attachment.Encoding.Plain) {
+            if (pa.length != length) {
+                throw new AttachmentNotSavedException(String.format("Actual length of %d does not equal expected length of %d", pa.length, length));
+            }
+        } else {
+            if (pa.encodedLength != encodedLength) {
+                throw new AttachmentNotSavedException(String.format("Actual encoded length of %d does not equal expected encoded length of %d", pa.encodedLength, pa.length));
+            }
+        }
+        return pa;
     }
 
     // take a set of attachments, and:
@@ -218,8 +237,8 @@ class AttachmentManager {
 
         for (Attachment a : attachments) {
             if (!(a instanceof SavedAttachment)) {
-                preparedAndSavedAttachments.preparedAttachments.add(
-                        new PreparedAttachment(a, this.attachmentsDir, this.attachmentStreamFactory));
+                PreparedAttachment pa = this.prepareAttachment(a);
+                preparedAndSavedAttachments.preparedAttachments.add(pa);
             } else {
                 preparedAndSavedAttachments.savedAttachments.add((SavedAttachment)a);
             }
@@ -262,14 +281,19 @@ class AttachmentManager {
              c = db.rawQuery(SQL_ATTACHMENTS_SELECT,
                      new String[]{attachmentName, String.valueOf(rev.getSequence())});
             if (c.moveToFirst()) {
-                int sequence = c.getInt(0);
-                byte[] key = c.getBlob(2);
-                String type = c.getString(3);
-                int encoding = c.getInt(4);
-                int revpos = c.getInt(7);
-                File file = fileFromKey(db, key, attachmentsDir, false);
-                return new SavedAttachment(attachmentName, revpos, sequence, key, type, file,
-                        Attachment.Encoding.values()[encoding], this.attachmentStreamFactory);
+                 int sequence = c.getInt(c.getColumnIndex("sequence"));
+                 String filename = c.getString(c.getColumnIndex("filename"));
+                 byte[] key = c.getBlob(c.getColumnIndex("key"));
+                 String type = c.getString(c.getColumnIndex("type"));
+                 int encoding = c.getInt(c.getColumnIndex("encoding"));
+                 long length = c.getInt(c.getColumnIndex("length"));
+                 long encodedLength = c.getInt(c.getColumnIndex("encoded_length"));
+                 int revpos = c.getInt(c.getColumnIndex("revpos"));
+                 File file = fileFromKey(db, key, attachmentsDir, false);
+ 
+                 return new SavedAttachment(sequence, filename, key, type, Attachment.Encoding
+                         .values()[encoding], length, encodedLength, revpos, file,
+                         attachmentStreamFactory);
             }
 
             return null;
@@ -290,14 +314,18 @@ class AttachmentManager {
             c = db.rawQuery(SQL_ATTACHMENTS_SELECT_ALL,
                     new String[]{String.valueOf(sequence)});
             while (c.moveToNext()) {
-                String name = c.getString(1);
-                byte[] key = c.getBlob(2);
-                String type = c.getString(3);
-                int encoding = c.getInt(4);
-                int revpos = c.getInt(7);
+                String filename = c.getString(c.getColumnIndex("filename"));
+                byte[] key = c.getBlob(c.getColumnIndex("key"));
+                String type = c.getString(c.getColumnIndex("type"));
+                int encoding = c.getInt(c.getColumnIndex("encoding"));
+                long length = c.getInt(c.getColumnIndex("length"));
+                long encodedLength = c.getInt(c.getColumnIndex("encoded_length"));
+                int revpos = c.getInt(c.getColumnIndex("revpos"));
                 File file = fileFromKey(db, key, attachmentsDir, false);
-                atts.add(new SavedAttachment(name, revpos, sequence, key, type, file,
-                        Attachment.Encoding.values()[encoding], this.attachmentStreamFactory));
+                
+                atts.add(new SavedAttachment(sequence, filename, key, type, Attachment.Encoding
+                        .values()[encoding], length, encodedLength, revpos, file,
+                        attachmentStreamFactory));
             }
             return atts;
         } catch (SQLException e) {
@@ -315,7 +343,7 @@ class AttachmentManager {
             String type = c.getString(3);
             int encoding = c.getInt(4);
             int length = c.getInt(5);
-            int encoded_length = c.getInt(6);
+            int encodedLength = c.getInt(6);
             int revpos = c.getInt(7);
 
             ContentValues values = new ContentValues();
@@ -325,7 +353,7 @@ class AttachmentManager {
             values.put("type", type);
             values.put("encoding", encoding);
             values.put("length", length);
-            values.put("encoded_length", encoded_length);
+            values.put("encoded_length", encodedLength);
             values.put("revpos", revpos);
             db.insert("attachments", values);
         }

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/BasicDatastore.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/BasicDatastore.java
@@ -296,7 +296,8 @@ class BasicDatastore implements Datastore, DatastoreExtended {
     @Override
     public BasicDocumentRevision getDocument(final String id, final String rev) throws DocumentNotFoundException{
         Preconditions.checkState(this.isOpen(), "Database is closed");
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(id), "DocumentRevisionTree id can not be empty");
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(id), "DocumentRevisionTree id can not " +
+                "be empty");
 
         try {
             return queue.submit(new SQLQueueCallable<BasicDocumentRevision>(){
@@ -617,7 +618,7 @@ class BasicDatastore implements Datastore, DatastoreExtended {
             return queue.submit(new SQLQueueCallable<LocalDocument>(){
                 @Override
                 public LocalDocument call(SQLDatabase db) throws Exception {
-                    return doGetLocalDocument(db,docId);
+                    return doGetLocalDocument(db, docId);
                 }
             }).get();
         } catch (InterruptedException e) {
@@ -921,7 +922,7 @@ class BasicDatastore implements Datastore, DatastoreExtended {
         options.current = false;
         options.data = JSONUtils.EMPTY_JSON;
         options.available = false;
-        return insertRevision(db,options);
+        return insertRevision(db, options);
     }
 
     private LocalDocument doGetLocalDocument(SQLDatabase db, String docId)
@@ -1055,25 +1056,24 @@ class BasicDatastore implements Datastore, DatastoreExtended {
                     if (pullAttachmentsInline) {
                         if (attachments != null) {
                             for (String att : attachments.keySet()) {
-                                Boolean stub = ((Map<String, Boolean>) attachments.get(att)).get
-                                        ("stub");
-                                if (stub != null && stub.booleanValue()) {
+                                Map attachmentMetadata = (Map)attachments.get(att);
+                                Boolean stub = (Boolean) attachmentMetadata.get("stub");
+
+                                if (stub != null && stub) {
                                     // stubs get copied forward at the end of
                                     // insertDocumentHistoryIntoExistingTree - nothing to do here
                                     continue;
                                 }
-                                String data = (String) ((Map<String,
-                                        Object>) attachments.get(att)).get("data");
+                                String data = (String) attachmentMetadata.get("data");
+                                String type = (String) attachmentMetadata.get("content_type");
                                 InputStream is = Base64InputStreamFactory.get(new
                                         ByteArrayInputStream(data.getBytes()));
-                                String type = (String) ((Map<String,
-                                        Object>) attachments.get(att)).get("content_type");
                                 // inline attachments are automatically decompressed,
                                 // so we don't have to worry about that
                                 UnsavedStreamAttachment usa = new UnsavedStreamAttachment(is,
                                         att, type);
                                 try {
-                                    PreparedAttachment pa = prepareAttachment(usa);
+                                    PreparedAttachment pa = attachmentManager.prepareAttachment(usa);
                                     attachmentManager.addAttachment(db, pa, rev);
                                 } catch (Exception e) {
                                     logger.log(Level.SEVERE, "There was a problem adding the " +
@@ -1520,7 +1520,7 @@ class BasicDatastore implements Datastore, DatastoreExtended {
         String[] keys = revisions.keySet().toArray(new String[revisions.keySet().size()]);
         String[] values = revisions.values().toArray(new String[revisions.size()]);
         System.arraycopy(keys, 0, args, 0, revisions.keySet().size());
-        System.arraycopy(values, 0,args, revisions.keySet().size(), revisions.size());
+        System.arraycopy(values, 0, args, revisions.keySet().size(), revisions.size());
 
         Cursor cursor = null;
         try {
@@ -1740,11 +1740,13 @@ class BasicDatastore implements Datastore, DatastoreExtended {
     }
 
 
+    // this is just a facade into attachmentManager.PrepareAttachment for the sake of DatastoreWrapper
     @Override
-    public PreparedAttachment prepareAttachment(Attachment att) throws AttachmentException {
-        return this.attachmentManager.prepareAttachment(att);
+    public PreparedAttachment prepareAttachment(Attachment att, long length, long encodedLength) throws AttachmentException {
+        PreparedAttachment pa = attachmentManager.prepareAttachment(att, length, encodedLength);
+        return pa;
     }
-
+    
     @Override
     public Attachment getAttachment(final BasicDocumentRevision rev, final String attachmentName) {
         try {

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/DatastoreExtended.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/DatastoreExtended.java
@@ -210,18 +210,23 @@ public interface DatastoreExtended extends Datastore {
     Map<String, Collection<String>> revsDiff(Multimap<String, String> revisions);
 
     /**
+     * <p>
      * Read attachment stream to a temporary location and calculate sha1,
      * prior to being added to the datastore.
-     *
+     * </p>
+     * <p>
      * Used by replicator when receiving new/updated attachments
+     *</p>
      *
-     * @param att Attachment to be prepared, providing data either from a file or a stream
+     * @param att           Attachment to be prepared, providing data either from a file or a stream
+     * @param length        Size in bytes of attachment as signalled by "length" metadata property
+     * @param encodedLength Size in bytes of attachment, after encoding, as signalled by
+     *                      "encoded_length" metadata property
      * @return A prepared attachment, ready to be added to the datastore
      * @throws AttachmentException if there was an error preparing the attachment, e.g., reading
-     *                  attachment data.
+     *                             attachment data.
      */
-    PreparedAttachment prepareAttachment(Attachment att) throws AttachmentException;
-
+    PreparedAttachment prepareAttachment(Attachment att, long length, long encodedLength) throws AttachmentException;
 
     /**
      * <p>Returns attachment <code>attachmentName</code> for the revision.</p>

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/MultipartAttachmentWriter.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/MultipartAttachmentWriter.java
@@ -132,12 +132,15 @@ public class MultipartAttachmentWriter extends InputStream {
      * entire attachment into memory.
      *
      * @param attachment The attachment to be streamed
-     * @throws IOException if there was an error getting the input stream from the {@code Attachment}
+     * @param length     Size in bytes of attachment, as it will be transmitted over the network
+     *                   (that is, after any encoding)
+     * @throws IOException if there was an error getting the input stream from the {@code
+     * Attachment}
      */
-    public void addAttachment(Attachment attachment) throws IOException {
+    public void addAttachment(Attachment attachment, long length) throws IOException {
         contentLength += partBoundary.length;
         contentLength += 6; // 3 * crlf
-        contentLength += attachment.getSize();
+        contentLength += length;
 
         components.add(new ByteArrayInputStream(crlf));
         components.add(new ByteArrayInputStream(partBoundary));

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/PreparedAttachment.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/PreparedAttachment.java
@@ -43,6 +43,8 @@ public class PreparedAttachment {
     public final long length;
     public final long encodedLength;
 
+    private static final int NO_ENCODED_LENGTH = 0;
+
     /**
      * Prepare an attachment by copying it to a temp location and calculating its sha1.
      *
@@ -97,9 +99,8 @@ public class PreparedAttachment {
         //Set attachment length from bytes read in input stream
         if (this.attachment.encoding == Attachment.Encoding.Plain) {
             this.length = totalRead;
-            // 0 signals "no encoded length" - this is consistent with couch which does not send
-            // encoded_length if the encoding is "plain"
-            this.encodedLength = 0;
+            // couch does not send encoded_length if the encoding is "plain"
+            this.encodedLength = NO_ENCODED_LENGTH;
         } else {
             // the pre-encoded length is known, so store it
             this.length = length;

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/RevisionHistoryHelper.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/RevisionHistoryHelper.java
@@ -197,7 +197,7 @@ public class RevisionHistoryHelper {
                         mpw = new MultipartAttachmentWriter();
                         mpw.setBody(revision);
                     }
-                    mpw.addAttachment(att);
+                    mpw.addAttachment(savedAtt, savedAtt.onDiskLength());
                 }
             } catch (IOException ioe) {
                 logger.log(Level.WARNING,"IOException caught when adding multiparts",ioe);
@@ -258,9 +258,13 @@ public class RevisionHistoryHelper {
                             IOUtils.closeQuietly(fis);
                         }
                     }
-                    theAtt.put("length", savedAtt.getSize());
+                    theAtt.put("length", savedAtt.length);
+                    theAtt.put("encoded_length", savedAtt.encodedLength);
                     theAtt.put("content_type", savedAtt.type);
                     theAtt.put("revpos", savedAtt.revpos);
+                    if (savedAtt.encoding != Attachment.Encoding.Plain) {
+                        theAtt.put("encoding", savedAtt.encoding.toString().toLowerCase());
+                    }
                 } else {
                     // if the revpos of the attachment is higher than the minimum, it's a stub
                     theAtt.put("stub", true);

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/SavedHttpAttachment.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/SavedHttpAttachment.java
@@ -69,11 +69,6 @@ public class SavedHttpAttachment extends Attachment {
     }
 
     @Override
-    public long getSize() {
-        return size;
-    }
-
-    @Override
     public InputStream getInputStream() throws IOException {
         if( data == null) {
             HttpConnection connection = Http.GET(attachmentURI);

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/UnsavedFileAttachment.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/UnsavedFileAttachment.java
@@ -42,10 +42,6 @@ public class UnsavedFileAttachment extends Attachment {
         return new FileInputStream(file);
     }
 
-    public long getSize() {
-        return file.length();
-    }
-
     private File file;
 
 }

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/UnsavedStreamAttachment.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/UnsavedStreamAttachment.java
@@ -40,14 +40,6 @@ public class UnsavedStreamAttachment extends Attachment {
         return stream;
     }
 
-    public long getSize() {
-        try {
-            return stream.available();
-        } catch(IOException ioe) {
-            return -1;
-        }
-    }
-
     private InputStream stream;
 
 }

--- a/sync-core/src/main/java/com/cloudant/sync/replication/DatastoreWrapper.java
+++ b/sync-core/src/main/java/com/cloudant/sync/replication/DatastoreWrapper.java
@@ -111,8 +111,8 @@ class DatastoreWrapper {
         return allDocumentTrees;
     }
 
-    protected PreparedAttachment prepareAttachment(Attachment att) throws AttachmentException {
-        return this.dbCore.prepareAttachment(att);
+    protected PreparedAttachment prepareAttachment(Attachment att, long length, long encodedLength) throws AttachmentException {
+        return this.dbCore.prepareAttachment(att, length, encodedLength);
     }
 
 }

--- a/sync-core/src/test/java/com/cloudant/sync/datastore/AttachmentStreamFactoryTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/datastore/AttachmentStreamFactoryTest.java
@@ -54,7 +54,7 @@ public class AttachmentStreamFactoryTest extends BasicDatastoreTestBase {
 
         UnsavedFileAttachment usf = new UnsavedFileAttachment(plainText, "text/plain");
         PreparedAttachment preparedAttachment = new PreparedAttachment(
-                usf, datastore_manager_dir, asf);
+                usf, datastore_manager_dir, 0, asf);
 
         Assert.assertTrue("Writing to unencrypted, un-encoded stream didn't give correct output",
                 IOUtils.contentEquals(
@@ -73,8 +73,8 @@ public class AttachmentStreamFactoryTest extends BasicDatastoreTestBase {
         AttachmentStreamFactory asf = new AttachmentStreamFactory(new NullKeyProvider());
 
         File plainText = f("fixture/EncryptedAttachmentTest_plainText");
-        SavedAttachment savedAttachment = new SavedAttachment("test", 0, 0, null, "text/plain",
-                plainText, Attachment.Encoding.Plain, asf);
+        SavedAttachment savedAttachment = new SavedAttachment(0, "test", null, "text/plain", Attachment.Encoding.Plain, 0, 0, 0,
+                plainText, asf);
 
         Assert.assertTrue("Reading unencrypted, un-encoded stream didn't give correct output",
                 IOUtils.contentEquals(
@@ -97,14 +97,14 @@ public class AttachmentStreamFactoryTest extends BasicDatastoreTestBase {
 
         UnsavedFileAttachment usf = new UnsavedFileAttachment(plainText, "text/plain");
         PreparedAttachment preparedAttachment = new PreparedAttachment(
-                usf, datastore_manager_dir, asf);
+                usf, datastore_manager_dir, 0, asf);
 
         Assert.assertTrue("Writing to unencrypted, unencoded stream didn't give correct output",
                 IOUtils.contentEquals(new FileInputStream(preparedAttachment.tempFile),
                         new FileInputStream(plainText)));
 
-        SavedAttachment savedAttachment = new SavedAttachment("test", 0, 0, null, "text/plain",
-                preparedAttachment.tempFile, Attachment.Encoding.Plain, asf);
+        SavedAttachment savedAttachment = new SavedAttachment(0, "test", null, "text/plain", Attachment.Encoding.Plain, 0, 0, 0,
+                preparedAttachment.tempFile, asf);
 
         Assert.assertTrue("Reading from written unencrypted, unencoded blob didn't give correct output",
                 IOUtils.contentEquals(
@@ -158,8 +158,8 @@ public class AttachmentStreamFactoryTest extends BasicDatastoreTestBase {
         File plainText = f("fixture/EncryptedAttachmentTest_plainText");
         File zippedPlainText = f("fixture/EncryptedAttachmentTest_plainText.gz");
 
-        SavedAttachment savedAttachment = new SavedAttachment("test", 0, 0, null, "text/plain",
-                zippedPlainText, Attachment.Encoding.Gzip, asf);
+        SavedAttachment savedAttachment = new SavedAttachment(0, "test", null, "text/plain", Attachment.Encoding.Gzip, 0, 0, 0,
+                zippedPlainText, asf);
 
         Assert.assertTrue("Reading unencrypted, encoded stream didn't give correct output",
                 IOUtils.contentEquals(
@@ -187,7 +187,7 @@ public class AttachmentStreamFactoryTest extends BasicDatastoreTestBase {
 
         UnsavedFileAttachment usf = new UnsavedFileAttachment(plainText, "text/plain");
         PreparedAttachment preparedAttachment = new PreparedAttachment(
-                usf, datastore_manager_dir, asf);
+                usf, datastore_manager_dir, 0, asf);
 
         // We check content using EncryptedAttachmentInputStream. It seems a bit circular,
         // but the aim of this test is to make sure AttachmentStreamFactory is providing
@@ -215,8 +215,8 @@ public class AttachmentStreamFactoryTest extends BasicDatastoreTestBase {
         File plainText = f("fixture/EncryptedAttachmentTest_plainText");
         File cipherAttachmentBlob = f("fixture/EncryptedAttachmentTest_cipherText_aes128");
 
-        SavedAttachment savedAttachment = new SavedAttachment("test", 0, 0, null, "text/plain",
-                cipherAttachmentBlob, Attachment.Encoding.Plain, asf);
+        SavedAttachment savedAttachment = new SavedAttachment(0, "test", null, "text/plain", Attachment.Encoding.Plain, 0, 0, 0,
+                cipherAttachmentBlob, asf);
 
         Assert.assertTrue("Reading encrypted, un-encoded stream didn't give correct output",
                 IOUtils.contentEquals(
@@ -241,7 +241,7 @@ public class AttachmentStreamFactoryTest extends BasicDatastoreTestBase {
 
         UnsavedFileAttachment usf = new UnsavedFileAttachment(plainText, "text/plain");
         PreparedAttachment preparedAttachment = new PreparedAttachment(
-                usf, datastore_manager_dir, asf);
+                usf, datastore_manager_dir, 0, asf);
 
         Assert.assertTrue("Writing to encrypted stream didn't give correct output",
                 IOUtils.contentEquals(
@@ -250,8 +250,8 @@ public class AttachmentStreamFactoryTest extends BasicDatastoreTestBase {
                                 EncryptionTestConstants.key16Byte),
                         new FileInputStream(plainText)));
 
-        SavedAttachment savedAttachment = new SavedAttachment("test", 0, 0, null, "text/plain",
-                preparedAttachment.tempFile, Attachment.Encoding.Plain, asf);
+        SavedAttachment savedAttachment = new SavedAttachment(0, "test", null, "text/plain", Attachment.Encoding.Plain, 0, 0, 0,
+                preparedAttachment.tempFile, asf);
 
         Assert.assertTrue("Reading from written encrypted, un-encoded blob didn't give correct output",
                 IOUtils.contentEquals(
@@ -284,7 +284,7 @@ public class AttachmentStreamFactoryTest extends BasicDatastoreTestBase {
 
         UnsavedFileAttachment usf = new UnsavedFileAttachment(plainText, "text/plain");
         PreparedAttachment preparedAttachment = new PreparedAttachment(
-                usf, datastore_manager_dir, asf);
+                usf, datastore_manager_dir, 0, asf);
 
         Assert.assertTrue("Writing to encrypted, un-encoded stream didn't give correct output",
                 IOUtils.contentEquals(
@@ -302,8 +302,8 @@ public class AttachmentStreamFactoryTest extends BasicDatastoreTestBase {
         AttachmentStreamFactory asf2 = new AttachmentStreamFactory(
                 EncryptionTestConstants.keyProviderUsingBytesAsKey(otherKey)
         );
-        SavedAttachment savedAttachment = new SavedAttachment("test", 0, 0, null, "text/plain",
-                preparedAttachment.tempFile, Attachment.Encoding.Plain, asf2);
+        SavedAttachment savedAttachment = new SavedAttachment(0, "test", null, "text/plain", Attachment.Encoding.Plain, 0, 0, 0,
+                preparedAttachment.tempFile, asf2);
 
         Assert.assertFalse("Reading with different key shouldn't produce plaintext content",
                 IOUtils.contentEquals(
@@ -365,8 +365,9 @@ public class AttachmentStreamFactoryTest extends BasicDatastoreTestBase {
         File plainText = f("fixture/EncryptedAttachmentTest_plainText");
         File cipherAttachmentBlob = f("fixture/EncryptedAttachmentTest_gzip_cipherText_aes128");
 
-        SavedAttachment savedAttachment = new SavedAttachment("test", 0, 0, null, "text/plain",
-                cipherAttachmentBlob, Attachment.Encoding.Gzip, asf);
+
+        SavedAttachment savedAttachment = new SavedAttachment(0, "test", null, "text/plain", Attachment.Encoding.Gzip, 0, 0, 0,
+                cipherAttachmentBlob, asf);
 
         Assert.assertTrue("Reading encrypted, encoded stream didn't give correct output",
                 IOUtils.contentEquals(

--- a/sync-core/src/test/java/com/cloudant/sync/datastore/AttachmentTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/datastore/AttachmentTest.java
@@ -282,13 +282,13 @@ public class AttachmentTest extends BasicDatastoreTestBase {
         long expectedImageFileLength = imageFile.length();
 
         Attachment att = new UnsavedFileAttachment(textFile, "text/plain");
-        PreparedAttachment textPatt = new PreparedAttachment(att, datastore_manager_dir,
+        PreparedAttachment textPatt = new PreparedAttachment(att, datastore_manager_dir, 0,
                 new AttachmentStreamFactory(new NullKeyProvider()));
         //Assert that the original file length is equal to the prepared attachment length
         Assert.assertEquals(expectedTextFileLength, textPatt.length);
 
         Attachment att2 = new UnsavedFileAttachment(imageFile, "image/jpeg");
-        PreparedAttachment imagePatt = new PreparedAttachment(att2, datastore_manager_dir,
+        PreparedAttachment imagePatt = new PreparedAttachment(att2, datastore_manager_dir, 0,
                 new AttachmentStreamFactory(new NullKeyProvider()));
         Assert.assertEquals(expectedImageFileLength, imagePatt.length);
     }
@@ -300,7 +300,7 @@ public class AttachmentTest extends BasicDatastoreTestBase {
 
         Attachment nonexistentAtt = new UnsavedFileAttachment(nonExistentFile, "text/plain");
 
-        PreparedAttachment nonexistentPatt = new PreparedAttachment(nonexistentAtt, datastore_manager_dir,
+        PreparedAttachment nonexistentPatt = new PreparedAttachment(nonexistentAtt, datastore_manager_dir, 0,
                 new AttachmentStreamFactory(new NullKeyProvider()));
     }
 
@@ -313,7 +313,7 @@ public class AttachmentTest extends BasicDatastoreTestBase {
         File imageFile = TestUtils.loadFixture("fixture/" + imageAttachmentName);
 
         Attachment att = new UnsavedFileAttachment(textFile, "text/plain");
-        PreparedAttachment textPatt = new PreparedAttachment(att, datastore_manager_dir,
+        PreparedAttachment textPatt = new PreparedAttachment(att, datastore_manager_dir, 0,
                 new AttachmentStreamFactory(new NullKeyProvider()));
 
         byte[] textExpectedSha1 = Misc.getSha1((new FileInputStream(textFile)));
@@ -321,7 +321,7 @@ public class AttachmentTest extends BasicDatastoreTestBase {
         Assert.assertArrayEquals(textExpectedSha1, textPatt.sha1);
 
         Attachment att2 = new UnsavedFileAttachment(imageFile, "image/jpeg");
-        PreparedAttachment imagePatt = new PreparedAttachment(att2, datastore_manager_dir,
+        PreparedAttachment imagePatt = new PreparedAttachment(att2, datastore_manager_dir, 0,
                 new AttachmentStreamFactory(new NullKeyProvider()));
 
         byte[] imageExpectedSha1 = Misc.getSha1((new FileInputStream(imageFile)));
@@ -337,7 +337,7 @@ public class AttachmentTest extends BasicDatastoreTestBase {
         File imageFile = TestUtils.loadFixture("fixture/" + imageAttachmentName);
 
         Attachment att2 = new UnsavedFileAttachment(imageFile, "image/jpeg");
-        PreparedAttachment imagePatt = new PreparedAttachment(att2, datastore_manager_dir,
+        PreparedAttachment imagePatt = new PreparedAttachment(att2, datastore_manager_dir, 0,
                 new AttachmentStreamFactory(new NullKeyProvider()));
 
         IOUtils.contentEquals(

--- a/sync-core/src/test/java/com/cloudant/sync/datastore/MultipartAttachmentWriterTests.java
+++ b/sync-core/src/test/java/com/cloudant/sync/datastore/MultipartAttachmentWriterTests.java
@@ -91,7 +91,7 @@ public class MultipartAttachmentWriterTests {
             }
             byte[] bytes = (s.toString()).getBytes();
             Attachment att0 = new UnsavedStreamAttachment(new ByteArrayInputStream(bytes), name, "text/plain");
-            mpw.addAttachment(att0);
+            mpw.addAttachment(att0, bytes.length);
         }
         mpw.close();
 
@@ -120,8 +120,9 @@ public class MultipartAttachmentWriterTests {
         MultipartAttachmentWriter mpw = new MultipartAttachmentWriter();
         mpw.setBody(doc);
 
-        Attachment att0 = new UnsavedFileAttachment(TestUtils.loadFixture("fixture/bonsai-boston.jpg"), "image/jpeg");
-        mpw.addAttachment(att0);
+        File f = TestUtils.loadFixture("fixture/bonsai-boston.jpg");
+        Attachment att0 = new UnsavedFileAttachment(f, "image/jpeg");
+        mpw.addAttachment(att0, f.length());
         mpw.close();
 
         int amountRead = 0;


### PR DESCRIPTION
What persist to the local DB the length and encoded_length metadata properties when they are sent with attachments.
Why currently this data is not persisted or used to check that the actual length equals the indicated length.
How update various Attachment classes and related methods to take length and encoded_length arguments and assert that actual attachment length equals signalled attachment length
Testing mostly covered by existing tests

reviewer @rhyshort 
reviewer @mikerhodes