### PR TITLE
Add $size operator support to Query

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - [NEW] Added query support for the `$mod` operator.
+- [NEW] Added query support for the `$size` operator.
 
 # 0.12.1 (2015-06-12)
 

--- a/doc/query.md
+++ b/doc/query.md
@@ -580,6 +580,7 @@ Selectors -> Condition -> Array
 
 - `$in`
 - `$nin`
+- `$size`
 
 
 Implicit operators
@@ -621,10 +622,6 @@ Selectors -> combination
 Selectors -> Condition -> Objects
 
 - `$type` (unplanned)
-
-Selectors -> Condition -> Array
-
-- `$size` (planned)
 
 Selectors -> Condition -> Misc
 
@@ -684,7 +681,7 @@ Here:
     <strong>{</strong> &quot;$regex&quot; <strong>:</strong> <em>Pattern</em> <strong>}</strong>  // not implemented
     <strong>{</strong> &quot;$mod&quot; <strong>:</strong> <strong>[</strong> <em>non-zero-number, number</em> <strong>] }</strong>
     <strong>{</strong> &quot;$elemMatch&quot; <strong>: {</strong> <em>many-expressions</em> <strong>} }</strong>  // not implemented
-    <strong>{</strong> &quot;$size&quot; <strong>:</strong> <em>positive-integer</em> <strong>}</strong>  // not implemented
+    <strong>{</strong> &quot;$size&quot; <strong>:</strong> <em>positive-integer</em> <strong>}</strong>
     <strong>{</strong> &quot;$all&quot; <strong>:</strong> <em>array-value</em> <strong>}</strong>  // not implemented
     <strong>{</strong> &quot;$in&quot; <strong>:</strong> <em>array-value</em> <strong>}</strong>
     <strong>{</strong> &quot;$nin&quot; <strong>:</strong> <em>array-value</em> <strong>}</strong>

--- a/sync-core/src/main/java/com/cloudant/sync/query/QueryConstants.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/QueryConstants.java
@@ -44,6 +44,8 @@ final class QueryConstants {
 
     public static final String MOD = "$mod";
 
+    public static final String SIZE = "$size";
+
     private QueryConstants() {
         throw new AssertionError();
     }

--- a/sync-core/src/main/java/com/cloudant/sync/query/QuerySqlTranslator.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/QuerySqlTranslator.java
@@ -341,6 +341,27 @@ class QuerySqlTranslator {
         return fieldNames;
     }
 
+    /*
+     * Checks for the existence of an operator in a query clause list
+     */
+    protected static boolean isOperatorFoundInClause(String operator, List<Object> clause) {
+        boolean found = false;
+        for (Object rawTerm : clause){
+            if (rawTerm instanceof Map) {
+                Map term = (Map) rawTerm;
+                if (term.size() == 1 && term.values().toArray()[0] instanceof Map) {
+                    Map predicate = (Map) term.values().toArray()[0];
+                    if (predicate.get(operator) != null) {
+                        found = true;
+                        break;
+                    }
+                }
+            }
+        }
+
+        return found;
+    }
+
     protected static String chooseIndexForAndClause(List<Object> clause,
                                                     Map<String, Object> indexes) {
         if (clause == null || clause.isEmpty()) {
@@ -348,6 +369,13 @@ class QuerySqlTranslator {
         }
 
         if (indexes == null || indexes.isEmpty()) {
+            return null;
+        }
+
+        if (isOperatorFoundInClause(SIZE, clause)) {
+            String msg = String.format("$size operator found in clause %s.  " +
+                                       "Indexes are not used with $size operations.", clause);
+            logger.log(Level.INFO, msg);
             return null;
         }
 

--- a/sync-core/src/main/java/com/cloudant/sync/query/QueryValidator.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/QueryValidator.java
@@ -488,7 +488,16 @@ class QueryValidator {
 
     @SuppressWarnings("unchecked")
     private static boolean validateClause(Map<String, Object> clause) {
-        List<String> validOperators = Arrays.asList(EQ, LT, GT, EXISTS, NOT, GTE, LTE, IN, MOD);
+        List<String> validOperators = Arrays.asList(EQ,
+                                                    LT,
+                                                    GT,
+                                                    EXISTS,
+                                                    NOT,
+                                                    GTE,
+                                                    LTE,
+                                                    IN,
+                                                    MOD,
+                                                    SIZE);
         if (clause.size() == 1) {
             String operator = (String) clause.keySet().toArray()[0];
             if (validOperators.contains(operator)) {

--- a/sync-core/src/test/java/com/cloudant/sync/query/AbstractQueryTestBase.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/AbstractQueryTestBase.java
@@ -26,7 +26,9 @@ import com.cloudant.sync.util.TestUtils;
 import org.junit.After;
 import org.junit.Before;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -469,6 +471,76 @@ public abstract class AbstractQueryTestBase {
 
         assertThat(im.ensureIndexed(Arrays.<Object>asList("name", "age"), "basic"), is("basic"));
         assertThat(im.ensureIndexed(Arrays.<Object>asList("name", "pet"), "pet"), is("pet"));
+    }
+
+    // Used to setup document data testing for queries containing a $size operator:
+    // - When executing queries containing $size operator
+    public void setUpSizeOperatorQueryData() throws Exception {
+        MutableDocumentRevision rev = new MutableDocumentRevision();
+        rev.docId = "mike24";
+        Map<String, Object> bodyMap = new HashMap<String, Object>();
+        bodyMap.put("name", "mike");
+        bodyMap.put("age", 24);
+        bodyMap.put("pet", Collections.singletonList("cat"));
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        ds.createDocumentFromRevision(rev);
+
+        rev.docId = "mike12";
+        bodyMap.clear();
+        bodyMap.put("name", "mike");
+        bodyMap.put("age", 12);
+        bodyMap.put("pet", Arrays.asList("cat", "dog"));
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        ds.createDocumentFromRevision(rev);
+
+        rev.docId = "fred34";
+        bodyMap.clear();
+        bodyMap.put("name", "fred");
+        bodyMap.put("age", 34);
+        bodyMap.put("pet", Arrays.asList("cat", "dog"));
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        ds.createDocumentFromRevision(rev);
+
+        rev.docId = "john44";
+        bodyMap.clear();
+        bodyMap.put("name", "john");
+        bodyMap.put("age", 44);
+        bodyMap.put("pet", "cat");
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        ds.createDocumentFromRevision(rev);
+
+        rev.docId = "fred72";
+        bodyMap.clear();
+        bodyMap.put("name", "fred");
+        bodyMap.put("age", 72);
+        bodyMap.put("pet", Collections.singletonList("dog"));
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        ds.createDocumentFromRevision(rev);
+
+        rev.docId = "john12";
+        bodyMap.clear();
+        bodyMap.put("name", "john");
+        bodyMap.put("age", 12);
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        ds.createDocumentFromRevision(rev);
+
+        rev.docId = "bill34";
+        bodyMap.clear();
+        bodyMap.put("name", "bill");
+        bodyMap.put("age", 34);
+        bodyMap.put("pet", Arrays.asList("cat", "parrot"));
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        ds.createDocumentFromRevision(rev);
+
+        rev.docId = "fred11";
+        bodyMap.clear();
+        bodyMap.put("name", "fred");
+        bodyMap.put("age", 11);
+        bodyMap.put("pet", new ArrayList<Object>());
+        rev.body = DocumentBodyFactory.create(bodyMap);
+        ds.createDocumentFromRevision(rev);
+
+        assertThat(im.ensureIndexed(Arrays.<Object>asList("name", "pet", "age"), "basic"), is("basic"));
     }
 
     // Used to setup document data testing for sorting:

--- a/sync-core/src/test/java/com/cloudant/sync/query/QuerySqlTranslatorTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/QuerySqlTranslatorTest.java
@@ -1261,4 +1261,42 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         assertThat(node, is(nullValue()));
     }
 
+    // When checking for a specific operator in a clause
+
+    @Test
+    public void findsOperatorInClauseList() {
+        Map<String, Object> nameMap = new HashMap<String, Object>();
+        Map<String, Object> nameEqMap = new HashMap<String, Object>();
+        nameEqMap.put("$eq", "mike");
+        nameMap.put("name", nameEqMap);
+        Map<String, Object> petMap = new HashMap<String, Object>();
+        Map<String, Object> petSizeMap = new HashMap<String, Object>();
+        petSizeMap.put("$size", 2);
+        petMap.put("pet", petSizeMap);
+        Map<String, Object> ageMap = new HashMap<String, Object>();
+        Map<String, Object> ageGteMap = new HashMap<String, Object>();
+        ageGteMap.put("$gte", 2);
+        ageMap.put("age", ageGteMap);
+        List<Object> clause = Arrays.<Object>asList(nameMap, petMap, ageMap);
+        assertThat(QuerySqlTranslator.isOperatorFoundInClause("$size", clause), is(true));
+    }
+
+    @Test
+    public void doesNotFindOperatorWhenNotInClauseList() {
+        Map<String, Object> nameMap = new HashMap<String, Object>();
+        Map<String, Object> nameEqMap = new HashMap<String, Object>();
+        nameEqMap.put("$eq", "mike");
+        nameMap.put("name", nameEqMap);
+        Map<String, Object> petMap = new HashMap<String, Object>();
+        Map<String, Object> petEqMap = new HashMap<String, Object>();
+        petEqMap.put("$eq", "cat");
+        petMap.put("pet", petEqMap);
+        Map<String, Object> ageMap = new HashMap<String, Object>();
+        Map<String, Object> ageGteMap = new HashMap<String, Object>();
+        ageGteMap.put("$gte", 2);
+        ageMap.put("age", ageGteMap);
+        List<Object> clause = Arrays.<Object>asList(nameMap, petMap, ageMap);
+        assertThat(QuerySqlTranslator.isOperatorFoundInClause("$size", clause), is(false));
+    }
+
 }

--- a/sync-core/src/test/java/com/cloudant/sync/query/QueryValidatorTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/QueryValidatorTest.java
@@ -642,4 +642,34 @@ public class QueryValidatorTest {
         assertThat(normalizedQuery, is(nullValue()));
     }
 
+    @Test
+    public void normalizesQueryWithSIZEOperator() {
+        Map<String, Object> query = new HashMap<String, Object>();
+        // query - { "pet" : { "$size" : 2 } }
+        Map<String, Object> size = new HashMap<String, Object>();
+        size.put("$size", 2);
+        query.put("pet", size);
+        Map<String, Object> normalizedQuery = QueryValidator.normaliseAndValidateQuery(query);
+
+        // normalized query - { "$and" : [ { "pet" : { "$size" : 2 } } ] }
+        Map<String, Object> expected = new LinkedHashMap<String, Object>();
+        Map<String, Object> exSize = new HashMap<String, Object>();
+        exSize.put("$size", 2);
+        Map<String, Object> exPet = new HashMap<String, Object>();
+        exPet.put("pet", exSize);
+        expected.put("$and", Collections.<Object>singletonList(exPet));
+        assertThat(normalizedQuery, is(expected));
+    }
+
+    @Test
+    public void returnsNullForQueryWhenSIZEArgumentInvalid() {
+        Map<String, Object> query = new HashMap<String, Object>();
+        // query - { "pet" : { "$size" : [2] } }
+        Map<String, Object> size = new HashMap<String, Object>();
+        size.put("$size", Collections.singletonList(2));
+        query.put("pet", size);
+        Map<String, Object> normalizedQuery = QueryValidator.normaliseAndValidateQuery(query);
+        assertThat(normalizedQuery, is(nullValue()));
+    }
+
 }

--- a/sync-core/src/test/java/com/cloudant/sync/query/UnindexedMatcherTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/UnindexedMatcherTest.java
@@ -28,6 +28,7 @@ import com.cloudant.sync.datastore.DocumentRevisionBuilder;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -42,12 +43,14 @@ public class UnindexedMatcherTest {
         // body content: { "name" : "mike",
         //                 "age" : 31,
         //                 "pets" : [ "white_cat", "black_cat" ],
+        //                 "hobbies" : [],
         //                 "address" : { "number" : "1", "road" : "infinite loop" }
         //               }
         Map<String, Object> bodyMap = new HashMap<String, Object>();
         bodyMap.put("name", "mike");
         bodyMap.put("age", 31);
         bodyMap.put("pets", Arrays.asList("white_cat", "black_cat"));
+        bodyMap.put("hobbies", new ArrayList<Object>());
         Map<String, String> addressDetail = new HashMap<String, String>();
         addressDetail.put("number", "1");
         addressDetail.put("road", "infinite loop");
@@ -895,6 +898,102 @@ public class UnindexedMatcherTest {
         selector = QueryValidator.normaliseAndValidateQuery(selector);
         UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
         assertThat(matcher.matches(negRev), is(false));
+    }
+
+    @Test
+    public void matchWhenUsingAPositiveIntegerWithSIZE() {
+        // Selector - { "pets": { "$size":  2 } }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        Map<String, Object> sizeOp = new HashMap<String, Object>();
+        sizeOp.put("$size", 2);
+        selector.put("pets", sizeOp);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(true));
+    }
+
+    @Test
+    public void noMatchWhenUsingAPositiveIntegerWithSIZE() {
+        // Selector - { "pets": { "$size":  3 } }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        Map<String, Object> sizeOp = new HashMap<String, Object>();
+        sizeOp.put("$size", 3);
+        selector.put("pets", sizeOp);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(false));
+    }
+
+    @Test
+    public void noMatchWhenFieldIsNotAnArrayWithSIZE() {
+        // Selector - { "name": { "$size":  1 } }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        Map<String, Object> sizeOp = new HashMap<String, Object>();
+        sizeOp.put("$size", 1);
+        selector.put("name", sizeOp);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(false));
+    }
+
+    @Test
+    public void noMatchWhenUsingANegativeIntegerWithSIZE() {
+        // Selector - { "pets": { "$size":  -2 } }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        Map<String, Object> sizeOp = new HashMap<String, Object>();
+        sizeOp.put("$size", -2);
+        selector.put("pets", sizeOp);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(false));
+    }
+
+    @Test
+    public void matchWhenUsingZeroWithSIZE() {
+        // Selector - { "hobbies": { "$size":  0 } }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        Map<String, Object> sizeOp = new HashMap<String, Object>();
+        sizeOp.put("$size", 0);
+        selector.put("hobbies", sizeOp);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(true));
+    }
+
+    @Test
+    public void noMatchWhenUsingZeroAndFieldMissingWithSIZE() {
+        // Selector - { "books": { "$size":  0 } }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        Map<String, Object> sizeOp = new HashMap<String, Object>();
+        sizeOp.put("$size", 0);
+        selector.put("books", sizeOp);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(false));
+    }
+
+    @Test
+    public void noMatchWhenUsingAStringWithSIZE() {
+        // Selector - { "pets": { "$size":  "2" } }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        Map<String, Object> sizeOp = new HashMap<String, Object>();
+        sizeOp.put("$size", "2");
+        selector.put("pets", sizeOp);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(false));
+    }
+
+    @Test
+    public void noMatchWhenNotUsingAnIntegerWithSIZE() {
+        // Selector - { "pets": { "$size":  2.2 } }
+        Map<String, Object> selector = new HashMap<String, Object>();
+        Map<String, Object> sizeOp = new HashMap<String, Object>();
+        sizeOp.put("$size", 2.2);
+        selector.put("pets", sizeOp);
+        selector = QueryValidator.normaliseAndValidateQuery(selector);
+        UnindexedMatcher matcher = UnindexedMatcher.matcherWithSelector(selector);
+        assertThat(matcher.matches(rev), is(false));
     }
 
     @Test


### PR DESCRIPTION
_What:_

This PR adds support for the $size operator for use in Query.  See [$size spec](https://github.com/cloudant/cloudant-sync/blob/master/specs/query_size_operator.md) for details.

_Why:_

In an effort to provide as much functionality to Query as is available elsewhere (such as MongoDB), we are adding support to the $size operator.  It provides a way to query for documents based on the size of an array that is a document field value.

_How:_

Add logic to the validator code, the SQLtranslator code, and the unindexed matcher code to support the use of `$size` in queries.  `$size` operator clauses are handled strictly by the unindexed matcher code.  There is no SQL translator component for `$size`.

_Tests:_

- Validation tests have been added to ensure that queries containing the `$size` operator are properly normalized and validated.
- Tests have been added to ensure that the new utility method used by the SQL translator to check for the `$size` operator functions as desired.
- Unindexed matcher tests have been added to ensure that the matcher functionality handles `$size` operations appropriately.
- Since the unindexed matcher handles all `$size` processing, execution tests have been added to ensure that `$size` query execution performs correctly.

reviewer @mikerhodes 
reviewer @rhyshort 

BugId: 44633