### PR TITLE
Jenkins build improvements

### DIFF
--- a/AndroidTest/app/build.gradle
+++ b/AndroidTest/app/build.gradle
@@ -53,8 +53,12 @@ android {
                 // TODO should these tests be skipped by marking them @RequiresDevice
                 exclude '**/ReplicationServiceTest*'
                 // some of these tests fail as follows:
-                // java.lang.OutOfMemoryError: Failed to allocate a 8204 byte allocation with 4194304 free bytes and 8MB until OOM; failed due to fragmentation (required continguous free 12288 bytes where largest contiguous free 8192 bytes)
-                exclude '**/KeyManagerTests/**'
+                // java.lang.OutOfMemoryError: Failed to allocate a
+                // 8204 byte allocation with 4194304 free bytes and
+                // 8MB until OOM; failed due to fragmentation
+                // (required continguous free 12288 bytes where
+                // largest contiguous free 8192 bytes)
+                exclude '**/KeyManagerTests*'
             }
         }
     }

--- a/AndroidTest/app/build.gradle
+++ b/AndroidTest/app/build.gradle
@@ -43,10 +43,16 @@ android {
                             "$scriptLocation/../../cloudant-sync-datastore-android-encryption/src/main/java"]
         }
         androidTest {
-            java.srcDirs = ["$scriptLocation/../../cloudant-sync-datastore-core/src/test/java/",
-                            "$scriptLocation/../../cloudant-sync-datastore-android/src/test/java/",
-                            "$scriptLocation/../../cloudant-sync-datastore-android-encryption/src/test/java/"
-            ]
+            java {
+                srcDirs = ["$scriptLocation/../../cloudant-sync-datastore-core/src/test/java/",
+                           "$scriptLocation/../../cloudant-sync-datastore-android/src/test/java/",
+                           "$scriptLocation/../../cloudant-sync-datastore-android-encryption/src/test/java/"
+                           ]
+                // we would exclude these via categories but it doesn't like the android runner respects them
+                exclude '**/Unreliable*Test*'
+                // TODO should these tests be skipped by marking them @RequiresDevice
+                exclude '**/ReplicationServiceTest*'
+            }
         }
     }
 

--- a/AndroidTest/app/build.gradle
+++ b/AndroidTest/app/build.gradle
@@ -52,6 +52,9 @@ android {
                 exclude '**/Unreliable*Test*'
                 // TODO should these tests be skipped by marking them @RequiresDevice
                 exclude '**/ReplicationServiceTest*'
+                // some of these tests fail as follows:
+                // java.lang.OutOfMemoryError: Failed to allocate a 8204 byte allocation with 4194304 free bytes and 8MB until OOM; failed due to fragmentation (required continguous free 12288 bytes where largest contiguous free 8192 bytes)
+                exclude '**/KeyManagerTests/**'
             }
         }
     }

--- a/AndroidTest/app/build.gradle
+++ b/AndroidTest/app/build.gradle
@@ -50,8 +50,6 @@ android {
                            ]
                 // we would exclude these via categories but it doesn't like the android runner respects them
                 exclude '**/Unreliable*Test*'
-                // TODO should these tests be skipped by marking them @RequiresDevice
-                exclude '**/ReplicationServiceTest*'
                 // some of these tests fail as follows:
                 // java.lang.OutOfMemoryError: Failed to allocate a
                 // 8204 byte allocation with 4194304 free bytes and

--- a/AndroidTest/app/build.gradle
+++ b/AndroidTest/app/build.gradle
@@ -56,6 +56,11 @@ android {
         exclude 'META-INF/NOTICE.txt'
 
     }
+
+    adbOptions {
+        timeOutInMs 30*1000 // 30 seconds in ms.
+    }
+
 }
 
 dependencies {

--- a/AndroidTest/build.gradle
+++ b/AndroidTest/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.1.3'
+        classpath 'com.android.tools.build:gradle:1.3.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/http/HttpTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/http/HttpTest.java
@@ -152,7 +152,7 @@ public class HttpTest extends CouchTestBase {
     @Test
     public void testCookieAuthWithoutRetry() throws IOException {
 
-        Assume.assumeFalse(TestOptions.IGNORE_AUTH_HEADERS);
+        if(TestOptions.IGNORE_AUTH_HEADERS){return;}
 
         CookieInterceptor interceptor = new CookieInterceptor(TestOptions.COUCH_USERNAME, TestOptions.COUCH_PASSWORD);
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/CompactedDBReplicationTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/CompactedDBReplicationTest.java
@@ -52,10 +52,10 @@ public class CompactedDBReplicationTest extends ReplicationTestBase {
     public void replicationFromCompactedDB() throws Exception{
         // if the test case is running against Cloudant, this test should not execute since
         // Cloudant returns 403 - Forbidden when attempting to call _compact
-        Assume.assumeFalse(TestOptions.IGNORE_COMPACTION);
+        if(TestOptions.IGNORE_COMPACTION){return;}
         // skip test if we are doing cookie auth, we don't have the interceptor chain to do it
         // when we call ClientTestUtils.executeHttpPostRequest
-        Assume.assumeFalse(TestOptions.COOKIE_AUTH);
+        if(TestOptions.COOKIE_AUTH){return;}
 
         String documentName;
         Bar bar = BarUtils.createBar(remoteDb, "Bob", 12);

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/UnreliableNetworkPullTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/UnreliableNetworkPullTest.java
@@ -36,7 +36,7 @@ import java.util.Map;
  * Created by tomblench on 15/07/15.
  */
 
-@Category({RequireRunningCouchDB.class, RequireRunningProxy.class})
+@Category(RequireRunningProxy.class)
 public class UnreliableNetworkPullTest extends ProxyTestBase {
 
     String jsonAddToxic = "{\"enabled\" :true, \"timeout\":50, \"sometimesToxic\": true, \"toxicity\" :0.5}";

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/UnreliableNetworkPushTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/UnreliableNetworkPushTest.java
@@ -37,7 +37,7 @@ import java.util.Map;
  */
 
 
-@Category({RequireRunningCouchDB.class, RequireRunningProxy.class})
+@Category(RequireRunningProxy.class)
 public class UnreliableNetworkPushTest extends ProxyTestBase {
 
 


### PR DESCRIPTION
A bundle of small changes to help get jenkins CI reliably running:

- Exit early instead of `Assume.assume*` - the Android runner will fail rather than skip these tests
- Exclude some tests from Android emulator testing by source path because we can't use Categories for that purpose
- Increase timeouts for ADB responses
- Upgrade android gradle tooling

reviewer: @rhyshort 