### PR TITLE
Run tests with cookie authentication

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,26 +153,29 @@ directory of the app module.
 
 #### Testing using remote CouchDB Instance
 
-Certain tests need a running CouchDB instance, by default they use the local
-CouchDB. To run tests with a remote CouchDB, you need set the details of this
-CouchDB server, including access credentials: add the following to
-`gradle.properties` in the same folder as `build.gradle`:
+Certain tests need a running CouchDB instance, by default they use the
+local CouchDB.
+
+To run tests with a remote CouchDB, you need set the details of this
+CouchDB server, including access credentials. This can be done by
+adding options to a file named `gradle.properties` in the same folder
+as `build.gradle`, eg:
 
 ```
-systemProp.test.with.specified.couch=[true|false] # default false
 systemProp.test.couch.username=yourUsername
-systemProp.test.couch.password=yourPassword
-systemProp.test.couch.host=couchdbHost # default localhost
-systemProp.test.couch.port=couchdbPort # default 5984
-systemProp.test.couch.http=[http|https] # default 5984
-systemProp.test.couch.ignore.compaction=[true|false] # default false
-systemProp.test.couch.auth.headers=[true|false] # default false
+...
 ```
+
+Consult the [list of test options](#test-options) for details of all
+options available.
+
+It is also possible to pass in these options from the gradle command
+line by using the -D switch eg. `-Dtest.couch.username=yourUsername`
+
 Note: some tests need to be ignored based on the configuration of the CouchDB
 instance you are using or if you are running against Cloudant. For example
 if the compaction endpoint is unavailable eg., returns a 403 response,
-these tests should be disabled. You can add also properties using the -D command
-line switch eg. `-Dtest.with.specified.couch=true`
+these tests should be disabled.
 
 Your gradle.properties should NEVER be checked into git repo as it contains your CouchDB credentials.
 
@@ -238,3 +241,82 @@ where the SQLite native library lives.
 ```
 -ea -Dsqlite4java.library.path=native
 ```
+
+## Test Options
+
+### Options which describe how to access the remote CouchDB/Cloudant server
+
+`test.couch.uri`
+
+If specified, tests will run against an instance described by this
+URI.
+
+This will over-ride any of the other `test.couch` options given.  This
+URI can include all of the components necessary including username and
+password for basic auth.
+
+It is not necessary to set `test.with.specified.couch` to true in
+order to use this option.
+
+`test.with.specified.couch`
+
+If true, tests will run against an instance described by
+`test.couch.username`, `test.couch.password`, `test.couch.host`,
+`test.couch.port`, `test.couch.http` with default values supplied as
+appropriate.
+
+If false, tests will run against a local couch instance on the default
+port over http.
+
+`test.couch.username`
+
+If specified, tests will use this username to access the instance with
+basic auth.
+
+Alternatively, if `test.couch.use.cookies` is true, tests will use
+this username to refresh cookies.
+
+`test.couch.password`
+
+If specified, tests will use this password to access the instance with
+basic auth.
+
+Alternatively, if `test.couch.use.cookies` is true, tests will use
+this password to refresh cookies.
+
+`test.couch.host`
+
+If specified, tests will use this hostname or IP address to access the
+instance.
+
+Otherwise, a default value of "localhost" is used.
+
+`test.couch.port`
+
+If specified, tests will use this port to access the instance.
+
+Otherwise, a default value of 5984 is used.
+
+`test.couch.http`
+
+If specified, tests will use this protocol to access the
+instance. Valid values are "http" and "https".
+
+Otherwise, a default value of "http" is used.
+
+`test.couch.use.cookies`
+
+If true, use cookie authentication (via the HTTP interceptors) instead
+of basic authentication to access the instance.
+
+### Options which control whether we should ignore certain tests
+
+`test.couch.ignore.compaction`
+
+If true, do not run tests which expect a /_compact endpoint to
+exist. The Cloudant service does not expose this endpoint as
+compaction is performed automatically.
+
+`test.couch.ignore.auth.headers`
+
+If true, do not run tests like testCookieAuthWithoutRetry.

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/common/CouchTestBase.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/common/CouchTestBase.java
@@ -50,18 +50,13 @@ public abstract class CouchTestBase {
         }
     }
 
-    private static final Boolean SPECIFIED_COUCH = Boolean.valueOf(
-            System.getProperty("test.with.specified.couch",Boolean.FALSE.toString()));
 
-    public static final Boolean IGNORE_COMPACTION = Boolean.valueOf(
-            System.getProperty("test.couch.ignore.compaction",Boolean.FALSE.toString()));
-
-    public static final Boolean IGNORE_AUTH_HEADERS = Boolean.valueOf(
-            System.getProperty("test.couch.ignore.auth.headers",Boolean.TRUE.toString()));
 
     public CouchConfig getCouchConfig(String db) {
 
-        if (SPECIFIED_COUCH) {
+        // setting COUCH_URI implies SPECIFIED_COUCH but means we are giving the full URI rather
+        // than the component parts
+        if (TestOptions.COUCH_URI != null || TestOptions.SPECIFIED_COUCH) {
             return SpecifiedCouch.defaultConfig(db);
         }
         else {

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/common/TestOptions.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/common/TestOptions.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2015 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.common;
+
+/**
+ * Created by tomblench on 05/10/15.
+ */
+
+/**
+ * Convenience methods for accessing various test options which can be set configured through JVM
+ * system properties
+ */
+public class TestOptions {
+
+    /*
+     * These options describe how to access the remote CouchDB/Cloudant server
+     */
+
+    /**
+     * If specified, tests will run against an instance described by this URI.
+     * This will over-ride any of the other COUCH_ options given.
+     * This URI can include all of the components necessary including username and password for
+     * basic auth.
+     * It is not necessary to set SPECIFIED_COUCH to true in order to use this option.
+     */
+    public static final String COUCH_URI = System.getProperty("test.couch.uri");
+
+    /**
+     * If true, tests will run against an instance described by
+     * COUCH_USERNAME, COUCH_PASSWORD, COUCH_HOST, COUCH_PORT, HTTP_PROTOCOL with default values
+     * supplied as appropriate.
+     * If false, tests will run against a local couch instance on the default port over http.
+     */
+    public static final Boolean SPECIFIED_COUCH = Boolean.valueOf(
+            System.getProperty("test.with.specified.couch", Boolean.FALSE.toString()));
+
+    /**
+     * If specified, tests will use this username to access the instance with basic auth.
+     * Alternatively, if COOKIE_AUTH is true, tests will use this username to refresh cookies.
+     */
+    public static final String COUCH_USERNAME = System.getProperty("test.couch.username");
+
+    /**
+     * If specified, tests will use this password to access the instance with basic auth.
+     * Alternatively, if COOKIE_AUTH is true, tests will use this password to refresh cookies.
+     */
+    public static final String COUCH_PASSWORD = System.getProperty("test.couch.password");
+
+    /**
+     * If specified, tests will use this hostname or IP address to access the instance.
+     * Otherwise, a default value of "localhost" is used.
+     */
+    public static final String COUCH_HOST = System.getProperty("test.couch.host", "localhost");
+
+    /**
+     * If specified, tests will use this port to access the instance.
+     * Otherwise, a default value of 5984 is used.
+     */
+    public static final String COUCH_PORT = System.getProperty("test.couch.port", "5984");
+
+    /**
+     * If specified, tests will use this protocol to access the instance. Valid values are "http"
+     * and "https".
+     * Otherwise, a default value of "http" is used.
+     */
+    public static final String HTTP_PROTOCOL = System.getProperty("test.couch.http", "http");
+
+    /**
+     * If true, use cookie authentication (via the HTTP interceptors)
+     * instead of basic authentication to access the instance.
+     */
+    public static final Boolean COOKIE_AUTH = Boolean.valueOf(System.getProperty("test.couch.use" +
+            ".cookies", Boolean.FALSE.toString()));
+
+    /*
+     * These options control whether we should ignore certain tests because they are not valid
+     * in all contexts.
+     */
+
+    /**
+     * If true, do not run tests which expect a /_compact endpoint to exist. The Cloudant service
+     * does not expose this endpoint as compaction is performed automatically.
+     */
+    public static final Boolean IGNORE_COMPACTION = Boolean.valueOf(
+            System.getProperty("test.couch.ignore.compaction", Boolean.FALSE.toString()));
+
+    /**
+     * If true, do not run tests like testCookieAuthWithoutRetry.
+     */
+    public static final Boolean IGNORE_AUTH_HEADERS = Boolean.valueOf(
+            System.getProperty("test.couch.ignore.auth.headers", Boolean.TRUE.toString()));
+
+}

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/http/HttpTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/http/HttpTest.java
@@ -12,6 +12,7 @@ package com.cloudant.http;
 
 import com.cloudant.common.CouchTestBase;
 import com.cloudant.common.RequireRunningCouchDB;
+import com.cloudant.common.TestOptions;
 import com.cloudant.mazha.CouchClient;
 import com.cloudant.mazha.CouchConfig;
 import com.cloudant.mazha.json.JSONHelper;
@@ -135,10 +136,9 @@ public class HttpTest extends CouchTestBase {
     @Test
     public void testCookieAuthWithoutRetry() throws IOException {
 
-        Assume.assumeFalse(IGNORE_AUTH_HEADERS);
+        Assume.assumeFalse(TestOptions.IGNORE_AUTH_HEADERS);
 
-        CookieInterceptor interceptor = new CookieInterceptor(System.getProperty("test.couch.username"),
-                System.getProperty("test.couch.password"));
+        CookieInterceptor interceptor = new CookieInterceptor(TestOptions.COUCH_USERNAME, TestOptions.COUCH_PASSWORD);
 
         CouchConfig config = getCouchConfig("cookie_test");
         HttpConnection conn = new HttpConnection("POST", config.getRootUri().toURL(),

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/DocumentRevisionBuilderAttachmentsTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/DocumentRevisionBuilderAttachmentsTest.java
@@ -16,12 +16,14 @@ package com.cloudant.sync.datastore;
 
 import com.cloudant.android.Base64OutputStreamFactory;
 import com.cloudant.common.RequireRunningCouchDB;
+import com.cloudant.common.TestOptions;
 import com.cloudant.mazha.Response;
 import com.cloudant.sync.replication.ReplicationTestBase;
 import com.cloudant.sync.util.TestUtils;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -101,6 +103,9 @@ public class DocumentRevisionBuilderAttachmentsTest extends ReplicationTestBase 
     @Test
     public void buildRevisionFromMapValidMapWithAttachmentsDataExcluded() throws Exception {
 
+        Assume.assumeFalse("Not running test as 'buildRevisionFromMap' can't retrieve the " +
+                "attachment with cookie authentication enabled", TestOptions.COOKIE_AUTH);
+
         //lets the get the attachment encoded
 
         File file = TestUtils.loadFixture("fixture/bonsai-boston.jpg");
@@ -150,6 +155,9 @@ public class DocumentRevisionBuilderAttachmentsTest extends ReplicationTestBase 
 
     @Test
     public void buildRevisionFromMapValidMapWithAttachmentsDataExcludedNonWinningRev() throws Exception {
+
+        Assume.assumeFalse("Not running test as 'buildRevisionFromMap' can't retrieve the " +
+                "attachment with cookie authentication enabled", TestOptions.COOKIE_AUTH);
 
         //lets the get the attachment encoded
 
@@ -205,6 +213,9 @@ public class DocumentRevisionBuilderAttachmentsTest extends ReplicationTestBase 
 
     @Test
     public void buildRevisionFromMapValidMapWithTextAttachmentsDataExcluded() throws Exception {
+
+        Assume.assumeFalse("Not running test as 'buildRevisionFromMap' can't retrieve the " +
+                "attachment with cookie authentication enabled", TestOptions.COOKIE_AUTH);
 
         //lets the get the attachment encoded
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/CompactedDBReplicationTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/CompactedDBReplicationTest.java
@@ -15,6 +15,7 @@
 package com.cloudant.sync.replication;
 
 import com.cloudant.common.RequireRunningCouchDB;
+import com.cloudant.common.TestOptions;
 import com.cloudant.mazha.ClientTestUtils;
 import com.cloudant.mazha.CouchClientTestBase;
 import com.cloudant.mazha.CouchDbInfo;
@@ -51,7 +52,10 @@ public class CompactedDBReplicationTest extends ReplicationTestBase {
     public void replicationFromCompactedDB() throws Exception{
         // if the test case is running against Cloudant, this test should not execute since
         // Cloudant returns 403 - Forbidden when attempting to call _compact
-        Assume.assumeTrue(!CouchClientTestBase.IGNORE_COMPACTION);
+        Assume.assumeFalse(TestOptions.IGNORE_COMPACTION);
+        // skip test if we are doing cookie auth, we don't have the interceptor chain to do it
+        // when we call ClientTestUtils.executeHttpPostRequest
+        Assume.assumeFalse(TestOptions.COOKIE_AUTH);
 
         String documentName;
         Bar bar = BarUtils.createBar(remoteDb, "Bob", 12);
@@ -72,7 +76,7 @@ public class CompactedDBReplicationTest extends ReplicationTestBase {
 
         URI postURI = new URI(couchClient.getRootUri().toString() + "/_compact");
 
-        Assert.assertEquals(ClientTestUtils.executeHttpPostRequest(postURI, ""), 202);
+        Assert.assertEquals(202, ClientTestUtils.executeHttpPostRequest(postURI, ""));
         CouchDbInfo info = couchClient.getDbInfo();
 
         while(info.isCompactRunning()) {

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/ReplicationTestBase.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/ReplicationTestBase.java
@@ -86,6 +86,8 @@ public abstract class ReplicationTestBase extends CouchTestBase {
         CouchConfig couchConfig = this.getCouchConfig(this.getDbName());
         pullReplication.source = couchConfig.getRootUri();
         pullReplication.target = this.datastore;
+        pullReplication.requestInterceptors.addAll(couchConfig.getRequestInterceptors());
+        pullReplication.responseInterceptors.addAll(couchConfig.getResponseInterceptors());
         return pullReplication;
     }
 
@@ -94,6 +96,8 @@ public abstract class ReplicationTestBase extends CouchTestBase {
         CouchConfig couchConfig = this.getCouchConfig(this.getDbName());
         pushReplication.target = couchConfig.getRootUri();
         pushReplication.source = this.datastore;
+        pushReplication.requestInterceptors.addAll(couchConfig.getRequestInterceptors());
+        pushReplication.responseInterceptors.addAll(couchConfig.getResponseInterceptors());
         return pushReplication;
     }
 


### PR DESCRIPTION
Allow tests to run with `CookieInterceptor`s enabled for replication
etc with cookie authentication switched on.

To run tests:

- Configure CouchDB instance with appropriate admin user and password
- Run test with flags as follows:

`gradle -Dtest.with.specified.couch=true -Dtest.couch.username=admin
-Dtest.couch.password=admin -Dtest.couch.use.cookies=true
integrationTest`