### PR TITLE
Fix NullPointerException in ReplicatorBuilder

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# Unreleased
+- [FIXED] Fix issue where the `ReplictorBuilder` would crash the application
+when creating a pull replication if `PullFilter` is `null`.
+
 # 0.13.0 (2015-08-13)
 - [BREAKING CHANGE] Moved code for encryption on Android to the
   `sync-android-encryption` subproject. See the instructions in the [README](https://github.com/cloudant/sync-android/blob/master/README.md)

--- a/sync-core/src/main/java/com/cloudant/sync/replication/PullFilter.java
+++ b/sync-core/src/main/java/com/cloudant/sync/replication/PullFilter.java
@@ -18,6 +18,7 @@ import com.google.common.base.Joiner;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -93,7 +94,7 @@ public class PullFilter {
      */
     public PullFilter(String filterName, Map<String, String> parameters) {
         this.name = filterName;
-        Map<String, String> internalParams = Collections.emptyMap();
+        Map<String, String> internalParams = new HashMap<String, String>();
         internalParams.putAll(parameters);
         this.parameters = Collections.unmodifiableMap(internalParams);
     }

--- a/sync-core/src/main/java/com/cloudant/sync/replication/ReplicatorBuilder.java
+++ b/sync-core/src/main/java/com/cloudant/sync/replication/ReplicatorBuilder.java
@@ -21,7 +21,9 @@ import com.cloudant.sync.datastore.Datastore;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 /**
  * A Builder to create a {@link Replicator Object}
@@ -75,11 +77,17 @@ public abstract class ReplicatorBuilder<S, T, E> {
             pullReplication.target = super.target;
             pullReplication.responseInterceptors.addAll(super.responseInterceptors);
             pullReplication.requestInterceptors.addAll(super.requestInterceptors);
-            //convert the new filter to the old one.
-            //this is to avoid invasive changes for now.
-            Replication.Filter filter = new Replication.Filter(this.pullPullFilter.getName(),
-                    this.pullPullFilter.getParameters());
-            pullReplication.filter = filter;
+
+            if(this.pullPullFilter != null) {
+                //convert the new filter to the old one.
+                //this is to avoid invasive changes for now.
+                Map<String,String> filterParams = this.pullPullFilter.getParameters();
+                filterParams = filterParams == null ? Collections.EMPTY_MAP : filterParams;
+
+                Replication.Filter filter = new Replication.Filter(this.pullPullFilter.getName(),
+                        filterParams);
+                pullReplication.filter = filter;
+            }
 
             return new BasicReplicator(pullReplication);
         }

--- a/sync-core/src/test/java/com/cloudant/sync/replication/PullReplicatorTest.java
+++ b/sync-core/src/test/java/com/cloudant/sync/replication/PullReplicatorTest.java
@@ -23,6 +23,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
 
 @Category(RequireRunningCouchDB.class)
 public class PullReplicatorTest extends ReplicationTestBase {
@@ -91,5 +93,56 @@ public class PullReplicatorTest extends ReplicationTestBase {
         runReplicationUntilComplete(pullReplication);
         Assert.assertTrue(interceptorCallCounter.interceptorResponseTimesCalled >= 1);
     }
+
+    @Test
+    public void testPullReplicationCreatedSuccessfullyWithoutFilter() throws Exception {
+
+        Replicator replicator = ReplicatorBuilder.pull()
+                .from(this.source)
+                .to(this.datastore)
+                .build();
+
+        Assert.assertNotNull(replicator);
+    }
+
+    @Test
+    public void testPullReplicationCreatedSuccessfullyWithFilter() throws Exception {
+
+        Replicator replicator = ReplicatorBuilder.pull()
+                .from(this.source)
+                .to(this.datastore)
+                .filter(new PullFilter("a_filter"))
+                .build();
+
+        Assert.assertNotNull(replicator);
+    }
+
+    @Test
+    public void testPullReplicationCreatedSuccessfullyWithFilterAndParams() throws Exception {
+
+        Map<String,String> params = new HashMap<String,String>();
+        params.put("a","parameter");
+        Replicator replicator = ReplicatorBuilder.pull()
+                .from(this.source)
+                .to(this.datastore)
+                .filter(new PullFilter("a_filter",params))
+                .build();
+
+        Assert.assertNotNull(replicator);
+    }
+
+    @Test
+    public void testPullReplicationCreatedSuccessfullyWithFilterAndEmptyParams() throws Exception {
+
+        Map<String,String> params = new HashMap<String,String>();
+        Replicator replicator = ReplicatorBuilder.pull()
+                .from(this.source)
+                .to(this.datastore)
+                .filter(new PullFilter("a_filter",params))
+                .build();
+
+        Assert.assertNotNull(replicator);
+    }
+
 
 }


### PR DESCRIPTION
## What
Do not attempt to generate a `Replication.Filter` when `PullFilter` is `null` in `ReplictorBuilder.`

## How 
Check if the `PullFilter` is `null` before attempting to generate the `Replication.Filter ` used by the Replicator.

## Why
Currently if a PullReplication is used without setting a filter, the application will crash.

## Testing
To test, build the sample application using the latest release. (it crashes during start up).
Apply patch and run again, replication should be able to complete successfully and the app,
launches.

## Reviewers

reviewer @tomblench 
reviewer @mikerhodes 

BugzId: 50635