### PR TITLE
55027: Handle missing open revision error

### DIFF
--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/BasicPullStrategyTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/BasicPullStrategyTest.java
@@ -413,7 +413,6 @@ public class BasicPullStrategyTest extends ReplicationTestBase {
         final ChangesResult changesResult2 = remoteDb.changes(null, 1000);
 
         // compact away the first rev
-        System.out.println("compact");
         URI postURI = new URI(couchClient.getRootUri().toString() + "/_compact");
         Assert.assertEquals(202, ClientTestUtils.executeHttpPostRequest(postURI, ""));
 
@@ -423,9 +422,6 @@ public class BasicPullStrategyTest extends ReplicationTestBase {
             Thread.sleep(1000);
             info = couchClient.getDbInfo();
         };
-
-
-        System.out.println("done compact");
 
         // set up replication...
         PullReplication pullReplication = this.createPullReplication();
@@ -440,16 +436,12 @@ public class BasicPullStrategyTest extends ReplicationTestBase {
                 changes((Replication.Filter)
                         anyObject(), anyObject(), anyInt());
         // do the actual replication
-        System.out.println("running....");
         customReplicator.run();
-        System.out.println("done....");
 
         // assert latest doc retrieved
         Map m = datastore.getDocument(bar1.getId()).asMap();
-        System.out.println(m);
         Assert.assertEquals(41, m.get("age"));
         Assert.assertEquals("Jerry", m.get("name"));
-        System.out.println("done asserts");
     }
 
     private class ChangesResultAnswer implements Answer {

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/BasicPullStrategyTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/BasicPullStrategyTest.java
@@ -428,10 +428,8 @@ public class BasicPullStrategyTest extends ReplicationTestBase {
         System.out.println("done compact");
 
         // set up replication...
-        //TestStrategyListener listener = new TestStrategyListener();
         PullReplication pullReplication = this.createPullReplication();
         BasicPullStrategy customReplicator = new BasicPullStrategy(pullReplication, null, this.config);
-        //customReplicator.getEventBus().register(listener);
 
         // inject our mocked changesresult via a 'spy'
         // ChangesResultAnswer returns the 'wrong' answer first and the 'right' after every

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/BasicPullStrategyTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/BasicPullStrategyTest.java
@@ -18,6 +18,7 @@ import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -28,6 +29,7 @@ import com.cloudant.mazha.AnimalDb;
 import com.cloudant.mazha.ChangesResult;
 import com.cloudant.mazha.ClientTestUtils;
 import com.cloudant.mazha.CouchClient;
+import com.cloudant.mazha.CouchDbInfo;
 import com.cloudant.mazha.Response;
 import com.cloudant.sync.datastore.BasicDocumentRevision;
 import com.cloudant.sync.datastore.DatastoreExtended;
@@ -390,31 +392,86 @@ public class BasicPullStrategyTest extends ReplicationTestBase {
 
     @Test
     public void pull_changesNewerThanOpenRevs() throws Exception {
+        // test for regressions against the following scenario:
+        // - changes feed tells us that 1-rev is a new rev we don't have
+        // - on remote db, 2-rev gets added and becomes the new leaf
+        // - compact() is called and 1-rev is compacted away
+        // - we try to pull 1-rev but it is no longer there
+        // the solution to this is to re-fetch the changes feed at the same checkpoint and continue
+        // replication - in the hope that the changes feed now reflects the revs available
+
         // upload some docs
         Bar bar1 = BarUtils.createBar(remoteDb, "Tom", 31);
 
-        // capture 'real' changes feed
-        final ChangesResult changesResult = remoteDb.changes(null, 1000);
+        // capture 'real' changes feed - after first rev
+        final ChangesResult changesResult1 = remoteDb.changes(null, 1000);
 
         // upload some more docs
         Bar bar2 = BarUtils.updateBar(remoteDb, bar1.getId(), "Jerry", 41);
 
+        // capture 'real' changes feed - after second rev
+        final ChangesResult changesResult2 = remoteDb.changes(null, 1000);
+
         // compact away the first rev
+        System.out.println("compact");
         URI postURI = new URI(couchClient.getRootUri().toString() + "/_compact");
         Assert.assertEquals(202, ClientTestUtils.executeHttpPostRequest(postURI, ""));
 
-        // replicate...
-        TestStrategyListener listener = new TestStrategyListener();
-        PullReplication pullReplication = this.createPullReplication();
-        this.replicator = new BasicPullStrategy(pullReplication, null, this.config);
-        this.replicator.getEventBus().register(listener);
-        // inject our mocked changesresult via a 'spy'
-        this.replicator.sourceDb = spy(this.replicator.sourceDb);
-        doReturn(changesResult).when(this.replicator.sourceDb).changes((Replication.Filter)
-                anyObject(), anyObject(), anyInt());
-        // do the actual replication
-        this.replicator.run();
+        CouchDbInfo info = couchClient.getDbInfo();
 
-        // TODO asserts
+        while(info.isCompactRunning()) {
+            Thread.sleep(1000);
+            info = couchClient.getDbInfo();
+        };
+
+
+        System.out.println("done compact");
+
+        // set up replication...
+        //TestStrategyListener listener = new TestStrategyListener();
+        PullReplication pullReplication = this.createPullReplication();
+        BasicPullStrategy customReplicator = new BasicPullStrategy(pullReplication, null, this.config);
+        //customReplicator.getEventBus().register(listener);
+
+        // inject our mocked changesresult via a 'spy'
+        // ChangesResultAnswer returns the 'wrong' answer first and the 'right' after every
+        // invocation after that
+        customReplicator.sourceDb = spy(customReplicator.sourceDb);
+        doAnswer(new ChangesResultAnswer(changesResult1, changesResult2))
+                .when(customReplicator.sourceDb).
+                changes((Replication.Filter)
+                        anyObject(), anyObject(), anyInt());
+        // do the actual replication
+        System.out.println("running....");
+        customReplicator.run();
+        System.out.println("done....");
+
+        // assert latest doc retrieved
+        Map m = datastore.getDocument(bar1.getId()).asMap();
+        System.out.println(m);
+        Assert.assertEquals(41, m.get("age"));
+        Assert.assertEquals("Jerry", m.get("name"));
+        System.out.println("done asserts");
+    }
+
+    private class ChangesResultAnswer implements Answer {
+        private ChangesResult changesResult1;
+        private ChangesResult changesResult2;
+        private int invocations;
+
+        public ChangesResultAnswer(ChangesResult changesResult1,
+                                   ChangesResult changesResult2) {
+            this.changesResult1 = changesResult1;
+            this.changesResult2 = changesResult2;
+            this.invocations = 0;
+        }
+
+        public Object answer(InvocationOnMock invocation) {
+            if (invocations++ == 0) {
+                return changesResult1;
+            } else {
+                return changesResult2;
+            }
+        }
     }
 }


### PR DESCRIPTION
See ticket for details - this is a fix for _transient_ "Missing open revision for document" exceptions thrown by `CouchClientWrapper#getRevisions`.

**What**: The customer originating the ticket has experienced this error, but have not provided details to reproduce. In the absence of hard information, it is possible that this error arises as the result of a race condition as follows:
```
        // - changes feed tells us that 1-rev is a new rev we don't have
        // - on remote db, 2-rev gets added and becomes the new leaf
        // - compact() is called and 1-rev is compacted away
        // - we try to pull 1-rev but it is no longer there
```

**How**: We alter `BasicPullStrategy#replicate` to use a `RetriableTask` to fetch the batch from the changes feed and process it. Note that it is OK to call nextBatch() repeatedly for each retry without missing any batches - this is because we know that the checkpoint has not been updated. 

**Testing**: See `BasicPullStrategyTest.pull_changesNewerThanOpenRevs`

reviewer @ricellis
reviewer @emlaver