### PR TITLE
Add ID to Replicator to enable replicators to be identified in callba…

### DIFF
--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/BasicReplicator.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/BasicReplicator.java
@@ -22,9 +22,11 @@ import com.google.common.eventbus.Subscribe;
 
 class BasicReplicator implements Replicator {
 
+    public static final int NULL_ID = -1;
     protected final Replication replication;
     protected Thread strategyThread;
     protected ReplicationStrategy strategy;
+    protected int id = NULL_ID;
 
     // Writes need synchronising.
     private State state = null;
@@ -34,6 +36,12 @@ class BasicReplicator implements Replicator {
     public BasicReplicator(Replication replication) {
         this.replication = replication;
         this.state = State.PENDING;
+    }
+
+    public BasicReplicator(Replication replication, int id) {
+        this.replication = replication;
+        this.state = State.PENDING;
+        this.id = id;
     }
 
     // method exists to be override for test purpose
@@ -145,5 +153,9 @@ class BasicReplicator implements Replicator {
      */
     public EventBus getEventBus() {
         return eventBus;
+    }
+
+    public int getId() {
+        return id;
     }
 }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/BasicReplicator.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/BasicReplicator.java
@@ -34,8 +34,7 @@ class BasicReplicator implements Replicator {
     private final EventBus eventBus = new EventBus();
 
     public BasicReplicator(Replication replication) {
-        this.replication = replication;
-        this.state = State.PENDING;
+        this(replication, NULL_ID);
     }
 
     public BasicReplicator(Replication replication, int id) {

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/Replicator.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/Replicator.java
@@ -154,5 +154,7 @@ public interface Replicator {
      * @return EventBus object.
      */
     EventBus getEventBus();
+
+    int getId();
 }
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ReplicatorBuilder.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ReplicatorBuilder.java
@@ -33,6 +33,7 @@ public abstract class ReplicatorBuilder<S, T, E> {
 
     private T target;
     private S source;
+    private int id = BasicReplicator.NULL_ID;
     private List<HttpConnectionRequestInterceptor> requestInterceptors = new ArrayList
             <HttpConnectionRequestInterceptor>();
     private List<HttpConnectionResponseInterceptor> responseInterceptors = new ArrayList
@@ -53,8 +54,7 @@ public abstract class ReplicatorBuilder<S, T, E> {
             PushReplication pushReplication = new PushReplication();
             pushReplication.source = super.source;
             pushReplication.target = super.target;
-            return new BasicReplicator(pushReplication);
-
+            return new BasicReplicator(pushReplication, super.id);
         }
     }
 
@@ -89,7 +89,7 @@ public abstract class ReplicatorBuilder<S, T, E> {
                 pullReplication.filter = filter;
             }
 
-            return new BasicReplicator(pullReplication);
+            return new BasicReplicator(pullReplication, super.id);
         }
 
         /**
@@ -125,6 +125,12 @@ public abstract class ReplicatorBuilder<S, T, E> {
      */
     public E from(S source) {
         this.source = source;
+        //noinspection unchecked
+        return (E) this;
+    }
+
+    public E withId(int id) {
+        this.id = id;
         //noinspection unchecked
         return (E) this;
     }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ReplicatorFactory.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ReplicatorFactory.java
@@ -41,4 +41,8 @@ public final class ReplicatorFactory {
     public static Replicator oneway(Replication replication) {
         return new BasicReplicator(replication);
     }
+
+    public static Replicator oneway(Replication replication, int id) {
+        return new BasicReplicator(replication, id);
+    }
 }


### PR DESCRIPTION
This is part 1 of a 6 part change to implement replication policies. Each of the 6 parts of the implementation of replication policies are each in a separate branch.

_The following text is common to all 6 PRs._

The 6 branches include:
1. _48607-policies-1-replicator-id_: Adding an ID to replicators so we can easily identify which replicators are completed or have errored in subsequent callbacks.
2. _48607-policies-2-java_: Adding replication policies for Java.
3. _48607-policies-3-android-service_:Adding basic replication policies for Android.
4. _48607-policies-4-android-periodic_: Adding replication at regular intervals for Android.
5. _48607-policies-5-android-wifi_: Adding replication only when on Wifi.
6. _48607-policies-6-docs_: Documentation updates.

_What?_
Add mechanism to enable users to more easily specify the circumstances under which they want replication to occur. This allows relatively simple definition of policies such as:
* Do a pull replication every 2 hours;
* Do a full sync every hour, but only when we have a Wifi connection;
* Sync whenever we connect to Wifi.

_Why?_
Prior to this PR, it was very difficult to implement such policies, particularly on Android where many aspects of the way the Android operating system works would need to be taken into account in order for such policies to work reliably.

_How?_
On Android we want the replication policy management to be reliable, battery efficient and not hog system resources unnecessarily. To achieve this we typically might trigger our replications from a `BroadcastReceiver`. This allows our code to be completely inactive on the device and be started when events of interest are broadcast.  We can also use a `BroadcastReceiver` to trigger periodic replications via the `AlarmManager` mechanism in an efficient way.  However, a `BroadcastReceiver` is intended to only run for a short time in response to receiving a broadcast, so the replication is carried on inside a `Service` that may be started from a `BroadcastReceiver`.

Running replications in a `Service` allows them to run independently of the lifecycle of other application components and be started easily via other application components.  We must also handle the fact that when we wish replication to occur, the device may be asleep, so we need to hold a `WakeLock` for the duration of the replication to prevent the device going back to sleep once the `onReceive()` method of the `BroadcastReceiver` triggering the replications has completed.  Also, if our replications are over Wifi, we need to hold a `Wifi` lock to keep the Wifi radio awake.

On Java, replication policies are much simpler than on Android. The new `ReplicationPolicyManager` class takes care of ensuring that if replications are in progress they are not restarted.

See the [Replication Policies User Guide](https://github.com/cloudant/sync-android/blob/48607-replication-policies/REPLICATION_POLICIES.md) for further information on how replication policies are implemented on Android and on Java.

reviewer @mikerhodes
reviewer @ricellis 