### PR TITLE
Fix javadoc warnings

### DIFF
--- a/sync-core/src/main/java/com/cloudant/common/CouchUtils.java
+++ b/sync-core/src/main/java/com/cloudant/common/CouchUtils.java
@@ -49,7 +49,7 @@ public class CouchUtils {
         return true;
     }
 
-    /**
+    /*
      * Parses the _revisions dict from a document into an array of revision ID strings
      */
     public static List<String> parseCouchDBRevisionHistory(Map<String, Object> docProperties) {

--- a/sync-core/src/main/java/com/cloudant/http/HttpConnection.java
+++ b/sync-core/src/main/java/com/cloudant/http/HttpConnection.java
@@ -138,7 +138,8 @@ public class HttpConnection  {
      * Call {@code responseAsString}, {@code responseAsBytes}, or {@code responseAsInputStream}
      * after {@code execute} if the response body is required.
      * </p>
-     * @throws IOException
+     * @return An {@link HttpConnection} which can be used to obtain the response body
+     * @throws IOException if there was a problem writing data to the server
      */
     public HttpConnection execute() throws IOException {
         System.setProperty("http.keepAlive", "false");
@@ -216,7 +217,7 @@ public class HttpConnection  {
      * <b>Important:</b> you must call <code>execute()</code> before calling this method.
      * </p>
      * @return String of response body data from server, if any
-     * @throws IOException
+     * @throws IOException if there was a problem reading data from the server
      */
     public String responseAsString() throws IOException {
         if (connection == null) {
@@ -236,7 +237,7 @@ public class HttpConnection  {
      * <b>Important:</b> you must call <code>execute()</code> before calling this method.
      * </p>
      * @return Byte array of response body data from server, if any
-     * @throws IOException
+     * @throws IOException if there was a problem reading data from the server
      */
     public byte[] responseAsBytes() throws IOException {
         if (connection == null) {
@@ -256,7 +257,7 @@ public class HttpConnection  {
      * <b>Important:</b> you must call <code>execute()</code> before calling this method.
      * </p>
      * @return InputStream of response body data from server, if any
-     * @throws IOException
+     * @throws IOException if there was a problem reading data from the server
      */
     public InputStream responseAsInputStream() throws IOException {
         if (connection == null) {
@@ -269,7 +270,7 @@ public class HttpConnection  {
     /**
      * Get the underlying HttpURLConnection object, allowing clients to set/get properties not
      * exposed here.
-     * @return HttpURLConnection
+     * @return HttpURLConnection the underlying {@link HttpURLConnection} object
      */
     public HttpURLConnection getConnection() {
         return connection;

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/Attachment.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/Attachment.java
@@ -48,7 +48,7 @@ public abstract class Attachment implements Comparable<Attachment>{
     public final Encoding encoding;
 
     /**
-     * Size in bytes, may be -1 if not known (e.g., HTTP URL for new attachment)
+     * @return Size in bytes, may be -1 if not known (e.g., HTTP URL for new attachment)
      */
     public abstract long getSize();
     
@@ -56,6 +56,8 @@ public abstract class Attachment implements Comparable<Attachment>{
      * Gets contents of attachments as a stream.
      *
      * Caller must call close() when done.
+     * @return contents of attachments as a stream
+     * @throws IOException there was an error obtaining the stream, eg from disk or network
      */     
     public abstract InputStream getInputStream() throws IOException;
 

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/BasicDatastore.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/BasicDatastore.java
@@ -1576,7 +1576,7 @@ class BasicDatastore implements Datastore, DatastoreExtended {
 
     @Override
     public void resolveConflictsForDocument(final String docId, final ConflictResolver resolver)
-            throws ConflictException, IOException {
+            throws ConflictException {
 
         // before starting the tx, get the 'new winner' and see if we need to prepare its attachments
 
@@ -1795,7 +1795,7 @@ class BasicDatastore implements Datastore, DatastoreExtended {
 
     @Override
     public BasicDocumentRevision createDocumentFromRevision(final MutableDocumentRevision rev)
-            throws DocumentException, AttachmentException {
+            throws DocumentException {
         Preconditions.checkNotNull(rev, "DocumentRevision can not be null");
         Preconditions.checkState(isOpen(), "Datastore is closed");
         final String docId;
@@ -1839,7 +1839,7 @@ class BasicDatastore implements Datastore, DatastoreExtended {
 
     @Override
     public BasicDocumentRevision updateDocumentFromRevision(final MutableDocumentRevision rev)
-            throws ConflictException, DocumentNotFoundException, AttachmentException, DocumentException {
+            throws DocumentException {
         final AttachmentManager.PreparedAndSavedAttachments preparedAndSavedAttachments =
                 this.attachmentManager.prepareAttachments(rev.attachments != null ? rev.attachments.values() : null);
 
@@ -1868,7 +1868,7 @@ class BasicDatastore implements Datastore, DatastoreExtended {
 
     private BasicDocumentRevision updateDocumentFromRevision(SQLDatabase db,MutableDocumentRevision rev,
                                                              AttachmentManager.PreparedAndSavedAttachments preparedAndSavedAttachments)
-            throws ConflictException, AttachmentNotSavedException, AttachmentException, DocumentNotFoundException, DatastoreException {
+            throws ConflictException, AttachmentException, DocumentNotFoundException, DatastoreException {
         Preconditions.checkNotNull(rev, "DocumentRevision can not be null");
 
             // update document with new body
@@ -1916,7 +1916,7 @@ class BasicDatastore implements Datastore, DatastoreExtended {
     // delete all leaf nodes
     @Override
     public List<BasicDocumentRevision> deleteDocument(final String id)
-            throws ConflictException, DocumentException  {
+            throws DocumentException  {
         Preconditions.checkNotNull(id, "id can not be null");
         // to return
 

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/BasicDocumentRevision.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/BasicDocumentRevision.java
@@ -129,8 +129,8 @@ public class BasicDocumentRevision implements DocumentRevision, Comparable<Basic
     }
 
     /**
-     * <p>Returns {@code true} if this revision is the current winner for the
-     * document.</p>
+     * @return {@code true} if this revision is the current winner for the
+     * document.
      */
     public boolean isCurrent(){
         return current;
@@ -144,6 +144,8 @@ public class BasicDocumentRevision implements DocumentRevision, Comparable<Basic
      * one tree, under certain circumstances, such as two documents with the
      * same ID being created in different datastores that are later replicated
      * across.</p>
+     *
+     * @return the sequence number of this revision's parent revision.
      */
     public long getParent() {
         return this.parent;
@@ -170,6 +172,9 @@ public class BasicDocumentRevision implements DocumentRevision, Comparable<Basic
      * <p>This Map includes reserved fields such as {@code _id} and
      * {@code _rev}. Changing the byte array may affect the {@code DocumentRevision},
      * as only a shallow copy is returned.</p>
+     *
+     * @return the JSON body of the document revision as a {@code Map}
+     * object.
      */
     public Map<String,Object> asMap() {
         if(map == null) {
@@ -196,6 +201,9 @@ public class BasicDocumentRevision implements DocumentRevision, Comparable<Basic
      * <p>This byte array includes reserved fields such as {@code _id} and
      * {@code _rev}. Changing the byte array does not affect the document
      * revisions contents.</p>
+     *
+     * @return the JSON body of the document revision as a {@code byte}
+     * array.
      */
     public byte[] asBytes() {
         byte[] result = null;
@@ -206,7 +214,7 @@ public class BasicDocumentRevision implements DocumentRevision, Comparable<Basic
     }
 
     /**
-     * <p>Returns {@code true} if this revision is marked deleted.</p>
+     * @return {@code true} if this revision is marked deleted.
      */
     public boolean isDeleted() {
         return deleted;
@@ -221,6 +229,8 @@ public class BasicDocumentRevision implements DocumentRevision, Comparable<Basic
      *
      * <p>The sequence number is unique across the database, it is updated
      * for every modification to the datastore.</p>
+     *
+     * @return the sequence number of this revision.
      */
     public long getSequence() {
         return sequence;

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/Datastore.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/Datastore.java
@@ -67,7 +67,7 @@ public interface Datastore {
      *
      * @return the name of this datastore
      */
-    public String getDatastoreName();
+    String getDatastoreName();
 
     /**
      * <p>Returns the encryption KeyProvider of this datastore.</p>
@@ -77,7 +77,7 @@ public interface Datastore {
      *
      * @return the key provider used by this datastore.
      */
-    public KeyProvider getKeyProvider();
+    KeyProvider getKeyProvider();
 
     /**
      * <p>Returns the current winning revision of a document.</p>
@@ -90,7 +90,7 @@ public interface Datastore {
      * @return {@code DocumentRevision} of the document or null if it doesn't exist.
      * @throws com.cloudant.sync.datastore.DocumentNotFoundException When the document specified was not found
      */
-    public BasicDocumentRevision getDocument(String documentId) throws DocumentNotFoundException;
+    BasicDocumentRevision getDocument(String documentId) throws DocumentNotFoundException;
 
     /**
      * <p>Retrieves a given revision of a document.</p>
@@ -108,7 +108,7 @@ public interface Datastore {
      * @return {@code DocumentRevision} of the document or null if it doesn't exist.
      * @throws com.cloudant.sync.datastore.DocumentNotFoundException if the document at the specified revision was not found
      */
-    public BasicDocumentRevision getDocument(String documentId, String revisionId) throws
+    BasicDocumentRevision getDocument(String documentId, String revisionId) throws
             DocumentNotFoundException;
 
     /**
@@ -122,7 +122,7 @@ public interface Datastore {
      * @return {@code true} if specified document's particular revision exists
      *         in the datastore, {@code false} otherwise.
      */
-    public boolean containsDocument(String documentId, String revisionId);
+    boolean containsDocument(String documentId, String revisionId);
 
     /**
      * <p>Returns whether this datastore contains any revisions of a document.
@@ -134,7 +134,7 @@ public interface Datastore {
      * @return {@code true} if specified document exists
      *         in the datastore, {@code false} otherwise.
      */
-    public boolean containsDocument(String documentId);
+    boolean containsDocument(String documentId);
 
     /**
      * <p>Enumerates the current winning revision for all documents in the
@@ -151,7 +151,7 @@ public interface Datastore {
      *                   descending order.
      * @return list of {@code DBObjects}, maximum length {@code limit}.
      */
-    public List<BasicDocumentRevision> getAllDocuments(int offset, int limit, boolean descending);
+    List<BasicDocumentRevision> getAllDocuments(int offset, int limit, boolean descending);
 
     /**
      * <p>Returns the current winning revisions for a set of documents.</p>
@@ -163,7 +163,7 @@ public interface Datastore {
      * @param documentIds list of document id
      * @return list of {@code DocumentRevision} objects.
      */
-    public List<BasicDocumentRevision> getDocumentsWithIds(List<String> documentIds);
+    List<BasicDocumentRevision> getDocumentsWithIds(List<String> documentIds);
 
     /**
      * <p>Retrieves the datastore's current sequence number.</p>
@@ -180,14 +180,14 @@ public interface Datastore {
      *
      * @return the last sequence number
      */
-    public long getLastSequence();
+    long getLastSequence();
 
     /**
      * <p>Return the number of documents in the datastore</p>
      *
      * @return number of non-deleted documents in datastore
      */
-    public int getDocumentCount();
+    int getDocumentCount();
 
     /**
      * <p>Returns a list of changed documents, from {@code since} to
@@ -200,7 +200,7 @@ public interface Datastore {
      * @return list of the documents and last sequence number of the change set
      *      (checkpoint)
      */
-    public Changes changes(long since, int limit);
+    Changes changes(long since, int limit);
 
     /**
      * <p>Returns the EventBus which this Datastore posts
@@ -209,7 +209,7 @@ public interface Datastore {
      *
      * @see <a href="https://code.google.com/p/guava-libraries/wiki/EventBusExplained">Google Guava EventBus documentation</a>
      */
-    public EventBus getEventBus();
+    EventBus getEventBus();
 
     /**
      * <p>Return the directory for specified extensionName</p>
@@ -218,7 +218,7 @@ public interface Datastore {
      *
      * @return the directory for specified extensionName
      */
-    public String extensionDataFolder(String extensionName);
+    String extensionDataFolder(String extensionName);
 
     /**
      * <p>Return {@code @Iterable<String>} over ids to all the Documents with
@@ -234,7 +234,7 @@ public interface Datastore {
      *
      * @see <a href="http://wiki.apache.org/couchdb/Replication_and_conflicts">Replication and conflicts</a>
      */
-    public Iterator<String> getConflictedDocumentIds();
+    Iterator<String> getConflictedDocumentIds();
 
     /**
      * <p>
@@ -253,16 +253,16 @@ public interface Datastore {
      *
      * @see com.cloudant.sync.datastore.ConflictResolver
      */
-    public void resolveConflictsForDocument(String docId, ConflictResolver resolver)
-        throws ConflictException, IOException;
+    void resolveConflictsForDocument(String docId, ConflictResolver resolver)
+        throws ConflictException;
 
     /**
      * Close the datastore
      */
-    public void close();
+    void close();
 
 
-    public List<String> getPossibleAncestorRevisionIDs(String docId,
+    List<String> getPossibleAncestorRevisionIDs(String docId,
                                                        String revId,
                                                        int limit);
 
@@ -278,11 +278,11 @@ public interface Datastore {
      *
      * @param rev the <code>MutableDocumentRevision</code> to be created
      * @return a <code>DocumentRevision</code> - the newly created document
-     * @throws com.cloudant.sync.datastore.AttachmentException if there is a problem saving any new attachments
-     * @throws com.cloudant.sync.datastore.DocumentException if there is a problem creating the document
+     * @throws com.cloudant.sync.datastore.AttachmentException if there was an error saving any new attachments
+     * @throws com.cloudant.sync.datastore.DocumentException if there was an error creating the document
      * @see Datastore#getEventBus()
      */
-    public BasicDocumentRevision createDocumentFromRevision(MutableDocumentRevision rev) throws DocumentException, AttachmentException;
+    BasicDocumentRevision createDocumentFromRevision(MutableDocumentRevision rev) throws DocumentException;
 
     /**
      * <p>Updates a document that exists in the datastore with with body and attachments
@@ -298,12 +298,11 @@ public interface Datastore {
      * @param rev the <code>MutableDocumentRevision</code> to be updated
      * @return a <code>DocumentRevision</code> - the updated document
      * @throws ConflictException <code>rev</code> is not a current revision for this document
-     * @throws com.cloudant.sync.datastore.AttachmentException if there is a problem saving any new attachments
-     * @throws com.cloudant.sync.datastore.DocumentNotFoundException if the document to be updated was not found
      * @throws com.cloudant.sync.datastore.AttachmentException if there was an error saving the attachments
+     * @throws com.cloudant.sync.datastore.DocumentException if there was an error updating the document
      * @see Datastore#getEventBus()
      */
-    public BasicDocumentRevision updateDocumentFromRevision(MutableDocumentRevision rev) throws ConflictException, DocumentNotFoundException, AttachmentException, DocumentException;
+    BasicDocumentRevision updateDocumentFromRevision(MutableDocumentRevision rev) throws DocumentException;
 
     /**
      * <p>Deletes a document from the datastore.</p>
@@ -330,7 +329,7 @@ public interface Datastore {
      * @see Datastore#getEventBus()
      * @see Datastore#resolveConflictsForDocument
      */
-    public BasicDocumentRevision deleteDocumentFromRevision(BasicDocumentRevision rev) throws ConflictException;
+    BasicDocumentRevision deleteDocumentFromRevision(BasicDocumentRevision rev) throws ConflictException;
 
     /**
      * <p>Delete all leaf revisions for the document</p>
@@ -341,18 +340,16 @@ public interface Datastore {
      *
      * @param id the ID of the document to delete leaf nodes for
      * @return a List of a <code>DocumentRevision</code>s - the deleted or "tombstone" documents
-     * @throws ConflictException
      * @throws com.cloudant.sync.datastore.DocumentException if there was an error deleting the document
      * @see Datastore#getEventBus()
      * @see com.cloudant.sync.datastore.Datastore#deleteDocumentFromRevision(BasicDocumentRevision)
      */
-    public List<BasicDocumentRevision> deleteDocument(String id) throws ConflictException,
-            DocumentException;
+    List<BasicDocumentRevision> deleteDocument(String id) throws DocumentException;
 
     /**
      * Compacts the sqlDatabase storage by removing the bodies and attachments of obsolete revisions.
      */
-    public void compact();
+    void compact();
 
 }
 

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/DatastoreManager.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/DatastoreManager.java
@@ -169,6 +169,9 @@ public class DatastoreManager {
      *
      * @param dbName name of datastore to open
      * @param provider  KeyProvider object; use a NullKeyProvider if database shouldn't be encrypted.
+     *
+     * @throws DatastoreNotCreatedException if the database cannot be opened
+     *
      * @return {@code Datastore} with the given name
      *
      * @see DatastoreManager#getEventBus()
@@ -205,6 +208,8 @@ public class DatastoreManager {
      * <p>If the datastore was successfully deleted, a 
      * {@link com.cloudant.sync.notifications.DatabaseDeleted DatabaseDeleted} 
      * event is posted on the event bus.</p>
+     *
+     * @param dbName Name of database to create
      *
      * @throws IOException if the datastore doesn't exist on disk or there is
      *      a problem deleting the files.

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/DocumentRevision.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/DocumentRevision.java
@@ -38,21 +38,21 @@ import java.util.Map;
 public interface DocumentRevision {
 
     /**
-     * <p>Returns the unique identifier of the document.</p>
+     * @return the unique identifier of the document
      */
-    public String getId();
+    String getId();
 
     /**
-     * <p>Returns the revision ID of this document revision.</p>
+     * @return the revision ID of this document revision
      */
-    public String getRevision();
+    String getRevision();
 
     /**
-     * <p>Returns the {@code DocumentBody} of the document.</p>
+     * @return the {@code DocumentBody} of the document
      */
-    public DocumentBody getBody();
+    DocumentBody getBody();
 
     // NB the key is purely for the user's convenience and doesn't have to be the same as the attachment name
-    public Map<String, Attachment> getAttachments();
+    Map<String, Attachment> getAttachments();
 
 }

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/DocumentRevisionTree.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/DocumentRevisionTree.java
@@ -176,6 +176,7 @@ public class DocumentRevisionTree {
      * the document tree.</p>
      *
      * @param documentRevision the {@code DocumentRevision} to add
+     * @return {@code DocumentRevisionTree} for method chaining
      */
     public DocumentRevisionTree add(BasicDocumentRevision documentRevision) {
         Preconditions.checkArgument(!sequenceMap.containsKey(documentRevision.getSequence()),
@@ -323,6 +324,7 @@ public class DocumentRevisionTree {
     /**
      * <p>Returns the root revision of this document with a given sequence number.
      * </p>
+     * @param sequence a sequence number
      * @return  the root revision of this document with a given sequence number
      */
     public DocumentRevisionNode root(long sequence) {

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/DocumentRevsList.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/DocumentRevsList.java
@@ -24,16 +24,17 @@ import java.util.Iterator;
 import java.util.List;
 
 /**
+ * <p>
  * List of <code>DocumentRevs</code>. All the <code>DocumentRevs</code> are for the same document.
  * If the DocumentRevisionTree is a forest, some of the <code>DocumentRevs</code> might from different tree (case 2).
  * If two <code>DocumentRevs</code> are from the same tree, they are different branch of that tree (case 1).
- * <p>
+ * </p>
  *
  * <pre>
- * Case 1: they are from same three.
- *   1 → 2 → 3
- *     \
- *     → 2 → 3*
+ * Case 1: they are from same tree.
+ *   1 → 2  → 3
+ *     |
+ *     → 2* → 3*
  *
  * Case 2: they are from different trees
  *   1  → 2  → 3
@@ -41,17 +42,22 @@ import java.util.List;
  *   1* → 2* → 3*
  * </pre>
  *
+ * <p>
  * The list can be iterated in the order of minimum generation id (min-generation). Each
  * <code>DocumentRevs</code> has a list of revisions ids (aka revision history), and "start".
  * The "start" number is largest generation. So the min-generation is:
+ * </p>
  * <pre>
  *   DocumentRevs.getRevisions().getStart() → DocumentRevs.getRevisions().getIds().size() + 1.
  * </pre>
- * This is very important since it decides which <code>DocumentRevs</code> is inserted to db first.
  * <p>
+ * This is very important since it decides which <code>DocumentRevs</code> is inserted to db first.
+ * </p>
  *
+ * <p>
  * For <code>DocumentRevs</code> with the same "min-generation", the order is un-determined. This is
  * probably the case two document with same id/body are created in different database.
+ * </p>
  */
 public class DocumentRevsList implements Iterable<DocumentRevs> {
 

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/DocumentRevsUtils.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/DocumentRevsUtils.java
@@ -27,13 +27,16 @@ import java.util.logging.Logger;
 
 public class DocumentRevsUtils {
 
-    private static final String LOG_TAG = "DocumentRevsUtils";
     private static final Logger logger = Logger.getLogger(DocumentRevsUtils.class.getCanonicalName());
 
     /**
-     * Create the list of the revisionId in ascending order.
+     * Create the list of the revision ids in ascending order.
      *
      * The DocumentRevs is for a single tree. There should be one DocumentRevs for each open revision.
+     * @param documentRevs a deserialised JSON document including the _revisions structure. See
+     * <a href="http://docs.couchdb.org/en/latest/api/document/common.html#getting-a-list-of-revisions">
+     * Getting a List of Revisions</a> for more information.
+     * @return list of revision ids in ascending order
      */
     public static List<String> createRevisionIdHistory(DocumentRevs documentRevs) {
         validateDocumentRevs(documentRevs);

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/MultipartAttachmentWriter.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/MultipartAttachmentWriter.java
@@ -83,6 +83,8 @@ public class MultipartAttachmentWriter extends InputStream {
 
     /**
      * Construct a <code>MultipartAttachmentWriter</code> with a specific <code>boundary</code>
+     * @param boundary The boundary sequence used to delimit each part. Must not occur anywhere in
+     *                 the data of any part.
      */
     public MultipartAttachmentWriter(String boundary) {
         // pick a boundary
@@ -130,7 +132,7 @@ public class MultipartAttachmentWriter extends InputStream {
      * entire attachment into memory.
      *
      * @param attachment The attachment to be streamed
-     * @throws IOException
+     * @throws IOException if there was an error getting the input stream from the {@code Attachment}
      */
     public void addAttachment(Attachment attachment) throws IOException {
         contentLength += partBoundary.length;
@@ -175,7 +177,7 @@ public class MultipartAttachmentWriter extends InputStream {
      * Read a single byte from the stream.
      * @return The next byte in the stream, expressed as an int in the range [0..255].
      *         If there are no more bytes available, return -1.
-     * @throws java.io.IOException
+     * @throws java.io.IOException if there was an error reading from one of the internal input streams
      */
     public int read() throws java.io.IOException {
         int c;
@@ -195,7 +197,7 @@ public class MultipartAttachmentWriter extends InputStream {
      * Read at most the next <code>bytes.length</code> bytes from the stream.
      * @param bytes A buffer to read the next <i>n</i> bytes into, up to the limit of the length of the buffer, or the number of bytes available, whichever is lower.
      * @return The actual number of bytes read, or -1 to signal the end of the stream has been reached.
-     * @throws java.io.IOException
+     * @throws java.io.IOException if there was an error reading from one of the internal input streams
      */
     @Override
     public int read(byte[] bytes) throws java.io.IOException {

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/PreparedAttachment.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/PreparedAttachment.java
@@ -41,7 +41,10 @@ public class PreparedAttachment {
      *
      * @param attachment The attachment to prepare
      * @param attachmentsDir The 'BLOB store' or location where attachments are stored for this database
-     * @throws AttachmentNotSavedException
+     * @param attachmentStreamFactory The {@link AttachmentStreamFactory} used for writing attachment
+     *                                data to disk
+     * @throws AttachmentNotSavedException if there was an error copying the attachment or
+     * calculating its SHA1
      */
     public PreparedAttachment(Attachment attachment,
                               String attachmentsDir,

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/encryption/KeyProvider.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/encryption/KeyProvider.java
@@ -23,9 +23,7 @@ package com.cloudant.sync.datastore.encryption;
 public interface KeyProvider {
 
     /**
-     * Returns the encryption key used to encrypt datastore data.
-     *
-     * @return
+     * @return the encryption key used to encrypt datastore data
      */
     EncryptionKey getEncryptionKey();
 }

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/migrations/Migration.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/migrations/Migration.java
@@ -25,7 +25,10 @@ public interface Migration {
      * Implementors should run all migration steps in this method.
      *
      * Throw an exception if the migration fails.
+     *
+     * @param db The {@link SQLDatabase} to migrate
+     * @throws Exception an exception was thrown during migration
      */
-    public void runMigration(SQLDatabase db) throws Exception;
+    void runMigration(SQLDatabase db) throws Exception;
 
 }

--- a/sync-core/src/main/java/com/cloudant/sync/query/IndexManager.java
+++ b/sync-core/src/main/java/com/cloudant/sync/query/IndexManager.java
@@ -89,6 +89,7 @@ public class IndexManager {
 
     /**
      *  Constructs a new IndexManager which indexes documents in 'datastore'
+     *  @param datastore The {@link Datastore} to index
      */
     public IndexManager(Datastore datastore) {
         this.datastore = datastore;

--- a/sync-core/src/main/java/com/cloudant/sync/replication/CouchDB.java
+++ b/sync-core/src/main/java/com/cloudant/sync/replication/CouchDB.java
@@ -29,30 +29,30 @@ import java.util.Set;
 
 interface CouchDB {
 
-    public String getIdentifier();
+    String getIdentifier();
 
     /**
-     * Returns true if database exists, otherwise false
+     * @return true if database exists, otherwise false
      */
-    public boolean exists();
+    boolean exists();
 
-    public Response create(Object object);
-    public Response update(String id, Object object);
-    public <T> T get(Class<T> classType, String id);
-    public Response delete(String id, String rev);
+    Response create(Object object);
+    Response update(String id, Object object);
+    <T> T get(Class<T> classType, String id);
+    Response delete(String id, String rev);
 
-    public String getCheckpoint(String checkpointId);
-    public void putCheckpoint(String checkpointId, String sequence);
+    String getCheckpoint(String checkpointId);
+    void putCheckpoint(String checkpointId, String sequence);
 
-    public ChangesResult changes(Object lastSequence, int limit);
-    public ChangesResult changes(Replication.Filter filter,Object lastSequence, int limit);
-    public List<DocumentRevs> getRevisions(String documentId,
+    ChangesResult changes(Object lastSequence, int limit);
+    ChangesResult changes(Replication.Filter filter,Object lastSequence, int limit);
+    List<DocumentRevs> getRevisions(String documentId,
                                            Collection<String> revisionIds,
                                            Collection<String> attsSince,
                                            boolean pullAttachmentsInline);
-    public void bulk(List<BasicDocumentRevision> revisions);
-    public void bulkSerializedDocs(List<String> serializedDocs);
-    public List<Response> putMultiparts(List<MultipartAttachmentWriter> multiparts);
-    public Map<String, CouchClient.MissingRevisions> revsDiff(Map<String, Set<String>> revisions);
-    public UnsavedStreamAttachment getAttachmentStream(String id, String rev, String attachmentName, String contentType, String encoding);
+    void bulk(List<BasicDocumentRevision> revisions);
+    void bulkSerializedDocs(List<String> serializedDocs);
+    List<Response> putMultiparts(List<MultipartAttachmentWriter> multiparts);
+    Map<String, CouchClient.MissingRevisions> revsDiff(Map<String, Set<String>> revisions);
+    UnsavedStreamAttachment getAttachmentStream(String id, String rev, String attachmentName, String contentType, String encoding);
 }

--- a/sync-core/src/main/java/com/cloudant/sync/replication/Replicator.java
+++ b/sync-core/src/main/java/com/cloudant/sync/replication/Replicator.java
@@ -58,7 +58,7 @@ public interface Replicator {
      *   second or further time.</li>
      * </ul>
      */
-    public void start();
+    void start();
 
     /**
      * <p>Stops an in-progress replication.</p>
@@ -91,7 +91,7 @@ public interface Replicator {
      * it will immediately move to the {@link Replicator.State#STOPPED} state.
      * </p>
      */
-    public void stop();
+    void stop();
 
     /**
      * <p>Returns the {@link Replicator.State} this replicator is in.</p>
@@ -101,13 +101,15 @@ public interface Replicator {
      * <p>In all states other than {@link Replicator.State#STARTED} and
      * {@link Replicator.State#STOPPING}, the replicator object
      * is idle with no background threads.</p>
+     *
+     * @return the {@link Replicator.State} this replicator is in
      */
-    public State getState();
+    State getState();
 
     /**
      * <p>Describes the state of a {@link Replicator} at a given moment.</p>
      */
-    public enum State {
+    enum State {
         /**
          * The replicator is initialised and is ready to start.
          */
@@ -151,6 +153,6 @@ public interface Replicator {
      *
      * @return EventBus object.
      */
-    public EventBus getEventBus();
+    EventBus getEventBus();
 }
 

--- a/sync-core/src/main/java/com/cloudant/sync/sqlite/SQLDatabaseFactory.java
+++ b/sync-core/src/main/java/com/cloudant/sync/sqlite/SQLDatabaseFactory.java
@@ -32,7 +32,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Factory class to create @{link SQLDatabase}, and update schema
+ * Factory class to create {@link SQLDatabase}, and update schema
  */
 public class SQLDatabaseFactory {
 

--- a/sync-core/src/main/java/com/cloudant/sync/sqlite/SQLDatabaseQueue.java
+++ b/sync-core/src/main/java/com/cloudant/sync/sqlite/SQLDatabaseQueue.java
@@ -157,8 +157,8 @@ public class SQLDatabaseQueue {
     }
 
     /**
-     * Checks if @{link shutdown} has been called
-     * @return true if @{link shutdown} has been called.
+     * Checks if {@link SQLDatabaseQueue#shutdown()} has been called
+     * @return true if {@link SQLDatabaseQueue#shutdown()} has been called.
      */
     public boolean isShutdown() {
         return queue.isShutdown();

--- a/sync-core/src/main/java/com/cloudant/sync/util/AbstractTreeNode.java
+++ b/sync-core/src/main/java/com/cloudant/sync/util/AbstractTreeNode.java
@@ -21,7 +21,7 @@ import java.util.logging.Logger;
 
 /**
  * Internal utility class
- * @param <T>
+ * @param <T> The type of data owned by each node
  */
 public abstract class AbstractTreeNode<T> {
 

--- a/sync-core/src/main/java/com/cloudant/sync/util/CouchUtils.java
+++ b/sync-core/src/main/java/com/cloudant/sync/util/CouchUtils.java
@@ -43,7 +43,7 @@ public class CouchUtils {
         return true;
     }
 
-    /**
+    /*
      * Parses the _revisions dict from a document into an array of revision ID strings
      */
     public static List<String> parseCouchDBRevisionHistory(Map<String, Object> docProperties) {


### PR DESCRIPTION
What:

* squash all javadoc warnings
* re-word some javadoc
* remove useless 'public' specifiers on public interface methods
* remove some redundant `throws` clauses

Why:

running `gradle docs` outputs extraneous noise and makes it difficult to spot when there are genuine javadoc errors

Testing:

run `gradle docs` and no errors/warnings are reported; briefly scan HTML javadoc output to ensure documentation looks OK.

reviewer: @brynh 
reviewer: @ricellis 