### PR TITLE
Expose HttpConnectionFilters

### DIFF
--- a/sync-core/src/main/java/com/cloudant/mazha/CouchClient.java
+++ b/sync-core/src/main/java/com/cloudant/mazha/CouchClient.java
@@ -21,6 +21,8 @@ package com.cloudant.mazha;
 
 import com.cloudant.http.Http;
 import com.cloudant.http.HttpConnection;
+import com.cloudant.http.HttpConnectionRequestFilter;
+import com.cloudant.http.HttpConnectionResponseFilter;
 import com.cloudant.mazha.json.JSONHelper;
 import com.cloudant.sync.datastore.MultipartAttachmentWriter;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -32,6 +34,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.reflect.Type;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -44,11 +47,23 @@ public class CouchClient  {
     protected final JSONHelper jsonHelper;
     private final Map<String, String> customHeaders;
     private CouchURIHelper uriHelper;
+    private List<HttpConnectionRequestFilter> requestFilters;
+    private List<HttpConnectionResponseFilter> responseFilters;
 
     public CouchClient(CouchConfig config) {
         this.jsonHelper = new JSONHelper();
         this.uriHelper = new CouchURIHelper(config.getRootUri());
         this.customHeaders = config.getCustomHeaders();
+        this.requestFilters = new ArrayList<HttpConnectionRequestFilter>();
+        this.responseFilters = new ArrayList<HttpConnectionResponseFilter>();
+
+        if(config.getRequestFilters() != null) {
+            this.requestFilters.addAll(config.getRequestFilters());
+        }
+
+        if(config.getResponseFilters() != null) {
+            this.responseFilters.addAll(config.getResponseFilters());
+        }
     }
 
     public URI getRootUri() {
@@ -76,6 +91,8 @@ public class CouchClient  {
         // all CouchClient requests want to receive application/json responses
         connection.requestProperties.put("Accept", "application/json");
         this.addCustomHeaders(connection);
+        connection.responseFilters.addAll(this.responseFilters);
+        connection.requestFilters.addAll(this.requestFilters);
         InputStream is = null; // input stream - response from server on success
         InputStream es = null; // error stream - response from server for a 500 etc
         String response = null;

--- a/sync-core/src/main/java/com/cloudant/mazha/CouchConfig.java
+++ b/sync-core/src/main/java/com/cloudant/mazha/CouchConfig.java
@@ -18,6 +18,9 @@
 
 package com.cloudant.mazha;
 
+import com.cloudant.http.HttpConnectionRequestFilter;
+import com.cloudant.http.HttpConnectionResponseFilter;
+
 import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
@@ -34,6 +37,9 @@ public class CouchConfig {
 
     // Optional custom headers
     private Map<String, String> customHeaders;
+
+    private List<HttpConnectionRequestFilter> requestFilters;
+    private List<HttpConnectionResponseFilter> responseFilters;
 
     public CouchConfig(URI rootUri) {
         this.rootUri = rootUri;
@@ -52,6 +58,22 @@ public class CouchConfig {
             }
         }
         this.customHeaders = customHeaders;
+    }
+
+    public List<HttpConnectionRequestFilter> getRequestFilters() {
+        return requestFilters;
+    }
+
+    public void setRequestFilters(List<HttpConnectionRequestFilter> requestFilters) {
+        this.requestFilters = requestFilters;
+    }
+
+    public List<HttpConnectionResponseFilter> getResponseFilters() {
+        return responseFilters;
+    }
+
+    public void setResponseFilters(List<HttpConnectionResponseFilter> responseFilters) {
+        this.responseFilters = responseFilters;
     }
 
     public URI getRootUri() {

--- a/sync-core/src/main/java/com/cloudant/sync/replication/Replication.java
+++ b/sync-core/src/main/java/com/cloudant/sync/replication/Replication.java
@@ -14,6 +14,8 @@
 
 package com.cloudant.sync.replication;
 
+import com.cloudant.http.HttpConnectionRequestFilter;
+import com.cloudant.http.HttpConnectionResponseFilter;
 import com.cloudant.mazha.CouchConfig;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
@@ -40,6 +42,12 @@ import java.util.Map;
  */
 @Deprecated
 public abstract class Replication {
+
+    final List<HttpConnectionRequestFilter> requestFilters = new ArrayList
+            <HttpConnectionRequestFilter>();
+    final List<HttpConnectionResponseFilter> responseFilters = new ArrayList
+            <HttpConnectionResponseFilter>();
+
 
     /**
      * <p>Provides the name and parameters for a filter function to be used
@@ -179,8 +187,11 @@ public abstract class Replication {
      */
     abstract ReplicationStrategy createReplicationStrategy();
 
-    CouchConfig createCouchConfig(URI uri) {
-        return new CouchConfig(uri);
+    final CouchConfig createCouchConfig(URI uri) {
+        CouchConfig config = new CouchConfig(uri);
+        config.setResponseFilters(responseFilters);
+        config.setRequestFilters(requestFilters);
+        return config;
     }
 
     void checkURI(URI uri) {

--- a/sync-core/src/main/java/com/cloudant/sync/replication/ReplicatorBuilder.java
+++ b/sync-core/src/main/java/com/cloudant/sync/replication/ReplicatorBuilder.java
@@ -14,9 +14,14 @@
 
 package com.cloudant.sync.replication;
 
+import com.cloudant.http.HttpConnectionRequestFilter;
+import com.cloudant.http.HttpConnectionResponseFilter;
 import com.cloudant.sync.datastore.Datastore;
 
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * A Builder to create a {@link Replicator Object}
@@ -26,6 +31,10 @@ public abstract class ReplicatorBuilder<S, T, E> {
 
     private T target;
     private S source;
+    private List<HttpConnectionRequestFilter> requestFilters = new ArrayList
+            <HttpConnectionRequestFilter>();
+    private List<HttpConnectionResponseFilter> responseFilters = new ArrayList
+            <HttpConnectionResponseFilter>();
 
     /**
      * A Push Replication Builder
@@ -64,6 +73,8 @@ public abstract class ReplicatorBuilder<S, T, E> {
             PullReplication pullReplication = new PullReplication();
             pullReplication.source = super.source;
             pullReplication.target = super.target;
+            pullReplication.responseFilters.addAll(super.responseFilters);
+            pullReplication.requestFilters.addAll(super.requestFilters);
             //convert the new filter to the old one.
             //this is to avoid invasive changes for now.
             Replication.Filter filter = new Replication.Filter(this.pullPullFilter.getName(),
@@ -94,6 +105,7 @@ public abstract class ReplicatorBuilder<S, T, E> {
      */
     public E to(T target) {
         this.target = target;
+        //noinspection unchecked
         return (E) this;
     }
 
@@ -105,6 +117,47 @@ public abstract class ReplicatorBuilder<S, T, E> {
      */
     public E from(S source) {
         this.source = source;
+        //noinspection unchecked
+        return (E) this;
+    }
+
+    /**
+     * Variable argument version of {@link #addRequestFilters(List)}
+     * @param filters The request filters to add.
+     * @return The current instance of {@link ReplicatorBuilder}
+     */
+    public E addRequestFilters(HttpConnectionRequestFilter ... filters){
+        return addRequestFilters(Arrays.asList(filters));
+    }
+
+    /**
+     * Adds filters to the list of request filters to use for each request made by this replication.
+     * @param filters The request filters to add.
+     * @return The current instance of {@link ReplicatorBuilder}
+     */
+    public E addRequestFilters(List<HttpConnectionRequestFilter> filters){
+        this.requestFilters.addAll(filters);
+        //noinspection unchecked
+        return (E)this;
+    }
+
+    /**
+     * Variable argument version of {@link #addResponseFilters(List)}
+     * @param filters The response filters to add.
+     * @return The current instance of {@link ReplicatorBuilder}
+     */
+    public E addResponseFilters(HttpConnectionResponseFilter ... filters){
+        return addResponseFilters(Arrays.asList(filters));
+    }
+
+    /**
+     * Adds filters to the list of response filters to use for each response received by this replication.
+     * @param filters The response filters to add.
+     * @return The current instance of {@link ReplicatorBuilder}
+     */
+    public E addResponseFilters(List<HttpConnectionResponseFilter> filters){
+        this.responseFilters.addAll(filters);
+        //noinspection unchecked
         return (E) this;
     }
 

--- a/sync-core/src/test/java/com/cloudant/sync/replication/FilterCallCounter.java
+++ b/sync-core/src/test/java/com/cloudant/sync/replication/FilterCallCounter.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2015 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.replication;
+
+import com.cloudant.http.HttpConnectionFilterContext;
+import com.cloudant.http.HttpConnectionRequestFilter;
+import com.cloudant.http.HttpConnectionResponseFilter;
+
+/**
+ * This request and response filter counts the number of times the filterRequest and filterResponse
+ * methods get called.
+ */
+public class FilterCallCounter implements HttpConnectionRequestFilter, HttpConnectionResponseFilter {
+
+    public int filterRequestTimesCalled = 0;
+    public int filterResponseTimesCalled = 0;
+
+    @Override
+    public HttpConnectionFilterContext filterRequest(HttpConnectionFilterContext context) {
+        filterRequestTimesCalled++;
+        return context;
+    }
+
+    @Override
+    public HttpConnectionFilterContext filterResponse(HttpConnectionFilterContext context) {
+        filterResponseTimesCalled++;
+        return context;
+    }
+}

--- a/sync-core/src/test/java/com/cloudant/sync/replication/PullReplicatorTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/replication/PullReplicatorTest.java
@@ -15,6 +15,7 @@
 package com.cloudant.sync.replication;
 
 import com.cloudant.common.RequireRunningCouchDB;
+
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -69,4 +70,26 @@ public class PullReplicatorTest extends ReplicationTestBase {
         Assert.assertTrue(listener.finishCalled);
         Assert.assertFalse(listener.errorCalled);
     }
+
+    @Test
+    public void testRequestFilters() throws Exception {
+
+        FilterCallCounter filterCallCounter = new FilterCallCounter();
+        PullReplication pullReplication = createPullReplication();
+        pullReplication.requestFilters.add(filterCallCounter);
+        runReplicationUntilComplete(pullReplication);
+        Assert.assertTrue(filterCallCounter.filterRequestTimesCalled >= 1);
+
+    }
+
+    @Test
+    public void testResponseFilters() throws Exception {
+
+        FilterCallCounter filterCallCounter = new FilterCallCounter();
+        PullReplication pullReplication = createPullReplication();
+        pullReplication.responseFilters.add(filterCallCounter);
+        runReplicationUntilComplete(pullReplication);
+        Assert.assertTrue(filterCallCounter.filterResponseTimesCalled >= 1);
+    }
+
 }

--- a/sync-core/src/test/java/com/cloudant/sync/replication/PushReplicatorTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/replication/PushReplicatorTest.java
@@ -22,9 +22,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import java.io.IOException;
-import java.net.URI;
-
 @Category(RequireRunningCouchDB.class)
 public class PushReplicatorTest extends ReplicationTestBase {
 
@@ -109,5 +106,30 @@ public class PushReplicatorTest extends ReplicationTestBase {
             Assert.fail("replicator did not stop before all docs were pushed");
         }
 
+    }
+
+    @Test
+    public void testRequestFilters() throws Exception {
+
+        //to test the filters we make an invalid request
+
+        FilterCallCounter filterCallCounter = new FilterCallCounter();
+        TestReplicationListener listener = new TestReplicationListener();
+        PushReplication pushReplication = createPushReplication();
+        pushReplication.requestFilters.add(filterCallCounter);
+        runReplicationUntilComplete(pushReplication);
+        Assert.assertTrue(filterCallCounter.filterRequestTimesCalled >= 1);
+
+    }
+
+    @Test
+    public void testResponseFilters() throws Exception {
+
+        FilterCallCounter filterCallCounter = new FilterCallCounter();
+        TestReplicationListener listener = new TestReplicationListener();
+        PushReplication pushReplication = createPushReplication();
+        pushReplication.responseFilters.add(filterCallCounter);
+        runReplicationUntilComplete(pushReplication);
+        Assert.assertTrue(filterCallCounter.filterResponseTimesCalled >= 1);
     }
 }

--- a/sync-core/src/test/java/com/cloudant/sync/replication/TestReplicationListener.java
+++ b/sync-core/src/test/java/com/cloudant/sync/replication/TestReplicationListener.java
@@ -22,6 +22,7 @@ public class TestReplicationListener {
 
     public boolean errorCalled = false;
     public boolean finishCalled = false;
+    public Throwable exception = null;
 
     @Subscribe
     public void complete(ReplicationCompleted rc) {
@@ -31,5 +32,6 @@ public class TestReplicationListener {
     @Subscribe
     public void error(ReplicationErrored re) {
         errorCalled = true;
+        exception = re.errorInfo.getException();
     }
 }


### PR DESCRIPTION
Expose HttpConnectionFilters via the ReplicatorBuilder.
Replication.createCouchConfig is now a final method, to guarantee that
the filters are added to CouchClient.

reviewer @tomblench 
reviewer @mikerhodes 