### PR TITLE
Fix query without any index capability

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 - [BREAKING CHANGE] Moved code for encryption on Android to the
   `sync-android-encryption` subproject. See the instructions in the [README](https://github.com/cloudant/sync-android/blob/master/README.md)
   file for how to include `sync-android-encryption` in your project.
+- [FIX] Fixed issue where at least one index had to be created before a query would execute.  
+  You can now query for documents without the existence of any indexes.
 
 # 0.12.3 (2015-06-30)
 

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/Datastore.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/Datastore.java
@@ -154,6 +154,14 @@ public interface Datastore {
     List<BasicDocumentRevision> getAllDocuments(int offset, int limit, boolean descending);
 
     /**
+     * <p>Enumerates the current winning revision for all documents in the
+     * datastore and return a list of their document identifiers.</p>
+     *
+     * @return list of {@code String}.
+     */
+    public List<String> getAllDocumentIds();
+
+    /**
      * <p>Returns the current winning revisions for a set of documents.</p>
      *
      * <p>If the {@code documentIds} list contains document IDs not present

--- a/sync-core/src/test/java/com/cloudant/sync/datastore/BasicDatastoreCRUDTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/datastore/BasicDatastoreCRUDTest.java
@@ -14,6 +14,10 @@
 
 package com.cloudant.sync.datastore;
 
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+
 import com.cloudant.sync.sqlite.Cursor;
 import com.cloudant.sync.sqlite.SQLDatabase;
 import com.cloudant.sync.sqlite.SQLQueueCallable;
@@ -21,12 +25,9 @@ import com.cloudant.sync.util.CouchUtils;
 import com.cloudant.sync.util.DatabaseUtils;
 
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.File;
-import java.io.IOException;
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -34,9 +35,6 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 import java.util.Set;
-
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.hasSize;
 
 public class BasicDatastoreCRUDTest extends BasicDatastoreTestBase {
 
@@ -555,6 +553,20 @@ public class BasicDatastoreCRUDTest extends BasicDatastoreTestBase {
         // Test count and offsets for descending and ascending
         getAllDocuments_testCountAndOffset(objectCount, documentRevisions, false);
         getAllDocuments_testCountAndOffset(objectCount, reversedObjects, true);
+    }
+
+    @Test
+    public void getAllDocumentIds() throws Exception {
+        Assert.assertTrue(datastore.getAllDocumentIds().isEmpty());
+        MutableDocumentRevision rev = new MutableDocumentRevision();
+        rev.docId = "document-one";
+        rev.body = bodyOne;
+        datastore.createDocumentFromRevision(rev);
+        rev.docId = "document-two";
+        rev.body = bodyTwo;
+        datastore.createDocumentFromRevision(rev);
+        Assert.assertThat(datastore.getAllDocumentIds(), containsInAnyOrder("document-one",
+                                                                            "document-two"));
     }
 
     @Test

--- a/sync-core/src/test/java/com/cloudant/sync/query/QueryWithoutCoveringIndexesTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/query/QueryWithoutCoveringIndexesTest.java
@@ -210,7 +210,7 @@ public class QueryWithoutCoveringIndexesTest extends AbstractQueryTestBase {
                                                                  "fred12"));
     }
 
-    // When executing queries containing $size operator
+// When executing queries containing $size operator
 
     @Test
     public void worksWhenArrayCountMatchesUsingSIZE() throws Exception {
@@ -396,6 +396,22 @@ public class QueryWithoutCoveringIndexesTest extends AbstractQueryTestBase {
         query.put("$and", Arrays.<Object>asList(petOp1, petOp2));
         QueryResult queryResult = im.find(query);
         assertThat(queryResult.documentIds(), is(empty()));
+    }
+
+    @Test
+    public void canQueryWithoutAnyUserDefinedIndexes() throws Exception {
+        setUpWithoutCoveringIndexesQueryData();
+        // query - { "town" : "bristol" }
+        // indexes - No user defined indexes found.  Retrieves
+        //           document ids directly from the datastore.
+        assertThat(im.deleteIndexNamed("basic"), is(true));
+        assertThat(im.deleteIndexNamed("pet"), is(true));
+        assertThat(im.listIndexes().keySet(), is(empty()));
+
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("town", "bristol");
+        QueryResult queryResult = im.find(query);
+        assertThat(queryResult.documentIds(), containsInAnyOrder("mike72", "fred12"));
     }
 
 }


### PR DESCRIPTION
_What:_

There is a bug in Query that requires at least one index be created before any query can execute.

_Why:_

The desired behavior is to allow for querying of documents regardless of the existence of any indexes.

_How:_

Remove the logic that causes a query to fail when no indexes are found and replace it with logic that catches the condition and instead retrieves a full list of document ids from the main datastore for the post-hoc matcher to use when generating the query results.

This logic is found in the SQL translator and the query executor.  Additionally a new method to retrieve just a list of document ids needs to be added to the datastore API.

reviewer @mikerhodes 
reviewer @gadamc 

BugId: 45362