### PR TITLE
Make AttachmentManager methods static

### DIFF
--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/AttachmentManager.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/AttachmentManager.java
@@ -43,7 +43,9 @@ import java.util.logging.Logger;
  * attachments for documents from disk. It handles both disk read/write and managing the
  * attachment related tables in the datastore's database.
  *
- * Attachments are stored on disk in an extension directory, {@code EXTENSION_NAME}.
+ * Attachments are stored on disk, in the folder specified by the {@code attachmentsDir}
+ * parameter to each method. AttachmentManager assumes it has sole control of this directory.
+ * For example, purging and compaction may delete non-attachment files.
  */
 class AttachmentManager {
 


### PR DESCRIPTION
# What

This commit removes all state from the AttachmentManager class and makes
its methods into static ones. The two items of state, attachmentsDir and
attachmentStreamFactory are made into instance variables on
BasicDatastore instead.

# Why

This should enable us to make the AttachmentManager methods into their
own classes, which will help when we break out the callables from
BasicDatastore. In general, the overall aim is to have small classes
which encapsulate small pieces of functionality, whereas now we
have a couple of large tightly coupled classes which both know about
each others internals.

Hopefully we end up with a single class, BasicDatastore, which
encodes the knowledge about the policies for manipulating documents,
with a bunch of fairly dumb classes doing the underlying database
and file system changes.

# Reviewers

reviewer @tomblench 
reviewer @emlaver