### PR TITLE
Call executeToInputStream in revsDiff

### DIFF
--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/mazha/CouchClient.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/mazha/CouchClient.java
@@ -547,15 +547,10 @@ public class CouchClient  {
         try {
             HttpConnection connection = Http.POST(uri, "application/json");
             connection.setRequestBody(payload);
-            try {
-                is = connection.execute().responseAsInputStream();
-                Map<String, MissingRevisions> diff = jsonHelper.fromJson(new InputStreamReader(is),
-                    new TypeReference<Map<String, MissingRevisions>>() { });
-                return diff;
-            } catch (IOException ioe) {
-                // return empty map
-                return new HashMap<String, MissingRevisions>();
-            }
+            is = executeToInputStream(connection);
+            Map<String, MissingRevisions> diff = jsonHelper.fromJson(new InputStreamReader(is),
+                new TypeReference<Map<String, MissingRevisions>>() { });
+            return diff;
         } finally {
             closeQuietly(is);
         }


### PR DESCRIPTION
This method erroneously called execute() directly on the underlying connection which meant that the interceptors did not run.

reviewer: @rhyshort 