### PR TITLE
Remove setCustomHeaders

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# Unreleased
+- [BREAKING CHANGE] Removed `setCustomHeaders` from `CouchConfig`. See
+  [Http Interceptors](https://github.com/cloudant/sync-android/blob/master/doc/interceptors.md)
+  for a code sample which shows how to add custom request headers
+  using an HTTP Request Interceptor.
+
 # 0.13.3 (2015-08-23)
 - [FIXED] Issue where the `ReplicatorBuilder` would not handle HTTP interceptors
   correctly for push replications.

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/mazha/CouchClient.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/mazha/CouchClient.java
@@ -45,7 +45,6 @@ import java.util.Set;
 public class CouchClient  {
 
     protected final JSONHelper jsonHelper;
-    private final Map<String, String> customHeaders;
     private CouchURIHelper uriHelper;
     private List<HttpConnectionRequestInterceptor> requestInterceptors;
     private List<HttpConnectionResponseInterceptor> responseInterceptors;
@@ -53,7 +52,6 @@ public class CouchClient  {
     public CouchClient(CouchConfig config) {
         this.jsonHelper = new JSONHelper();
         this.uriHelper = new CouchURIHelper(config.getRootUri());
-        this.customHeaders = config.getCustomHeaders();
         this.requestInterceptors = new ArrayList<HttpConnectionRequestInterceptor>();
         this.responseInterceptors = new ArrayList<HttpConnectionResponseInterceptor>();
 
@@ -70,16 +68,6 @@ public class CouchClient  {
         return this.uriHelper.getRootUri();
     }
 
-    /**
-     * Adds headers from CouchConfig to {@code connection}.
-     * @param connection connection to add headers to.
-     */
-    public void addCustomHeaders(HttpConnection connection) {
-        if (this.customHeaders != null) {
-            connection.requestProperties.putAll(this.customHeaders);
-        }
-    }
-
     // - if 2xx then return stream
     // - map 404 to NoResourceException
     // - if there's a couch error returned as json, un-marshall and throw
@@ -90,7 +78,6 @@ public class CouchClient  {
 
         // all CouchClient requests want to receive application/json responses
         connection.requestProperties.put("Accept", "application/json");
-        this.addCustomHeaders(connection);
         connection.responseInterceptors.addAll(this.responseInterceptors);
         connection.requestInterceptors.addAll(this.requestInterceptors);
         InputStream is = null; // input stream - response from server on success
@@ -561,7 +548,6 @@ public class CouchClient  {
             HttpConnection connection = Http.POST(uri, "application/json");
             connection.setRequestBody(payload);
             try {
-                this.addCustomHeaders(connection);
                 is = connection.execute().responseAsInputStream();
                 Map<String, MissingRevisions> diff = jsonHelper.fromJson(new InputStreamReader(is),
                     new TypeReference<Map<String, MissingRevisions>>() { });

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/mazha/CouchConfig.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/mazha/CouchConfig.java
@@ -22,9 +22,8 @@ import com.cloudant.http.HttpConnectionRequestInterceptor;
 import com.cloudant.http.HttpConnectionResponseInterceptor;
 
 import java.net.URI;
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 public class CouchConfig {
 
@@ -35,29 +34,13 @@ public class CouchConfig {
     // a reverse proxy
     private URI rootUri;
 
-    // Optional custom headers
-    private Map<String, String> customHeaders;
-
-    private List<HttpConnectionRequestInterceptor> requestInterceptors;
-    private List<HttpConnectionResponseInterceptor> responseInterceptors;
+    private List<HttpConnectionRequestInterceptor> requestInterceptors = new ArrayList
+            <HttpConnectionRequestInterceptor>();
+    private List<HttpConnectionResponseInterceptor> responseInterceptors = new ArrayList
+            <HttpConnectionResponseInterceptor>();
 
     public CouchConfig(URI rootUri) {
         this.rootUri = rootUri;
-    }
-
-    public Map<String, String> getCustomHeaders() {
-        return customHeaders;
-    }
-
-    public void setCustomHeaders(Map<String, String> customHeaders) {
-        List<String> prohibitedHeaders = Arrays.asList("www-authenticate", "host", "connection",
-                "content-type", "accept", "content-length");
-        for (Map.Entry<String, String> header : customHeaders.entrySet()) {
-            if (prohibitedHeaders.contains(header.getKey().toLowerCase())) {
-                throw new IllegalArgumentException("Bad optional HTTP header: " + header);
-            }
-        }
-        this.customHeaders = customHeaders;
     }
 
     public List<HttpConnectionRequestInterceptor> getRequestInterceptors() {

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/PullReplication.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/PullReplication.java
@@ -33,8 +33,8 @@ public class PullReplication extends Replication {
     /**
      * URI for this replication's remote database.
      *
-     * Include username and password in the URL, or supply an Authorization header using
-     * setCustomHeaders() in CouchConfig.
+     * Include username and password in the URL, or supply an Authorization header using an
+     * HttpConnectionRequestInterceptor
      */
     public URI source;
     /**

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/PushReplication.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/PushReplication.java
@@ -33,8 +33,8 @@ public class PushReplication extends Replication {
     /**
      * URI for this replication's remote database.
      *
-     * Include username and password in the URL, or supply an Authorization header using
-     * setCustomHeaders() in CouchConfig.
+     * Include username and password in the URL, or supply an Authorization header using an
+     * HttpConnectionRequestInterceptor
      */
     public URI target;
     /**

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/mazha/HttpRequestsTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/mazha/HttpRequestsTest.java
@@ -23,26 +23,55 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import com.cloudant.common.RequireRunningCouchDB;
+import com.cloudant.http.HttpConnectionInterceptorContext;
+import com.cloudant.http.HttpConnectionRequestInterceptor;
 import com.google.common.base.Strings;
 
 import java.io.InputStream;
+import java.net.HttpURLConnection;
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 
 @Category(RequireRunningCouchDB.class)
 public class HttpRequestsTest extends CouchClientTestBase {
 
+    private HttpConnectionRequestInterceptor makeHeaderInterceptor(final String headerKey,
+                                                                   final String headerValue)
+    {
+        HttpConnectionRequestInterceptor interceptor = new HttpConnectionRequestInterceptor() {
+            @Override
+            public HttpConnectionInterceptorContext interceptRequest
+            (HttpConnectionInterceptorContext context) {
+                HttpURLConnection connection = context.connection.getConnection();
+                connection.setRequestProperty(headerKey, headerValue);
+                return context;
+            }
+        };
+        return interceptor;
+    };
+
     // test we can set a custom header and make a request
     // (we don't check the header is received at the server!)
     @Test
     public void customHeader() throws Exception {
         CouchConfig customCouchConfig = getCouchConfig(testDb);
-        Map<String, String> customHeaders = new HashMap<String, String>();
-        customHeaders.put("x-good-header", "test");
-        customCouchConfig.setCustomHeaders(customHeaders);
-        Assert.assertEquals("test", customCouchConfig.getCustomHeaders().get("x-good-header"));
+        ArrayList<HttpConnectionRequestInterceptor> customInterceptors = new ArrayList<HttpConnectionRequestInterceptor>();
+        // add interceptor to set header
+        customInterceptors.add(makeHeaderInterceptor("x-good-header", "test"));
+        // add interceptor to check that the header has been set
+        customInterceptors.add(new HttpConnectionRequestInterceptor() {
+            @Override
+            public HttpConnectionInterceptorContext interceptRequest(HttpConnectionInterceptorContext context) {
+                Assert.assertEquals(context.connection.getConnection().getRequestProperty("x-good-header"), "test");
+                return context;
+            }
+        });
+        customCouchConfig.setRequestInterceptors(customInterceptors);
         CouchClient customClient = new CouchClient(customCouchConfig);
         CouchDbInfo dbInfo = customClient.getDbInfo();
         Assert.assertNotNull(dbInfo);
@@ -54,9 +83,13 @@ public class HttpRequestsTest extends CouchClientTestBase {
     // on the fact that any auth string other than "basic: <user:pass>" is accepted
     @Test
     public void customHeaderAuthOverride() throws Exception {
-        // skip if not running against local CouchDB
-        org.junit.Assume.assumeTrue(!IGNORE_AUTH_HEADERS);
 
+        // check that we are running in a configuration where there is no username/password set:
+        // (most commonly this would be the default config of running against a local couch instance
+        // in admin party mode)
+        org.junit.Assume.assumeTrue("Test skipped because Basic Auth credentials are required to " +
+                        "access this server",
+                Strings.isNullOrEmpty(couchConfig.getRootUri().getUserInfo()));
         URI root = couchConfig.getRootUri();
 
         // copy the basic test url but add user:foo, pass:bar as credentials
@@ -68,7 +101,6 @@ public class HttpRequestsTest extends CouchClientTestBase {
                 null,
                 null);
         CouchConfig customCouchConfig = new CouchConfig(rootWithUserCreds);
-        Map<String, String> customHeaders = new HashMap<String, String>();
 
         // first we check that foo/bar is unauthorized
         try {
@@ -80,9 +112,9 @@ public class HttpRequestsTest extends CouchClientTestBase {
         }
 
         // now put in a string which isn't basic auth, it will be ignored by the server
-        customHeaders.put("Authorization", "test");
-        customCouchConfig.setCustomHeaders(customHeaders);
-        Assert.assertEquals("test", customCouchConfig.getCustomHeaders().get("Authorization"));
+        ArrayList<HttpConnectionRequestInterceptor> customInterceptors = new ArrayList<HttpConnectionRequestInterceptor>();
+        customInterceptors.add(makeHeaderInterceptor("Authorization", "test"));
+        customCouchConfig.setRequestInterceptors(customInterceptors);
         CouchClient clientAuthHeader = new CouchClient(customCouchConfig);
         CouchDbInfo dbInfo = clientAuthHeader.getDbInfo();
         Assert.assertNotNull(dbInfo);
@@ -93,22 +125,23 @@ public class HttpRequestsTest extends CouchClientTestBase {
     // NB this test relies on the fact that foo/bar is not a working username/password
     @Test
     public void customHeaderAuth() throws Exception {
-        // skip if not running against local CouchDB
-        org.junit.Assume.assumeTrue(!IGNORE_AUTH_HEADERS);
 
         CouchConfig customCouchConfig = getCouchConfig(testDb);
-        // we're not testing on Cloudant, so we can be sure user/pass is not set - double check:
-        Assert.assertTrue(Strings.isNullOrEmpty(customCouchConfig.getRootUri().getUserInfo()));
 
-        Map<String, String> customHeaders = new HashMap<String, String>();
-        URI thisDbUri = couchConfig.getRootUri();
+        // check that we are running in a configuration where there is no username/password set:
+        // (most commonly this would be the default config of running against a local couch instance
+        // in admin party mode)
+        org.junit.Assume.assumeTrue("Test skipped because Basic Auth credentials are required to " +
+                        "access this server",
+                Strings.isNullOrEmpty(customCouchConfig.getRootUri().getUserInfo()));
 
         try {
             String authString = "foo:bar";
             Base64 base64 = new Base64();
             String authHeaderValue = "Basic " + new String(base64.encode(authString.getBytes()));
-            customHeaders.put("Authorization", authHeaderValue);
-            customCouchConfig.setCustomHeaders(customHeaders);
+            ArrayList<HttpConnectionRequestInterceptor> customInterceptors = new ArrayList<HttpConnectionRequestInterceptor>();
+            customInterceptors.add(makeHeaderInterceptor("Authorization", authHeaderValue));
+            customCouchConfig.setRequestInterceptors(customInterceptors);
             CouchClient customClient = new CouchClient(customCouchConfig);
             customClient.getDbInfo();
             Assert.fail("Expected CouchException to be thrown");
@@ -116,5 +149,4 @@ public class HttpRequestsTest extends CouchClientTestBase {
             Assert.assertEquals("unauthorized", ce.getError());
         }
     }
-
 }

--- a/doc/interceptors.md
+++ b/doc/interceptors.md
@@ -42,6 +42,20 @@ Replicator replicator = ReplicatorBuilder.pull()
 replicator.start();
 ```
 
+## Adding Custom Request Headers
+
+Request Interceptors can be used to add custom HTTP headers by
+accessing the underlying `HttpUrlconnection`, as in this example:
+
+```java
+@Override
+public HttpConnectionInterceptorContext interceptRequest
+(HttpConnectionInterceptorContext context) {
+    HttpURLConnection connection = context.connection.getConnection();
+    connection.setRequestProperty("x-my-header", "value");
+    return context;
+}
+```
 
 ## Things to Avoid
 


### PR DESCRIPTION
- What: Remove `setCustomHeaders` from `CouchConfig`

- How: Remove methods and associated code. Add documentation explaining how to set headers via Request Interceptors

- Testing: `HttpRequestsTest` modified to set headers via Request Interceptors