### PR TITLE
54145 Make BasicDatastore handle preparing attachments more explicitly

### DIFF
--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/AttachmentManager.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/AttachmentManager.java
@@ -227,11 +227,9 @@ class AttachmentManager {
     // * if attachment is not saved, prepare it, and add it to the prepared list
     // this way, the attachments are sifted through ready to be added in the database for a given revision
     protected PreparedAndSavedAttachments prepareAttachments(Collection<? extends Attachment> attachments) throws AttachmentException {
-        if (attachments == null || attachments.size() == 0) {
-            // nothing to do
-            return null;
-        }
-        // actually a list of prepared or saved attachments
+        // Ensure we have at least an empty attachments array
+        attachments = attachments != null ? attachments : new ArrayList<Attachment>();
+        // Actually a list of prepared or saved attachments
         PreparedAndSavedAttachments preparedAndSavedAttachments = new PreparedAndSavedAttachments();
         preparedAndSavedAttachments.preparedAttachments = this.prepareNewAttachments(this.findNewAttachments(attachments));
         preparedAndSavedAttachments.savedAttachments = this.findExistingAttachments(attachments);

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/AttachmentManager.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/AttachmentManager.java
@@ -179,16 +179,6 @@ class AttachmentManager {
 
     }
 
-    class PreparedAndSavedAttachments
-    {
-        List<SavedAttachment> savedAttachments = new ArrayList<SavedAttachment>();
-        List<PreparedAttachment> preparedAttachments = new ArrayList<PreparedAttachment>();
-
-        public boolean isEmpty() {
-            return savedAttachments.isEmpty() && preparedAttachments.isEmpty();
-        }
-    }
-
     /**
      * Creates a PreparedAttachment from {@code attachment}, preparing it for insertion into
      * the datastore.
@@ -223,27 +213,13 @@ class AttachmentManager {
         return pa;
     }
 
-    // take a set of attachments, and:
-    // * if attachment is saved, add it to the saved list
-    // * if attachment is not saved, prepare it, and add it to the prepared list
-    // this way, the attachments are sifted through ready to be added in the database for a given revision
-    protected PreparedAndSavedAttachments prepareAttachments(Collection<? extends Attachment> attachments) throws AttachmentException {
-        // Ensure we have at least an empty attachments array
-        attachments = attachments != null ? attachments : new ArrayList<Attachment>();
-        // Actually a list of prepared or saved attachments
-        PreparedAndSavedAttachments preparedAndSavedAttachments = new PreparedAndSavedAttachments();
-        preparedAndSavedAttachments.preparedAttachments = this.prepareNewAttachments(this.findNewAttachments(attachments));
-        preparedAndSavedAttachments.savedAttachments = this.findExistingAttachments(attachments);
-        return preparedAndSavedAttachments;
-    }
-
     /**
      * Return a list of the existing attachments in the list passed in.
      *
      * @param attachments Attachments to search.
      * @return List of attachments which already exist in the attachment store, or an empty list if none.
      */
-    private List<SavedAttachment> findExistingAttachments(Collection<? extends Attachment> attachments) {
+    protected List<SavedAttachment> findExistingAttachments(Collection<? extends Attachment> attachments) {
         ArrayList<SavedAttachment> list = new ArrayList<SavedAttachment>();
         for (Attachment a : attachments) {
             if (a instanceof SavedAttachment) {
@@ -259,7 +235,7 @@ class AttachmentManager {
      * @param attachments Attachments to search.
      * @return List of attachments which need adding to the attachment store, or an empty list if none.
      */
-    private List<Attachment> findNewAttachments(Collection<? extends Attachment> attachments) {
+    protected List<Attachment> findNewAttachments(Collection<? extends Attachment> attachments) {
         ArrayList<Attachment> list = new ArrayList<Attachment>();
         for (Attachment a : attachments) {
             if (!(a instanceof SavedAttachment)) {
@@ -278,7 +254,7 @@ class AttachmentManager {
      * @param attachments List of attachments to prepare.
      * @return Attachments prepared for inserting into attachment store.
      */
-    private List<PreparedAttachment> prepareNewAttachments(List<Attachment> attachments)
+    protected List<PreparedAttachment> prepareAttachments(List<Attachment> attachments)
         throws AttachmentException {
         ArrayList<PreparedAttachment> list = new ArrayList<PreparedAttachment>();
         for (Attachment a : attachments) {

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/AttachmentManager.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/AttachmentManager.java
@@ -78,23 +78,23 @@ class AttachmentManager {
     /**
      * Name of database mapping key to filename.
      */
-    public static final String ATTACHMENTS_KEY_FILENAME = "attachments_key_filename";
+    private static final String ATTACHMENTS_KEY_FILENAME = "attachments_key_filename";
     /**
      * SQL statement to look up filename for key.
      */
-    public static final String SQL_FILENAME_LOOKUP_QUERY = String.format(
+    private static final String SQL_FILENAME_LOOKUP_QUERY = String.format(
             "SELECT filename FROM %1$s WHERE key=?", ATTACHMENTS_KEY_FILENAME);
     /**
      * SQL statement to return all key,filename mappings.
      */
-    public static final String SQL_ATTACHMENTS_SELECT_KEYS_FILENAMES = String.format(
+    private static final String SQL_ATTACHMENTS_SELECT_KEYS_FILENAMES = String.format(
             "SELECT key,filename FROM %1$s", ATTACHMENTS_KEY_FILENAME);
     /**
      * Random number generator used to generate filenames.
      */
     private static final Random filenameRandom = new Random();
 
-    public final String attachmentsDir;
+    private final String attachmentsDir;
 
     private final AttachmentStreamFactory attachmentStreamFactory;
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/AttachmentManager.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/AttachmentManager.java
@@ -197,7 +197,8 @@ class AttachmentManager {
      * @return PreparedAttachment, which can be used in addAttachment methods
      * @throws AttachmentException if there was an error preparing the attachment, e.g., reading
      *                  attachment data.
-     */    protected PreparedAttachment prepareAttachment(Attachment attachment) throws AttachmentException {
+     */
+    protected PreparedAttachment prepareAttachment(Attachment attachment) throws AttachmentException {
         if (attachment.encoding != Attachment.Encoding.Plain) {
             throw new AttachmentNotSavedException("Encoded attachments can only be prepared if the value of \"length\" is known");
         }
@@ -287,23 +288,21 @@ class AttachmentManager {
         return list;
     }
 
-    protected void setAttachments(SQLDatabase db,BasicDocumentRevision rev, PreparedAndSavedAttachments preparedAndSavedAttachments) throws AttachmentNotSavedException, DatastoreException {
+    protected void setAttachments(SQLDatabase db,BasicDocumentRevision rev,
+                                  List<PreparedAttachment> newAttachments,
+                                  List<SavedAttachment> existingAttachments)
+            throws AttachmentNotSavedException, DatastoreException {
 
         // set attachments for revision:
         // * prepared attachments are added
         // * copy existing attachments forward to the next revision
 
-        if (preparedAndSavedAttachments == null || preparedAndSavedAttachments.isEmpty()) {
-            // nothing to do
-            return;
-        }
-
         try {
-            for (PreparedAttachment a : preparedAndSavedAttachments.preparedAttachments) {
+            for (PreparedAttachment a : newAttachments) {
                 // go thru prepared attachments and add them
                 this.addAttachment(db,a, rev);
             }
-            for (SavedAttachment a : preparedAndSavedAttachments.savedAttachments) {
+            for (SavedAttachment a : existingAttachments) {
                 // go thru existing (from previous rev) and new (from another document) saved attachments
                 // and add them (the effect on existing attachments is to copy them forward to this revision)
                 long parentSequence = a.seq;

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/BasicDatastore.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/BasicDatastore.java
@@ -746,11 +746,11 @@ class BasicDatastore implements Datastore, DatastoreExtended {
         return null;
     }
 
-    private BasicDocumentRevision updateDocument(SQLDatabase db,String docId,
-                                                 String prevRevId,
-                                                 final DocumentBody body,
-                                                 boolean validateBody,
-                                                 boolean copyAttachments)
+    private BasicDocumentRevision updateDocumentBody(SQLDatabase db, String docId,
+                                                     String prevRevId,
+                                                     final DocumentBody body,
+                                                     boolean validateBody,
+                                                     boolean copyAttachments)
             throws ConflictException, AttachmentException, DocumentNotFoundException, DatastoreException {
         Preconditions.checkState(this.isOpen(), "Database is closed");
         Preconditions.checkArgument(!Strings.isNullOrEmpty(docId),
@@ -1900,8 +1900,7 @@ class BasicDatastore implements Datastore, DatastoreExtended {
             throws ConflictException, AttachmentException, DocumentNotFoundException, DatastoreException {
         Preconditions.checkNotNull(rev, "DocumentRevision can not be null");
 
-            // update document with new body
-            BasicDocumentRevision updated = updateDocument(db,rev.docId, rev.sourceRevisionId, rev.body, true, false);
+            BasicDocumentRevision updated = updateDocumentBody(db,rev.docId, rev.sourceRevisionId, rev.body, true, false);
             attachmentManager.addAttachmentsToRevision(db, preparedNewAttachments, updated);
             attachmentManager.copyAttachmentsToRevision(db, existingAttachments, updated);
             // now re-fetch the revision with updated attachments

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/BasicDatastore.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/BasicDatastore.java
@@ -1853,6 +1853,7 @@ class BasicDatastore implements Datastore, DatastoreExtended {
     @Override
     public BasicDocumentRevision updateDocumentFromRevision(final MutableDocumentRevision rev)
             throws DocumentException {
+        // Prepare attachments with copy/download/retrieve attachments into the temp folder
         final AttachmentManager.PreparedAndSavedAttachments preparedAndSavedAttachments =
                 this.attachmentManager.prepareAttachments(rev.attachments != null ? rev.attachments.values() : null);
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/BasicDatastore.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/BasicDatastore.java
@@ -643,7 +643,7 @@ class BasicDatastore implements Datastore, DatastoreExtended {
         return null;
     }
 
-    private BasicDocumentRevision createDocument(SQLDatabase db,String docId, final DocumentBody body)
+    private BasicDocumentRevision createDocumentBody(SQLDatabase db, String docId, final DocumentBody body)
             throws AttachmentException, ConflictException, DatastoreException {
         Preconditions.checkState(this.isOpen(), "Database is closed");
         CouchUtils.validateDocumentId(docId);
@@ -1832,10 +1832,12 @@ class BasicDatastore implements Datastore, DatastoreExtended {
             created = queue.submitTransaction(new SQLQueueCallable<BasicDocumentRevision>(){
                 @Override
                 public BasicDocumentRevision call(SQLDatabase db) throws Exception {
-                        // save document with body
-                        BasicDocumentRevision saved = createDocument(db,docId, rev.body);
+
+                        // Save document with new JSON body, add new attachments and copy over existing attachments
+                        BasicDocumentRevision saved = createDocumentBody(db, docId, rev.body);
                         attachmentManager.addAttachmentsToRevision(db, preparedNewAttachments, saved);
                         attachmentManager.copyAttachmentsToRevision(db, existingAttachments, saved);
+
                         // now re-fetch the revision with updated attachments
                         BasicDocumentRevision updatedWithAttachments = getDocumentInQueue(db,
                                 saved.getId(), saved.getRevision());

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/BasicDatastore.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/BasicDatastore.java
@@ -1825,7 +1825,10 @@ class BasicDatastore implements Datastore, DatastoreExtended {
                         // save document with body
                         BasicDocumentRevision saved = createDocument(db,docId, rev.body);
                         // set attachments
-                        attachmentManager.setAttachments(db,saved, preparedAndSavedAttachments);
+                        attachmentManager.setAttachments(db,
+                                saved,
+                                preparedAndSavedAttachments.preparedAttachments,
+                                preparedAndSavedAttachments.savedAttachments);
                         // now re-fetch the revision with updated attachments
                         BasicDocumentRevision updatedWithAttachments = getDocumentInQueue(db,
                                 saved.getId(), saved.getRevision());
@@ -1850,6 +1853,7 @@ class BasicDatastore implements Datastore, DatastoreExtended {
     @Override
     public BasicDocumentRevision updateDocumentFromRevision(final MutableDocumentRevision rev)
             throws DocumentException {
+
         // Prepare attachments with copy/download/retrieve attachments into the temp folder
         final AttachmentManager.PreparedAndSavedAttachments preparedAndSavedAttachments =
                 this.attachmentManager.prepareAttachments(rev.attachments != null ? rev.attachments.values() : null);
@@ -1885,7 +1889,10 @@ class BasicDatastore implements Datastore, DatastoreExtended {
             // update document with new body
             BasicDocumentRevision updated = updateDocument(db,rev.docId, rev.sourceRevisionId, rev.body, true, false);
             // set attachments
-            this.attachmentManager.setAttachments(db,updated, preparedAndSavedAttachments);
+            this.attachmentManager.setAttachments(db,
+                    updated,
+                    preparedAndSavedAttachments.preparedAttachments,
+                    preparedAndSavedAttachments.savedAttachments);
             // now re-fetch the revision with updated attachments
             BasicDocumentRevision updatedWithAttachments = this.getDocumentInQueue(db, updated.getId(), updated.getRevision());
             return updatedWithAttachments;

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/BasicDatastore.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/BasicDatastore.java
@@ -1630,12 +1630,6 @@ class BasicDatastore implements Datastore, DatastoreExtended {
                         return null;
                     }
 
-                    AttachmentManager.PreparedAndSavedAttachments preparedAndSavedAttachments = null;
-                    if (newWinner.getClass() == MutableDocumentRevision.class) {
-                        preparedAndSavedAttachments = attachmentManager.prepareAttachments(
-                                newWinner.getAttachments() != null ? newWinner.getAttachments().values() : null);
-                    }
-
                         // if it's BasicDocumentRev:
                         // - keep the winner, delete the rest
                         // if it's MutableDocumentRev:
@@ -1670,6 +1664,9 @@ class BasicDatastore implements Datastore, DatastoreExtended {
 
                         // if it's MutableDocumentRev: graft the new revision on
                         if (newWinner.getClass() == MutableDocumentRevision.class) {
+                            AttachmentManager.PreparedAndSavedAttachments preparedAndSavedAttachments = null;
+                            preparedAndSavedAttachments = attachmentManager.prepareAttachments(
+                                    newWinner.getAttachments() != null ? newWinner.getAttachments().values() : null);
                             updateDocumentFromRevision(db,(MutableDocumentRevision) newWinner,
                                     preparedAndSavedAttachments);
                         }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/BasicDatastore.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/BasicDatastore.java
@@ -1108,10 +1108,8 @@ class BasicDatastore implements Datastore, DatastoreExtended {
                                     try {
                                         BasicDocumentRevision doc = getDocumentInQueue(db, id, rev);
                                         if (doc != null) {
-                                            for (PreparedAttachment att : preparedAttachments.get
-                                                    (key)) {
-                                                attachmentManager.addAttachment(db, att, doc);
-                                            }
+                                            attachmentManager.addAttachmentsToRevision(db,
+                                                    preparedAttachments.get(key), doc);
                                         }
                                     } catch (DocumentNotFoundException e){
                                         //safe to continue, previously getDocumentInQueue could return
@@ -1836,11 +1834,8 @@ class BasicDatastore implements Datastore, DatastoreExtended {
                 public BasicDocumentRevision call(SQLDatabase db) throws Exception {
                         // save document with body
                         BasicDocumentRevision saved = createDocument(db,docId, rev.body);
-                        // set attachments
-                        attachmentManager.setAttachments(db,
-                                saved,
-                                preparedNewAttachments,
-                                existingAttachments);
+                        attachmentManager.addAttachmentsToRevision(db, preparedNewAttachments, saved);
+                        attachmentManager.copyAttachmentsToRevision(db, existingAttachments, saved);
                         // now re-fetch the revision with updated attachments
                         BasicDocumentRevision updatedWithAttachments = getDocumentInQueue(db,
                                 saved.getId(), saved.getRevision());
@@ -1905,11 +1900,8 @@ class BasicDatastore implements Datastore, DatastoreExtended {
 
             // update document with new body
             BasicDocumentRevision updated = updateDocument(db,rev.docId, rev.sourceRevisionId, rev.body, true, false);
-            // set attachments
-            this.attachmentManager.setAttachments(db,
-                    updated,
-                    preparedNewAttachments,
-                    existingAttachments);
+            attachmentManager.addAttachmentsToRevision(db, preparedNewAttachments, updated);
+            attachmentManager.copyAttachmentsToRevision(db, existingAttachments, updated);
             // now re-fetch the revision with updated attachments
             BasicDocumentRevision updatedWithAttachments = this.getDocumentInQueue(db, updated.getId(), updated.getRevision());
             return updatedWithAttachments;


### PR DESCRIPTION
# What

BasicDatastore and AttachmentManager are tightly coupled classes. In Objective-C the attachment code would probably be a category on the datastore class, as the split it more to keep logic together rather than encapsulate functionality.

This PR makes the preparing of attachments more explicit in the BasicDatastore code, while still leaving most of the logic in AttachmentManager. The problem was that prepareAttachments method did several things, which made it a bit harder to follow the code in BasicDatastore. The PR:

* Splits `prepareAttachments` into several explicit methods which make the logic in BasicDatastore slightly more complicated as it now splits out the unsaved from the already existing attachments. But it's clearer what's going on.
* Removes `setAttachments` in favour of explicit adding and copying operation from BasicDatastore, making it clearer that some attachments are copied and some are new. It's still a bit unclear what existing/copying means, given existing only actually means that it's a saved attachment and copying means only copying the database entries, so the method calls don't make it too clear what their cost is likely to be.
* The last couple of commits are cleanups -- they seemed small, but I can remove them in favour of a new PR is it'd help.

# Reviewers

reviewer @tomblench 
reviewer @rhyshort 