### PR TITLE
49297 connection resilience

### DIFF
--- a/cloudant-sync-datastore-core/build.gradle
+++ b/cloudant-sync-datastore-core/build.gradle
@@ -48,25 +48,50 @@ tasks.withType(Test) {
 
 test {
     useJUnit {
-        excludeCategories 'com.cloudant.common.SystemTest', 'com.cloudant.common.RequireRunningCouchDB', 'com.cloudant.common.PerformanceTest'
+        excludeCategories \
+        'com.cloudant.common.SystemTest', \
+        'com.cloudant.common.RequireRunningCouchDB', \
+        'com.cloudant.common.PerformanceTest', \
+        'com.cloudant.common.RequireRunningProxy'
     }
 }
 
 task integrationTest(type: Test, dependsOn: testClasses) {
     useJUnit {
-        excludeCategories 'com.cloudant.common.SystemTest', 'com.cloudant.common.PerformanceTest'
+        excludeCategories \
+        'com.cloudant.common.SystemTest', \
+        'com.cloudant.common.PerformanceTest', \
+        'com.cloudant.common.RequireRunningProxy'
     }
 }
 
+
 task performanceTest(type: Test, dependsOn: testClasses) {
     useJUnit {
-        includeCategories 'com.cloudant.common.PerformanceTest'
+        includeCategories
+        'com.cloudant.common.PerformanceTest'
     }
 }
 
 task systemTest(type: Test, dependsOn: testClasses) {
-    // Run all tests
+    // Run all tests except unreliable network test (which requires a proxy)
+    useJUnit {
+        excludeCategories
+        'com.cloudant.common.RequireRunningProxy'
+    }
 }
+
+task unreliableNetworkTest(type: Test, dependsOn: testClasses) {
+    systemProperty "test.with.specified.couch", true
+    systemProperty "test.couch.port", 8000
+    systemProperty "test.couch.proxy.admin.port", 8474
+    systemProperty "test.couch.proxy.target.port", 5984    
+    // ensure proxy is running!
+    filter {        
+        includeTestsMatching "com.cloudant.sync.replication.Unreliable*.*"
+    }
+}
+
 
 //
 // Publishing

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/mazha/DocumentConflictException.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/mazha/DocumentConflictException.java
@@ -19,9 +19,9 @@
 package com.cloudant.mazha;
 
 
-public class DocumentConflictException extends RuntimeException {
+public class DocumentConflictException extends CouchException {
 	
 	public DocumentConflictException(String message) {
-		super(message);
+		super(message, 409);
 	}
 }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/mazha/OkOpenRevision.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/mazha/OkOpenRevision.java
@@ -34,4 +34,8 @@ public class OkOpenRevision implements OpenRevision {
     public void setDocumentRevs(DocumentRevs documentRevs) {
         this.documentRevs = documentRevs;
     }
+
+    @Override
+    public String toString() {return documentRevs.toString();}
+
 }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/RevisionHistoryHelper.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/RevisionHistoryHelper.java
@@ -203,9 +203,6 @@ public class RevisionHistoryHelper {
                 logger.log(Level.WARNING,"IOException caught when adding multiparts",ioe);
             }
         }
-        if (mpw != null) {
-            mpw.close();
-        }
         return mpw;
     }
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/common/ProxyTestBase.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/common/ProxyTestBase.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2015 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.common;
+
+import com.cloudant.http.Http;
+import com.cloudant.mazha.CouchConfig;
+import com.cloudant.mazha.SpecifiedCouch;
+import com.cloudant.sync.replication.ReplicationTestBase;
+import com.cloudant.sync.util.Misc;
+
+import java.net.URL;
+
+/**
+ * Created by tomblench on 23/07/15.
+ */
+public class ProxyTestBase extends ReplicationTestBase {
+
+    // this is where toxiproxy listens
+    protected int proxyPort = Integer.parseInt(System.getProperty("test.couch.port", "8000"));
+    // this is the toxiproxy admin port
+    protected int proxyAdminPort = Integer.parseInt(System.getProperty("test.couch.proxy.admin.port",
+            "8474"));
+    // this is where couchdb listens
+    protected int targetPort = Integer.parseInt(System.getProperty("test.couch.proxy.target.port",
+            "5984"));
+    protected String proxyName = "default";
+    protected String proxyHost = "127.0.0.1";
+
+    protected String jsonAddProxy = String.format("{\"name\": \"%s\", \"upstream\": \"localhost:%d\", \"listen\": \"localhost:%d\"}",
+            proxyName, targetPort, proxyPort);
+
+
+    protected void startProxy() throws Exception {
+        // clear proxy
+        try {
+            Http.DELETE(new URL(String.format("http://%s:%d/proxies/%s", proxyHost,
+                    proxyAdminPort, proxyName))).execute().responseAsString();
+        } catch (Exception e) {
+            // 404?
+        }
+        // set up fresh proxy
+        Http.POST(new URL(String.format("http://%s:%d/proxies", proxyHost, proxyAdminPort)), "application/json")
+                .setRequestBody(jsonAddProxy).execute().responseAsString();
+    }
+
+    protected void stopProxy() throws Exception {
+        // clear proxy
+        Http.DELETE(new URL(String.format("http://%s:%d/proxies/%s", proxyHost, proxyAdminPort, proxyName)))
+                .execute().responseAsString();
+    }
+
+}

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/common/RequireRunningProxy.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/common/RequireRunningProxy.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2015 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.common;
+
+/**
+ * Created by tomblench on 23/07/15.
+ */
+public class RequireRunningProxy {
+}

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/common/RetriableTaskTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/common/RetriableTaskTest.java
@@ -31,7 +31,7 @@ public class RetriableTaskTest {
         RetriableTask<Integer> retriableTask = new RetriableTask<Integer>(task);
         Assert.assertTrue(1 == retriableTask.call());
 
-        Assert.assertEquals(3, retriableTask.getTotalRetries());
+        Assert.assertEquals(3, retriableTask.getTotalTries());
         Assert.assertEquals(3, retriableTask.getTriesRemaining());
     }
 
@@ -42,7 +42,7 @@ public class RetriableTaskTest {
         RetriableTask<Integer> retriableTask = new RetriableTask<Integer>(task);
         Assert.assertTrue(1 == retriableTask.call());
 
-        Assert.assertEquals(3, retriableTask.getTotalRetries());
+        Assert.assertEquals(3, retriableTask.getTotalTries());
         Assert.assertEquals(2, retriableTask.getTriesRemaining());
     }
 
@@ -53,7 +53,7 @@ public class RetriableTaskTest {
         RetriableTask<Integer> retriableTask = new RetriableTask<Integer>(task);
         Assert.assertTrue(1 == retriableTask.call());
 
-        Assert.assertEquals(3, retriableTask.getTotalRetries());
+        Assert.assertEquals(3, retriableTask.getTotalTries());
         Assert.assertEquals(1, retriableTask.getTriesRemaining());
     }
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/http/HttpTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/http/HttpTest.java
@@ -23,6 +23,7 @@ import org.junit.experimental.categories.Category;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.Map;
 
@@ -52,12 +53,17 @@ public class HttpTest extends CouchTestBase {
         CouchConfig config = getCouchConfig("no_such_database");
         HttpConnection conn = new HttpConnection("POST", config.getRootUri().toURL(),
                 "application/json");
-        ByteArrayInputStream bis = new ByteArrayInputStream(data.getBytes());
+        final ByteArrayInputStream bis = new ByteArrayInputStream(data.getBytes());
 
         // nothing read from stream
         Assert.assertEquals(bis.available(), data.getBytes().length);
 
-        conn.setRequestBody(bis);
+        conn.setRequestBody(new HttpConnection.InputStreamGenerator() {
+            @Override
+            public InputStream getInputStream() {
+                return bis;
+            }
+        });
         boolean thrown = false;
         try {
             conn.execute();
@@ -82,12 +88,17 @@ public class HttpTest extends CouchTestBase {
         client.createDb();
         HttpConnection conn = new HttpConnection("POST", config.getRootUri().toURL(),
                 "application/json");
-        ByteArrayInputStream bis = new ByteArrayInputStream(data.getBytes());
+        final ByteArrayInputStream bis = new ByteArrayInputStream(data.getBytes());
 
         // nothing read from stream
         Assert.assertEquals(bis.available(), data.getBytes().length);
 
-        conn.setRequestBody(bis);
+        conn.setRequestBody(new HttpConnection.InputStreamGenerator() {
+            @Override
+            public InputStream getInputStream() {
+                return bis;
+            }
+        });
         conn.execute();
 
         // stream was read to end
@@ -106,12 +117,17 @@ public class HttpTest extends CouchTestBase {
         client.createDb();
         HttpConnection conn = new HttpConnection("POST", config.getRootUri().toURL(),
                 "application/json");
-        ByteArrayInputStream bis = new ByteArrayInputStream(data.getBytes());
+        final ByteArrayInputStream bis = new ByteArrayInputStream(data.getBytes());
 
         // nothing read from stream
         Assert.assertEquals(bis.available(), data.getBytes().length);
 
-        conn.setRequestBody(bis);
+        conn.setRequestBody(new HttpConnection.InputStreamGenerator() {
+            @Override
+            public InputStream getInputStream() {
+                return bis;
+            }
+        });
         try {
             conn.responseAsString();
             Assert.fail("IOException not thrown as expected");
@@ -145,12 +161,17 @@ public class HttpTest extends CouchTestBase {
                 "application/json");
         conn.responseInterceptors.add(interceptor);
         conn.requestInterceptors.add(interceptor);
-        ByteArrayInputStream bis = new ByteArrayInputStream(data.getBytes());
+        final ByteArrayInputStream bis = new ByteArrayInputStream(data.getBytes());
 
         // nothing read from stream
         Assert.assertEquals(bis.available(), data.getBytes().length);
 
-        conn.setRequestBody(bis);
+        conn.setRequestBody(new HttpConnection.InputStreamGenerator() {
+            @Override
+            public InputStream getInputStream() {
+                return bis;
+            }
+        });
         conn.execute();
 
         // stream was read to end

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/MultipartAttachmentWriterTests.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/MultipartAttachmentWriterTests.java
@@ -28,6 +28,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -93,14 +94,14 @@ public class MultipartAttachmentWriterTests {
             Attachment att0 = new UnsavedStreamAttachment(new ByteArrayInputStream(bytes), name, "text/plain");
             mpw.addAttachment(att0, bytes.length);
         }
-        mpw.close();
+        InputStream is = mpw.makeInputStream();
 
         int amountRead = 0;
         int totalRead = 0;
 
         do {
             byte buf[] = new byte[chunkSize];
-            amountRead = mpw.read(buf);
+            amountRead = is.read(buf);
             if (amountRead > 0) {
                 totalRead += amountRead;
                 System.out.print(new String(buf, 0, amountRead));
@@ -123,7 +124,7 @@ public class MultipartAttachmentWriterTests {
         File f = TestUtils.loadFixture("fixture/bonsai-boston.jpg");
         Attachment att0 = new UnsavedFileAttachment(f, "image/jpeg");
         mpw.addAttachment(att0, f.length());
-        mpw.close();
+        InputStream is = mpw.makeInputStream();
 
         int amountRead = 0;
         int totalRead = 0;
@@ -132,7 +133,7 @@ public class MultipartAttachmentWriterTests {
 
         do {
             byte buf[] = new byte[chunkSize];
-            amountRead = mpw.read(buf);
+            amountRead = is.read(buf);
             if (amountRead > 0) {
                 bos.write(buf, 0, amountRead);
                 totalRead += amountRead;

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/ReplicationTestBase.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/ReplicationTestBase.java
@@ -56,20 +56,20 @@ public abstract class ReplicationTestBase extends CouchTestBase {
     }
 
 
-    private void createDatastore() throws Exception {
+    protected void createDatastore() throws Exception {
         datastoreManagerPath = TestUtils.createTempTestingDir(this.getClass().getName());
         datastoreManager = new DatastoreManager(this.datastoreManagerPath);
         datastore = (DatastoreExtended) datastoreManager.openDatastore(getClass().getSimpleName());
         datastoreWrapper = new DatastoreWrapper(datastore);
     }
 
-    private void createRemoteDB() {
+    protected void createRemoteDB() {
         remoteDb = new CouchClientWrapper(super.getCouchConfig(getDbName()));
         remoteDb.createDatabase();
         couchClient = remoteDb.getCouchClient();
     }
 
-    private void cleanUpTempFiles() {
+    protected void cleanUpTempFiles() {
         TestUtils.deleteTempTestingDir(datastoreManagerPath);
         CouchClientWrapperDbUtils.deleteDbQuietly(remoteDb);
     }
@@ -81,7 +81,7 @@ public abstract class ReplicationTestBase extends CouchTestBase {
         return dbName.replaceAll(regex, replacement).toLowerCase();
     }
 
-    PullReplication createPullReplication() throws URISyntaxException {
+    protected PullReplication createPullReplication() throws URISyntaxException {
         PullReplication pullReplication = new PullReplication();
         CouchConfig couchConfig = this.getCouchConfig(this.getDbName());
         pullReplication.source = couchConfig.getRootUri();
@@ -89,7 +89,7 @@ public abstract class ReplicationTestBase extends CouchTestBase {
         return pullReplication;
     }
 
-    PushReplication createPushReplication() throws URISyntaxException {
+    protected PushReplication createPushReplication() throws URISyntaxException {
         PushReplication pushReplication = new PushReplication();
         CouchConfig couchConfig = this.getCouchConfig(this.getDbName());
         pushReplication.target = couchConfig.getRootUri();

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/UnreliableNetworkPullTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/UnreliableNetworkPullTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2015 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.replication;
+
+import com.cloudant.common.ProxyTestBase;
+import com.cloudant.common.RequireRunningCouchDB;
+import com.cloudant.common.RequireRunningProxy;
+import com.cloudant.http.Http;
+import com.cloudant.mazha.CouchException;
+import com.cloudant.mazha.Response;
+import com.cloudant.sync.util.TestUtils;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Created by tomblench on 15/07/15.
+ */
+
+@Category({RequireRunningCouchDB.class, RequireRunningProxy.class})
+public class UnreliableNetworkPullTest extends ProxyTestBase {
+
+    String jsonAddToxic = "{\"enabled\" :true, \"timeout\":50, \"sometimesToxic\": true, \"toxicity\" :0.5}";
+
+    @Test
+    public void unreliableNetworkPullTest() throws Exception {
+        // test needs to create documents before adding the toxic
+        // otherwise document creation may fail or at best take a long time
+        int nDocs = 500;
+        for (int i=0; i<nDocs; i++) {
+            createRemoteDocument("doc" + i);
+        }
+        this.addToxic();
+        BasicPullStrategy pull = new BasicPullStrategy(this.createPullReplication());
+        Thread t = new Thread(pull);
+        t.start();
+        t.join();
+        Assert.assertEquals(nDocs, this.datastore.getAllDocumentIds().size());
+        // TODO a number of extra document updates and pulls to ensure checkpointing is correct
+    }
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        this.startProxy();
+        super.setUp();
+    }
+
+    @After
+    @Override
+    public void tearDown() throws Exception {
+        this.removeToxic();
+        super.tearDown();
+        this.stopProxy();
+    }
+
+    private void createRemoteDocument(String docid) {
+        Map<String, Object> doc = new HashMap<String, Object>();
+        doc.put("_id", docid);
+        // TODO make a much more complex document
+        int nKeys = 50;
+        for (int i=0; i<nKeys; i++) {
+            doc.put("key_"+i, "value_"+i);
+        }
+        this.remoteDb.create(doc);
+    }
+
+    private void addToxic() throws Exception {
+        Http.POST(new URL(String.format("http://%s:%d/proxies/%s/downstream/toxics/timeout",
+                proxyHost, proxyAdminPort, proxyName)), "application/json").setRequestBody(jsonAddToxic).execute();
+    }
+
+    private void removeToxic() throws Exception {
+        Http.DELETE(new URL(String.format("http://%s:%d/proxies/%s/downstream/toxics/timeout",
+                proxyHost, proxyAdminPort, proxyName))).execute();
+    }
+
+}

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/UnreliableNetworkPushTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/UnreliableNetworkPushTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2015 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.replication;
+
+import com.cloudant.common.ProxyTestBase;
+import com.cloudant.common.RequireRunningCouchDB;
+import com.cloudant.common.RequireRunningProxy;
+import com.cloudant.http.Http;
+import com.cloudant.sync.datastore.DocumentBodyFactory;
+import com.cloudant.sync.datastore.DocumentException;
+import com.cloudant.sync.datastore.MutableDocumentRevision;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Created by tomblench on 09/09/15.
+ */
+
+
+@Category({RequireRunningCouchDB.class, RequireRunningProxy.class})
+public class UnreliableNetworkPushTest extends ProxyTestBase {
+
+
+    String jsonAddToxic = "{\"enabled\" :true, \"timeout\":50, \"sometimesToxic\": true, \"toxicity\" :0.5}";
+
+    @Test
+    public void unreliableNetworkPullTest() throws Exception {
+        this.addToxic();
+        int nDocs = 500;
+        for (int i=0; i<nDocs; i++) {
+            createLocalDocument("doc" + i);
+        }
+        BasicPushStrategy push = new BasicPushStrategy(this.createPushReplication());
+        Thread t = new Thread(push);
+        t.start();
+        t.join();
+        Assert.assertEquals(nDocs, push.getDocumentCounter());
+        for (int i=0; i<nDocs; i++) {
+            try {
+                Map<String, Object> doc = this.remoteDb.get(Map.class, "doc" + i);
+                Assert.assertEquals("doc" + i, doc.get("_id"));
+            } catch(Exception e) {
+                System.out.println(e);
+                Assert.fail("Couldn't get doc with exception "+e);
+            }
+        }
+        // TODO a number of extra document updates and pulls to ensure checkpointing is correct
+    }
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        this.startProxy();
+        super.setUp();
+    }
+
+    @After
+    @Override
+    public void tearDown() throws Exception {
+        this.removeToxic();
+        super.tearDown();
+        this.stopProxy();
+    }
+
+    private void createLocalDocument(String docid) throws DocumentException {
+        MutableDocumentRevision mdr = new MutableDocumentRevision();
+        mdr.docId = docid;
+        Map<String, Object> doc = new HashMap<String, Object>();
+        // TODO make a much more complex document
+        int nKeys = 50;
+        for (int i=0; i<nKeys; i++) {
+            doc.put("key_"+i, "value_"+i);
+        }
+        mdr.body = DocumentBodyFactory.create(doc);
+        datastore.createDocumentFromRevision(mdr);
+    }
+
+    private void addToxic() throws Exception {
+        Http.POST(new URL(String.format("http://%s:%d/proxies/%s/downstream/toxics/timeout",
+                proxyHost, proxyAdminPort, proxyName)), "application/json").setRequestBody(jsonAddToxic).execute();
+    }
+
+    private void removeToxic() throws Exception {
+        Http.DELETE(new URL(String.format("http://%s:%d/proxies/%s/downstream/toxics/timeout",
+                proxyHost, proxyAdminPort, proxyName))).execute();
+    }
+
+}


### PR DESCRIPTION
_What_: Ensure pull replication reliability when transferring data over unreliable networks.

_Why_: A quick code audit after HTTP layer replacement shows that our current ability to recover from transient network errors is poor.

_How_: Modify all CouchClient methods to retry when they fail due to a transient error (500-599 error codes, socket closed, connection reset). This is the job of the new `ExecuteResult` class.

All payloads have to be capable of being resent. In the case of `String` or `byte[]` this is easy because the payload is held in memory. For `InputStream`s they must be re-generated with each attempt. This is the purpose of the `InputStreamGenerator` class. `MultipartAttachmentWriter` has been re-written to hold references to the attachments and body and (re-)generate the stream on demand, through `makeInputStream` and `makeInputStreamGenerator`.

_Testing_: Add `UnreliableNetwork{Pull,Push}Test` class and `unreliableNetworkTest` gradle target. Running this will require our custom fork of `toxiproxy` to be running, but the test performs all proxy configuration. The `toxiproxy` fork can be found at https://github.com/tomblench/toxiproxy 

reviewer: @mikerhodes 
reviewer: @rhyshort 
reviewer: @ricellis 