### PR TITLE
Fix encoding for document IDs containing colons

### DIFF
--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/mazha/CouchURIHelper.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/mazha/CouchURIHelper.java
@@ -22,8 +22,10 @@ import com.cloudant.common.CouchConstants;
 import com.cloudant.mazha.json.JSONHelper;
 import com.google.common.base.Joiner;
 
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Map;
 
@@ -188,24 +190,9 @@ public class CouchURIHelper {
      * @return The encoded Document or Attachment ID, eg "a%2Fdocument"
      */
     String encodeId(String in) {
-        // The only way to URL-encode in the Java library is to call the URI
-        // constructor passing in the parts of the URL to encode. This makes
-        // sense as the different parts of the URL require different encoding
-        // methods (e.g., reserved chars changes by URI part).
-        // It's unclear to me whether we need to use toASCIIString or whether
-        // the characters in the "other" set are okay in URIs constructed
-        // using new URI(uri).
-        // We then have to encode the "/" manually, as we know it needs
-        // encoding in this context.
         try {
-            URI uri = new URI(
-                    null, // scheme
-                    null, // authority
-                    in, // path
-                    null, // query
-                    null // fragment
-            );
-            String encodedString = uri.toASCIIString().replace("/", "%2F");
+            String encodedString = HierarchicalUriComponents.encodeUriComponent(in, Charset
+                    .defaultCharset().toString(), HierarchicalUriComponents.Type.PATH_SEGMENT);
             if (encodedString.startsWith(CouchConstants._design_prefix_encoded) ||
                     encodedString.startsWith(CouchConstants._local_prefix_encoded)) {
                 // we replaced a the first slash in the design or local doc URL, which we shouldn't
@@ -214,10 +201,10 @@ public class CouchURIHelper {
             } else {
                 return encodedString;
             }
-        } catch (URISyntaxException e) {
+        } catch (UnsupportedEncodingException uee) {
             throw new RuntimeException(
-                    "Couldn't encode path component " + in,
-                    e);
+                    "Couldn't encode ID " + in,
+                    uee);
         }
     }
 
@@ -228,22 +215,13 @@ public class CouchURIHelper {
         // As this is to escape individual parameters, we need to
         // escape & and =.
         try {
-            URI uri = new URI(
-                    null, // scheme
-                    null, // authority
-                    null, // path
-                    in, // query
-                    null // fragment
-            );
-            return uri.toASCIIString()
-                    .replace("&", "%26")
-                    .replace("=", "%3D")  // encode qs separators
-                    .replace("+", "%2B")
-                    .substring(1);  // remove leading ?
-        } catch (URISyntaxException e) {
+            String encodedString = HierarchicalUriComponents.encodeUriComponent(in, Charset
+                    .defaultCharset().toString(), HierarchicalUriComponents.Type.QUERY_PARAM);
+            return encodedString;
+        } catch (UnsupportedEncodingException uee) {
             throw new RuntimeException(
                     "Couldn't encode query parameter " + in,
-                    e);
+                    uee);
         }
     }
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/mazha/CouchURIHelper.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/mazha/CouchURIHelper.java
@@ -191,8 +191,8 @@ public class CouchURIHelper {
      */
     String encodeId(String in) {
         try {
-            String encodedString = HierarchicalUriComponents.encodeUriComponent(in, Charset
-                    .defaultCharset().toString(), HierarchicalUriComponents.Type.PATH_SEGMENT);
+            String encodedString = HierarchicalUriComponents.encodeUriComponent(in, "UTF-8",
+                    HierarchicalUriComponents.Type.PATH_SEGMENT);
             if (encodedString.startsWith(CouchConstants._design_prefix_encoded) ||
                     encodedString.startsWith(CouchConstants._local_prefix_encoded)) {
                 // we replaced a the first slash in the design or local doc URL, which we shouldn't
@@ -215,8 +215,8 @@ public class CouchURIHelper {
         // As this is to escape individual parameters, we need to
         // escape & and =.
         try {
-            String encodedString = HierarchicalUriComponents.encodeUriComponent(in, Charset
-                    .defaultCharset().toString(), HierarchicalUriComponents.Type.QUERY_PARAM);
+            String encodedString = HierarchicalUriComponents.encodeUriComponent(in, "UTF-8",
+                    HierarchicalUriComponents.Type.QUERY_PARAM);
             return encodedString;
         } catch (UnsupportedEncodingException uee) {
             throw new RuntimeException(

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/mazha/HierarchicalUriComponents.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/mazha/HierarchicalUriComponents.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) 2015 IBM Corp. All rights reserved.
+ * Copyright 2002-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Code based on commit 0f7fc125698b523eb56093f75c3191cf4b5551b8 of HierarchicalUriComponents.java
+ * from The Spring Framework http://projects.spring.io/spring-framework
+ * see https://raw.githubusercontent.com/spring-projects/spring-framework/master/spring-web/src/main/java/org/springframework/web/util/HierarchicalUriComponents.java
+ */
+
+package com.cloudant.mazha;
+
+import com.google.common.base.Preconditions;
+
+import java.io.ByteArrayOutputStream;
+import java.io.UnsupportedEncodingException;
+
+public class HierarchicalUriComponents {
+
+    /**
+     * Encode the given source into an encoded String using the rules specified
+     * by the given component and with the given options.
+     * @param source the source string
+     * @param encoding the encoding of the source string
+     * @param type the URI component for the source
+     * @return the encoded URI
+     * @throws IllegalArgumentException when the given uri parameter is not a valid URI
+     */
+    static String encodeUriComponent(String source, String encoding, Type type)
+            throws UnsupportedEncodingException {
+
+        if (source == null) {
+            return null;
+        }
+        Preconditions.checkNotNull(encoding, "Encoding must not be null");
+        Preconditions.checkArgument(!encoding.isEmpty(), "Encoding must not be empty");
+        byte[] bytes = encodeBytes(source.getBytes(encoding), type);
+        return new String(bytes, "US-ASCII");
+    }
+
+    private static byte[] encodeBytes(byte[] source, Type type) {
+        Preconditions.checkNotNull(source, "Source must not be null");
+        Preconditions.checkNotNull(type, "Type must not be null");
+        ByteArrayOutputStream bos = new ByteArrayOutputStream(source.length);
+        for (byte b : source) {
+            if (b < 0) {
+                b += 256;
+            }
+            if (type.isAllowed(b)) {
+                bos.write(b);
+            }
+            else {
+                bos.write('%');
+                char hex1 = Character.toUpperCase(Character.forDigit((b >> 4) & 0xF, 16));
+                char hex2 = Character.toUpperCase(Character.forDigit(b & 0xF, 16));
+                bos.write(hex1);
+                bos.write(hex2);
+            }
+        }
+        return bos.toByteArray();
+    }
+
+    /**
+     * Enumeration used to identify the allowed characters per URI component.
+     * <p>Contains methods to indicate whether a given character is valid in a specific URI component.
+     * @see <a href="http://www.ietf.org/rfc/rfc3986.txt">RFC 3986</a>
+     */
+    enum Type {
+
+        SCHEME {
+            @Override
+            public boolean isAllowed(int c) {
+                return isAlpha(c) || isDigit(c) || '+' == c || '-' == c || '.' == c;
+            }
+        },
+        AUTHORITY {
+            @Override
+            public boolean isAllowed(int c) {
+                return isUnreserved(c) || isSubDelimiter(c) || ':' == c || '@' == c;
+            }
+        },
+        USER_INFO {
+            @Override
+            public boolean isAllowed(int c) {
+                return isUnreserved(c) || isSubDelimiter(c) || ':' == c;
+            }
+        },
+        HOST_IPV4 {
+            @Override
+            public boolean isAllowed(int c) {
+                return isUnreserved(c) || isSubDelimiter(c);
+            }
+        },
+        HOST_IPV6 {
+            @Override
+            public boolean isAllowed(int c) {
+                return isUnreserved(c) || isSubDelimiter(c) || '[' == c || ']' == c || ':' == c;
+            }
+        },
+        PORT {
+            @Override
+            public boolean isAllowed(int c) {
+                return isDigit(c);
+            }
+        },
+        PATH {
+            @Override
+            public boolean isAllowed(int c) {
+                return isPchar(c) || '/' == c;
+            }
+        },
+        PATH_SEGMENT {
+            @Override
+            public boolean isAllowed(int c) {
+                return isPchar(c);
+            }
+        },
+        QUERY {
+            @Override
+            public boolean isAllowed(int c) {
+                return isPchar(c) || '/' == c || '?' == c;
+            }
+        },
+        QUERY_PARAM {
+            @Override
+            public boolean isAllowed(int c) {
+                if ('=' == c || '+' == c || '&' == c) {
+                    return false;
+                }
+                else {
+                    return isPchar(c) || '/' == c || '?' == c;
+                }
+            }
+        },
+        FRAGMENT {
+            @Override
+            public boolean isAllowed(int c) {
+                return isPchar(c) || '/' == c || '?' == c;
+            }
+        },
+        URI {
+            @Override
+            public boolean isAllowed(int c) {
+                return isUnreserved(c);
+            }
+        };
+
+        /**
+         * Indicates whether the given character is allowed in this URI component.
+         * @return {@code true} if the character is allowed; {@code false} otherwise
+         */
+        public abstract boolean isAllowed(int c);
+
+        /**
+         * Indicates whether the given character is in the {@code ALPHA} set.
+         * @see <a href="http://www.ietf.org/rfc/rfc3986.txt">RFC 3986, appendix A</a>
+         */
+        protected boolean isAlpha(int c) {
+            return c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z';
+        }
+
+        /**
+         * Indicates whether the given character is in the {@code DIGIT} set.
+         * @see <a href="http://www.ietf.org/rfc/rfc3986.txt">RFC 3986, appendix A</a>
+         */
+        protected boolean isDigit(int c) {
+            return c >= '0' && c <= '9';
+        }
+
+        /**
+         * Indicates whether the given character is in the {@code gen-delims} set.
+         * @see <a href="http://www.ietf.org/rfc/rfc3986.txt">RFC 3986, appendix A</a>
+         */
+        protected boolean isGenericDelimiter(int c) {
+            return ':' == c || '/' == c || '?' == c || '#' == c || '[' == c || ']' == c || '@' == c;
+        }
+
+        /**
+         * Indicates whether the given character is in the {@code sub-delims} set.
+         * @see <a href="http://www.ietf.org/rfc/rfc3986.txt">RFC 3986, appendix A</a>
+         */
+        protected boolean isSubDelimiter(int c) {
+            return '!' == c || '$' == c || '&' == c || '\'' == c || '(' == c || ')' == c || '*' == c || '+' == c ||
+                    ',' == c || ';' == c || '=' == c;
+        }
+
+        /**
+         * Indicates whether the given character is in the {@code reserved} set.
+         * @see <a href="http://www.ietf.org/rfc/rfc3986.txt">RFC 3986, appendix A</a>
+         */
+        protected boolean isReserved(int c) {
+            return isGenericDelimiter(c) || isSubDelimiter(c);
+        }
+
+        /**
+         * Indicates whether the given character is in the {@code unreserved} set.
+         * @see <a href="http://www.ietf.org/rfc/rfc3986.txt">RFC 3986, appendix A</a>
+         */
+        protected boolean isUnreserved(int c) {
+            return isAlpha(c) || isDigit(c) || '-' == c || '.' == c || '_' == c || '~' == c;
+        }
+
+        /**
+         * Indicates whether the given character is in the {@code pchar} set.
+         * @see <a href="http://www.ietf.org/rfc/rfc3986.txt">RFC 3986, appendix A</a>
+         */
+        protected boolean isPchar(int c) {
+            return isUnreserved(c) || isSubDelimiter(c) || ':' == c || '@' == c;
+        }
+    }
+
+}

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/mazha/HierarchicalUriComponents.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/mazha/HierarchicalUriComponents.java
@@ -16,9 +16,9 @@
  */
 
 /**
- * Code based on commit 0f7fc125698b523eb56093f75c3191cf4b5551b8 of HierarchicalUriComponents.java
- * from The Spring Framework http://projects.spring.io/spring-framework
- * see https://raw.githubusercontent.com/spring-projects/spring-framework/master/spring-web/src/main/java/org/springframework/web/util/HierarchicalUriComponents.java
+ * Code based on commit a0b231d36d7baf295a91e052cd2eb02a37a16a80 of HierarchicalUriComponents.java
+ * from The Spring Framework http://projects.spring.io/spring-framework version 4.1.7
+ * see https://raw.githubusercontent.com/spring-projects/spring-framework/v4.1.7.RELEASE/spring-web/src/main/java/org/springframework/web/util/HierarchicalUriComponents.java
  */
 
 package com.cloudant.mazha;

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/mazha/CouchURIHelperTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/mazha/CouchURIHelperTest.java
@@ -84,10 +84,10 @@ public class CouchURIHelperTest {
 
     @Test
     public void buildChangesUri_options_optionsEncoded() throws Exception {
-        URI expected = new URI(uriBase + "/test/_changes?limit=100&since=%22[]");
+        URI expected = new URI(uriBase + "/test/_changes?limit=100&since=%22%5B%5D%22");
 
         Map<String, Object> options = new HashMap<String, Object>();
-        options.put("since", "\"[]");
+        options.put("since", "\"[]\"");
         options.put("limit", 100);
         URI actual = helper(path+"/test").changesUri(options);
         Assert.assertEquals(expected, actual);
@@ -144,8 +144,15 @@ public class CouchURIHelperTest {
     }
 
     @Test
+    public void buildDocumentUri_colonInDocumentId() throws Exception {
+        URI expected = new URI(uriBase + "/test/:this:has:colons:");
+        URI actual = helper(path+"/test").documentUri(":this:has:colons:");
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
     public void buildDocumentUri_options_optionsEncoded() throws Exception {
-        URI expected = new URI(uriBase + "/test/path1%2Fpath2?detail=true&revs=[1-2]");
+        URI expected = new URI(uriBase + "/test/path1%2Fpath2?detail=true&revs=%5B1-2%5D");
 
         Map<String, Object> options = new TreeMap<String, Object>();
         options.put("revs", "[1-2]");
@@ -156,7 +163,7 @@ public class CouchURIHelperTest {
 
     @Test
     public void buildDocumentUri_options_encodeSeparators() throws Exception {
-        URI expected = new URI(uriBase + "/test/path1%2Fpath2?d%26etail%3D=%26%3D%3Dds%26&revs=[1-2]");
+        URI expected = new URI(uriBase + "/test/path1%2Fpath2?d%26etail%3D=%26%3D%3Dds%26&revs=%5B1-2%5D");
 
         TreeMap<String, Object> options = new TreeMap<String, Object>();
         options.put("revs", "[1-2]");
@@ -181,7 +188,7 @@ public class CouchURIHelperTest {
     // correctly escaped in the document part of the url
     @Test
     public void buildVeryEscapedUri() throws Exception {
-        URI expected = new URI(uriBase + "/SDF@%23%25$%23)KLDfdffdg%C3%A9/%2FSF@%23%25$%23)DFGKLDfdffdg%C3%A9%2Fpath2?detail=/SDF@%23%25$%23)%C3%A9&revs=[1-2]");
+        URI expected = new URI(uriBase + "/SDF@%23%25$%23)KLDfdffdg%C3%A9/%2FSF@%23%25$%23)DFGKLDfdffdg%C3%A9%2Fpath2?detail=/SDF@%23%25$%23)%C3%A9&revs=%5B1-2%5D");
 
         Map<String, Object> options = new TreeMap<String, Object>();
         options.put("revs", "[1-2]");

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/BasicPullStrategyTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/BasicPullStrategyTest.java
@@ -244,6 +244,21 @@ public class BasicPullStrategyTest extends ReplicationTestBase {
     }
 
     @Test
+    public void pull_documentIdColons_success() throws Exception {
+        String id = ":this:has:colons:";
+        Bar bar = BarUtils.createBar(this.remoteDb, id, "Tom", 21);
+        Assert.assertEquals(id, bar.getId());
+        this.pull(1);
+        {
+            Bar bar2 = this.getDocument(bar.getId());
+            Assert.assertEquals(bar.getId(), bar2.getId());
+            Assert.assertEquals(bar.getRevision(), bar2.getRevision());
+            Assert.assertEquals("Tom", bar2.getName());
+            Assert.assertTrue(21 == bar2.getAge());
+        }
+    }
+
+    @Test
     public void pull_oneDocOneRevResetCheckpoint_revisionShouldNotBePulled() throws Exception {
         oneDocCreatedAndThenPulled();
         Assert.assertEquals(1, replicator.getDocumentCounter());


### PR DESCRIPTION
- Introduce `HierarchicalUriComponents` for URI encoding, based on
  code from the Spring Framework. See file for full attribution.
- Add tests for replication of documents containing the colon (`:`)
  character. Previously this was incorrectly handled.
- Update tests to reflect encoding of `[` and `]`
  characters. Previously these were not encoded. RFC 3986 suggests
  that it is correct to encode these characters.