### PR TITLE
Support bulk get endpoint backend implementation

### DIFF
--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/mazha/BulkGetResponse.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/mazha/BulkGetResponse.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2015 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.mazha;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * Created by tomblench on 19/11/15.
+ */
+
+/*
+ * For deserialising the response from the _bulk_get endpoint
+ */
+public class BulkGetResponse {
+
+    @JsonProperty
+    public List<Result> results;
+
+    static public class Result {
+
+        @JsonProperty
+        public String id;
+
+        @JsonProperty
+        public List<Doc> docs;
+    }
+
+    static public class Doc {
+
+        @JsonProperty
+        public DocumentRevs ok;
+    }
+}

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/mazha/CouchClient.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/mazha/CouchClient.java
@@ -419,7 +419,20 @@ public class CouchClient  {
         });
     }
 
-    public Iterable<DocumentRevsList> bulkReadDocsWithOpenRevisions(List<BulkGetRequest> request, boolean pullAttachmentsInline) {
+    /**
+     * <p>
+     * Return an iterator representing the result of calling the _bulk_docs endpoint.
+     * </p>
+     * <p>
+     * Each time the iterator is advanced, a DocumentRevsList is returned, which represents the
+     * leaf nodes and their ancestries for a given document id.
+     * </p>
+     * @param request A request for 1 or more (id,rev) pairs.
+     * @param pullAttachmentsInline If true, retrieve attachments as inline base64
+     * @return An iterator representing the result of calling the _bulk_docs endpoint.
+     */
+    public Iterable<DocumentRevsList> bulkReadDocsWithOpenRevisions(List<BulkGetRequest> request,
+                                                                    boolean pullAttachmentsInline) {
         Map<String, Object> options = new HashMap<String, Object>();
         options.put("revs", true);
 
@@ -435,13 +448,13 @@ public class CouchClient  {
         jsonRequest.put("docs", request);
         // build request
         connection.setRequestBody(jsonHelper.toJson(jsonRequest));
-        // deserialise reponse
+        // deserialise response
         BulkGetResponse response = executeToJsonObjectWithRetry(connection, BulkGetResponse.class);
 
         Map<String,ArrayList<DocumentRevs>> revsMap = new HashMap<String,ArrayList<DocumentRevs>>();
 
         // merge results back in, so there is one list of DocumentRevs per id
-        for (BulkGetResponse.Result result: response.results) {
+        for (BulkGetResponse.Result result : response.results) {
             for (BulkGetResponse.Doc doc : result.docs) {
                 if (doc.ok != null) {
                     String id = doc.ok.getId();

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/mazha/CouchClient.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/mazha/CouchClient.java
@@ -419,11 +419,47 @@ public class CouchClient  {
         });
     }
 
-    public Iterable<DocumentRevsList> bulkReadDocsWithOpenRevisions(List<BulkGetRequest> request) {
-        // not implemented yet
-        // the idea here is to provide an iterator which will pull more data from the
-        // response stream each time next() is called
-        return null;
+    public Iterable<DocumentRevsList> bulkReadDocsWithOpenRevisions(List<BulkGetRequest> request, boolean pullAttachmentsInline) {
+        Map<String, Object> options = new HashMap<String, Object>();
+        options.put("revs", true);
+
+        if (pullAttachmentsInline) {
+            options.put("attachments", true);
+        } else {
+            options.put("attachments", false);
+            options.put("att_encoding_info", true);
+        }
+        URI bulkGet = this.uriHelper.documentUri("_bulk_get", options);
+        HttpConnection connection = Http.POST(bulkGet, "application/json");
+        Map<String, List<BulkGetRequest>> jsonRequest = new HashMap<String, List<BulkGetRequest>>();
+        jsonRequest.put("docs", request);
+        // build request
+        connection.setRequestBody(jsonHelper.toJson(jsonRequest));
+        // deserialise reponse
+        BulkGetResponse response = executeToJsonObjectWithRetry(connection, BulkGetResponse.class);
+
+        Map<String,ArrayList<DocumentRevs>> revsMap = new HashMap<String,ArrayList<DocumentRevs>>();
+
+        // merge results back in, so there is one list of DocumentRevs per id
+        for (BulkGetResponse.Result result: response.results) {
+            for (BulkGetResponse.Doc doc : result.docs) {
+                if (doc.ok != null) {
+                    String id = doc.ok.getId();
+                    if (!revsMap.containsKey(id)) {
+                        revsMap.put(id, new ArrayList<DocumentRevs>());
+                    }
+                    revsMap.get(id).add(doc.ok);
+                }
+            }
+        }
+
+        List<DocumentRevsList> allRevs = new ArrayList<DocumentRevsList>();
+
+        // flatten out revsMap hash so that there is one entry in our return array for each id
+        for (ArrayList<DocumentRevs> value : revsMap.values()) {
+            allRevs.add(new DocumentRevsList(value));
+        }
+        return allRevs;
     }
 
     public Map<String, Object> getDocument(String id) {
@@ -492,7 +528,8 @@ public class CouchClient  {
      *
      */
     public DocumentRevs getDocRevisions(String id, String rev) {
-        return getDocRevisions(id, rev, new TypeReference<DocumentRevs>() {});
+        return getDocRevisions(id, rev, new TypeReference<DocumentRevs>() {
+        });
     }
 
     public <T> T getDocRevisions(String id, String rev, TypeReference<T> type) {
@@ -670,6 +707,22 @@ public class CouchClient  {
         HttpConnection connection = Http.PUT(uri, contentType);
         connection.setRequestBody(mpw.makeInputStreamGenerator(), mpw.getContentLength());
         return executeToJsonObjectWithRetry(connection, Response.class);
+    }
+
+    public boolean isBulkSupported() {
+        URI bulkGet = this.uriHelper.documentUri("_bulk_get");
+        HttpConnection connection = Http.GET(bulkGet);
+        ExecuteResult result = this.execute(connection);
+        switch (result.responseCode) {
+            case 404:
+                // not found: _bulk_get not supported
+                return false;
+            case 405:
+                // method not allowed: this endpoint exists, we called with the wrong method
+                return true;
+            default:
+                throw(result.exception);
+        }
     }
 
     public static class MissingRevisions {

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/BasicPullStrategy.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/BasicPullStrategy.java
@@ -67,8 +67,8 @@ class BasicPullStrategy implements ReplicationStrategy {
     
     private final EventBus eventBus = new EventBus();
 
-    // is _bulk_get endpoint supported?
-    private boolean bulkSupported = false;
+    // Is _bulk_get endpoint supported?
+    private boolean useBulkGet = false;
 
     /**
      * Flag is set when the replication process is complete. The thread
@@ -129,7 +129,7 @@ class BasicPullStrategy implements ReplicationStrategy {
         ErrorInfo errorInfo = null;
 
         try {
-            this.bulkSupported = sourceDb.isBulkSupported();
+            this.useBulkGet = sourceDb.isBulkSupported();
             replicate();
 
         } catch (ExecutionException ex) {
@@ -375,7 +375,7 @@ class BasicPullStrategy implements ReplicationStrategy {
     }
 
     public Iterable<DocumentRevsList> createTask(List<String> ids,
-                                                        Map<String, Collection<String>> revisions) {
+                                                 Map<String, Collection<String>> revisions) {
 
         List<BulkGetRequest> requests = new ArrayList<BulkGetRequest>();
 
@@ -403,7 +403,7 @@ class BasicPullStrategy implements ReplicationStrategy {
                     new ArrayList<String>(possibleAncestors)));
         }
 
-        if (bulkSupported) {
+        if (useBulkGet) {
             return new GetRevisionTaskBulk(this.sourceDb, requests, config.pullAttachmentsInline);
         } else {
             return new GetRevisionTaskThreaded(this.sourceDb, requests, config.pullAttachmentsInline);

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/BasicPullStrategy.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/BasicPullStrategy.java
@@ -67,6 +67,9 @@ class BasicPullStrategy implements ReplicationStrategy {
     
     private final EventBus eventBus = new EventBus();
 
+    // is _bulk_get endpoint supported?
+    private boolean bulkSupported = false;
+
     /**
      * Flag is set when the replication process is complete. The thread
      * may live on because the listener's callback is executed on the thread.
@@ -126,7 +129,7 @@ class BasicPullStrategy implements ReplicationStrategy {
         ErrorInfo errorInfo = null;
 
         try {
-
+            this.bulkSupported = sourceDb.isBulkSupported();
             replicate();
 
         } catch (ExecutionException ex) {
@@ -373,8 +376,6 @@ class BasicPullStrategy implements ReplicationStrategy {
 
     public Iterable<DocumentRevsList> createTask(List<String> ids,
                                                         Map<String, Collection<String>> revisions) {
-
-        boolean bulkSupported = false;
 
         List<BulkGetRequest> requests = new ArrayList<BulkGetRequest>();
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/BulkGetRequest.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/BulkGetRequest.java
@@ -39,6 +39,36 @@ public class BulkGetRequest {
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        BulkGetRequest that = (BulkGetRequest) o;
+
+        if (id != null ? !id.equals(that.id) : that.id != null) {
+            return false;
+        }
+        if (revs != null ? !revs.equals(that.revs) : that.revs != null) {
+            return false;
+        }
+        return !(atts_since != null ? !atts_since.equals(that.atts_since) : that.atts_since !=
+                null);
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = id != null ? id.hashCode() : 0;
+        result = 31 * result + (revs != null ? revs.hashCode() : 0);
+        result = 31 * result + (atts_since != null ? atts_since.hashCode() : 0);
+        return result;
+    }
+
+    @Override
     public String toString() {
         return "BulkGetRequest{" +
                 "id='" + id + '\'' +

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/BulkGetRequest.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/BulkGetRequest.java
@@ -57,7 +57,6 @@ public class BulkGetRequest {
         }
         return !(atts_since != null ? !atts_since.equals(that.atts_since) : that.atts_since !=
                 null);
-
     }
 
     @Override

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/CouchClientWrapper.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/CouchClientWrapper.java
@@ -133,11 +133,13 @@ public class CouchClientWrapper implements CouchDB {
                 com.cloudant.mazha.BulkGetRequest splitRequest = new com.cloudant.mazha.BulkGetRequest();
                 splitRequest.id = request.id;
                 splitRequest.rev = rev;
-                splitRequest.atts_since = request.atts_since;
+                if (pullAttachmentsInline) {
+                    splitRequest.atts_since = request.atts_since;
+                }
                 splitRequests.add(splitRequest);
             }
         }
-        return couchClient.bulkReadDocsWithOpenRevisions(splitRequests);
+        return couchClient.bulkReadDocsWithOpenRevisions(splitRequests, pullAttachmentsInline);
     }
 
     /**
@@ -214,7 +216,8 @@ public class CouchClientWrapper implements CouchDB {
 
     @Override
     public void bulkCreateDocs(List<BasicDocumentRevision> revisions) {
-        logger.entering("com.cloudant.sync.replication.CouchClientWrapper","bulkCreateDocs",revisions);
+        logger.entering("com.cloudant.sync.replication.CouchClientWrapper", "bulkCreateDocs",
+                revisions);
 
         List<Map> allObjs = new ArrayList<Map>();
         for (BasicDocumentRevision obj : revisions) {
@@ -265,6 +268,11 @@ public class CouchClientWrapper implements CouchDB {
         Attachment.Encoding encoding = Attachment.getEncodingFromString(encodingStr);
         UnsavedStreamAttachment usa = new UnsavedStreamAttachment(is, attachmentName, contentType, encoding);
         return usa;
+    }
+
+    @Override
+    public boolean isBulkSupported() {
+        return this.couchClient.isBulkSupported();
     }
 
 }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/CouchDB.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/CouchDB.java
@@ -59,5 +59,6 @@ interface CouchDB {
 
     Iterable<DocumentRevsList> bulkGetRevisions(List<BulkGetRequest> requests,
                                                    boolean pullAttachmentsInline);
+    boolean isBulkSupported();
 
 }


### PR DESCRIPTION
FB: 57109

_What_
Add support for fetching documents efficiently during sync via `_bulk_get` which is available in DBNext and Couch 2.0

_How_
- Implement `bulkReadDocsWithOpenRevisions` to call `_bulk_get` and deserialise results
- Implement `isBulkSupported` to automatically switch between `GetRevisionTaskBulk` and `GetRevisionTaskThreaded` implementations
- Fix up some mock tests which only worked for the non-bulk implementation

_Testing_
All existing tests pass

reviewer: @alfinkel
reviewer: @brynh 
