### PR TITLE
Fix pickWinnerOfConflicts to select current revision:

### DIFF
--- a/sync-core/src/main/java/com/cloudant/sync/datastore/BasicDocumentRevision.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/BasicDocumentRevision.java
@@ -244,7 +244,7 @@ public class BasicDocumentRevision implements DocumentRevision, Comparable<Basic
 
     @Override
     public String toString() {
-        return "{ id: " + this.id + ", rev: " + this.revision + ", seq: " + sequence + ", parent: " + parent + " }";
+        return "{ id: " + this.id + ", rev: " + this.revision + ", seq: " + sequence + ", parent: " + parent + ", current: " + current + ", deleted " + deleted +" }";
     }
 
     public int getGeneration() {


### PR DESCRIPTION
* What: fix pickWinnerOfConflicts which had incorrect behaviour with regard to deleted revisions, depending on the order of documents being inserted via replication.

Apply the CouchDB sorting criteria (highest rev wins, if there
is a tie then do a lexicographical compare of the revision id strings)
to all non-deleted leafs

* Why: previous behaviour was incorrect and could sometimes return deleted revisions as being 'current', as noticed by a customer

* Testing: new test cases `forceInsert_pickWinnerOfConflicts_Simple`, `forceInsert_pickWinnerOfConflicts_Complex` - see tests and comments for details