### PR TITLE
Add replication policies for Java.

### DIFF
--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/IntervalTimerReplicationPolicyManager.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/IntervalTimerReplicationPolicyManager.java
@@ -4,7 +4,7 @@ import java.util.Timer;
 import java.util.TimerTask;
 
 /**
- * This is a sample replication policy that invokes replications at regular intervals.
+ * This replication policy invokes replications at regular intervals.
  * This is not suitable for use on Android because the timer task is likely to be killed
  * by the operating system and this does not handle the case where the device is asleep.
  */

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/IntervalTimerReplicationPolicyManager.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/IntervalTimerReplicationPolicyManager.java
@@ -1,0 +1,39 @@
+package com.cloudant.sync.replication;
+
+import java.util.Timer;
+import java.util.TimerTask;
+
+/**
+ * This is a sample replication policy that invokes replications at regular intervals.
+ * This is not suitable for use on Android because the timer task is likely to be killed
+ * by the operating system and this does not handle the case where the device is asleep.
+ */
+public class IntervalTimerReplicationPolicyManager extends ReplicationPolicyManager {
+
+    private int intervalInSeconds;
+    private Timer timer;
+
+    public IntervalTimerReplicationPolicyManager(int intervalInSeconds) {
+        this.intervalInSeconds = intervalInSeconds;
+        timer = new Timer();
+    }
+
+    @Override
+    public void start() {
+        // Schedule first replication immediately, then every intervalInSeconds seconds.
+        timer.schedule(new IntervalTimerTask(), 0, intervalInSeconds * 1000);
+    }
+
+    @Override
+    public void stop() {
+        stopReplications();
+        timer.cancel();
+    }
+
+    private class IntervalTimerTask extends TimerTask {
+
+        public void run() {
+            startReplications();
+        }
+    }
+}

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ReplicationPolicyManager.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ReplicationPolicyManager.java
@@ -83,28 +83,34 @@ public abstract class ReplicationPolicyManager {
     public abstract void stop();
 
     protected void startReplications() {
-        for (Replicator replicator : replicators) {
-            if (!replicationListener.inProgress(replicator)) {
-                replicationListener.add(replicator);
-                replicator.getEventBus().register(replicationListener);
+        synchronized (replicators) {
+            for (Replicator replicator : replicators) {
+                if (!replicationListener.inProgress(replicator)) {
+                    replicationListener.add(replicator);
+                    replicator.getEventBus().register(replicationListener);
 
-                replicator.start();
+                    replicator.start();
+                }
             }
         }
     }
 
     protected void stopReplications() {
-        for (Replicator replicator : replicators) {
-            replicationListener.remove(replicator);
-            replicator.stop();
+        synchronized (replicators) {
+            for (Replicator replicator : replicators) {
+                replicationListener.remove(replicator);
+                replicator.stop();
+            }
         }
     }
 
     public void addReplicators(Replicator... replicators) {
-        if (this.replicators == null) {
-            this.replicators = new ArrayList<Replicator>();
+        synchronized (this.replicators) {
+            if (this.replicators == null) {
+                this.replicators = new ArrayList<Replicator>();
+            }
+            this.replicators.addAll(Arrays.asList(replicators));
         }
-        this.replicators.addAll(Arrays.asList(replicators));
     }
 
     public void setReplicationsCompletedListener(ReplicationsCompletedListener listener) {

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ReplicationPolicyManager.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ReplicationPolicyManager.java
@@ -1,0 +1,110 @@
+package com.cloudant.sync.replication;
+
+import com.cloudant.sync.notifications.ReplicationCompleted;
+import com.cloudant.sync.notifications.ReplicationErrored;
+import com.google.common.eventbus.Subscribe;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public abstract class ReplicationPolicyManager {
+
+    private List<Replicator> replicators;
+    private ReplicationListener replicationListener;
+    private ReplicationsCompletedListener mReplicationsCompletedListener;
+
+    public interface ReplicationsCompletedListener {
+        void allReplicationsCompleted();
+
+        void replicationCompleted(int id);
+
+        void replicationErrored(int id);
+    }
+
+    private class ReplicationListener {
+
+        Set<Replicator> replicatorsInProgress;
+
+        ReplicationListener() {
+            replicatorsInProgress = new HashSet<Replicator>();
+        }
+
+        synchronized void add(Replicator replicator) {
+            replicatorsInProgress.add(replicator);
+        }
+
+        synchronized void remove(Replicator replicator) {
+            if (replicatorsInProgress.remove(replicator)) {
+                replicator.getEventBus().unregister(this);
+            }
+        }
+
+        boolean inProgress(Replicator replicator) {
+            return replicatorsInProgress.contains(replicator);
+        }
+
+        @Subscribe
+        public void complete(ReplicationCompleted event) {
+            finishedReplication(event.replicator);
+            if (mReplicationsCompletedListener != null) {
+                mReplicationsCompletedListener.replicationCompleted(event.replicator.getId());
+            }
+        }
+
+        @Subscribe
+        public void error(ReplicationErrored event) {
+            finishedReplication(event.replicator);
+            if (mReplicationsCompletedListener != null) {
+                mReplicationsCompletedListener.replicationErrored(event.replicator.getId());
+            }
+        }
+
+        public void finishedReplication(Replicator replicator) {
+            remove(replicator);
+            if (replicatorsInProgress.size() == 0 && mReplicationsCompletedListener != null) {
+                mReplicationsCompletedListener.allReplicationsCompleted();
+            }
+        }
+    }
+
+    public ReplicationPolicyManager() {
+        replicators = new ArrayList<Replicator>();
+        replicationListener = new ReplicationListener();
+    }
+
+    public abstract void start();
+
+    public abstract void stop();
+
+    protected void startReplications() {
+        for (Replicator replicator : replicators) {
+            if (!replicationListener.inProgress(replicator)) {
+                replicationListener.add(replicator);
+                replicator.getEventBus().register(replicationListener);
+
+                replicator.start();
+            }
+        }
+    }
+
+    protected void stopReplications() {
+        for (Replicator replicator : replicators) {
+            replicationListener.remove(replicator);
+            replicator.stop();
+        }
+    }
+
+    public void addReplicators(Replicator... replicators) {
+        if (this.replicators == null) {
+            this.replicators = new ArrayList<Replicator>();
+        }
+        this.replicators.addAll(Arrays.asList(replicators));
+    }
+
+    public void setReplicationsCompletedListener(ReplicationsCompletedListener listener) {
+        mReplicationsCompletedListener = listener;
+    }
+}

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ReplicationPolicyManager.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ReplicationPolicyManager.java
@@ -30,21 +30,27 @@ public abstract class ReplicationPolicyManager {
         Set<Replicator> replicatorsInProgress;
 
         ReplicationListener() {
-            replicatorsInProgress = Collections.synchronizedSet(new HashSet<Replicator>());
+            replicatorsInProgress = new HashSet<Replicator>();
         }
 
         void add(Replicator replicator) {
-            replicatorsInProgress.add(replicator);
+            synchronized (replicatorsInProgress) {
+                replicatorsInProgress.add(replicator);
+            }
         }
 
         void remove(Replicator replicator) {
-            if (replicatorsInProgress.remove(replicator)) {
-                replicator.getEventBus().unregister(this);
+            synchronized (replicatorsInProgress) {
+                if (replicatorsInProgress.remove(replicator)) {
+                    replicator.getEventBus().unregister(this);
+                }
             }
         }
 
         boolean inProgress(Replicator replicator) {
-            return replicatorsInProgress.contains(replicator);
+            synchronized (replicatorsInProgress) {
+                return replicatorsInProgress.contains(replicator);
+            }
         }
 
         @Subscribe

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ReplicationPolicyManager.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ReplicationPolicyManager.java
@@ -64,7 +64,7 @@ public abstract class ReplicationPolicyManager {
         }
 
         public void finishedReplication(Replicator replicator) {
-            synchronized (replicator) {
+            synchronized (replicatorsInProgress) {
                 remove(replicator);
                 if (replicatorsInProgress.size() == 0 && mReplicationsCompletedListener != null) {
                     mReplicationsCompletedListener.allReplicationsCompleted();

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ReplicationPolicyManager.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ReplicationPolicyManager.java
@@ -13,7 +13,7 @@ import java.util.Set;
 
 public abstract class ReplicationPolicyManager {
 
-    private List<Replicator> replicators;
+    private final List<Replicator> replicators = new ArrayList<Replicator>();
     private ReplicationListener replicationListener;
     private ReplicationsCompletedListener mReplicationsCompletedListener;
 
@@ -74,7 +74,6 @@ public abstract class ReplicationPolicyManager {
     }
 
     public ReplicationPolicyManager() {
-        replicators = new ArrayList<Replicator>();
         replicationListener = new ReplicationListener();
     }
 
@@ -106,9 +105,6 @@ public abstract class ReplicationPolicyManager {
 
     public void addReplicators(Replicator... replicators) {
         synchronized (this.replicators) {
-            if (this.replicators == null) {
-                this.replicators = new ArrayList<Replicator>();
-            }
             this.replicators.addAll(Arrays.asList(replicators));
         }
     }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/ReplicationPolicyManagerTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/ReplicationPolicyManagerTest.java
@@ -42,7 +42,7 @@ public class ReplicationPolicyManagerTest extends ReplicationTestBase {
     }
 
     /**
-     * Check that when the {@link }ReplicationPolicyManager} is setup with a single
+     * Check that when the {@link ReplicationPolicyManager} is setup with a single
      * {@link Replicator}, when {@link ReplicationPolicyManager#start()} is called,
      * the {@link Replicator#start()} method is called on the {@link Replicator}.
      */
@@ -59,7 +59,7 @@ public class ReplicationPolicyManagerTest extends ReplicationTestBase {
     }
 
     /**
-     * Check that when the {@link }ReplicationPolicyManager} is setup with multiple
+     * Check that when the {@link ReplicationPolicyManager} is setup with multiple
      * {@link Replicator}s, when {@link ReplicationPolicyManager#start()} is called,
      * the {@link Replicator#start()} method is called on each {@link Replicator}.
      */
@@ -84,7 +84,7 @@ public class ReplicationPolicyManagerTest extends ReplicationTestBase {
     }
 
     /**
-     * Check that when the {@link }ReplicationPolicyManager} is setup with a single
+     * Check that when the {@link ReplicationPolicyManager} is setup with a single
      * {@link Replicator}, when {@link ReplicationPolicyManager#start()} is called,
      * more than once before the {@link Replicator} has completed replication,
      * the {@link Replicator#start()} method is called only once the {@link Replicator}.
@@ -103,7 +103,7 @@ public class ReplicationPolicyManagerTest extends ReplicationTestBase {
     }
 
     /**
-     * Check that when the {@link }ReplicationPolicyManager} is setup with multiple
+     * Check that when the {@link ReplicationPolicyManager} is setup with multiple
      * {@link Replicator}s, when {@link ReplicationPolicyManager#start()} is called,
      * more than once before {@link Replicator} has completed replication,
      * the {@link Replicator#start()} method is called only once on each {@link Replicator}.
@@ -130,7 +130,7 @@ public class ReplicationPolicyManagerTest extends ReplicationTestBase {
     }
 
     /**
-     * Check that when the {@link }ReplicationPolicyManager} is setup with a single
+     * Check that when the {@link ReplicationPolicyManager} is setup with a single
      * {@link Replicator}, when {@link ReplicationPolicyManager#start()} is called,
      * the {@link Replicator#start()} method is called on the {@link Replicator}.
      */
@@ -148,7 +148,7 @@ public class ReplicationPolicyManagerTest extends ReplicationTestBase {
     }
 
     /**
-     * Check that when the {@link }ReplicationPolicyManager} is setup with multiple
+     * Check that when the {@link ReplicationPolicyManager} is setup with multiple
      * {@link Replicator}s, when {@link ReplicationPolicyManager#start()} is called,
      * more than once before {@link Replicator} has completed replication,
      * the {@link Replicator#start()} method is called only once on each {@link Replicator}.
@@ -175,7 +175,7 @@ public class ReplicationPolicyManagerTest extends ReplicationTestBase {
     }
 
     /**
-     * Check that when the {@link }ReplicationPolicyManager} is setup with a single
+     * Check that when the {@link ReplicationPolicyManager} is setup with a single
      * {@link Replicator}, when {@link ReplicationPolicyManager#start()} is called for a
      * second time after the replicator is explicitly stopped, the {@link Replicator#start()} method
      * is called a second time on the {@link Replicator}.
@@ -195,7 +195,7 @@ public class ReplicationPolicyManagerTest extends ReplicationTestBase {
     }
 
     /**
-     * Check that when the {@link }ReplicationPolicyManager} is setup with multiple
+     * Check that when the {@link ReplicationPolicyManager} is setup with multiple
      * {@link Replicator}s, when {@link ReplicationPolicyManager#start()} is called for a
      * second time after the replicator is explicitly stopped, the {@link Replicator#start()} method
      * is called a second time on the {@link Replicator}.
@@ -223,7 +223,7 @@ public class ReplicationPolicyManagerTest extends ReplicationTestBase {
     }
 
     /**
-     * Check that when the {@link }ReplicationPolicyManager} is setup with a single
+     * Check that when the {@link ReplicationPolicyManager} is setup with a single
      * {@link Replicator}, when {@link ReplicationPolicyManager#start()} is called for a
      * second time after the replicator completed normally, the {@link Replicator#start()} method
      * is called a second time on the {@link Replicator}.
@@ -243,7 +243,7 @@ public class ReplicationPolicyManagerTest extends ReplicationTestBase {
     }
 
     /**
-     * Check that when the {@link }ReplicationPolicyManager} is setup with multiple
+     * Check that when the {@link ReplicationPolicyManager} is setup with multiple
      * {@link Replicator}s, when {@link ReplicationPolicyManager#start()} is called for a
      * second time after each replicator completed normally, the {@link Replicator#start()} method
      * is called a second time on the {@link Replicator}s.
@@ -275,7 +275,7 @@ public class ReplicationPolicyManagerTest extends ReplicationTestBase {
     }
 
     /**
-     * Check that when the {@link }ReplicationPolicyManager} is setup with a single
+     * Check that when the {@link ReplicationPolicyManager} is setup with a single
      * {@link Replicator}, when {@link ReplicationPolicyManager#start()} is called for a
      * second time after the replicator errored, the {@link Replicator#start()} method
      * is called a second time on the {@link Replicator}.
@@ -295,7 +295,7 @@ public class ReplicationPolicyManagerTest extends ReplicationTestBase {
     }
 
     /**
-     * Check that when the {@link }ReplicationPolicyManager} is setup with multiple
+     * Check that when the {@link ReplicationPolicyManager} is setup with multiple
      * {@link Replicator}s, when {@link ReplicationPolicyManager#start()} is called for a
      * second time after each replicator errored, the {@link Replicator#start()} method
      * is called a second time on the {@link Replicator}s.

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/ReplicationPolicyManagerTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/ReplicationPolicyManagerTest.java
@@ -1,0 +1,349 @@
+package com.cloudant.sync.replication;
+
+import com.cloudant.sync.notifications.ReplicationCompleted;
+import com.cloudant.sync.notifications.ReplicationErrored;
+import com.google.common.eventbus.EventBus;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.URI;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ReplicationPolicyManagerTest extends ReplicationTestBase {
+
+    URI source;
+    BasicReplicator replicator;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        source = getCouchConfig(getDbName()).getRootUri();
+
+        prepareTwoDocumentsInRemoteDB();
+    }
+
+    private void prepareTwoDocumentsInRemoteDB() {
+        Bar bar1 = BarUtils.createBar(remoteDb, "Tom", 31);
+        couchClient.create(bar1);
+        Bar bar2 = BarUtils.createBar(remoteDb, "Jerry", 52);
+        couchClient.create(bar2);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    /**
+     * Check that when the {@link }ReplicationPolicyManager} is setup with a single
+     * {@link Replicator}, when {@link ReplicationPolicyManager#start()} is called,
+     * the {@link Replicator#start()} method is called on the {@link Replicator}.
+     */
+    @Test
+    public void testSingleStartSingleReplicator() {
+        Replicator mockReplicator = mock(Replicator.class);
+        EventBus mockEventBus = mock(EventBus.class);
+        when(mockReplicator.getEventBus()).thenReturn(mockEventBus);
+        ReplicationPolicyManager rpm = new TestPolicy();
+        rpm.addReplicators(mockReplicator);
+        verify(mockReplicator, never()).start();
+        rpm.start();
+        verify(mockReplicator, times(1)).start();
+    }
+
+    /**
+     * Check that when the {@link }ReplicationPolicyManager} is setup with multiple
+     * {@link Replicator}s, when {@link ReplicationPolicyManager#start()} is called,
+     * the {@link Replicator#start()} method is called on each {@link Replicator}.
+     */
+    @Test
+    public void testSingleStartMultipleReplicators() {
+        Replicator mockReplicator1 = mock(Replicator.class);
+        Replicator mockReplicator2 = mock(Replicator.class);
+        Replicator mockReplicator3 = mock(Replicator.class);
+        EventBus mockEventBus = mock(EventBus.class);
+        when(mockReplicator1.getEventBus()).thenReturn(mockEventBus);
+        when(mockReplicator2.getEventBus()).thenReturn(mockEventBus);
+        when(mockReplicator3.getEventBus()).thenReturn(mockEventBus);
+        ReplicationPolicyManager rpm = new TestPolicy();
+        rpm.addReplicators(mockReplicator1, mockReplicator2, mockReplicator3);
+        verify(mockReplicator1, never()).start();
+        verify(mockReplicator2, never()).start();
+        verify(mockReplicator3, never()).start();
+        rpm.start();
+        verify(mockReplicator1, times(1)).start();
+        verify(mockReplicator2, times(1)).start();
+        verify(mockReplicator3, times(1)).start();
+    }
+
+    /**
+     * Check that when the {@link }ReplicationPolicyManager} is setup with a single
+     * {@link Replicator}, when {@link ReplicationPolicyManager#start()} is called,
+     * more than once before the {@link Replicator} has completed replication,
+     * the {@link Replicator#start()} method is called only once the {@link Replicator}.
+     */
+    @Test
+    public void testMultipleStartSingleReplicator() {
+        Replicator mockReplicator = mock(Replicator.class);
+        EventBus mockEventBus = mock(EventBus.class);
+        when(mockReplicator.getEventBus()).thenReturn(mockEventBus);
+        ReplicationPolicyManager rpm = new TestPolicy();
+        rpm.addReplicators(mockReplicator);
+        verify(mockReplicator, never()).start();
+        rpm.start();
+        rpm.start();
+        verify(mockReplicator, times(1)).start();
+    }
+
+    /**
+     * Check that when the {@link }ReplicationPolicyManager} is setup with multiple
+     * {@link Replicator}s, when {@link ReplicationPolicyManager#start()} is called,
+     * more than once before {@link Replicator} has completed replication,
+     * the {@link Replicator#start()} method is called only once on each {@link Replicator}.
+     */
+    @Test
+    public void testMultipleStartMultipleReplicators() {
+        Replicator mockReplicator1 = mock(Replicator.class);
+        Replicator mockReplicator2 = mock(Replicator.class);
+        Replicator mockReplicator3 = mock(Replicator.class);
+        EventBus mockEventBus = mock(EventBus.class);
+        when(mockReplicator1.getEventBus()).thenReturn(mockEventBus);
+        when(mockReplicator2.getEventBus()).thenReturn(mockEventBus);
+        when(mockReplicator3.getEventBus()).thenReturn(mockEventBus);
+        ReplicationPolicyManager rpm = new TestPolicy();
+        rpm.addReplicators(mockReplicator1, mockReplicator2, mockReplicator3);
+        verify(mockReplicator1, never()).start();
+        verify(mockReplicator2, never()).start();
+        verify(mockReplicator3, never()).start();
+        rpm.start();
+        rpm.start();
+        verify(mockReplicator1, times(1)).start();
+        verify(mockReplicator2, times(1)).start();
+        verify(mockReplicator3, times(1)).start();
+    }
+
+    /**
+     * Check that when the {@link }ReplicationPolicyManager} is setup with a single
+     * {@link Replicator}, when {@link ReplicationPolicyManager#start()} is called,
+     * the {@link Replicator#start()} method is called on the {@link Replicator}.
+     */
+    @Test
+    public void testStopSingleReplicator() {
+        Replicator mockReplicator = mock(Replicator.class);
+        EventBus mockEventBus = mock(EventBus.class);
+        when(mockReplicator.getEventBus()).thenReturn(mockEventBus);
+        ReplicationPolicyManager rpm = new TestPolicy();
+        rpm.addReplicators(mockReplicator);
+        verify(mockReplicator, never()).start();
+        rpm.start();
+        rpm.stop();
+        verify(mockReplicator, times(1)).stop();
+    }
+
+    /**
+     * Check that when the {@link }ReplicationPolicyManager} is setup with multiple
+     * {@link Replicator}s, when {@link ReplicationPolicyManager#start()} is called,
+     * more than once before {@link Replicator} has completed replication,
+     * the {@link Replicator#start()} method is called only once on each {@link Replicator}.
+     */
+    @Test
+    public void testStopMultipleReplicators() {
+        Replicator mockReplicator1 = mock(Replicator.class);
+        Replicator mockReplicator2 = mock(Replicator.class);
+        Replicator mockReplicator3 = mock(Replicator.class);
+        EventBus mockEventBus = mock(EventBus.class);
+        when(mockReplicator1.getEventBus()).thenReturn(mockEventBus);
+        when(mockReplicator2.getEventBus()).thenReturn(mockEventBus);
+        when(mockReplicator3.getEventBus()).thenReturn(mockEventBus);
+        ReplicationPolicyManager rpm = new TestPolicy();
+        rpm.addReplicators(mockReplicator1, mockReplicator2, mockReplicator3);
+        verify(mockReplicator1, never()).start();
+        verify(mockReplicator2, never()).start();
+        verify(mockReplicator3, never()).start();
+        rpm.start();
+        rpm.stop();
+        verify(mockReplicator1, times(1)).stop();
+        verify(mockReplicator2, times(1)).stop();
+        verify(mockReplicator3, times(1)).stop();
+    }
+
+    /**
+     * Check that when the {@link }ReplicationPolicyManager} is setup with a single
+     * {@link Replicator}, when {@link ReplicationPolicyManager#start()} is called for a
+     * second time after the replicator is explicitly stopped, the {@link Replicator#start()} method
+     * is called a second time on the {@link Replicator}.
+     */
+    @Test
+    public void testRestartStoppedSingleReplicator() {
+        Replicator mockReplicator = mock(Replicator.class);
+        EventBus mockEventBus = mock(EventBus.class);
+        when(mockReplicator.getEventBus()).thenReturn(mockEventBus);
+        ReplicationPolicyManager rpm = new TestPolicy();
+        rpm.addReplicators(mockReplicator);
+        verify(mockReplicator, never()).start();
+        rpm.start();
+        rpm.stop();
+        rpm.start();
+        verify(mockReplicator, times(2)).start();
+    }
+
+    /**
+     * Check that when the {@link }ReplicationPolicyManager} is setup with multiple
+     * {@link Replicator}s, when {@link ReplicationPolicyManager#start()} is called for a
+     * second time after the replicator is explicitly stopped, the {@link Replicator#start()} method
+     * is called a second time on the {@link Replicator}.
+     */
+    @Test
+    public void testRestartStoppedMultipleReplicators() {
+        Replicator mockReplicator1 = mock(Replicator.class);
+        Replicator mockReplicator2 = mock(Replicator.class);
+        Replicator mockReplicator3 = mock(Replicator.class);
+        EventBus mockEventBus = mock(EventBus.class);
+        when(mockReplicator1.getEventBus()).thenReturn(mockEventBus);
+        when(mockReplicator2.getEventBus()).thenReturn(mockEventBus);
+        when(mockReplicator3.getEventBus()).thenReturn(mockEventBus);
+        ReplicationPolicyManager rpm = new TestPolicy();
+        rpm.addReplicators(mockReplicator1, mockReplicator2, mockReplicator3);
+        verify(mockReplicator1, never()).start();
+        verify(mockReplicator2, never()).start();
+        verify(mockReplicator3, never()).start();
+        rpm.start();
+        rpm.stop();
+        rpm.start();
+        verify(mockReplicator1, times(2)).start();
+        verify(mockReplicator2, times(2)).start();
+        verify(mockReplicator3, times(2)).start();
+    }
+
+    /**
+     * Check that when the {@link }ReplicationPolicyManager} is setup with a single
+     * {@link Replicator}, when {@link ReplicationPolicyManager#start()} is called for a
+     * second time after the replicator completed normally, the {@link Replicator#start()} method
+     * is called a second time on the {@link Replicator}.
+     */
+    @Test
+    public void testRestartCompletedSingleReplicator() {
+        Replicator mockReplicator = mock(Replicator.class);
+        EventBus mockEventBus = new EventBus();
+        when(mockReplicator.getEventBus()).thenReturn(mockEventBus);
+        ReplicationPolicyManager rpm = new TestPolicy();
+        rpm.addReplicators(mockReplicator);
+        verify(mockReplicator, never()).start();
+        rpm.start();
+        mockEventBus.post(new ReplicationCompleted(mockReplicator, 1, 1));
+        rpm.start();
+        verify(mockReplicator, times(2)).start();
+    }
+
+    /**
+     * Check that when the {@link }ReplicationPolicyManager} is setup with multiple
+     * {@link Replicator}s, when {@link ReplicationPolicyManager#start()} is called for a
+     * second time after each replicator completed normally, the {@link Replicator#start()} method
+     * is called a second time on the {@link Replicator}s.
+     */
+    @Test
+    public void testRestartCompletedMultipleReplicators() {
+        Replicator mockReplicator1 = mock(Replicator.class);
+        Replicator mockReplicator2 = mock(Replicator.class);
+        Replicator mockReplicator3 = mock(Replicator.class);
+        EventBus mockEventBus1 = new EventBus();
+        EventBus mockEventBus2 = new EventBus();
+        EventBus mockEventBus3 = new EventBus();
+        when(mockReplicator1.getEventBus()).thenReturn(mockEventBus1);
+        when(mockReplicator2.getEventBus()).thenReturn(mockEventBus2);
+        when(mockReplicator3.getEventBus()).thenReturn(mockEventBus3);
+        ReplicationPolicyManager rpm = new TestPolicy();
+        rpm.addReplicators(mockReplicator1, mockReplicator2, mockReplicator3);
+        verify(mockReplicator1, never()).start();
+        verify(mockReplicator2, never()).start();
+        verify(mockReplicator3, never()).start();
+        rpm.start();
+        mockEventBus1.post(new ReplicationCompleted(mockReplicator1, 1, 1));
+        mockEventBus2.post(new ReplicationCompleted(mockReplicator2, 1, 1));
+        mockEventBus3.post(new ReplicationCompleted(mockReplicator3, 1, 1));
+        rpm.start();
+        verify(mockReplicator1, times(2)).start();
+        verify(mockReplicator2, times(2)).start();
+        verify(mockReplicator3, times(2)).start();
+    }
+
+    /**
+     * Check that when the {@link }ReplicationPolicyManager} is setup with a single
+     * {@link Replicator}, when {@link ReplicationPolicyManager#start()} is called for a
+     * second time after the replicator errored, the {@link Replicator#start()} method
+     * is called a second time on the {@link Replicator}.
+     */
+    @Test
+    public void testRestartErroredSingleReplicator() {
+        Replicator mockReplicator = mock(Replicator.class);
+        EventBus mockEventBus = new EventBus();
+        when(mockReplicator.getEventBus()).thenReturn(mockEventBus);
+        ReplicationPolicyManager rpm = new TestPolicy();
+        rpm.addReplicators(mockReplicator);
+        verify(mockReplicator, never()).start();
+        rpm.start();
+        mockEventBus.post(new ReplicationErrored(mockReplicator, null));
+        rpm.start();
+        verify(mockReplicator, times(2)).start();
+    }
+
+    /**
+     * Check that when the {@link }ReplicationPolicyManager} is setup with multiple
+     * {@link Replicator}s, when {@link ReplicationPolicyManager#start()} is called for a
+     * second time after each replicator errored, the {@link Replicator#start()} method
+     * is called a second time on the {@link Replicator}s.
+     */
+    @Test
+    public void testRestartErroredMultipleReplicators() {
+        Replicator mockReplicator1 = mock(Replicator.class);
+        Replicator mockReplicator2 = mock(Replicator.class);
+        Replicator mockReplicator3 = mock(Replicator.class);
+        EventBus mockEventBus1 = new EventBus();
+        EventBus mockEventBus2 = new EventBus();
+        EventBus mockEventBus3 = new EventBus();
+        when(mockReplicator1.getEventBus()).thenReturn(mockEventBus1);
+        when(mockReplicator2.getEventBus()).thenReturn(mockEventBus2);
+        when(mockReplicator3.getEventBus()).thenReturn(mockEventBus3);
+        ReplicationPolicyManager rpm = new TestPolicy();
+        rpm.addReplicators(mockReplicator1, mockReplicator2, mockReplicator3);
+        verify(mockReplicator1, never()).start();
+        verify(mockReplicator2, never()).start();
+        verify(mockReplicator3, never()).start();
+        rpm.start();
+        mockEventBus1.post(new ReplicationErrored(mockReplicator1, null));
+        mockEventBus2.post(new ReplicationErrored(mockReplicator2, null));
+        mockEventBus3.post(new ReplicationErrored(mockReplicator3, null));
+        rpm.start();
+        verify(mockReplicator1, times(2)).start();
+        verify(mockReplicator2, times(2)).start();
+        verify(mockReplicator3, times(2)).start();
+    }
+
+    /** A trivial policy where when you call {@link TestPolicy#start()} it calls
+     * {@link ReplicationPolicyManager#startReplications()} and when you call {@link TestPolicy#stop()}
+     * it calls {@link ReplicationPolicyManager#stopReplications()}.
+     */
+    class TestPolicy extends ReplicationPolicyManager {
+        public TestPolicy() {
+            super();
+        }
+
+        @Override
+        public void start() {
+            startReplications();
+        }
+
+        @Override
+        public void stop() {
+            stopReplications();
+        }
+    }
+
+}


### PR DESCRIPTION
This is part 2 of a 6 part change to implement replication policies. Each of the 6 parts of the implementation of replication policies are each in a separate branch.

_The following text is common to all 6 PRs._

The 6 branches include:
1. _48607-policies-1-replicator-id_: Adding an ID to replicators so we can easily identify which replicators are completed or have errored in subsequent callbacks.
2. _48607-policies-2-java_: Adding replication policies for Java.
3. _48607-policies-3-android-service_:Adding basic replication policies for Android.
4. _48607-policies-4-android-periodic_: Adding replication at regular intervals for Android.
5. _48607-policies-5-android-wifi_: Adding replication only when on Wifi.
6. _48607-policies-6-docs_: Documentation updates.

_What?_
Add mechanism to enable users to more easily specify the circumstances under which they want replication to occur. This allows relatively simple definition of policies such as:
* Do a pull replication every 2 hours;
* Do a full sync every hour, but only when we have a Wifi connection;
* Sync whenever we connect to Wifi.

_Why?_
Prior to this PR, it was very difficult to implement such policies, particularly on Android where many aspects of the way the Android operating system works would need to be taken into account in order for such policies to work reliably.

_How?_
On Android we want the replication policy management to be reliable, battery efficient and not hog system resources unnecessarily. To achieve this we typically might trigger our replications from a `BroadcastReceiver`. This allows our code to be completely inactive on the device and be started when events of interest are broadcast.  We can also use a `BroadcastReceiver` to trigger periodic replications via the `AlarmManager` mechanism in an efficient way.  However, a `BroadcastReceiver` is intended to only run for a short time in response to receiving a broadcast, so the replication is carried on inside a `Service` that may be started from a `BroadcastReceiver`.

Running replications in a `Service` allows them to run independently of the lifecycle of other application components and be started easily via other application components.  We must also handle the fact that when we wish replication to occur, the device may be asleep, so we need to hold a `WakeLock` for the duration of the replication to prevent the device going back to sleep once the `onReceive()` method of the `BroadcastReceiver` triggering the replications has completed.  Also, if our replications are over Wifi, we need to hold a `Wifi` lock to keep the Wifi radio awake.

On Java, replication policies are much simpler than on Android. The new `ReplicationPolicyManager` class takes care of ensuring that if replications are in progress they are not restarted.

See the [Replication Policies User Guide](https://github.com/cloudant/sync-android/blob/48607-replication-policies/REPLICATION_POLICIES.md) for further information on how replication policies are implemented on Android and on Java.

reviewer @mikerhodes
reviewer @ricellis 