### PR TITLE
Add policy for periodic replication only on Wifi.

### DIFF
--- a/cloudant-sync-datastore-android/src/main/java/com/cloudant/sync/replication/PeriodicReplicationService.java
+++ b/cloudant-sync-datastore-android/src/main/java/com/cloudant/sync/replication/PeriodicReplicationService.java
@@ -73,15 +73,12 @@ public abstract class PeriodicReplicationService<T extends PeriodicReplicationRe
             switch (msg.arg2) {
                 case COMMAND_START_PERIODIC_REPLICATION:
                     startPeriodicReplication();
-                    notifyTestOperationComplete();
                     break;
                 case COMMAND_STOP_PERIODIC_REPLICATION:
                     stopPeriodicReplication();
-                    notifyTestOperationComplete();
                     break;
                 case COMMAND_DEVICE_REBOOTED:
                     resetAlarmDueTimesOnReboot();
-                    notifyTestOperationComplete();
                     break;
             }
 

--- a/cloudant-sync-datastore-android/src/main/java/com/cloudant/sync/replication/WifiPeriodicReplicationReceiver.java
+++ b/cloudant-sync-datastore-android/src/main/java/com/cloudant/sync/replication/WifiPeriodicReplicationReceiver.java
@@ -6,18 +6,20 @@ import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 
 /**
- * This class extends {@link PeriodicReplicationReceiver} so that periodic replications are only
+ * <p>This class extends {@link PeriodicReplicationReceiver} so that periodic replications are only
  * started when the device is connected to a WiFi network and are stopped when the device
- * disconnects from a WiFi network.
+ * disconnects from a WiFi network.</p>
  *
- * This uses the standard Android broadcasts to detect connectivity change and then trigger the
- * periodic replications.
+ * <p>This uses the standard Android broadcasts to detect connectivity change and then trigger the
+ * periodic replications.</p>
  *
- * To use this, you should create a subclass of this class whose default constructor calls
- * the constructor of this class passing in the name of the concrete {@link PeriodicReplicationService}
- * you are using - e.g.:
+ * <p>To use this, you should create a subclass of this class whose default constructor calls
+ * the constructor of this class passing in the name of the concrete
+ * {@link PeriodicReplicationService}
+ * you are using - e.g.:</p>
  * <pre>
- * public class MyWifiPeriodicReplicationReceiver extends WifiPeriodicReplicationReceiver<MyReplicationService> {
+ * public class MyWifiPeriodicReplicationReceiver
+ *     extends WifiPeriodicReplicationReceiver<MyReplicationService> {
  *
  *     public MyWifiPeriodicReplicationReceiver() {
  *         super(MyReplicationService.class);
@@ -26,8 +28,8 @@ import android.net.NetworkInfo;
  * }
  * </pre>
  *
- * You should then add your subclass to the {@code AndroidManifest.xml} as a child of the {@code application} tag
- * and add {@link android.content.IntentFilter}s as follows:
+ * <p>You should then add your subclass to the {@code AndroidManifest.xml} as a child of the {@code
+ * application} tag and add {@link android.content.IntentFilter}s as follows:</p>
  * <pre>
  * &lt;receiver android:name=".MyWifiPeriodicReplicationReceiver" android:exported="false"&gt;
  *     &lt;intent-filter&gt;
@@ -38,7 +40,7 @@ import android.net.NetworkInfo;
  * &lt;/receiver&gt;
  * </pre>
  *
- * You must then add the following permissions to your {@code AndroidManifest.xml} file:
+ * <p>You must then add the following permissions to your {@code AndroidManifest.xml} file:</p>
  * <pre>
  * &lt;uses-permission android:name="android.permission.INTERNET" /&gt;
  * &lt;uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" /&gt;

--- a/cloudant-sync-datastore-android/src/main/java/com/cloudant/sync/replication/WifiPeriodicReplicationReceiver.java
+++ b/cloudant-sync-datastore-android/src/main/java/com/cloudant/sync/replication/WifiPeriodicReplicationReceiver.java
@@ -52,7 +52,8 @@ import android.net.NetworkInfo;
  * {@link android.content.BroadcastReceiver}
  */
 
-public abstract class WifiPeriodicReplicationReceiver<T extends PeriodicReplicationService> extends PeriodicReplicationReceiver {
+public abstract class WifiPeriodicReplicationReceiver<T extends PeriodicReplicationService>
+    extends PeriodicReplicationReceiver {
 
     protected WifiPeriodicReplicationReceiver(Class<T> clazz) {
         super(clazz);

--- a/cloudant-sync-datastore-android/src/main/java/com/cloudant/sync/replication/WifiPeriodicReplicationReceiver.java
+++ b/cloudant-sync-datastore-android/src/main/java/com/cloudant/sync/replication/WifiPeriodicReplicationReceiver.java
@@ -1,0 +1,90 @@
+package com.cloudant.sync.replication;
+
+import android.content.Context;
+import android.content.Intent;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
+
+/**
+ * This class extends {@link PeriodicReplicationReceiver} so that periodic replications are only
+ * started when the device is connected to a WiFi network and are stopped when the device
+ * disconnects from a WiFi network.
+ *
+ * This uses the standard Android broadcasts to detect connectivity change and then trigger the
+ * periodic replications.
+ *
+ * To use this, you should create a subclass of this class whose default constructor calls
+ * the constructor of this class passing in the name of the concrete {@link PeriodicReplicationService}
+ * you are using - e.g.:
+ * <pre>
+ * public class MyWifiPeriodicReplicationReceiver extends WifiPeriodicReplicationReceiver<MyReplicationService> {
+ *
+ *     public MyWifiPeriodicReplicationReceiver() {
+ *         super(MyReplicationService.class);
+ *     }
+ *
+ * }
+ * </pre>
+ *
+ * You should then add your subclass to the {@code AndroidManifest.xml} as a child of the {@code application} tag
+ * and add {@link android.content.IntentFilter}s as follows:
+ * <pre>
+ * &lt;receiver android:name=".MyWifiPeriodicReplicationReceiver" android:exported="false"&gt;
+ *     &lt;intent-filter&gt;
+ *         &lt;action android:name="android.net.conn.CONNECTIVITY_CHANGE" /&gt;
+ *         &lt;action android:name="com.cloudant.sync.replication.PeriodicReplicationReceiver.Alarm" /&gt;
+ *         &lt;action android:name="android.intent.action.BOOT_COMPLETED" /&gt;
+ *     &lt;/intent-filter&gt;
+ * &lt;/receiver&gt;
+ * </pre>
+ *
+ * You must then add the following permissions to your {@code AndroidManifest.xml} file:
+ * <pre>
+ * &lt;uses-permission android:name="android.permission.INTERNET" /&gt;
+ * &lt;uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" /&gt;
+ * &lt;uses-permission android:name="android.permission.WAKE_LOCK" /&gt;
+ * &lt;uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" /&gt;
+ * </pre>
+ *
+ * @param <T> The {@link PeriodicReplicationService} component triggered by this
+ * {@link android.content.BroadcastReceiver}
+ */
+
+public abstract class WifiPeriodicReplicationReceiver<T extends PeriodicReplicationService> extends PeriodicReplicationReceiver {
+
+    protected WifiPeriodicReplicationReceiver(Class<T> clazz) {
+        super(clazz);
+    }
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        if (ConnectivityManager.CONNECTIVITY_ACTION.equals(intent.getAction())) {
+
+            int command;
+            if (isConnectedToWifi(context)) {
+                // State has changed to connected.
+                command = PeriodicReplicationService.COMMAND_START_PERIODIC_REPLICATION;
+            } else {
+                // State has changed to disconnected.
+                command = PeriodicReplicationService.COMMAND_STOP_PERIODIC_REPLICATION;
+            }
+            Intent serviceIntent = new Intent(context.getApplicationContext(), clazz);
+            serviceIntent.putExtra(PeriodicReplicationService.EXTRA_COMMAND, command);
+            startWakefulService(context, serviceIntent);
+        } else {
+            // Pass on the processing to the superclass to handle alarms and reboot.
+            super.onReceive(context, intent);
+        }
+    }
+
+    public static boolean isConnectedToWifi(Context context) {
+        ConnectivityManager cm =
+            (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+        NetworkInfo activeNetwork = cm.getActiveNetworkInfo();
+
+        return activeNetwork != null
+            && activeNetwork.getType() == ConnectivityManager.TYPE_WIFI
+            && activeNetwork.isConnectedOrConnecting();
+    }
+
+}

--- a/cloudant-sync-datastore-android/src/test/java/com/cloudant/android/TestReplicationService.java
+++ b/cloudant-sync-datastore-android/src/test/java/com/cloudant/android/TestReplicationService.java
@@ -51,6 +51,7 @@ public class TestReplicationService extends PeriodicReplicationService {
                 Log.e(TAG, "Unable to open Datastore", dnce);
             }
 
+            // Set some arbitrary URI. Our tests use mocks, so we're not going to communicate with it anyway.
             URI uri = new URI("https://test.cloudant.com");
             Replicator pullReplicator = ReplicatorBuilder.pull().from(uri).to(datastore).withId(0).build();
             return new Replicator[] {pullReplicator};

--- a/cloudant-sync-datastore-android/src/test/java/com/cloudant/android/TestReplicationService.java
+++ b/cloudant-sync-datastore-android/src/test/java/com/cloudant/android/TestReplicationService.java
@@ -1,0 +1,75 @@
+package com.cloudant.android;
+
+import android.content.Context;
+import android.util.Log;
+
+import com.cloudant.sync.datastore.Datastore;
+import com.cloudant.sync.datastore.DatastoreManager;
+import com.cloudant.sync.datastore.DatastoreNotCreatedException;
+import com.cloudant.sync.replication.WifiPeriodicReplicationReceiver;
+import com.cloudant.sync.replication.PeriodicReplicationService;
+import com.cloudant.sync.replication.Replicator;
+import com.cloudant.sync.replication.ReplicatorBuilder;
+
+import java.io.File;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class TestReplicationService extends PeriodicReplicationService {
+
+    private static final String TASKS_DATASTORE_NAME = "tasks";
+    private static final String DATASTORE_MANGER_DIR = "data";
+    private static final String TAG = "TestReplicationService";
+
+    class TestReceiver extends WifiPeriodicReplicationReceiver<TestReplicationService> {
+        public TestReceiver() {
+            super(TestReplicationService.class);
+        }
+    }
+
+    public TestReplicationService() {
+        super(TestReceiver.class);
+    }
+
+    /* Only used for test purposes. */
+    public TestReplicationService(Context baseContext) {
+        this();
+        attachBaseContext(baseContext);
+    }
+
+    protected Replicator[] getReplicators(Context context) {
+        try {
+            File path = context.getDir(
+                DATASTORE_MANGER_DIR,
+                Context.MODE_PRIVATE
+            );
+            DatastoreManager manager = new DatastoreManager(path.getAbsolutePath());
+            Datastore datastore = null;
+            try {
+                datastore = manager.openDatastore(TASKS_DATASTORE_NAME);
+            } catch (DatastoreNotCreatedException dnce) {
+                Log.e(TAG, "Unable to open Datastore", dnce);
+            }
+
+            URI uri = new URI("https://test.cloudant.com");
+            Replicator pullReplicator = ReplicatorBuilder.pull().from(uri).to(datastore).withId(0).build();
+            return new Replicator[] {pullReplicator};
+        } catch (URISyntaxException e) {
+            e.printStackTrace();
+        }
+
+        return null;
+    }
+
+    protected int getBoundIntervalInSeconds() {
+        return 60;
+    }
+
+    protected int getUnboundIntervalInSeconds() {
+        return 120;
+    }
+    
+    protected boolean startReplicationOnBind() {
+        return true;
+    }
+}

--- a/cloudant-sync-datastore-android/src/test/java/com/cloudant/sync/replication/ReplicationServiceTest.java
+++ b/cloudant-sync-datastore-android/src/test/java/com/cloudant/sync/replication/ReplicationServiceTest.java
@@ -87,10 +87,13 @@ public class ReplicationServiceTest extends ServiceTestCase<TestReplicationServi
         service.onCreate();
         final CountDownLatch latch = new CountDownLatch(1);
 
-        service.setTestCompletionListener(new PeriodicReplicationService.TestOperationCompleteListener() {
+        service.setOperationStartedListener(new PeriodicReplicationService
+                .OperationStartedListener() {
             @Override
-            public void operationComplete() {
-                latch.countDown();
+            public void operationStarted(int operationId) {
+                if (operationId == PeriodicReplicationService.COMMAND_DEVICE_REBOOTED) {
+                    latch.countDown();
+                }
             }
         });
 
@@ -107,7 +110,7 @@ public class ReplicationServiceTest extends ServiceTestCase<TestReplicationServi
                 Math.abs(SystemClock.elapsedRealtime() - prefsValues.get(0)) < ALARM_TOLERANCE_MS);
             assertEquals("alarmDueClock", prefsKeys.get(1));
             assertTrue("Alarm clock time not within " + ALARM_TOLERANCE_MS + "ms of current time",
-                Math.abs(System.currentTimeMillis() - prefsValues.get(1)) < ALARM_TOLERANCE_MS);
+                    Math.abs(System.currentTimeMillis() - prefsValues.get(1)) < ALARM_TOLERANCE_MS);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }
@@ -128,10 +131,13 @@ public class ReplicationServiceTest extends ServiceTestCase<TestReplicationServi
         long timeReturned = System.currentTimeMillis() + ((1000 * service.getUnboundIntervalInSeconds()) / 2);
         when(mMockPreferences.getLong("alarmDueClock", 0)).thenReturn(timeReturned);
 
-        service.setTestCompletionListener(new PeriodicReplicationService.TestOperationCompleteListener() {
+        service.setOperationStartedListener(new PeriodicReplicationService
+                .OperationStartedListener() {
             @Override
-            public void operationComplete() {
-                latch.countDown();
+            public void operationStarted(int operationId) {
+                if (operationId == PeriodicReplicationService.COMMAND_DEVICE_REBOOTED) {
+                    latch.countDown();
+                }
             }
         });
 
@@ -162,10 +168,13 @@ public class ReplicationServiceTest extends ServiceTestCase<TestReplicationServi
         long timeReturned = System.currentTimeMillis() + ((1000 * service.getUnboundIntervalInSeconds()) * 10);
         when(mMockPreferences.getLong("alarmDueClock", 0)).thenReturn(timeReturned);
 
-        service.setTestCompletionListener(new PeriodicReplicationService.TestOperationCompleteListener() {
+        service.setOperationStartedListener(new PeriodicReplicationService
+                .OperationStartedListener() {
             @Override
-            public void operationComplete() {
-                latch.countDown();
+            public void operationStarted(int operationId) {
+                if (operationId == PeriodicReplicationService.COMMAND_DEVICE_REBOOTED) {
+                    latch.countDown();
+                }
             }
         });
 
@@ -207,10 +216,13 @@ public class ReplicationServiceTest extends ServiceTestCase<TestReplicationServi
         when(mMockContext.getSystemService(Context.ALARM_SERVICE)).thenReturn(mMockAlarmManager);
         when(mMockPreferences.getLong("alarmDueElapsed", 0)).thenReturn(timeReturned);
 
-        service.setTestCompletionListener(new PeriodicReplicationService.TestOperationCompleteListener() {
+        service.setOperationStartedListener(new PeriodicReplicationService
+                .OperationStartedListener() {
             @Override
-            public void operationComplete() {
-                latch.countDown();
+            public void operationStarted(int operationId) {
+                if (operationId == PeriodicReplicationService.COMMAND_START_PERIODIC_REPLICATION) {
+                    latch.countDown();
+                }
             }
         });
 
@@ -256,10 +268,13 @@ public class ReplicationServiceTest extends ServiceTestCase<TestReplicationServi
 
         when(mMockPreferences.getBoolean("periodicReplicationsActive", false)).thenReturn(true);
 
-        service.setTestCompletionListener(new PeriodicReplicationService.TestOperationCompleteListener() {
+        service.setOperationStartedListener(new PeriodicReplicationService
+                .OperationStartedListener() {
             @Override
-            public void operationComplete() {
-                latch.countDown();
+            public void operationStarted(int operationId) {
+                if (operationId == PeriodicReplicationService.COMMAND_START_PERIODIC_REPLICATION) {
+                    latch.countDown();
+                }
             }
         });
 
@@ -288,10 +303,13 @@ public class ReplicationServiceTest extends ServiceTestCase<TestReplicationServi
         when(mMockContext.getSystemService(Context.ALARM_SERVICE)).thenReturn(mMockAlarmManager);
         when(mMockPreferences.getLong("alarmDueElapsed", 0)).thenReturn(timeReturned);
 
-        service.setTestCompletionListener(new PeriodicReplicationService.TestOperationCompleteListener() {
+        service.setOperationStartedListener(new PeriodicReplicationService
+                .OperationStartedListener() {
             @Override
-            public void operationComplete() {
-                latch.countDown();
+            public void operationStarted(int operationId) {
+                if (operationId == PeriodicReplicationService.COMMAND_STOP_PERIODIC_REPLICATION) {
+                    latch.countDown();
+                }
             }
         });
 
@@ -329,10 +347,13 @@ public class ReplicationServiceTest extends ServiceTestCase<TestReplicationServi
         when(mMockContext.getSystemService(Context.ALARM_SERVICE)).thenReturn(mMockAlarmManager);
         when(mMockPreferences.getLong("alarmDueElapsed", 0)).thenReturn(timeReturned);
 
-        service.setTestCompletionListener(new PeriodicReplicationService.TestOperationCompleteListener() {
+        service.setOperationStartedListener(new PeriodicReplicationService
+                .OperationStartedListener() {
             @Override
-            public void operationComplete() {
-                latch.countDown();
+            public void operationStarted(int operationId) {
+                if (operationId == PeriodicReplicationService.COMMAND_STOP_PERIODIC_REPLICATION) {
+                    latch.countDown();
+                }
             }
         });
 
@@ -362,10 +383,13 @@ public class ReplicationServiceTest extends ServiceTestCase<TestReplicationServi
         when(mMockContext.getSystemService(Context.WIFI_SERVICE)).thenReturn(mMockWifiManager);
         when(mMockWifiManager.createWifiLock(WifiManager.WIFI_MODE_FULL_HIGH_PERF, "ReplicationService")).thenReturn(mMockWifiLock);
 
-        service.setTestCompletionListener(new PeriodicReplicationService.TestOperationCompleteListener() {
+        service.setOperationStartedListener(new PeriodicReplicationService
+                .OperationStartedListener() {
             @Override
-            public void operationComplete() {
-                latch.countDown();
+            public void operationStarted(int operationId) {
+                if (operationId == PeriodicReplicationService.COMMAND_START_REPLICATION) {
+                    latch.countDown();
+                }
             }
         });
 
@@ -405,10 +429,16 @@ public class ReplicationServiceTest extends ServiceTestCase<TestReplicationServi
         when(mMockWifiManager.createWifiLock(WifiManager.WIFI_MODE_FULL_HIGH_PERF, "ReplicationService")).thenReturn(mMockWifiLock);
         when(mMockWifiLock.isHeld()).thenReturn(true);
 
-        service.setTestCompletionListener(new PeriodicReplicationService.TestOperationCompleteListener() {
+        service.setOperationStartedListener(new PeriodicReplicationService
+                .OperationStartedListener() {
             @Override
-            public void operationComplete() {
-                latch.countDown();
+            public void operationStarted(int operationId) {
+                if (operationId == PeriodicReplicationService.COMMAND_START_REPLICATION && latch.getCount() == 2) {
+                    latch.countDown();
+                }
+                else if (operationId == PeriodicReplicationService.COMMAND_STOP_REPLICATION && latch.getCount() == 1) {
+                    latch.countDown();
+                }
             }
         });
 

--- a/cloudant-sync-datastore-android/src/test/java/com/cloudant/sync/replication/ReplicationServiceTest.java
+++ b/cloudant-sync-datastore-android/src/test/java/com/cloudant/sync/replication/ReplicationServiceTest.java
@@ -1,0 +1,430 @@
+package com.cloudant.sync.replication;
+
+import android.app.AlarmManager;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.net.wifi.WifiManager;
+import android.os.SystemClock;
+import android.test.ServiceTestCase;
+
+import com.cloudant.android.TestReplicationService;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.io.File;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ReplicationServiceTest extends ServiceTestCase<TestReplicationService> {
+
+    private static final long ALARM_TOLERANCE_MS = 500;
+    private Context mMockContext;
+    private SharedPreferences mMockPreferences;
+    private SharedPreferences.Editor mMockPreferencesEditor;
+    private AlarmManager mMockAlarmManager;
+    private WifiManager mMockWifiManager;
+    private WifiManager.WifiLock mMockWifiLock;
+
+    ReplicationPolicyManager mMockReplicationPolicyManager;
+    private TestReplicationService mService;
+
+    public ReplicationServiceTest() {
+        super(TestReplicationService.class);
+    }
+
+    @BeforeClass
+    public void setUp() {
+        mMockContext = mock(Context.class);
+        mMockPreferences = mock(SharedPreferences.class);
+        when(mMockContext.getSharedPreferences("com.cloudant.preferences", Context.MODE_PRIVATE)).thenReturn(mMockPreferences);
+        when(mMockContext.getPackageName()).thenReturn("cloudant.com.androidtest");
+        when(mMockContext.getDir(anyString(), anyInt())).thenReturn(new File("/data/data/cloudant.com.androidtest/files"));
+        when(mMockContext.getApplicationContext()).thenReturn(mMockContext);
+        mMockPreferencesEditor = mock(SharedPreferences.Editor.class);
+        when(mMockPreferences.edit()).thenReturn(mMockPreferencesEditor);
+        mMockAlarmManager = mock(AlarmManager.class);
+        mMockWifiManager = mock(WifiManager.class);
+        mMockWifiLock = mock(WifiManager.WifiLock.class);
+        mMockReplicationPolicyManager = mock(ReplicationPolicyManager.class);
+    }
+
+    @Test
+    public void testServiceStart() {
+        Intent intent = new Intent(getContext(), TestReplicationService.class);
+        startService(intent);
+    }
+
+    @Test
+    public void testServiceBind() {
+        Intent intent = new Intent(getContext(), TestReplicationService.class);
+        bindService(intent);
+    }
+
+    /**
+     * Check that when an intent is sent to the {@link PeriodicReplicationService} indicating that
+     * the device has been rebooted, if the value for the next alarm scheduled in SharedPreferences
+     * is in the past, then the SharedPreferences are updated to indicate that the next
+     * alarm should be triggered immediately.
+     */
+    @Test
+    public void testOnStartCommandRebootImmediateAlarm() {
+        PeriodicReplicationService service = new TestReplicationService(mMockContext);
+        Intent intent = new Intent(mMockContext, TestReplicationService.class);
+        intent.putExtra(ReplicationService.EXTRA_COMMAND, PeriodicReplicationService.COMMAND_DEVICE_REBOOTED);
+        service.onCreate();
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        service.setTestCompletionListener(new PeriodicReplicationService.TestOperationCompleteListener() {
+            @Override
+            public void operationComplete() {
+                latch.countDown();
+            }
+        });
+
+        ArgumentCaptor<String> captorPrefKeys = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Long> captorPrefValues = ArgumentCaptor.forClass(Long.class);
+        service.onStartCommand(intent, 0, 0);
+        try {
+            latch.await();
+            verify(mMockPreferencesEditor, times(2)).putLong(captorPrefKeys.capture(), captorPrefValues.capture());
+            List<String> prefsKeys = captorPrefKeys.getAllValues();
+            List<Long> prefsValues = captorPrefValues.getAllValues();
+            assertEquals("alarmDueElapsed", prefsKeys.get(0));
+            assertTrue("Alarm elapsed time not within " + ALARM_TOLERANCE_MS + "ms of current time",
+                Math.abs(SystemClock.elapsedRealtime() - prefsValues.get(0)) < ALARM_TOLERANCE_MS);
+            assertEquals("alarmDueClock", prefsKeys.get(1));
+            assertTrue("Alarm clock time not within " + ALARM_TOLERANCE_MS + "ms of current time",
+                Math.abs(System.currentTimeMillis() - prefsValues.get(1)) < ALARM_TOLERANCE_MS);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Check that when an intent is sent to the {@link PeriodicReplicationService} indicating that
+     * the device has been rebooted, if the next alarm scheduled in SharedPreferences is within
+     * the alarm period of the current time, the alarm scheduled in SharedPreferences is unchanged.
+     */
+    public void testOnStartCommandRebootDelayedAlarm() {
+        PeriodicReplicationService service = new TestReplicationService(mMockContext);
+        Intent intent = new Intent(mMockContext, TestReplicationService.class);
+        intent.putExtra(ReplicationService.EXTRA_COMMAND, PeriodicReplicationService.COMMAND_DEVICE_REBOOTED);
+        service.onCreate();
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        long timeReturned = System.currentTimeMillis() + ((1000 * service.getUnboundIntervalInSeconds()) / 2);
+        when(mMockPreferences.getLong("alarmDueClock", 0)).thenReturn(timeReturned);
+
+        service.setTestCompletionListener(new PeriodicReplicationService.TestOperationCompleteListener() {
+            @Override
+            public void operationComplete() {
+                latch.countDown();
+            }
+        });
+
+        ArgumentCaptor<String> captorPrefKeys = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Long> captorPrefValues = ArgumentCaptor.forClass(Long.class);
+        service.onStartCommand(intent, 0, 0);
+        try {
+            latch.await();
+            verify(mMockPreferencesEditor, never()).putLong(captorPrefKeys.capture(), captorPrefValues.capture());
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Check that when an intent is sent to the {@link PeriodicReplicationService} indicating that
+     * the device has been rebooted, if the next alarm scheduled in SharedPreferences is scheduled
+     * more than the alarm period in the future, the next alarm is scheduled one alarm period from
+     * the current time.
+     */
+    public void testOnStartCommandRebootLateAlarm() {
+        PeriodicReplicationService service = new TestReplicationService(mMockContext);
+        Intent intent = new Intent(mMockContext, TestReplicationService.class);
+        intent.putExtra(PeriodicReplicationService.EXTRA_COMMAND, PeriodicReplicationService.COMMAND_DEVICE_REBOOTED);
+        service.onCreate();
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        long timeReturned = System.currentTimeMillis() + ((1000 * service.getUnboundIntervalInSeconds()) * 10);
+        when(mMockPreferences.getLong("alarmDueClock", 0)).thenReturn(timeReturned);
+
+        service.setTestCompletionListener(new PeriodicReplicationService.TestOperationCompleteListener() {
+            @Override
+            public void operationComplete() {
+                latch.countDown();
+            }
+        });
+
+        ArgumentCaptor<String> captorPrefKeys = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Long> captorPrefValues = ArgumentCaptor.forClass(Long.class);
+        service.onStartCommand(intent, 0, 0);
+        try {
+            latch.await();
+            verify(mMockPreferencesEditor, times(2)).putLong(captorPrefKeys.capture(), captorPrefValues.capture());
+            List<String> prefsKeys = captorPrefKeys.getAllValues();
+            List<Long> prefsValues = captorPrefValues.getAllValues();
+            assertEquals("alarmDueElapsed", prefsKeys.get(0));
+            long expectedElapsedTime = SystemClock.elapsedRealtime() + (1000 * service.getUnboundIntervalInSeconds());
+            long expectedRealTime = System.currentTimeMillis() + (1000 * service.getUnboundIntervalInSeconds());
+            assertTrue("Alarm elapsed time not within " + ALARM_TOLERANCE_MS + "ms of expected time",
+                Math.abs(expectedElapsedTime - prefsValues.get(0)) < ALARM_TOLERANCE_MS);
+            assertEquals("alarmDueClock", prefsKeys.get(1));
+            assertTrue("Alarm clock time not within " + ALARM_TOLERANCE_MS + "ms of expected time",
+                Math.abs(expectedRealTime - prefsValues.get(1)) < ALARM_TOLERANCE_MS);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Check that when an intent is sent to the {@link PeriodicReplicationService} indicating that
+     * periodic replications should be started, the {@link AlarmManager}, is setup to fire
+     * at the correct time and with the correct frequency.
+     */
+    public void testOnStartCommandStartPeriodicReplications() {
+        PeriodicReplicationService service = new TestReplicationService(mMockContext);
+        Intent intent = new Intent(mMockContext, TestReplicationService.class);
+        intent.putExtra(PeriodicReplicationService.EXTRA_COMMAND, PeriodicReplicationService.COMMAND_START_PERIODIC_REPLICATION);
+        service.onCreate();
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        long timeReturned = SystemClock.elapsedRealtime();
+        when(mMockPreferences.getBoolean("periodicReplicationsActive", false)).thenReturn(false);
+        when(mMockContext.getSystemService(Context.ALARM_SERVICE)).thenReturn(mMockAlarmManager);
+        when(mMockPreferences.getLong("alarmDueElapsed", 0)).thenReturn(timeReturned);
+
+        service.setTestCompletionListener(new PeriodicReplicationService.TestOperationCompleteListener() {
+            @Override
+            public void operationComplete() {
+                latch.countDown();
+            }
+        });
+
+        service.onStartCommand(intent, 0, 0);
+        try {
+            latch.await();
+            ArgumentCaptor<String> captorPrefKeys = ArgumentCaptor.forClass(String.class);
+            ArgumentCaptor<Boolean> captorPrefValues = ArgumentCaptor.forClass(Boolean.class);
+            verify(mMockPreferencesEditor, times(1)).putBoolean(captorPrefKeys.capture(), captorPrefValues.capture());
+            String prefsKey = captorPrefKeys.getValue();
+            Boolean prefsValue = captorPrefValues.getValue();
+            assertEquals("periodicReplicationsActive", prefsKey);
+            assertTrue("Alarm manager should be set in running state", prefsValue);
+
+
+            ArgumentCaptor<Integer> captorType = ArgumentCaptor.forClass(Integer.class);
+            ArgumentCaptor<Long> captorTriggerAtMillis = ArgumentCaptor.forClass(Long.class);
+            ArgumentCaptor<Long> captorIntervalMillis = ArgumentCaptor.forClass(Long.class);
+
+            verify(mMockAlarmManager, times(1)).setInexactRepeating(captorType.capture(), captorTriggerAtMillis.capture(), captorIntervalMillis.capture(), Mockito.any(PendingIntent.class));
+            assertEquals("Incorrect alarm type", AlarmManager.ELAPSED_REALTIME_WAKEUP, (int) captorType.getValue());
+            assertEquals("Incorrect initial trigger time", timeReturned, (long) captorTriggerAtMillis.getValue());
+            assertEquals("Incorrect alarm period", service.getUnboundIntervalInSeconds() * 1000, (long) captorIntervalMillis.getValue());
+
+            // Unfortunately, we can't do much testing of the PendingIntent itself as there aren't
+            // methods to extract anything useful.
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Check that when an intent is sent to the {@link PeriodicReplicationService} indicating that
+     * periodic replications should be started, if they have already been started, the
+     * {@link AlarmManager} is not invoked to restart the periodic replications..
+     */
+    public void testOnStartCommandStartPeriodicReplicationsAlreadyStarted() {
+        PeriodicReplicationService service = new TestReplicationService(mMockContext);
+        Intent intent = new Intent(mMockContext, TestReplicationService.class);
+        intent.putExtra(PeriodicReplicationService.EXTRA_COMMAND, PeriodicReplicationService.COMMAND_START_PERIODIC_REPLICATION);
+        service.onCreate();
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        when(mMockPreferences.getBoolean("periodicReplicationsActive", false)).thenReturn(true);
+
+        service.setTestCompletionListener(new PeriodicReplicationService.TestOperationCompleteListener() {
+            @Override
+            public void operationComplete() {
+                latch.countDown();
+            }
+        });
+
+        service.onStartCommand(intent, 0, 0);
+        try {
+            latch.await();
+             verify(mMockAlarmManager, never()).setInexactRepeating(Mockito.anyInt(), Mockito.anyLong(), Mockito.anyLong(), Mockito.any(PendingIntent.class));
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Check that when an intent is sent to the {@link PeriodicReplicationService} indicating that
+     * periodic replications should be stopped, the {@link AlarmManager}, is cancelled.
+     */
+    public void testOnStartCommandStopPeriodicReplications() {
+        PeriodicReplicationService service = new TestReplicationService(mMockContext);
+        Intent intent = new Intent(mMockContext, TestReplicationService.class);
+        intent.putExtra(PeriodicReplicationService.EXTRA_COMMAND, PeriodicReplicationService.COMMAND_STOP_PERIODIC_REPLICATION);
+        service.onCreate();
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        long timeReturned = SystemClock.elapsedRealtime();
+        when(mMockPreferences.getBoolean("periodicReplicationsActive", false)).thenReturn(true);
+        when(mMockContext.getSystemService(Context.ALARM_SERVICE)).thenReturn(mMockAlarmManager);
+        when(mMockPreferences.getLong("alarmDueElapsed", 0)).thenReturn(timeReturned);
+
+        service.setTestCompletionListener(new PeriodicReplicationService.TestOperationCompleteListener() {
+            @Override
+            public void operationComplete() {
+                latch.countDown();
+            }
+        });
+
+        service.onStartCommand(intent, 0, 0);
+        try {
+            latch.await();
+            ArgumentCaptor<String> captorPrefKeys = ArgumentCaptor.forClass(String.class);
+            ArgumentCaptor<Boolean> captorPrefValues = ArgumentCaptor.forClass(Boolean.class);
+            verify(mMockPreferencesEditor, times(1)).putBoolean(captorPrefKeys.capture(), captorPrefValues.capture());
+            String prefsKey = captorPrefKeys.getValue();
+            Boolean prefsValue = captorPrefValues.getValue();
+            assertEquals("periodicReplicationsActive", prefsKey);
+            assertFalse("Alarm manager should be set in stopped state", prefsValue);
+
+            verify(mMockAlarmManager, times(1)).cancel(Mockito.any(PendingIntent.class));
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Check that when an intent is sent to the {@link PeriodicReplicationService} indicating that
+     * periodic replications should be stopped, if they have already been stopped, the
+     * {@link AlarmManager} is not cancelled again.
+     */
+    public void testOnStartCommandStopPeriodicReplicationsAlreadyStopped() {
+        PeriodicReplicationService service = new TestReplicationService(mMockContext);
+        Intent intent = new Intent(mMockContext, TestReplicationService.class);
+        intent.putExtra(PeriodicReplicationService.EXTRA_COMMAND, PeriodicReplicationService.COMMAND_STOP_PERIODIC_REPLICATION);
+        service.onCreate();
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        long timeReturned = SystemClock.elapsedRealtime();
+        when(mMockPreferences.getBoolean("periodicReplicationsActive", false)).thenReturn(false);
+        when(mMockContext.getSystemService(Context.ALARM_SERVICE)).thenReturn(mMockAlarmManager);
+        when(mMockPreferences.getLong("alarmDueElapsed", 0)).thenReturn(timeReturned);
+
+        service.setTestCompletionListener(new PeriodicReplicationService.TestOperationCompleteListener() {
+            @Override
+            public void operationComplete() {
+                latch.countDown();
+            }
+        });
+
+        service.onStartCommand(intent, 0, 0);
+        try {
+            latch.await();
+            verify(mMockAlarmManager, never()).cancel(Mockito.any(PendingIntent.class));
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Check that when an intent is sent to the {@link PeriodicReplicationService} indicating that
+     * a replication should be started, a {@link android.net.wifi.WifiManager.WifiLock} is acquired,
+     * the {@link ReplicationPolicyManager} is started and the next alarm time is stored in
+     * SharedPreferences.
+     */
+    public void testOnStartCommandStartReplication() {
+        PeriodicReplicationService service = new TestReplicationService(mMockContext);
+        Intent intent = new Intent(mMockContext, TestReplicationService.class);
+        intent.putExtra(PeriodicReplicationService.EXTRA_COMMAND, PeriodicReplicationService.COMMAND_START_REPLICATION);
+        service.setReplicationPolicyManager(mMockReplicationPolicyManager);
+        service.onCreate();
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        when(mMockContext.getSystemService(Context.WIFI_SERVICE)).thenReturn(mMockWifiManager);
+        when(mMockWifiManager.createWifiLock(WifiManager.WIFI_MODE_FULL_HIGH_PERF, "ReplicationService")).thenReturn(mMockWifiLock);
+
+        service.setTestCompletionListener(new PeriodicReplicationService.TestOperationCompleteListener() {
+            @Override
+            public void operationComplete() {
+                latch.countDown();
+            }
+        });
+
+        service.onStartCommand(intent, 0, 0);
+        try {
+            latch.await();
+            verify(mMockWifiLock, times(1)).acquire();
+            verify(mMockReplicationPolicyManager, times(1)).startReplications();
+            ArgumentCaptor<String> captorPrefKeys = ArgumentCaptor.forClass(String.class);
+            ArgumentCaptor<Long> captorPrefValues = ArgumentCaptor.forClass(Long.class);
+            verify(mMockPreferencesEditor, times(2)).putLong(captorPrefKeys.capture(), captorPrefValues.capture());
+            List<String> prefsKeys = captorPrefKeys.getAllValues();
+            List<Long> prefsValues = captorPrefValues.getAllValues();
+            assertEquals("alarmDueElapsed", prefsKeys.get(0));
+            assertTrue("Alarm elapsed time not within " + ALARM_TOLERANCE_MS + "ms of current time",
+                Math.abs(SystemClock.elapsedRealtime() + (service.getUnboundIntervalInSeconds() * 1000) - prefsValues.get(0)) < ALARM_TOLERANCE_MS);
+            assertEquals("alarmDueClock", prefsKeys.get(1));
+            assertTrue("Alarm clock time not within " + ALARM_TOLERANCE_MS + "ms of current time",
+                Math.abs(System.currentTimeMillis() + (service.getUnboundIntervalInSeconds() * 1000) - prefsValues.get(1)) < ALARM_TOLERANCE_MS);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Check that when an intent is sent to the {@link PeriodicReplicationService} indicating that
+     * a replication should be stopped, the {@link android.net.wifi.WifiManager.WifiLock} is
+     * released and the {@link ReplicationPolicyManager} is stopped.
+     */
+    public void testOnStartCommandStopReplication() {
+        PeriodicReplicationService service = new TestReplicationService(mMockContext);
+        service.setReplicationPolicyManager(mMockReplicationPolicyManager);
+        service.onCreate();
+        final CountDownLatch latch = new CountDownLatch(2);
+
+        when(mMockContext.getSystemService(Context.WIFI_SERVICE)).thenReturn(mMockWifiManager);
+        when(mMockWifiManager.createWifiLock(WifiManager.WIFI_MODE_FULL_HIGH_PERF, "ReplicationService")).thenReturn(mMockWifiLock);
+        when(mMockWifiLock.isHeld()).thenReturn(true);
+
+        service.setTestCompletionListener(new PeriodicReplicationService.TestOperationCompleteListener() {
+            @Override
+            public void operationComplete() {
+                latch.countDown();
+            }
+        });
+
+        Intent startIntent = new Intent(mMockContext, TestReplicationService.class);
+        startIntent.putExtra(PeriodicReplicationService.EXTRA_COMMAND, PeriodicReplicationService.COMMAND_START_REPLICATION);
+        service.onStartCommand(startIntent, 0, 0);
+        Intent stopIntent = new Intent(mMockContext, TestReplicationService.class);
+        stopIntent.putExtra(PeriodicReplicationService.EXTRA_COMMAND, PeriodicReplicationService.COMMAND_STOP_REPLICATION);
+        service.onStartCommand(stopIntent, 0, 0);
+        try {
+            latch.await();
+            verify(mMockWifiLock, times(1)).release();
+            verify(mMockReplicationPolicyManager, times(1)).stopReplications();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/cloudant-sync-datastore-android/src/test/java/com/cloudant/sync/replication/WifiPeriodicReplicationReceiverTest.java
+++ b/cloudant-sync-datastore-android/src/test/java/com/cloudant/sync/replication/WifiPeriodicReplicationReceiverTest.java
@@ -178,7 +178,7 @@ public class WifiPeriodicReplicationReceiverTest extends AndroidTestCase {
      * {@link ReplicationService} associated with
      * {@link WifiPeriodicReplicationReceiver} containing the extra
      * {@link ReplicationService#EXTRA_COMMAND} with the value
-     * {@link PeriodicReplicationService#COMMAND_START_PERIODIC_REPLICATION}.
+     * {@link PeriodicReplicationService#COMMAND_STOP_PERIODIC_REPLICATION}.
      */
     public void testConnectedToMobileNetwork() {
         Intent intent = new Intent(ConnectivityManager.CONNECTIVITY_ACTION);

--- a/cloudant-sync-datastore-android/src/test/java/com/cloudant/sync/replication/WifiPeriodicReplicationReceiverTest.java
+++ b/cloudant-sync-datastore-android/src/test/java/com/cloudant/sync/replication/WifiPeriodicReplicationReceiverTest.java
@@ -1,0 +1,210 @@
+package com.cloudant.sync.replication;
+
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
+import android.test.AndroidTestCase;
+import android.test.mock.MockContext;
+
+import org.junit.Test;
+import org.junit.BeforeClass;
+import org.mockito.Mockito;
+
+import java.lang.Override;
+import java.util.List;
+import java.util.ArrayList;
+
+import static org.mockito.Mockito.when;
+
+public class WifiPeriodicReplicationReceiverTest extends AndroidTestCase {
+
+    private WifiPeriodicReplicationReceiver mReceiver;
+    private TestContext mMockContext;
+
+    class TestContext extends MockContext {
+        private List<Intent> mIntentsReceived = new ArrayList<Intent>();
+        private ConnectivityManager mMockedConnectivityManager;
+
+        @Override
+        public String getPackageName() {
+            return "com.cloudant.android";
+        }
+
+        @Override
+        public Context getApplicationContext() {
+            return this;
+        }
+
+        @Override
+        public ComponentName startService(Intent service) {
+            mIntentsReceived.add(service);
+            if (service.hasExtra("android.support.content.wakelockid")) {
+                return null;
+            } else {
+                return new ComponentName("mock.package.name", "MockClassName");
+            }
+        }
+
+        @Override
+        public Object getSystemService(String name) {
+            if (name.equals(Context.CONNECTIVITY_SERVICE)) {
+                return mMockedConnectivityManager;
+            }
+
+            return null;
+        }
+
+        public List<Intent> getIntentsReceived() {
+            return mIntentsReceived;
+        }
+
+        public void setMockConnectivityManager(int type, boolean isConnectedOrConnecting) {
+            NetworkInfo mockedNetworkInfo = Mockito.mock(NetworkInfo.class);
+            when(mockedNetworkInfo.getType()).thenReturn(type);
+            when(mockedNetworkInfo.isConnectedOrConnecting()).thenReturn(isConnectedOrConnecting);
+
+            mMockedConnectivityManager = Mockito.mock(ConnectivityManager.class);
+            when(mMockedConnectivityManager.getActiveNetworkInfo()).thenReturn(mockedNetworkInfo);
+        }
+    }
+
+    private static class ReplicationService extends PeriodicReplicationService {
+        public ReplicationService() {
+            super(Receiver.class);
+        }
+        @Override
+        protected Replicator[] getReplicators(Context context) {
+            return null;
+        }
+        @Override
+        protected int getBoundIntervalInSeconds() {
+            return 20;
+        }
+        @Override
+        protected int getUnboundIntervalInSeconds() {
+            return 120;
+        }
+        @Override
+        protected boolean startReplicationOnBind() {
+            return true;
+        }
+    }
+
+    private static class Receiver extends WifiPeriodicReplicationReceiver {
+        public Receiver() {
+            super(ReplicationService.class);
+        }
+    }
+
+    @BeforeClass
+    public void setUp() {
+        mReceiver = new Receiver();
+        mMockContext = new TestContext();
+    }
+
+    /**
+     * Check that when {@link WifiPeriodicReplicationReceiver} receives
+     * {@link Intent#ACTION_BOOT_COMPLETED}, an {@link Intent} is sent out to start the Service
+     * {@link ReplicationService} associated with
+     * {@link WifiPeriodicReplicationReceiver} containing the extra
+     * {@link ReplicationService#EXTRA_COMMAND} with the value
+     * {@link PeriodicReplicationService#COMMAND_DEVICE_REBOOTED}.
+     */
+    @Test
+    public void testBootCompleted() {
+        Intent intent = new Intent(Intent.ACTION_BOOT_COMPLETED);
+
+        mReceiver.onReceive(mMockContext, intent);
+        assertEquals(1, mMockContext.getIntentsReceived().size());
+
+        Intent receivedIntent = mMockContext.getIntentsReceived().get(0);
+        assertEquals(ReplicationService.class.getName(), receivedIntent.getComponent().getClassName());
+        assertNull(receivedIntent.getAction());
+        assertEquals(PeriodicReplicationService.COMMAND_DEVICE_REBOOTED, receivedIntent.getIntExtra(ReplicationService.EXTRA_COMMAND, ReplicationService.COMMAND_NONE));
+    }
+
+    /**
+     * Check that when {@link WifiPeriodicReplicationReceiver} receives
+     * {@link ConnectivityManager#CONNECTIVITY_ACTION} and WiFi is connected,
+     * an {@link Intent} is sent out to start the Service
+     * {@link ReplicationService} associated with
+     * {@link WifiPeriodicReplicationReceiver} containing the extra
+     * {@link ReplicationService#EXTRA_COMMAND} with the value
+     * {@link PeriodicReplicationService#COMMAND_START_PERIODIC_REPLICATION}.
+     */
+    public void testWifiConnected() {
+        Intent intent = new Intent(ConnectivityManager.CONNECTIVITY_ACTION);
+
+        mMockContext.setMockConnectivityManager(ConnectivityManager.TYPE_WIFI, true);
+
+        mReceiver.onReceive(mMockContext, intent);
+        assertEquals(1, mMockContext.getIntentsReceived().size());
+
+        Intent receivedIntent = mMockContext.getIntentsReceived().get(0);
+        assertEquals(ReplicationService.class.getName(), receivedIntent.getComponent().getClassName());
+        assertNull(receivedIntent.getAction());
+        assertEquals(PeriodicReplicationService.COMMAND_START_PERIODIC_REPLICATION, receivedIntent.getIntExtra(ReplicationService.EXTRA_COMMAND, ReplicationService.COMMAND_NONE));
+    }
+
+    /**
+     * Check that when {@link WifiPeriodicReplicationReceiver} receives
+     * {@link ConnectivityManager#CONNECTIVITY_ACTION} and WiFi is not connected,
+     * an {@link Intent} is sent out to start the Service
+     * {@link ReplicationService} associated with
+     * {@link WifiPeriodicReplicationReceiver} containing the extra
+     * {@link ReplicationService#EXTRA_COMMAND} with the value
+     * {@link PeriodicReplicationService#COMMAND_START_PERIODIC_REPLICATION}.
+     */
+    public void testWifiDisconnected() {
+        Intent intent = new Intent(ConnectivityManager.CONNECTIVITY_ACTION);
+
+        mMockContext.setMockConnectivityManager(ConnectivityManager.TYPE_WIFI, false);
+
+        mReceiver.onReceive(mMockContext, intent);
+        assertEquals(1, mMockContext.getIntentsReceived().size());
+
+        Intent receivedIntent = mMockContext.getIntentsReceived().get(0);
+        assertEquals(ReplicationService.class.getName(), receivedIntent.getComponent().getClassName());
+        assertNull(receivedIntent.getAction());
+        assertEquals(PeriodicReplicationService.COMMAND_STOP_PERIODIC_REPLICATION, receivedIntent.getIntExtra(ReplicationService.EXTRA_COMMAND, ReplicationService.COMMAND_NONE));
+    }
+
+    /**
+     * Check that when {@link WifiPeriodicReplicationReceiver} receives
+     * {@link ConnectivityManager#CONNECTIVITY_ACTION} and the device is connected to
+     * a non-WiFi network, an {@link Intent} is sent out to start the Service
+     * {@link ReplicationService} associated with
+     * {@link WifiPeriodicReplicationReceiver} containing the extra
+     * {@link ReplicationService#EXTRA_COMMAND} with the value
+     * {@link PeriodicReplicationService#COMMAND_START_PERIODIC_REPLICATION}.
+     */
+    public void testConnectedToMobileNetwork() {
+        Intent intent = new Intent(ConnectivityManager.CONNECTIVITY_ACTION);
+
+        mMockContext.setMockConnectivityManager(ConnectivityManager.TYPE_MOBILE, true);
+
+        mReceiver.onReceive(mMockContext, intent);
+        assertEquals(1, mMockContext.getIntentsReceived().size());
+
+        Intent receivedIntent = mMockContext.getIntentsReceived().get(0);
+        assertEquals(ReplicationService.class.getName(), receivedIntent.getComponent().getClassName());
+        assertNull(receivedIntent.getAction());
+        assertEquals(PeriodicReplicationService.COMMAND_STOP_PERIODIC_REPLICATION, receivedIntent.getIntExtra(ReplicationService.EXTRA_COMMAND, ReplicationService.COMMAND_NONE));
+    }
+
+    /**
+     * Check that when {@link WifiPeriodicReplicationReceiver} receives
+     * an unknown action no Intent is sent.
+     */
+    public void testUnknownAction() {
+        Intent intent = new Intent(Intent.ACTION_ANSWER);
+
+        mMockContext.setMockConnectivityManager(ConnectivityManager.TYPE_WIFI, true);
+
+        mReceiver.onReceive(mMockContext, intent);
+        assertEquals(0, mMockContext.getIntentsReceived().size());
+    }
+
+}

--- a/cloudant-sync-datastore-android/src/test/java/com/cloudant/sync/replication/WifiPeriodicReplicationReceiverTest.java
+++ b/cloudant-sync-datastore-android/src/test/java/com/cloudant/sync/replication/WifiPeriodicReplicationReceiverTest.java
@@ -155,7 +155,7 @@ public class WifiPeriodicReplicationReceiverTest extends AndroidTestCase {
      * {@link ReplicationService} associated with
      * {@link WifiPeriodicReplicationReceiver} containing the extra
      * {@link ReplicationService#EXTRA_COMMAND} with the value
-     * {@link PeriodicReplicationService#COMMAND_START_PERIODIC_REPLICATION}.
+     * {@link PeriodicReplicationService#COMMAND_STOP_PERIODIC_REPLICATION}.
      */
     public void testWifiDisconnected() {
         Intent intent = new Intent(ConnectivityManager.CONNECTIVITY_ACTION);


### PR DESCRIPTION
This is part 5 of a 6 part change to implement replication policies. Each of the 6 parts of the implementation of replication policies are each in a separate branch.

_The following text is common to all 6 PRs._

The 6 branches include:
1. _48607-policies-1-replicator-id_: Adding an ID to replicators so we can easily identify which replicators are completed or have errored in subsequent callbacks.
2. _48607-policies-2-java_: Adding replication policies for Java.
3. _48607-policies-3-android-service_:Adding basic replication policies for Android.
4. _48607-policies-4-android-periodic_: Adding replication at regular intervals for Android.
5. _48607-policies-5-android-wifi_: Adding replication only when on Wifi.
6. _48607-policies-6-docs_: Documentation updates.

_What?_
Add mechanism to enable users to more easily specify the circumstances under which they want replication to occur. This allows relatively simple definition of policies such as:
* Do a pull replication every 2 hours;
* Do a full sync every hour, but only when we have a Wifi connection;
* Sync whenever we connect to Wifi.

_Why?_
Prior to this PR, it was very difficult to implement such policies, particularly on Android where many aspects of the way the Android operating system works would need to be taken into account in order for such policies to work reliably.

_How?_
On Android we want the replication policy management to be reliable, battery efficient and not hog system resources unnecessarily. To achieve this we typically might trigger our replications from a `BroadcastReceiver`. This allows our code to be completely inactive on the device and be started when events of interest are broadcast.  We can also use a `BroadcastReceiver` to trigger periodic replications via the `AlarmManager` mechanism in an efficient way.  However, a `BroadcastReceiver` is intended to only run for a short time in response to receiving a broadcast, so the replication is carried on inside a `Service` that may be started from a `BroadcastReceiver`.

Running replications in a `Service` allows them to run independently of the lifecycle of other application components and be started easily via other application components.  We must also handle the fact that when we wish replication to occur, the device may be asleep, so we need to hold a `WakeLock` for the duration of the replication to prevent the device going back to sleep once the `onReceive()` method of the `BroadcastReceiver` triggering the replications has completed.  Also, if our replications are over Wifi, we need to hold a `Wifi` lock to keep the Wifi radio awake.

On Java, replication policies are much simpler than on Android. The new `ReplicationPolicyManager` class takes care of ensuring that if replications are in progress they are not restarted.

See the [Replication Policies User Guide](https://github.com/cloudant/sync-android/blob/48607-replication-policies/REPLICATION_POLICIES.md) for further information on how replication policies are implemented on Android and on Java.

reviewer @mikerhodes
reviewer @ricellis 