### PR TITLE
Report documents and batches replicated on completion

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
   file for how to include `sync-android-encryption` in your project.
 - [FIX] Fixed issue where at least one index had to be created before a query would execute.  
   You can now query for documents without the existence of any indexes.
+- [NEW] New fields `documentsReplicated` and `batchesReplicated` added
+  to ReplicationCompleted class
 
 # 0.12.3 (2015-06-30)
 

--- a/doc/replication.md
+++ b/doc/replication.md
@@ -96,6 +96,8 @@ private class Listener {
 
     private final CountDownLatch latch;
     public ErrorInfo error = null;
+    public int documentsReplicated;
+    public int batchesReplicated;
 
     Listener(CountDownLatch latch) {
         this.latch = latch;
@@ -103,6 +105,8 @@ private class Listener {
 
     @Subscribe
     public void complete(ReplicationCompleted event) {
+        this.documentsReplicated = event.documentsReplicated;
+        this.batchesReplicated = event.batchesReplicated;
         latch.countDown();
     }
 
@@ -143,6 +147,9 @@ replicator.getEventBus().unregister(listener);
 if (replicator.getState() != Replicator.State.COMPLETE) {
     System.out.println("Error replicating TO remote");
     System.out.println(listener.error);
+} else {
+    System.out.println(String.format("Replicated %d documents in %d batches",
+            listener.documentsReplicated, listener.batchesReplicated));
 }
 ```
 

--- a/sync-core/src/main/java/com/cloudant/sync/notifications/ReplicationCompleted.java
+++ b/sync-core/src/main/java/com/cloudant/sync/notifications/ReplicationCompleted.java
@@ -28,14 +28,28 @@ import com.cloudant.sync.replication.Replicator;
  */
 public class ReplicationCompleted {
 
-    public ReplicationCompleted(Replicator replicator) {
+    public ReplicationCompleted(Replicator replicator,
+                                int documentsReplicated,
+                                int batchesReplicated) {
         this.replicator = replicator;
+        this.documentsReplicated = documentsReplicated;
+        this.batchesReplicated = batchesReplicated;
     }
     
     /** 
      * The {@code Replicator} issuing the event
      */
     public final Replicator replicator;
+
+    /**
+     * The total number of documents replicated by the {@link #replicator}
+     */
+    public final int documentsReplicated;
+
+    /**
+     * The total number of batches replicated by the {@link #replicator}
+     */
+    public final int batchesReplicated;
     
     @Override
     public boolean equals(Object other) {

--- a/sync-core/src/main/java/com/cloudant/sync/replication/BasicPullStrategy.java
+++ b/sync-core/src/main/java/com/cloudant/sync/replication/BasicPullStrategy.java
@@ -121,10 +121,12 @@ class BasicPullStrategy implements ReplicationStrategy {
         this.executor.shutdownNow();
     }
 
+    @Override
     public int getDocumentCounter() {
         return this.documentCounter;
     }
 
+    @Override
     public int getBatchCounter() {
         return this.batchCounter;
     }

--- a/sync-core/src/main/java/com/cloudant/sync/replication/BasicPushStrategy.java
+++ b/sync-core/src/main/java/com/cloudant/sync/replication/BasicPushStrategy.java
@@ -106,10 +106,12 @@ class BasicPushStrategy implements ReplicationStrategy {
         this.cancel = true;
     }
 
+    @Override
     public int getDocumentCounter() {
         return this.documentCounter;
     }
 
+    @Override
     public int getBatchCounter() {
         return this.batchCounter;
     }

--- a/sync-core/src/main/java/com/cloudant/sync/replication/BasicReplicator.java
+++ b/sync-core/src/main/java/com/cloudant/sync/replication/BasicReplicator.java
@@ -115,7 +115,9 @@ class BasicReplicator implements Replicator {
         }
 
         // Fill in new ReplicationCompleted event with pointer to us
-        ReplicationCompleted rcUs = new ReplicationCompleted(this);
+        ReplicationCompleted rcUs = new ReplicationCompleted(this,
+                rc.replicationStrategy.getDocumentCounter(),
+                rc.replicationStrategy.getBatchCounter());
         eventBus.post(rcUs);        
     }
 

--- a/sync-core/src/main/java/com/cloudant/sync/replication/ReplicationStrategy.java
+++ b/sync-core/src/main/java/com/cloudant/sync/replication/ReplicationStrategy.java
@@ -27,4 +27,8 @@ interface ReplicationStrategy extends Runnable {
 
     String getReplicationId() throws DatastoreException;
 
+    int getDocumentCounter();
+
+    int getBatchCounter();
+
 }

--- a/sync-core/src/test/java/com/cloudant/sync/replication/BasicReplicatorMockTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/replication/BasicReplicatorMockTest.java
@@ -131,7 +131,7 @@ public class BasicReplicatorMockTest {
         startAndVerify();
 
         ReplicationStrategyCompleted rsc = new ReplicationStrategyCompleted(mockStrategy);
-        ReplicationCompleted rc = new ReplicationCompleted(replicator);
+        ReplicationCompleted rc = new ReplicationCompleted(replicator, 0, 0);
         
         replicator.complete(rsc);
 
@@ -148,7 +148,7 @@ public class BasicReplicatorMockTest {
         startAndVerify();
 
         ReplicationStrategyCompleted rsc = new ReplicationStrategyCompleted(mockStrategy);
-        ReplicationCompleted rc = new ReplicationCompleted(replicator);
+        ReplicationCompleted rc = new ReplicationCompleted(replicator, 0, 0);
         
         doThrow(new RuntimeException("Mocked error")).when(mockListener).complete(rc);
         
@@ -207,7 +207,7 @@ public class BasicReplicatorMockTest {
         Assert.assertFalse(replicator.strategyThread().isAlive());
 
         ReplicationStrategyCompleted rsc = new ReplicationStrategyCompleted(mockStrategy);
-        ReplicationCompleted rc = new ReplicationCompleted(replicator);
+        ReplicationCompleted rc = new ReplicationCompleted(replicator, 0, 0);
         
         replicator.complete(rsc);
         verify(mockListener).complete(rc);
@@ -252,7 +252,7 @@ public class BasicReplicatorMockTest {
         Assert.assertEquals(Replicator.State.STOPPING, replicator.getState());
 
         ReplicationStrategyCompleted rsc = new ReplicationStrategyCompleted(mockStrategy);
-        ReplicationCompleted rc = new ReplicationCompleted(replicator);
+        ReplicationCompleted rc = new ReplicationCompleted(replicator, 0, 0);
         replicator.complete(rsc);
         Assert.assertEquals(Replicator.State.STOPPED, replicator.getState());
         verify(mockListener).complete(rc);

--- a/sync-core/src/test/java/com/cloudant/sync/replication/TestStrategyListener.java
+++ b/sync-core/src/test/java/com/cloudant/sync/replication/TestStrategyListener.java
@@ -27,10 +27,14 @@ public class TestStrategyListener {
 
     public boolean errorCalled = false;
     public boolean finishCalled = false;
+    public int documentsReplicated = 0;
+    public int batchesReplicated = 0;
 
     @Subscribe
     public void complete(ReplicationStrategyCompleted rc) {
         finishCalled = true;
+        documentsReplicated = rc.replicationStrategy.getDocumentCounter();
+        batchesReplicated = rc.replicationStrategy.getBatchCounter();
     }
 
     @Subscribe


### PR DESCRIPTION
FB 46079

- Add `documentsReplicated` and `batchesReplicated` members to
  `ReplicationCompleted`

- Expose `getDocumentCounter` and `getBatchCounter` in
  `ReplicationStrategy` interface and pass these values in to
  `ReplicationCompleted` constructor

- Add assertions in `BasicPullStrategyTest` and
  `BasicPushStrategyTest` to check values of `documentsReplicated`

reviewer: @gadamc 
reviewer: @mikerhodes 