### PR TITLE
Remove unused addAttachment methods from classes and interface

### DIFF
--- a/sync-core/src/main/java/com/cloudant/sync/datastore/BasicDatastore.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/BasicDatastore.java
@@ -1746,25 +1746,6 @@ class BasicDatastore implements Datastore, DatastoreExtended {
     }
 
     @Override
-    public void addAttachment(final PreparedAttachment att, final BasicDocumentRevision rev) throws AttachmentException {
-
-        try {
-            queue.submit(new SQLQueueCallable<Object>(){
-                @Override
-                public Object call(SQLDatabase db) throws Exception {
-                    attachmentManager.addAttachment(db,att, rev);
-                    return null;
-                }
-            }).get();
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        } catch (ExecutionException e) {
-           throw new AttachmentException(e);
-        }
-
-    }
-
-    @Override
     public Attachment getAttachment(final BasicDocumentRevision rev, final String attachmentName) {
         try {
             return queue.submit(new SQLQueueCallable<Attachment>() {

--- a/sync-core/src/main/java/com/cloudant/sync/datastore/DatastoreExtended.java
+++ b/sync-core/src/main/java/com/cloudant/sync/datastore/DatastoreExtended.java
@@ -222,17 +222,6 @@ public interface DatastoreExtended extends Datastore {
      */
     PreparedAttachment prepareAttachment(Attachment att) throws AttachmentException;
 
-    /**
-     * Add attachment to document revision without incrementing revision.
-     *
-     * Used by replicator when receiving new/updated attachments
-     *
-     * @param att The attachment to add
-     * @param rev The DocumentRevision to add the attachment to
-     * @throws AttachmentException if there was an error inserting the attachment metadata into the
-     * database or if there was an error moving the attachment file on the file system
-     */
-    void addAttachment(PreparedAttachment att, BasicDocumentRevision rev) throws  AttachmentException;
 
     /**
      * <p>Returns attachment <code>attachmentName</code> for the revision.</p>

--- a/sync-core/src/main/java/com/cloudant/sync/replication/DatastoreWrapper.java
+++ b/sync-core/src/main/java/com/cloudant/sync/replication/DatastoreWrapper.java
@@ -115,9 +115,4 @@ class DatastoreWrapper {
         return this.dbCore.prepareAttachment(att);
     }
 
-    protected void addAttachment(PreparedAttachment att, BasicDocumentRevision rev) throws AttachmentException {
-        this.dbCore.addAttachment(att, rev);
-    }
-
-
 }


### PR DESCRIPTION
- What: Remove unused methods

- Why: `addAttachment` is now called on the `AttachmentManager` object directly from `BasicDatastore`

- Testing: All existing tests pass

reviewer: @brynh 
reviewer: @ricellis 