### PR TITLE
Make Push and Pull Replication follow builder pattern.

### DIFF
--- a/sample/todo-sync/src/com/cloudant/todo/TasksModel.java
+++ b/sample/todo-sync/src/com/cloudant/todo/TasksModel.java
@@ -238,18 +238,10 @@ class TasksModel {
         // Set up the new replicator objects
         URI uri = this.createServerURI();
 
-        PushReplication push = new PushReplication();
-        push.source = mDatastore;
-        push.target = uri;
+        mPullReplicator = ReplicatorBuilder.pull().to(mDatastore).from(uri).build();
+        mPushReplicator = ReplicatorBuilder.push().from(mDatastore).to(uri).build();
 
-        mPushReplicator = ReplicatorFactory.oneway(push);
         mPushReplicator.getEventBus().register(this);
-
-        PullReplication pull = new PullReplication();
-        pull.source = uri;
-        pull.target = mDatastore;
-
-        mPullReplicator = ReplicatorFactory.oneway(pull);
         mPullReplicator.getEventBus().register(this);
 
         Log.d(LOG_TAG, "Set up replicators for URI:" + uri.toString());

--- a/sync-core/src/main/java/com/cloudant/sync/replication/PullFilter.java
+++ b/sync-core/src/main/java/com/cloudant/sync/replication/PullFilter.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2015 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.replication;
+
+import com.google.common.base.Joiner;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * <p>Provides the name and parameters for a filter function to be used
+ * when a pull replication calls the source database's {@code _changes}
+ * feed.</p>
+ *
+ * <p>For a filter function that takes no parameters, use this
+ * constructor:</p>
+ *
+ * <pre>
+ * PullFilter filter = new PullFilter("filterDoc/filterFunctionName")
+ * </pre>
+ *
+ * <p>For a filter function that requires parameters, use this
+ * constructor:</p>
+ *
+ * <pre>
+ * Map&lt;String, String&gt; params = new HashMap();
+ * map.put("max_age", "10");
+ * map.put("name", "john");
+ * PullFilter pullFilter = new PullFilter("doc/filterName", map);
+ * </pre>
+ *
+ * @see <a href="http://couchdb.readthedocs.org/en/1.6.x/replication/intro.html#controlling-which-documents-to-replicate">Controlling documents replicated</a>
+ * @see <a href="http://docs.couchdb.org/en/1.6.x/couchapp/ddocs.html#filter-functions">Filter functions CouchDB docs</a>
+ */
+public class PullFilter {
+
+    private final String name;
+
+    private final Map<String, String> parameters;
+
+    /**
+     * Constructs a filter object for a function that requires no
+     * parameters.
+     *
+     *
+     *
+     *
+     * @param filterName filter function name. The {@code filterName} argument is the name of the
+     *                   filter, as passed to
+     *                   the {@code filter} parameter of CouchDB's {@code _changes} feed. This
+     *                   and the name of the filter function, separated by a slash. For example,
+     *                   {@code filterDoc/filterFunctionName}
+     */
+    public PullFilter(String filterName) {
+        this.name = filterName;
+        this.parameters = null;
+    }
+
+    /**
+     * Constructs a filter object for a function that requires no
+     * parameters.
+     *
+     *
+     *
+     *
+     * @param filterName filter function name. The {@code filterName} argument is the name of the
+     *                   filter, as passed to
+     *                   the {@code filter} parameter of CouchDB's {@code _changes} feed. This
+     *                   and the name of the filter function, separated by a slash. For example,
+     *                   {@code filterDoc/filterFunctionName}
+     *
+     * @param parameters Any parameters required for the function. Can be {@code null}. The contents
+     *                   of {@code properties} are expanded to {@code key=value} pairs when
+     *                   constructing the {@code _changes} feed call for the remote database.
+     *                   Integer values should be added as String objects.
+     *
+     * @see <a href="http://docs.couchdb.org/en/1.6.x/couchapp/ddocs.html#filter-functions">Filter
+     * functions CouchDB docs</a>
+     */
+    public PullFilter(String filterName, Map<String, String> parameters) {
+        this.name = filterName;
+        Map<String, String> internalParams = Collections.emptyMap();
+        internalParams.putAll(parameters);
+        this.parameters = Collections.unmodifiableMap(internalParams);
+    }
+
+     public String getName() {
+        return this.name;
+    }
+
+     public Map<String, String> getParameters() {
+        return this.parameters;
+    }
+
+    /**
+     * <p>Generate a string representation of this {@code Filter} object
+     * that is consistent for a given name and parameter set.</p>
+     *
+     * <p>The string is not intended for use in URLs as it's not
+     * escaped.</p>
+     *
+     * <p>Filter parameters are sorted by key so that the  generated
+     * String are the same for different calls. This is important
+     * because the String can therefore be part of the replication ID.</p>
+     *
+     * @return Query string like representation of the filter
+     *
+     * @see BasicPullStrategy#getReplicationId()
+     */
+    public String toQueryString() {
+        if (this.parameters == null) {
+            return String.format("filter=%s", this.name);
+        } else {
+            List<String> queries = new ArrayList<String>();
+
+            for(Map.Entry<String, String> parameter : this.parameters.entrySet()) {
+                queries.add(String.format("%s=%s", parameter.getKey(), parameter.getValue()));
+            }
+            Collections.sort(queries);
+
+            queries.add(0, String.format("filter=%s", this.name));
+
+            return Joiner.on('&').skipNulls().join(queries);
+        }
+    }
+}

--- a/sync-core/src/main/java/com/cloudant/sync/replication/PullReplication.java
+++ b/sync-core/src/main/java/com/cloudant/sync/replication/PullReplication.java
@@ -25,7 +25,9 @@ import java.net.URI;
  *
  * <p>A pull replication is <em>from</em> a remote Cloudant or CouchDB database
  * to the device's local datastore.</p>
+ * @deprecated Use {@link ReplicatorBuilder} instead.
  */
+@Deprecated
 public class PullReplication extends Replication {
 
     /**

--- a/sync-core/src/main/java/com/cloudant/sync/replication/PushReplication.java
+++ b/sync-core/src/main/java/com/cloudant/sync/replication/PushReplication.java
@@ -25,7 +25,9 @@ import java.net.URI;
  *
  * <p>A push replication is <em>to</em> a remote Cloudant or CouchDB database
  * from the device's local datastore.</p>
+ * @deprecated Use {@link ReplicatorBuilder} instead.
  */
+@Deprecated
 public class PushReplication extends Replication {
 
     /**

--- a/sync-core/src/main/java/com/cloudant/sync/replication/Replication.java
+++ b/sync-core/src/main/java/com/cloudant/sync/replication/Replication.java
@@ -20,7 +20,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -34,10 +33,12 @@ import java.util.Map;
  * and {@link com.cloudant.sync.replication.PushReplication} are used to
  * configure pull and push replications respectively.</p>
  *
+ * @deprecated Use {@link ReplicatorBuilder} instead
  * @see com.cloudant.sync.replication.PullReplication
  * @see com.cloudant.sync.replication.PushReplication
  * @see ReplicatorFactory#oneway(Replication)
  */
+@Deprecated
 public abstract class Replication {
 
     /**
@@ -61,11 +62,12 @@ public abstract class Replication {
      * map.put("name", "john");
      * Filter filter = new Filter("doc/filterName", map);
      * </pre>
-     *
+     *@deprecated Use {@link PullFilter} instead
      * @see com.cloudant.sync.replication.PullReplication
      * @see <a href="http://docs.couchdb.org/en/1.4.x/replication.html#controlling-which-documents-to-replicate">Controlling documents replicated</a>
      * @see <a href="http://docs.couchdb.org/en/1.4.x/ddocs.html#filterfun">Filter functions CouchDB docs</a>
      */
+    @Deprecated
     public static class Filter {
 
         /**

--- a/sync-core/src/main/java/com/cloudant/sync/replication/ReplicatorBuilder.java
+++ b/sync-core/src/main/java/com/cloudant/sync/replication/ReplicatorBuilder.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2015 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.replication;
+
+import com.cloudant.sync.datastore.Datastore;
+
+import java.net.URI;
+
+/**
+ * A Builder to create a {@link Replicator Object}
+ */
+// S = Source Type, T = target Type, E = Extending class Type
+public abstract class ReplicatorBuilder<S, T, E> {
+
+    private T target;
+    private S source;
+
+    /**
+     * A Push Replication Builder
+     */
+    public static class Push extends ReplicatorBuilder<Datastore, URI, Push> {
+
+        @Override
+        public Replicator build() {
+
+            if (super.source == null || super.target == null) {
+                throw new IllegalStateException("Source and target cannot be null");
+            }
+
+            PushReplication pushReplication = new PushReplication();
+            pushReplication.source = super.source;
+            pushReplication.target = super.target;
+            return new BasicReplicator(pushReplication);
+
+        }
+    }
+
+    /**
+     * A Pull Replication Builder
+     */
+    public static class Pull extends ReplicatorBuilder<URI, Datastore, Pull> {
+
+        private PullFilter pullPullFilter = null;
+
+        @Override
+        public Replicator build() {
+
+            if (super.source == null || super.target == null) {
+                throw new IllegalStateException("Source and target cannot be null");
+            }
+
+            PullReplication pullReplication = new PullReplication();
+            pullReplication.source = super.source;
+            pullReplication.target = super.target;
+            //convert the new filter to the old one.
+            //this is to avoid invasive changes for now.
+            Replication.Filter filter = new Replication.Filter(this.pullPullFilter.getName(),
+                    this.pullPullFilter.getParameters());
+            pullReplication.filter = filter;
+
+            return new BasicReplicator(pullReplication);
+        }
+
+        /**
+         * Sets the filter to use for a pull replication
+         *
+         * @param pullPullFilter The Filter to use during a pull replication
+         * @return This instance of {@link ReplicatorBuilder}
+         */
+        public Pull filter(PullFilter pullPullFilter) {
+            this.pullPullFilter = pullPullFilter;
+            return this;
+        }
+    }
+
+
+    /**
+     * Sets the target database for the replication
+     *
+     * @param target The target for the replication
+     * @return This instance of {@link ReplicatorBuilder}
+     */
+    public E to(T target) {
+        this.target = target;
+        return (E) this;
+    }
+
+    /**
+     * Sets the source database for the replication
+     *
+     * @param source The source database for the replication
+     * @return This instance of {@link ReplicatorBuilder}
+     */
+    public E from(S source) {
+        this.source = source;
+        return (E) this;
+    }
+
+    /**
+     * Builds a replicator by calling {@link #build()} and then {@link Replicator#start()}
+     * on the replicator returned.
+     *
+     * @return The replicator running the replication for this builder.
+     */
+    public Replicator start() {
+        Replicator replicator = this.build();
+        replicator.start();
+        return replicator;
+    }
+
+    /**
+     * Builds a replicator based on the configuration set.
+     *
+     * @return {@link Replicator} that will carry out the replication
+     */
+    public abstract Replicator build();
+
+    /**
+     * Creates a pull replication builder.
+     *
+     * @return A newly created {@link Pull} replication builder
+     */
+    public static Pull pull() {
+        return new Pull();
+    }
+
+    /**
+     * Creates a {@link Push} replication builder.
+     *
+     * @return A newly created @{Link Push} replication builder
+     */
+    public static Push push() {
+        return new Push();
+    }
+
+}

--- a/sync-core/src/main/java/com/cloudant/sync/replication/ReplicatorFactory.java
+++ b/sync-core/src/main/java/com/cloudant/sync/replication/ReplicatorFactory.java
@@ -14,14 +14,11 @@
 
 package com.cloudant.sync.replication;
 
-import com.cloudant.sync.datastore.Datastore;
-
-import java.net.URI;
-import java.net.URISyntaxException;
-
 /**
  * <p>Factory for {@link Replicator} objects.</p>
+ * @deprecated Use {@link ReplicatorBuilder} instead
  */
+@Deprecated
 public final class ReplicatorFactory {
 
     private ReplicatorFactory() {


### PR DESCRIPTION
Make Push and Pull replication follow builder pattern by creating
APIs so you can do the following:

```
new PushReplication().source().target().start()

```

Split out from PR #181 

reviewer @mikerhodes 
reviewer @tomblench 