### PR TITLE
Fix url encoding of local document urls

### DIFF
--- a/sync-core/src/main/java/com/cloudant/common/CouchConstants.java
+++ b/sync-core/src/main/java/com/cloudant/common/CouchConstants.java
@@ -37,5 +37,6 @@ public class CouchConstants {
     public static final String _design_prefix = "_design/";
     public static final String _design_prefix_encoded = "_design%2F";
     public static final String _local_prefix = "_local/";
+    public static final String _local_prefix_encoded = "_local%2F";
 
 }

--- a/sync-core/src/main/java/com/cloudant/mazha/CouchURIHelper.java
+++ b/sync-core/src/main/java/com/cloudant/mazha/CouchURIHelper.java
@@ -25,7 +25,6 @@ import com.google.common.base.Joiner;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -207,8 +206,9 @@ public class CouchURIHelper {
                     null // fragment
             );
             String encodedString = uri.toASCIIString().replace("/", "%2F");
-            if (encodedString.startsWith(CouchConstants._design_prefix_encoded)) {
-                // we replaced a the first slash in the design doc URL, which we shouldn't
+            if (encodedString.startsWith(CouchConstants._design_prefix_encoded) ||
+                    encodedString.startsWith(CouchConstants._local_prefix_encoded)) {
+                // we replaced a the first slash in the design or local doc URL, which we shouldn't
                 // so let's put it back
                 return encodedString.replaceFirst("%2F", "/");
             } else {

--- a/sync-core/src/test/java/com/cloudant/mazha/CouchURIHelperTest.java
+++ b/sync-core/src/test/java/com/cloudant/mazha/CouchURIHelperTest.java
@@ -57,6 +57,16 @@ public class CouchURIHelperTest {
     }
 
     @Test
+    public void _localDocumentURI() throws Exception {
+        final String expected = uriBase + "/db_name/_local/mylocaldoc";
+
+        CouchURIHelper helper = helper(path+"/db_name");
+        URI localDoc = helper.documentUri("_local/mylocaldoc");
+
+        Assert.assertEquals(expected,localDoc.toString());
+    }
+
+    @Test
     public void buildDbUri() throws Exception {
         URI expected = new URI(uriBase + "/db_name");
         URI actual = helper(path+"/db_name").getRootUri();


### PR DESCRIPTION
Local documents should not be url encoded, remove / encoding so url
is correctly generated as _local/mylocal instead of _local&2FmyLocal

reviewer @tomblench 
reviewer @ricellis 