### PR TITLE
Add updateOneFieldIndexMultithreaded test

### DIFF
--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexUpdaterTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexUpdaterTest.java
@@ -234,8 +234,8 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
                 }
             }
             // check that the number of values on the name field is correct
-            assertThat(mikes, is(nDocs*nThreads/2));
-            assertThat(toms, is(nDocs*nThreads/2));
+            assertThat(mikes, is(nDocs/2*nThreads + nDocs%2*nThreads));
+            assertThat(toms, is(nDocs/2*nThreads));
         }catch (SQLException e) {
             Assert.fail(String.format("SQLException occurred executing %s: %s", sql, e));
         } finally {

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexUpdaterTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexUpdaterTest.java
@@ -159,6 +159,8 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         class PopulateThread extends Thread {
             @Override
             public void run() {
+                // try to get all threads to start simultaneously
+                latch.countDown();
                 try {
                     latch.await();
                 } catch (InterruptedException e) {
@@ -167,7 +169,6 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
                 for (int i = 0; i < nDocs; i++) {
                     MutableDocumentRevision rev = new MutableDocumentRevision();
                     rev.docId = String.format("id_%d_%s",i,Thread.currentThread().getName());
-                    System.out.println("creating "+rev.docId);
                     Map<String, Object> bodyMap = new HashMap<String, Object>();
                     if (i % 2 == 0) {
                         bodyMap.put("name", "mike");
@@ -196,8 +197,6 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         }
         for (Thread t : threads) {
             t.start();
-            // try to get all threads to start simultaneously
-            latch.countDown();
         }
         for (Thread t : threads) {
             t.join();

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexUpdaterTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexUpdaterTest.java
@@ -152,7 +152,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         final int nUpdates = 10; // update index after how many docs?
 
         // populate nDocs documents per thread, across nThreads simultaneously
-        // and update index after each insert
+        // and update index in batches (update occurs every nUpdates docs)
 
         final CountDownLatch latch = new CountDownLatch(nThreads);
 
@@ -182,7 +182,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
                         Assert.fail("Exception thrown when creating revision " + de);
                     }
                     // batch up index updates
-                    if (i % nUpdates == 0) {
+                    if (i % nUpdates == nUpdates-1) {
                         IndexUpdater.updateIndex("basic", fields, db, ds, im.getQueue());
                     }
                 }
@@ -202,7 +202,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
             t.join();
         }
 
-        // catch any missing index updates
+        // catch any missing index updates (needed where nDocs % nUpdates != 0)
         IndexUpdater.updateIndex("basic", fields, db, ds, im.getQueue());
 
         // now the "basic" index should be up to date, check the sequence number


### PR DESCRIPTION
- What: Check that a non-trivial number of threads (currently 20) can concurrently create documents and update the query index for those documents
- Why: Previous threading implementations of our database access layer were prone to error or deadlock when accessed by non-trivial numbers of threads
- Testing: Add new `updateOneFieldIndexMultithreaded` test to check the above

reviewers: @ricellis @brynh 

FB ticket 34396