### PR TITLE
Fix AES key creation for Android versions less then KitKat (API 19)

### DIFF
--- a/sync-android/src/main/java/com/cloudant/sync/datastore/encryption/DPKEncryptionUtil.java
+++ b/sync-android/src/main/java/com/cloudant/sync/datastore/encryption/DPKEncryptionUtil.java
@@ -82,6 +82,7 @@ class DPKEncryptionUtil {
             InvalidKeyException, BadPaddingException, IllegalBlockSizeException {
         Cipher aesCipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
         IvParameterSpec ivParameter = new IvParameterSpec(iv);
+        // see http://stackoverflow.com/a/11506343
         Key encryptionKey = new SecretKeySpec(key.getEncoded(),"AES");
         aesCipher.init(Cipher.ENCRYPT_MODE, encryptionKey, ivParameter);
         return aesCipher.doFinal(unencryptedBytes);
@@ -106,6 +107,7 @@ class DPKEncryptionUtil {
             InvalidKeyException, BadPaddingException, IllegalBlockSizeException {
         Cipher aesCipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
         IvParameterSpec ivParameter = new IvParameterSpec(iv);
+        // see http://stackoverflow.com/a/11506343
         Key encryptionKey = new SecretKeySpec(key.getEncoded(),"AES");
         aesCipher.init(Cipher.DECRYPT_MODE, encryptionKey, ivParameter);
         return aesCipher.doFinal(encryptedBytes);

--- a/sync-android/src/main/java/com/cloudant/sync/datastore/encryption/DPKEncryptionUtil.java
+++ b/sync-android/src/main/java/com/cloudant/sync/datastore/encryption/DPKEncryptionUtil.java
@@ -23,6 +23,7 @@ import org.json.JSONObject;
 
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
+import java.security.Key;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.Formatter;
@@ -35,6 +36,7 @@ import javax.crypto.SecretKey;
 import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.PBEKeySpec;
+import javax.crypto.spec.SecretKeySpec;
 
 /**
  * A utility to aid in encrypting/decrypting the DPK
@@ -80,7 +82,8 @@ class DPKEncryptionUtil {
             InvalidKeyException, BadPaddingException, IllegalBlockSizeException {
         Cipher aesCipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
         IvParameterSpec ivParameter = new IvParameterSpec(iv);
-        aesCipher.init(Cipher.ENCRYPT_MODE, key, ivParameter);
+        Key encryptionKey = new SecretKeySpec(key.getEncoded(),"AES");
+        aesCipher.init(Cipher.ENCRYPT_MODE, encryptionKey, ivParameter);
         return aesCipher.doFinal(unencryptedBytes);
     }
 
@@ -103,7 +106,8 @@ class DPKEncryptionUtil {
             InvalidKeyException, BadPaddingException, IllegalBlockSizeException {
         Cipher aesCipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
         IvParameterSpec ivParameter = new IvParameterSpec(iv);
-        aesCipher.init(Cipher.DECRYPT_MODE, key, ivParameter);
+        Key encryptionKey = new SecretKeySpec(key.getEncoded(),"AES");
+        aesCipher.init(Cipher.DECRYPT_MODE, encryptionKey, ivParameter);
         return aesCipher.doFinal(encryptedBytes);
     }
 }


### PR DESCRIPTION
Encrypt/Decrypt methods now have a create the SecretKeySpec for the AES key.  This fixes issues with encryption of the PBK on versions of Android less than KitKat (API 19)

reviewer @mikerhodes 
reviewer @tomblench