### PR TITLE
Add replications at periodic intervals.

### DIFF
--- a/cloudant-sync-datastore-android/src/main/java/com/cloudant/sync/replication/PeriodicReplicationReceiver.java
+++ b/cloudant-sync-datastore-android/src/main/java/com/cloudant/sync/replication/PeriodicReplicationReceiver.java
@@ -1,0 +1,46 @@
+package com.cloudant.sync.replication;
+
+import android.content.Context;
+import android.content.Intent;
+import android.support.v4.content.WakefulBroadcastReceiver;
+
+/**
+ * This class implements a {@link WakefulBroadcastReceiver} that handles events related to
+ * periodic replication.  It responds to reboot of the device to trigger the resetting of
+ * the {@link android.app.AlarmManager} used to trigger periodic replication, and it
+ * handles the periodic alarms sent by the {@link android.app.AlarmManager} to trigger
+ * the periodic replications.
+ *
+ * The resetting of periodic alarms after reboot and the handling of the periodic alarms
+ * are delegated to the {@link PeriodicReplicationService} associated with this
+ * {@link android.content.BroadcastReceiver}.
+ *
+ * @param <T> The {@link PeriodicReplicationService} component triggered by this
+ * {@link android.content.BroadcastReceiver}
+ */
+public class PeriodicReplicationReceiver<T extends PeriodicReplicationService> extends WakefulBroadcastReceiver {
+
+    static final String ALARM_ACTION = "com.cloudant.sync.replication.PeriodicReplicationReceiver.Alarm";
+
+    Class<T> clazz;
+
+    protected PeriodicReplicationReceiver(Class<T> clazz) {
+        this.clazz = clazz;
+    }
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        int command = PeriodicReplicationService.COMMAND_NONE;
+        if (ALARM_ACTION.equals(intent.getAction())) {
+            command = PeriodicReplicationService.COMMAND_START_REPLICATION;
+        } else if (Intent.ACTION_BOOT_COMPLETED.equals(intent.getAction())) {
+            command = PeriodicReplicationService.COMMAND_DEVICE_REBOOTED;
+        }
+
+        if (command != PeriodicReplicationService.COMMAND_NONE) {
+            Intent serviceIntent = new Intent(context.getApplicationContext(), clazz);
+            serviceIntent.putExtra(PeriodicReplicationService.EXTRA_COMMAND, command);
+            startWakefulService(context, serviceIntent);
+        }
+    }
+}

--- a/cloudant-sync-datastore-android/src/main/java/com/cloudant/sync/replication/PeriodicReplicationReceiver.java
+++ b/cloudant-sync-datastore-android/src/main/java/com/cloudant/sync/replication/PeriodicReplicationReceiver.java
@@ -30,17 +30,19 @@ public class PeriodicReplicationReceiver<T extends PeriodicReplicationService> e
 
     @Override
     public void onReceive(Context context, Intent intent) {
-        int command = PeriodicReplicationService.COMMAND_NONE;
-        if (ALARM_ACTION.equals(intent.getAction())) {
-            command = PeriodicReplicationService.COMMAND_START_REPLICATION;
-        } else if (Intent.ACTION_BOOT_COMPLETED.equals(intent.getAction())) {
-            command = PeriodicReplicationService.COMMAND_DEVICE_REBOOTED;
-        }
+        if (intent != null) {
+            int command = PeriodicReplicationService.COMMAND_NONE;
+            if (ALARM_ACTION.equals(intent.getAction())) {
+                command = PeriodicReplicationService.COMMAND_START_REPLICATION;
+            } else if (Intent.ACTION_BOOT_COMPLETED.equals(intent.getAction())) {
+                command = PeriodicReplicationService.COMMAND_DEVICE_REBOOTED;
+            }
 
-        if (command != PeriodicReplicationService.COMMAND_NONE) {
-            Intent serviceIntent = new Intent(context.getApplicationContext(), clazz);
-            serviceIntent.putExtra(PeriodicReplicationService.EXTRA_COMMAND, command);
-            startWakefulService(context, serviceIntent);
+            if (command != PeriodicReplicationService.COMMAND_NONE) {
+                Intent serviceIntent = new Intent(context.getApplicationContext(), clazz);
+                serviceIntent.putExtra(PeriodicReplicationService.EXTRA_COMMAND, command);
+                startWakefulService(context, serviceIntent);
+            }
         }
     }
 }

--- a/cloudant-sync-datastore-android/src/main/java/com/cloudant/sync/replication/PeriodicReplicationReceiver.java
+++ b/cloudant-sync-datastore-android/src/main/java/com/cloudant/sync/replication/PeriodicReplicationReceiver.java
@@ -5,15 +5,15 @@ import android.content.Intent;
 import android.support.v4.content.WakefulBroadcastReceiver;
 
 /**
- * This class implements a {@link WakefulBroadcastReceiver} that handles events related to
+ * <p>This class implements a {@link WakefulBroadcastReceiver} that handles events related to
  * periodic replication.  It responds to reboot of the device to trigger the resetting of
  * the {@link android.app.AlarmManager} used to trigger periodic replication, and it
  * handles the periodic alarms sent by the {@link android.app.AlarmManager} to trigger
- * the periodic replications.
+ * the periodic replications.</p>
  *
- * The resetting of periodic alarms after reboot and the handling of the periodic alarms
+ * <p>The resetting of periodic alarms after reboot and the handling of the periodic alarms
  * are delegated to the {@link PeriodicReplicationService} associated with this
- * {@link android.content.BroadcastReceiver}.
+ * {@link android.content.BroadcastReceiver}.</p>
  *
  * @param <T> The {@link PeriodicReplicationService} component triggered by this
  * {@link android.content.BroadcastReceiver}

--- a/cloudant-sync-datastore-android/src/main/java/com/cloudant/sync/replication/PeriodicReplicationService.java
+++ b/cloudant-sync-datastore-android/src/main/java/com/cloudant/sync/replication/PeriodicReplicationService.java
@@ -101,7 +101,7 @@ public abstract class PeriodicReplicationService<T extends PeriodicReplicationRe
     }
 
     @Override
-    public IBinder onBind(Intent intent) {
+    public synchronized IBinder onBind(Intent intent) {
         mBound = true;
         if (isPeriodicReplicationEnabled()) {
             updateAlarmTimeOnBind();
@@ -113,7 +113,7 @@ public abstract class PeriodicReplicationService<T extends PeriodicReplicationRe
     }
 
     @Override
-    public boolean onUnbind(Intent intent) {
+    public synchronized boolean onUnbind(Intent intent) {
         super.onUnbind(intent);
         mBound = false;
         if (isPeriodicReplicationEnabled()) {
@@ -125,7 +125,7 @@ public abstract class PeriodicReplicationService<T extends PeriodicReplicationRe
     }
 
     @Override
-    public void onRebind(Intent intent) {
+    public synchronized void onRebind(Intent intent) {
         super.onRebind(intent);
         mBound = true;
         if (isPeriodicReplicationEnabled()) {
@@ -143,7 +143,7 @@ public abstract class PeriodicReplicationService<T extends PeriodicReplicationRe
     }
 
     /** Start periodic replications. */
-    public void startPeriodicReplication() {
+    public synchronized void startPeriodicReplication() {
         if (!isPeriodicReplicationEnabled()) {
             setPeriodicReplicationEnabled(true);
             AlarmManager alarmManager = (AlarmManager) getSystemService(Context.ALARM_SERVICE);
@@ -164,7 +164,7 @@ public abstract class PeriodicReplicationService<T extends PeriodicReplicationRe
     }
 
     /** Stop replications currently in progress and cancel future scheduled replications. */
-    public void stopPeriodicReplication() {
+    public synchronized void stopPeriodicReplication() {
         if (isPeriodicReplicationEnabled()) {
             setPeriodicReplicationEnabled(false);
             AlarmManager alarmManager = (AlarmManager) getSystemService(Context.ALARM_SERVICE);

--- a/cloudant-sync-datastore-android/src/main/java/com/cloudant/sync/replication/PeriodicReplicationService.java
+++ b/cloudant-sync-datastore-android/src/main/java/com/cloudant/sync/replication/PeriodicReplicationService.java
@@ -181,7 +181,7 @@ public abstract class PeriodicReplicationService<T extends PeriodicReplicationRe
     }
 
     /** Stop and restart periodic replication. */
-    protected void restartPeriodicReplications() {
+    final protected void restartPeriodicReplications() {
         stopPeriodicReplication();
         startPeriodicReplication();
     }
@@ -195,7 +195,7 @@ public abstract class PeriodicReplicationService<T extends PeriodicReplicationRe
      * useless.
      * @param intervalMillis The time interval in milliseconds until the next alarm.
      */
-    protected void setNextAlarmDue(long intervalMillis) {
+    private void setNextAlarmDue(long intervalMillis) {
         SharedPreferences.Editor editor = mPrefs.edit();
         editor.putLong(PREFERENCE_ALARM_DUE_ELAPSED_TIME,
             SystemClock.elapsedRealtime() + intervalMillis);
@@ -208,7 +208,7 @@ public abstract class PeriodicReplicationService<T extends PeriodicReplicationRe
      * @return The SharedPreferences value indicating the time since the device was booted,
      * at which the next periodic replication should begin.
      */
-    protected long getNextAlarmDueElapsedTime() {
+    private long getNextAlarmDueElapsedTime() {
         return mPrefs.getLong(PREFERENCE_ALARM_DUE_ELAPSED_TIME, 0);
     }
 
@@ -216,7 +216,7 @@ public abstract class PeriodicReplicationService<T extends PeriodicReplicationRe
      * @return The SharedPreferences value indicating the wall clock time at which the next
      * periodic replication should begin.
      */
-    protected long getNextAlarmDueClockTime() {
+    private long getNextAlarmDueClockTime() {
         return mPrefs.getLong(PREFERENCE_ALARM_DUE_CLOCK_TIME, 0);
     }
 
@@ -224,7 +224,7 @@ public abstract class PeriodicReplicationService<T extends PeriodicReplicationRe
      * Set a flag in SharedPreferences to indicate whether periodic replications are enabled.
      * @param running true to indicate that periodic replications are enabled, otherwise false.
      */
-    protected void setPeriodicReplicationEnabled(boolean running) {
+    private void setPeriodicReplicationEnabled(boolean running) {
         SharedPreferences.Editor editor = mPrefs.edit();
         editor.putBoolean(PREFERENCE_PERIODIC_REPLICATION_ENABLED, running);
         editor.apply();
@@ -234,7 +234,7 @@ public abstract class PeriodicReplicationService<T extends PeriodicReplicationRe
      * @return The value of the flag stored in SharedPreferences indicating whether periodic
      * replications are currently enabled.
      */
-    protected boolean isPeriodicReplicationEnabled() {
+    private boolean isPeriodicReplicationEnabled() {
         return mPrefs.getBoolean(PREFERENCE_PERIODIC_REPLICATION_ENABLED, false);
     }
 
@@ -243,7 +243,7 @@ public abstract class PeriodicReplicationService<T extends PeriodicReplicationRe
      * After a reboot, the AlarmManager must be setup again so that periodic replications will
      * occur following reboot.
      */
-    protected void resetAlarmDueTimesOnReboot() {
+    private void resetAlarmDueTimesOnReboot() {
         // As the device has been rebooted, we use clock time rather than elapsed time since
         // booting to set the interval for the first alarm as the elapsed time since boot will
         // have been reset.
@@ -272,7 +272,7 @@ public abstract class PeriodicReplicationService<T extends PeriodicReplicationRe
      * @return The interval (in seconds) between replications depending on whether a component is
      * bound to the service or not.
      */
-    protected int getIntervalInSeconds() {
+    private int getIntervalInSeconds() {
         if (mBound) {
             return getBoundIntervalInSeconds();
         } else {
@@ -283,7 +283,7 @@ public abstract class PeriodicReplicationService<T extends PeriodicReplicationRe
     /** Update the SharedPreferences to store the time the next alarm is due at using the
      *  bound time interval between replications.
      */
-    protected void updateAlarmTimeOnBind() {
+    private void updateAlarmTimeOnBind() {
         long dueTime = getNextAlarmDueElapsedTime();
         long newDueTime = dueTime - (getUnboundIntervalInSeconds() * MILLISECONDS_IN_SECOND)
             + (getBoundIntervalInSeconds() * MILLISECONDS_IN_SECOND)
@@ -294,7 +294,7 @@ public abstract class PeriodicReplicationService<T extends PeriodicReplicationRe
     /** Update the SharedPreferences to store the time the next alarm is due at using the
      *  unbound time interval between replications.
      */
-    protected void updateAlarmTimeOnUnbind() {
+    private void updateAlarmTimeOnUnbind() {
         long dueTime = getNextAlarmDueElapsedTime();
         long newDueTime = dueTime - (getBoundIntervalInSeconds() * MILLISECONDS_IN_SECOND)
             + (getUnboundIntervalInSeconds() * MILLISECONDS_IN_SECOND)

--- a/cloudant-sync-datastore-android/src/main/java/com/cloudant/sync/replication/PeriodicReplicationService.java
+++ b/cloudant-sync-datastore-android/src/main/java/com/cloudant/sync/replication/PeriodicReplicationService.java
@@ -35,17 +35,17 @@ public abstract class PeriodicReplicationService<T extends PeriodicReplicationRe
     /* We store the elapsed time since booting at which the next alarm is due in SharedPreferences
      * using this key. This is used to adjust alarm times when components bind to or unbind from
      * this Service. */
-    private static final String PREFERENCE_ALARM_DUE_ELAPSED_TIME = "alarmDueElapsed";
+    private static final String PREFERENCE_ALARM_DUE_ELAPSED_TIME = "com.cloudant.sync.replication.PeriodicReplicationService.alarmDueElapsed";
 
     /* We store the wall-clock time at which the next alarm is due in SharedPreferences
      * using this key. This is used to set the initial alarm after a reboot. */
-    private static final String PREFERENCE_ALARM_DUE_CLOCK_TIME = "alarmDueClock";
+    private static final String PREFERENCE_ALARM_DUE_CLOCK_TIME = "com.cloudant.sync.replication.PeriodicReplicationService.alarmDueClock";
 
     /* We store a flag indicating whether periodic replications are enabled in SharedPreferences
      * using this key. We have to store the flag persistently as the service may be stopped and
      * started by the operating system. */
     private static final String PREFERENCE_PERIODIC_REPLICATION_ENABLED
-        = "periodicReplicationsActive";
+        = "com.cloudant.sync.replication.PeriodicReplicationService.periodicReplicationsActive";
 
     private static final int MILLISECONDS_IN_SECOND = 1000;
 

--- a/cloudant-sync-datastore-android/src/main/java/com/cloudant/sync/replication/PeriodicReplicationService.java
+++ b/cloudant-sync-datastore-android/src/main/java/com/cloudant/sync/replication/PeriodicReplicationService.java
@@ -1,0 +1,300 @@
+package com.cloudant.sync.replication;
+
+import android.app.AlarmManager;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.os.Handler;
+import android.os.IBinder;
+import android.os.Looper;
+import android.os.Message;
+import android.os.SystemClock;
+import android.util.Log;
+
+/**
+ * This {@link android.app.Service} is an abstract class that is the basis for creating a service
+ * that performs periodic replications (i.e. replications that occur at regular intervals). The
+ * period between replications may be varied depending on whether other application components
+ * are bound to the service or not, so as to allow for more frequent replications when an app
+ * is in active use and less frequent replications the rest of the time.
+ *
+ * @param <T> The {@link PeriodicReplicationReceiver} associated with this Service that is
+ *           responsible for handling the alarms triggered by the {@link AlarmManager} at
+ *           the intervals when replication is required and handles resetting of alarms after
+ *           reboot of the device.
+ */
+public abstract class PeriodicReplicationService<T extends PeriodicReplicationReceiver> extends ReplicationService {
+
+    private static final String PREFERENCES_FILE_NAME = "com.cloudant.preferences";
+    private static final String PREFERENCE_ALARM_DUE_ELAPSED_TIME = "alarmDueElapsed";
+    private static final String PREFERENCE_ALARM_DUE_CLOCK_TIME = "alarmDueClock";
+    private static final String PREFERENCE_PERIODIC_REPLICATION_ENABLED = "periodicReplicationsActive";
+
+    private static final int MILLISECONDS_IN_SECOND = 1000;
+
+    public static final int COMMAND_START_PERIODIC_REPLICATION = 2;
+    public static final int COMMAND_STOP_PERIODIC_REPLICATION = 3;
+    public static final int COMMAND_DEVICE_REBOOTED = 4;
+
+    private static final String TAG = "PRS";
+
+    private SharedPreferences mPrefs;
+    Class<T> clazz;
+    protected boolean mBound;
+
+    protected PeriodicReplicationService(Class<T> clazz) {
+        this.clazz = clazz;
+    }
+
+    protected class ServiceHandler extends ReplicationService.ServiceHandler {
+        public ServiceHandler(Looper looper) {
+            super(looper);
+        }
+
+        @Override
+        public void handleMessage(Message msg) {
+            switch (msg.arg2) {
+                case COMMAND_START_PERIODIC_REPLICATION:
+                    startPeriodicReplication();
+                    notifyTestOperationComplete();
+                    break;
+                case COMMAND_STOP_PERIODIC_REPLICATION:
+                    stopPeriodicReplication();
+                    notifyTestOperationComplete();
+                    break;
+                case COMMAND_DEVICE_REBOOTED:
+                    resetAlarmDueTimesOnReboot();
+                    notifyTestOperationComplete();
+                    break;
+            }
+
+            super.handleMessage(msg);
+        }
+    }
+
+    @Override
+    protected Handler getHandler(Looper looper) {
+        return new ServiceHandler(looper);
+    }
+
+    @Override
+    public void onCreate() {
+        mPrefs = getSharedPreferences(PREFERENCES_FILE_NAME, Context.MODE_PRIVATE);
+        super.onCreate();
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        mBound = true;
+        if (isPeriodicReplicationEnabled()) {
+            updateAlarmTimeOnBind();
+            restartPeriodicReplications();
+        } else if (startReplicationOnBind()) {
+            startPeriodicReplication();
+        }
+        return super.onBind(intent);
+    }
+
+    @Override
+    public boolean onUnbind(Intent intent) {
+        super.onUnbind(intent);
+        mBound = false;
+        if (isPeriodicReplicationEnabled()) {
+            updateAlarmTimeOnUnbind();
+            restartPeriodicReplications();
+        }
+        // Ensure onRebind is called when new clients bind to the service.
+        return true;
+    }
+
+    @Override
+    public void onRebind(Intent intent) {
+        super.onRebind(intent);
+        mBound = true;
+        if (isPeriodicReplicationEnabled()) {
+            updateAlarmTimeOnBind();
+            restartPeriodicReplications();
+        } else if (startReplicationOnBind()) {
+            startPeriodicReplication();
+        }
+    }
+
+    @Override
+    protected void startReplications() {
+        super.startReplications();
+        setNextAlarmDue(getIntervalInSeconds() * MILLISECONDS_IN_SECOND);
+    }
+
+    /** Start periodic replications. */
+    public void startPeriodicReplication() {
+        if (!isPeriodicReplicationEnabled()) {
+            setPeriodicReplicationEnabled(true);
+            AlarmManager alarmManager = (AlarmManager) getSystemService(Context.ALARM_SERVICE);
+            Intent alarmIntent = new Intent(this, clazz);
+            alarmIntent.setAction(PeriodicReplicationReceiver.ALARM_ACTION);
+            // We need to use a BroadcastReceiver rather than sending the Intent directly to the
+            // Service to ensure the device wakes up if it's asleep. Sending the Intent directly
+            // to the Service would be unreliable.
+            PendingIntent pendingAlarmIntent = PendingIntent.getBroadcast(this, 0, alarmIntent, 0);
+
+            alarmManager.setInexactRepeating(AlarmManager.ELAPSED_REALTIME_WAKEUP,
+                getNextAlarmDueElapsedTime(), getIntervalInSeconds() * MILLISECONDS_IN_SECOND, pendingAlarmIntent);
+        } else {
+            Log.i(TAG, "Attempted to start an already running alarm manager");
+        }
+    }
+
+    /** Stop replications currently in progress and cancel future scheduled replications. */
+    public void stopPeriodicReplication() {
+        if (isPeriodicReplicationEnabled()) {
+            setPeriodicReplicationEnabled(false);
+            AlarmManager alarmManager = (AlarmManager) getSystemService(Context.ALARM_SERVICE);
+            Intent alarmIntent = new Intent(this, clazz);
+            alarmIntent.setAction(PeriodicReplicationReceiver.ALARM_ACTION);
+            PendingIntent pendingAlarmIntent = PendingIntent.getBroadcast(this, 0, alarmIntent, 0);
+
+            alarmManager.cancel(pendingAlarmIntent);
+
+            stopReplications();
+        } else {
+            Log.i(TAG, "Attempted to stop an already stopped alarm manager");
+        }
+    }
+
+    /** Stop and restart periodic replication. */
+    protected void restartPeriodicReplications() {
+        stopPeriodicReplication();
+        startPeriodicReplication();
+    }
+
+    /**
+     * Store the time of the next alarm both as elapsed time since boot (using
+     * {@link SystemClock#elapsedRealtime()}) and as standard "wall" clock time (using
+     * {@link System#currentTimeMillis()}. We generally want to set our alarms based on the elapsed
+     * time since booting as that is not affected by the system clock being reset. However, we use
+     * the clock time to set the alarm after a reboot as clearly in this case the time since boot is
+     * useless.
+     * @param intervalMillis The time interval in milliseconds until the next alarm.
+     */
+    protected void setNextAlarmDue(long intervalMillis) {
+        SharedPreferences.Editor editor = mPrefs.edit();
+        editor.putLong(PREFERENCE_ALARM_DUE_ELAPSED_TIME, SystemClock.elapsedRealtime() + intervalMillis);
+        editor.putLong(PREFERENCE_ALARM_DUE_CLOCK_TIME, System.currentTimeMillis() + intervalMillis);
+        editor.apply();
+    }
+
+    /**
+     * @return The SharedPreferences value indicating the time since the device was booted,
+     * at which the next periodic replication should begin.
+     */
+    protected long getNextAlarmDueElapsedTime() {
+        return mPrefs.getLong(PREFERENCE_ALARM_DUE_ELAPSED_TIME, 0);
+    }
+
+    /**
+     * @return The SharedPreferences value indicating the wall clock time at which the next
+     * periodic replication should begin.
+     */
+    protected long getNextAlarmDueClockTime() {
+        return mPrefs.getLong(PREFERENCE_ALARM_DUE_CLOCK_TIME, 0);
+    }
+
+    /**
+     * Set a flag in SharedPreferences to indicate whether periodic replications are enabled.
+     * @param running true to indicate that periodic replications are enabled, otherwise false.
+     */
+    protected void setPeriodicReplicationEnabled(boolean running) {
+        SharedPreferences.Editor editor = mPrefs.edit();
+        editor.putBoolean(PREFERENCE_PERIODIC_REPLICATION_ENABLED, running);
+        editor.apply();
+    }
+
+    /**
+     * @return The value of the flag stored in SharedPreferences indicating whether periodic
+     * replications are currently enabled.
+     */
+    protected boolean isPeriodicReplicationEnabled() {
+        return mPrefs.getBoolean(PREFERENCE_PERIODIC_REPLICATION_ENABLED, false);
+    }
+
+    /**
+     * Reset the alarm times stored in SharedPreferences following a reboot of the device.
+     * After a reboot, the AlarmManager must be setup again so that periodic replications will
+     * occur following reboot.
+     */
+    protected void resetAlarmDueTimesOnReboot() {
+        // As the device has been rebooted, we use clock time to set the interval for the
+        // first alarm as the elapsed time since boot will have been reset. There is a slight
+        // risk that we might set it wrongly if the system clock has been reset since the last
+        // alarm was fired.  Therefore, we check that we're not setting the initial interval
+        // for the alarm to any later than getIntervalInSeconds after the current time so
+        // we minimise the impact of the system clock being reset.
+        // We don't actually setup the AlarmManager here as after a reboot, when the device
+        // next connects to WiFi, the alarm will be scheduled with AlarmManager.
+        setPeriodicReplicationEnabled(false);
+        long initialInterval = getNextAlarmDueClockTime() - System.currentTimeMillis();
+        if (initialInterval < 0) {
+            initialInterval = 0;
+            setNextAlarmDue(initialInterval);
+        } else if (initialInterval > getIntervalInSeconds() * MILLISECONDS_IN_SECOND) {
+            initialInterval = getIntervalInSeconds() * MILLISECONDS_IN_SECOND;
+            setNextAlarmDue(initialInterval);
+        }
+    }
+
+    /**
+     * @return The interval (in seconds) between replications depending on whether a component is
+     * bound to the service or not.
+     */
+    protected int getIntervalInSeconds() {
+        if (mBound) {
+            return getBoundIntervalInSeconds();
+        } else {
+            return getUnboundIntervalInSeconds();
+        }
+    }
+
+    /** Update the SharedPreferences to store the time the next alarm is due at using the
+     *  bound time interval between replications.
+     */
+    protected void updateAlarmTimeOnBind() {
+        long dueTime = getNextAlarmDueElapsedTime();
+        long newDueTime = dueTime - (getUnboundIntervalInSeconds() * MILLISECONDS_IN_SECOND) + (getBoundIntervalInSeconds() * MILLISECONDS_IN_SECOND) - SystemClock.elapsedRealtime();
+        setNextAlarmDue(newDueTime);
+    }
+
+    /** Update the SharedPreferences to store the time the next alarm is due at using the 
+     *  unbound time interval between replications.
+     */
+    protected void updateAlarmTimeOnUnbind() {
+        long dueTime = getNextAlarmDueElapsedTime();
+        long newDueTime = dueTime - (getBoundIntervalInSeconds() * MILLISECONDS_IN_SECOND) + (getUnboundIntervalInSeconds() * MILLISECONDS_IN_SECOND) - SystemClock.elapsedRealtime();
+        setNextAlarmDue(newDueTime);
+    }
+
+    /**
+     * @return The interval between replications to be used when a client is bound to the service.
+     * To prolong battery life, this should be made as long as possible. Note that on Android 5.1
+     * and above (API Level 22), if the interval is less than 60 seconds, Android expands the
+     * interval to 60 seconds.
+     */
+    protected abstract int getBoundIntervalInSeconds();
+
+    /**
+     * @return The interval between replications to be used when no client is bound to the service.
+     * To prolong battery life, this should be made as long as possible. Note that on Android 5.1
+     * and above (API Level 22), if the interval is less than 60 seconds, Android expands the
+     * interval to 60 seconds.
+     */
+    protected abstract int getUnboundIntervalInSeconds();
+
+    /**
+     * @return True if you want periodic replication to start when a client binds to the service and
+     * false otherwise. This is called each when a client binds to the service, so should contain
+     * any logic to determine whether replications should begin. E.g. if you want replications to
+     * only happen when on WiFi, this should only return true if you are on WiFi when it is called.
+     */
+    protected abstract boolean startReplicationOnBind();
+}
+

--- a/cloudant-sync-datastore-android/src/main/java/com/cloudant/sync/replication/PeriodicReplicationService.java
+++ b/cloudant-sync-datastore-android/src/main/java/com/cloudant/sync/replication/PeriodicReplicationService.java
@@ -24,12 +24,14 @@ import android.util.Log;
  *           the intervals when replication is required and handles resetting of alarms after
  *           reboot of the device.
  */
-public abstract class PeriodicReplicationService<T extends PeriodicReplicationReceiver> extends ReplicationService {
+public abstract class PeriodicReplicationService<T extends PeriodicReplicationReceiver>
+    extends ReplicationService {
 
     private static final String PREFERENCES_FILE_NAME = "com.cloudant.preferences";
     private static final String PREFERENCE_ALARM_DUE_ELAPSED_TIME = "alarmDueElapsed";
     private static final String PREFERENCE_ALARM_DUE_CLOCK_TIME = "alarmDueClock";
-    private static final String PREFERENCE_PERIODIC_REPLICATION_ENABLED = "periodicReplicationsActive";
+    private static final String PREFERENCE_PERIODIC_REPLICATION_ENABLED
+        = "periodicReplicationsActive";
 
     private static final int MILLISECONDS_IN_SECOND = 1000;
 
@@ -139,7 +141,9 @@ public abstract class PeriodicReplicationService<T extends PeriodicReplicationRe
             PendingIntent pendingAlarmIntent = PendingIntent.getBroadcast(this, 0, alarmIntent, 0);
 
             alarmManager.setInexactRepeating(AlarmManager.ELAPSED_REALTIME_WAKEUP,
-                getNextAlarmDueElapsedTime(), getIntervalInSeconds() * MILLISECONDS_IN_SECOND, pendingAlarmIntent);
+                getNextAlarmDueElapsedTime(),
+                getIntervalInSeconds() * MILLISECONDS_IN_SECOND,
+                pendingAlarmIntent);
         } else {
             Log.i(TAG, "Attempted to start an already running alarm manager");
         }
@@ -179,8 +183,10 @@ public abstract class PeriodicReplicationService<T extends PeriodicReplicationRe
      */
     protected void setNextAlarmDue(long intervalMillis) {
         SharedPreferences.Editor editor = mPrefs.edit();
-        editor.putLong(PREFERENCE_ALARM_DUE_ELAPSED_TIME, SystemClock.elapsedRealtime() + intervalMillis);
-        editor.putLong(PREFERENCE_ALARM_DUE_CLOCK_TIME, System.currentTimeMillis() + intervalMillis);
+        editor.putLong(PREFERENCE_ALARM_DUE_ELAPSED_TIME,
+            SystemClock.elapsedRealtime() + intervalMillis);
+        editor.putLong(PREFERENCE_ALARM_DUE_CLOCK_TIME,
+            System.currentTimeMillis() + intervalMillis);
         editor.apply();
     }
 
@@ -260,16 +266,20 @@ public abstract class PeriodicReplicationService<T extends PeriodicReplicationRe
      */
     protected void updateAlarmTimeOnBind() {
         long dueTime = getNextAlarmDueElapsedTime();
-        long newDueTime = dueTime - (getUnboundIntervalInSeconds() * MILLISECONDS_IN_SECOND) + (getBoundIntervalInSeconds() * MILLISECONDS_IN_SECOND) - SystemClock.elapsedRealtime();
+        long newDueTime = dueTime - (getUnboundIntervalInSeconds() * MILLISECONDS_IN_SECOND)
+            + (getBoundIntervalInSeconds() * MILLISECONDS_IN_SECOND)
+            - SystemClock.elapsedRealtime();
         setNextAlarmDue(newDueTime);
     }
 
-    /** Update the SharedPreferences to store the time the next alarm is due at using the 
+    /** Update the SharedPreferences to store the time the next alarm is due at using the
      *  unbound time interval between replications.
      */
     protected void updateAlarmTimeOnUnbind() {
         long dueTime = getNextAlarmDueElapsedTime();
-        long newDueTime = dueTime - (getBoundIntervalInSeconds() * MILLISECONDS_IN_SECOND) + (getUnboundIntervalInSeconds() * MILLISECONDS_IN_SECOND) - SystemClock.elapsedRealtime();
+        long newDueTime = dueTime - (getBoundIntervalInSeconds() * MILLISECONDS_IN_SECOND)
+            + (getUnboundIntervalInSeconds() * MILLISECONDS_IN_SECOND)
+            - SystemClock.elapsedRealtime();
         setNextAlarmDue(newDueTime);
     }
 


### PR DESCRIPTION
This is part 4 of a 6 part change to implement replication policies. Each of the 6 parts of the implementation of replication policies are each in a separate branch.

_The following text is common to all 6 PRs._

The 6 branches include:
1. _48607-policies-1-replicator-id_: Adding an ID to replicators so we can easily identify which replicators are completed or have errored in subsequent callbacks.
2. _48607-policies-2-java_: Adding replication policies for Java.
3. _48607-policies-3-android-service_:Adding basic replication policies for Android.
4. _48607-policies-4-android-periodic_: Adding replication at regular intervals for Android.
5. _48607-policies-5-android-wifi_: Adding replication only when on Wifi.
6. _48607-policies-6-docs_: Documentation updates.

_What?_
Add mechanism to enable users to more easily specify the circumstances under which they want replication to occur. This allows relatively simple definition of policies such as:
* Do a pull replication every 2 hours;
* Do a full sync every hour, but only when we have a Wifi connection;
* Sync whenever we connect to Wifi.

_Why?_
Prior to this PR, it was very difficult to implement such policies, particularly on Android where many aspects of the way the Android operating system works would need to be taken into account in order for such policies to work reliably.

_How?_
On Android we want the replication policy management to be reliable, battery efficient and not hog system resources unnecessarily. To achieve this we typically might trigger our replications from a `BroadcastReceiver`. This allows our code to be completely inactive on the device and be started when events of interest are broadcast.  We can also use a `BroadcastReceiver` to trigger periodic replications via the `AlarmManager` mechanism in an efficient way.  However, a `BroadcastReceiver` is intended to only run for a short time in response to receiving a broadcast, so the replication is carried on inside a `Service` that may be started from a `BroadcastReceiver`.

Running replications in a `Service` allows them to run independently of the lifecycle of other application components and be started easily via other application components.  We must also handle the fact that when we wish replication to occur, the device may be asleep, so we need to hold a `WakeLock` for the duration of the replication to prevent the device going back to sleep once the `onReceive()` method of the `BroadcastReceiver` triggering the replications has completed.  Also, if our replications are over Wifi, we need to hold a `Wifi` lock to keep the Wifi radio awake.

On Java, replication policies are much simpler than on Android. The new `ReplicationPolicyManager` class takes care of ensuring that if replications are in progress they are not restarted.

See the [Replication Policies User Guide](https://github.com/cloudant/sync-android/blob/48607-replication-policies/REPLICATION_POLICIES.md) for further information on how replication policies are implemented on Android and on Java.

reviewer @mikerhodes
reviewer @ricellis 