### PR TITLE
Remove some of the unused CouchClient methods

### DIFF
--- a/sync-core/src/main/java/com/cloudant/mazha/CouchClient.java
+++ b/sync-core/src/main/java/com/cloudant/mazha/CouchClient.java
@@ -221,13 +221,6 @@ public class CouchClient  {
         }
     }
 
-    public InputStream getDocumentStream(String id) {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(id), "id must not be empty");
-        URI doc = this.uriHelper.documentUri(id);
-        HttpConnection connection = Http.GET(doc);
-        return this.executeToInputStream(connection);
-    }
-
     public InputStream getDocumentStream(String id, String rev) {
         Preconditions.checkArgument(!Strings.isNullOrEmpty(id), "id must not be empty");
         Preconditions.checkArgument(!Strings.isNullOrEmpty(rev), "rev must not be empty");
@@ -238,51 +231,17 @@ public class CouchClient  {
         return this.executeToInputStream(connection);
     }
 
-    public InputStream getAttachmentStream(String id, String attachmentName) {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(id), "id must not be empty");
-        URI doc = this.uriHelper.attachmentUri(id, attachmentName);
-        HttpConnection connection = Http.GET(doc);
-        connection.requestProperties.put("Accept-Encoding", "gzip");
-        return this.executeToInputStream(connection);
-    }
-
-    public InputStream getAttachmentStreamUncompressed(String id, String attachmentName) {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(id), "id must not be empty");
-        URI doc = this.uriHelper.attachmentUri(id, attachmentName);
-        HttpConnection connection = Http.GET(doc);
-        return this.executeToInputStream(connection);
-    }
-
-    public InputStream getAttachmentStream(String id, String rev, String attachmentName) {
+    public InputStream getAttachmentStream(String id, String rev, String attachmentName, final boolean acceptGzip) {
         Preconditions.checkArgument(!Strings.isNullOrEmpty(id), "id must not be empty");
         Preconditions.checkArgument(!Strings.isNullOrEmpty(rev), "rev must not be empty");
         Map<String, Object> queries = new HashMap<String, Object>();
         queries.put("rev", rev);
         URI doc = this.uriHelper.attachmentUri(id, queries, attachmentName);
         HttpConnection connection = Http.GET(doc);
-        connection.requestProperties.put("Accept-Encoding", "gzip");
+        if (acceptGzip) {
+            connection.requestProperties.put("Accept-Encoding", "gzip");
+        }
         return this.executeToInputStream(connection);
-    }
-
-    public InputStream getAttachmentStreamUncompressed(String id, String rev, String attachmentName) {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(id), "id must not be empty");
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(rev), "rev must not be empty");
-        Map<String, Object> queries = new HashMap<String, Object>();
-        queries.put("rev", rev);
-        URI doc = this.uriHelper.attachmentUri(id, queries, attachmentName);
-        HttpConnection connection = Http.GET(doc);
-        return this.executeToInputStream(connection);
-    }
-
-    public void putAttachmentStream(String id, String rev, String attachmentName, String attachmentString) {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(id), "id must not be empty");
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(rev), "rev must not be empty");
-        Map<String, Object> queries = new HashMap<String, Object>();
-        queries.put("rev", rev);
-        URI doc = this.uriHelper.attachmentUri(id, queries, attachmentName);
-        HttpConnection connection = Http.PUT(doc, "application/json");
-        connection.setRequestBody(attachmentString);
-        this.executeToInputStream(connection);
     }
 
     public void putAttachmentStream(String id, String rev, String attachmentName, String contentType, byte[] attachmentData) {

--- a/sync-core/src/main/java/com/cloudant/sync/replication/CouchClientWrapper.java
+++ b/sync-core/src/main/java/com/cloudant/sync/replication/CouchClientWrapper.java
@@ -243,7 +243,8 @@ public class CouchClientWrapper implements CouchDB {
 
     @Override
     public UnsavedStreamAttachment getAttachmentStream(String id, String rev, String attachmentName, String contentType, String encodingStr) {
-        InputStream is = this.couchClient.getAttachmentStream(id, rev, attachmentName);
+        // call with last arg `true` to indicate we will accept gzipped data
+        InputStream is = this.couchClient.getAttachmentStream(id, rev, attachmentName, true);
         Attachment.Encoding encoding = Attachment.getEncodingFromString(encodingStr);
         UnsavedStreamAttachment usa = new UnsavedStreamAttachment(is, attachmentName, contentType, encoding);
         return usa;

--- a/sync-core/src/test/java/com/cloudant/mazha/CouchClientBasicTest.java
+++ b/sync-core/src/test/java/com/cloudant/mazha/CouchClientBasicTest.java
@@ -169,7 +169,7 @@ public class CouchClientBasicTest extends CouchClientTestBase {
     @Test
     public void getDocumentInputStream_id_success() {
         Response res = ClientTestUtils.createHelloWorldDoc(client);
-        InputStream is = client.getDocumentStream(res.getId());
+        InputStream is = client.getDocumentStream(res.getId(), res.getRev());
         try {
             Map<String, Object> doc = client.jsonHelper.fromJson(new InputStreamReader(is));
             assertHelloWorldMapObject(res, doc);
@@ -196,7 +196,7 @@ public class CouchClientBasicTest extends CouchClientTestBase {
 
     @Test(expected = NoResourceException.class)
     public void getDocumentInputStream_idNotExist_exception() {
-        client.getDocumentStream("id_not_exist");
+        client.getDocumentStream("id_not_exist", "1-no_such_rev");
     }
 
     @Test(expected = NoResourceException.class)
@@ -352,13 +352,6 @@ public class CouchClientBasicTest extends CouchClientTestBase {
     public void delete_revNotExist_exception() {
         Response res = ClientTestUtils.createHelloWorldDoc(client);
         client.delete(res.getId(), "1-some_rev_not_exist");
-    }
-
-    @Test(expected = NoResourceException.class)
-    public void getDocument_docDeleted_exception() {
-        Response res = ClientTestUtils.createHelloWorldDoc(client);
-        Response res2 = client.delete(res.getId(), res.getRev());
-        client.getDocumentStream(res2.getId());
     }
 
     @Test

--- a/sync-core/src/test/java/com/cloudant/sync/replication/AttachmentsPullTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/replication/AttachmentsPullTest.java
@@ -239,7 +239,7 @@ public class AttachmentsPullTest extends ReplicationTestBase {
 
         id = res.getId();
         rev = res.getRev();
-        remoteDb.getCouchClient().putAttachmentStream(id, rev, attachmentName, attachmentData);
+        remoteDb.getCouchClient().putAttachmentStream(id, rev, attachmentName, "text/plain", attachmentData.getBytes());
 
         // putting attachment will have updated the rev
         bar = remoteDb.get(BarWithAttachments.class, res.getId());
@@ -299,7 +299,7 @@ public class AttachmentsPullTest extends ReplicationTestBase {
 
         Response res = remoteDb.update(id, bar);
         rev = res.getRev();
-        remoteDb.getCouchClient().putAttachmentStream(id, rev, attachmentName, attachmentData2);
+        remoteDb.getCouchClient().putAttachmentStream(id, rev, attachmentName, "text/plain", attachmentData2.getBytes());
 
         // putting attachment will have updated the rev
         bar = remoteDb.get(Bar.class, res.getId());

--- a/sync-core/src/test/java/com/cloudant/sync/replication/AttachmentsPushTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/replication/AttachmentsPushTest.java
@@ -131,7 +131,7 @@ public class AttachmentsPushTest extends ReplicationTestBase {
         push();
 
         // check it's in the DB
-        InputStream is1 = this.couchClient.getAttachmentStreamUncompressed(id1, attachmentName);
+        InputStream is1 = this.couchClient.getAttachmentStream(id1, newRevision.getRevision(), attachmentName, false);
         InputStream is2 = new FileInputStream(f);
         Assert.assertTrue("Attachment not the same", TestUtils.streamsEqual(is1, is2));
     }
@@ -155,7 +155,7 @@ public class AttachmentsPushTest extends ReplicationTestBase {
         push();
 
         // check it's in the DB
-        InputStream is1 = this.couchClient.getAttachmentStreamUncompressed(id1, attachmentName);
+        InputStream is1 = this.couchClient.getAttachmentStream(id1, newRevision.getRevision(), attachmentName, false);
         InputStream is2 = new FileInputStream(f);
         Assert.assertTrue("Attachment not the same", TestUtils.streamsEqual(is1, is2));
     }
@@ -198,10 +198,10 @@ public class AttachmentsPushTest extends ReplicationTestBase {
         InputStream isOriginal1;
         InputStream isOriginal2;
 
-        InputStream isRev2 = this.couchClient.getAttachmentStreamUncompressed(id1, rev2.getRevision(), attachmentName1);
-        InputStream isRev3 = this.couchClient.getAttachmentStreamUncompressed(id1, rev3.getRevision(), attachmentName1);
-        InputStream isRev4Att1 = this.couchClient.getAttachmentStreamUncompressed(id1, rev4.getRevision(), attachmentName1);
-        InputStream isRev4Att2 = this.couchClient.getAttachmentStreamUncompressed(id1, rev4.getRevision(), attachmentName2);
+        InputStream isRev2 = this.couchClient.getAttachmentStream(id1, rev2.getRevision(), attachmentName1, false);
+        InputStream isRev3 = this.couchClient.getAttachmentStream(id1, rev3.getRevision(), attachmentName1, false);
+        InputStream isRev4Att1 = this.couchClient.getAttachmentStream(id1, rev4.getRevision(), attachmentName1, false);
+        InputStream isRev4Att2 = this.couchClient.getAttachmentStream(id1, rev4.getRevision(), attachmentName2, false);
 
         isOriginal1 = new FileInputStream(f1);
         Assert.assertTrue("Attachment not the same", TestUtils.streamsEqual(isRev2, isOriginal1));
@@ -250,8 +250,8 @@ public class AttachmentsPushTest extends ReplicationTestBase {
         InputStream isOriginal1;
         InputStream isOriginal2;
 
-        InputStream isRev4Att1 = this.couchClient.getAttachmentStreamUncompressed(id1, rev4.getRevision(), attachmentName1);
-        InputStream isRev4Att2 = this.couchClient.getAttachmentStreamUncompressed(id1, rev4.getRevision(), attachmentName2);
+        InputStream isRev4Att1 = this.couchClient.getAttachmentStream(id1, rev4.getRevision(), attachmentName1, false);
+        InputStream isRev4Att2 = this.couchClient.getAttachmentStream(id1, rev4.getRevision(), attachmentName2, false);
 
         isOriginal1 = new FileInputStream(f1);
         isOriginal2 = new FileInputStream(f2);


### PR DESCRIPTION
- What: Remove unused and unnecessary `CouchClient` methods

- Why: More preperation for the 49297 'HTTP connection resilience'. This helps us to identify which methods need to be wrapped in a `retry` loop by ensuring that each method has a clear purpose and that there are not multiple overloaded methods which do very similar tasks. Also some methods were only ever called by test code.

- Testing: One test which is no longer relevant has been removed: `getDocument_docDeleted_exception`. This fetched a document without specifying a revid which never happens in production code. All tests pass.

reviewer: @mikerhodes 
reviewer: @rhyshort 