### PR TITLE
Correctly handle interceptors for Push Replications

### DIFF
--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ReplicatorBuilder.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ReplicatorBuilder.java
@@ -53,6 +53,8 @@ public abstract class ReplicatorBuilder<S, T, E> {
             PushReplication pushReplication = new PushReplication();
             pushReplication.source = super.source;
             pushReplication.target = super.target;
+            pushReplication.responseInterceptors.addAll(super.responseInterceptors);
+            pushReplication.requestInterceptors.addAll(super.requestInterceptors);
             return new BasicReplicator(pushReplication);
 
         }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/PullReplicatorTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/PullReplicatorTest.java
@@ -144,5 +144,33 @@ public class PullReplicatorTest extends ReplicationTestBase {
         Assert.assertNotNull(replicator);
     }
 
+    @Test
+    public void testRequestInterceptorsThroughBuilder() throws Exception {
+        InterceptorCallCounter interceptorCallCounter = new InterceptorCallCounter();
+
+        TestReplicationListener listener = new TestReplicationListener();
+        Replicator replicator = ReplicatorBuilder.pull()
+                .to(this.datastore)
+                .from(this.remoteDb.couchClient.getRootUri())
+                .addRequestInterceptors(interceptorCallCounter)
+                .addResponseInterceptors(interceptorCallCounter)
+                .build();
+        replicator.getEventBus().register(listener);
+        replicator.start();
+
+        while(replicator.getState() != Replicator.State.COMPLETE && replicator.getState() != Replicator.State.ERROR) {
+            Thread.sleep(50);
+        }
+
+        Assert.assertEquals(Replicator.State.COMPLETE, replicator.getState());
+        Assert.assertFalse(listener.errorCalled);
+        Assert.assertTrue(listener.finishCalled);
+
+        //check that the response and request interceptors have been called.
+        Assert.assertTrue(interceptorCallCounter.interceptorResponseTimesCalled >= 1);
+        Assert.assertTrue(interceptorCallCounter.interceptorRequestTimesCalled >= 1);
+
+    }
+
 
 }


### PR DESCRIPTION
Fixed issue where interceptors were not set on the Replication object backing the
replication builder, So when `build` was called HTTP interceptors were not added
to the replicator.

BugzId: 52511

reviewer @ricellis 
reviewer @tomblench 