### PR TITLE
Use Maven Central to publish Sync-Android packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ line.
 
 ## Using in your project
 
-Using the library in your project should be as simple as adding it as
-a dependency via [maven][maven] or [gradle][gradle].
+The library is published via Maven Central and using it in your project should
+be as simple as adding it as a dependency via [maven][maven] or [gradle][gradle].
 
 [maven]: http://maven.apache.org/
 [gradle]: http://www.gradle.org/
@@ -52,21 +52,17 @@ Add the maven repo and a compile time dependency on the datastore jar:
 ```groovy
 repositories {
     mavenLocal()
-    maven { url "http://cloudant.github.io/cloudant-sync-eap/repository/" }
     mavenCentral()
 }
 
 dependencies {
-    // Other dependencies
-    compile group: 'com.cloudant', name: 'cloudant-sync-datastore-core', version:'0.14.0'
     // include this if you're targeting Android. If you also want datastore encryption
-    // you will need to include cloudant-sync-datastore-android-encryption as well (see below).
-    compile group: 'com.cloudant', name: 'cloudant-sync-datastore-android', version:'0.14.0'
-    // include this if you're targeting Android and want datastore encryption. You will also need
-    // cloudant-sync-datastore-android (see above).
-    compile group: 'com.cloudant', name: 'cloudant-sync-datastore-android-encryption', version:'0.14.0'
+    // you will need to include cloudant-sync-datastore-android-encryption instead (see below).
+    compile group: 'com.cloudant', name: 'cloudant-sync-datastore-android', version:'latest.release'
+    // include this if you're targeting Android and want datastore encryption.
+    compile group: 'com.cloudant', name: 'cloudant-sync-datastore-android-encryption', version:'latest.release'
     // include this if you're targeting Java SE
-    compile group: 'com.cloudant', name: 'cloudant-sync-datastore-javase', version:'0.14.0'
+    compile group: 'com.cloudant', name: 'cloudant-sync-datastore-javase', version:'latest.release'
 }
 ```
 
@@ -84,42 +80,30 @@ It's a similar story in maven, add the repo and the dependency:
 
   <repositories>
     ...
-    <repository>
-      <id>cloudant-sync-eap</id>
-      <name>Cloudant Sync EAP</name>
-      <url>http://cloudant.github.io/cloudant-sync-eap/repository/</url>
-    </repository>
   </repositories>
 
   <dependencies>
     ...
-    <dependency>
-      <groupId>com.cloudant</groupId>
-      <artifactId>cloudant-sync-datastore-core</artifactId>
-      <version>0.14.0</version>
-      <scope>compile</scope>
-    </dependency>
-    <!-- include this if you're targeting Android. If you also want datastore encryption
-         you will need to include cloudant-sync-datastore-android-encryption as well (see below). -->
+    <!-- include this if you're targeting Android. If you want datastore encryption
+         you will need to include cloudant-sync-datastore-android-encryption instead (see below). -->
     <dependency>
       <groupId>com.cloudant</groupId>
       <artifactId>cloudant-sync-datastore-android</artifactId>
-      <version>0.14.0</version>
+      <version>latest.release</version>
       <scope>compile</scope>
     </dependency>
-    <!-- include this if you're targeting Android and want datastore encryption. You will also need
-         cloudant-sync-datastore-android (see above). -->
+    <!-- include this if you're targeting Android and want datastore encryption. -->
     <dependency>
       <groupId>com.cloudant</groupId>
       <artifactId>cloudant-sync-datastore-android-encryption</artifactId>
-      <version>0.14.0</version>
+      <version>latest.release</version>
       <scope>compile</scope>
     </dependency>
     <!-- include this if you're targeting Java SE -->
     <dependency>
       <groupId>com.cloudant</groupId>
       <artifactId>cloudant-sync-datastore-javase</artifactId>
-      <version>0.14.0</version>
+      <version>latest.release</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/build.gradle
+++ b/build.gradle
@@ -198,9 +198,7 @@ def getProjectDocSources(project) {
     // Get the projects from the dependencies
     def dependentProjects = projectDependencies*.dependencyProject
     // Recurse
-    if (dependentProjects.size > 0) {
     dependentProjects.each { dependentProjects += getProjectDocSources(it) }
-    }
     // Finally add the original project
     dependentProjects.add(project)
     // Return without duplicates

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,8 @@
 // ************ //
 
 apply plugin: 'java'
+apply plugin: 'maven'
+apply plugin: 'signing'
 
 //
 // General settings
@@ -14,6 +16,9 @@ allprojects {
     description = """cloudant-sync"""
 }
 
+
+//if the version says "snapshot" anywhere assume it is not a release
+ext.isReleaseVersion = !version.toUpperCase(Locale.ENGLISH).contains("SNAPSHOT")
 dependencies {
     compile project(':cloudant-sync-datastore-core')
     compile project(':cloudant-sync-datastore-javase')
@@ -52,18 +57,6 @@ subprojects {
     repositories {
         mavenLocal()
         mavenCentral()
-        maven { url "http://cloudant.github.io/cloudant-sync-eap/repository/" }
-    }
-
-    // local.gradle defines ghpages, so we want to publish somewhere specific for release
-    if (project.hasProperty('ghpages')) {
-        publishing {
-            repositories {
-                maven {
-                    url "$ghpages/repository"
-                }
-            }
-        }
     }
 
     //
@@ -74,43 +67,142 @@ subprojects {
         configurations.testCompile.each { File file -> println file.name }
     }
 
-}
+    //
+    // *** DOCS AND PUBLISHING ***
+    //
 
-//
-// *** DOCS AND PUBLISHING ***
-//
+    // see http://issues.gradle.org/browse/GRADLE-1876
+    // run javadoc over union of all projects
+    gradle.projectsEvaluated {
+        javadoc {
 
-// see http://issues.gradle.org/browse/GRADLE-1876
-// run javadoc over union of all projects
-task docs(type: Javadoc) {
+            options.encoding = "UTF-8"
+            options.docEncoding = "UTF-8"
+            options.charSet = "UTF-8"
 
-    options.encoding = "UTF-8"
-    options.docEncoding = "UTF-8"
-    options.charSet = "UTF-8"
+            options.showFromPublic()
+            title = "sync-android ${version} API"
 
-    options.showFromPublic()
-    title = "sync-android ${version} API"
-    source subprojects.collect {project -> project.sourceSets.main.allJava.matching{exclude "**/*sql*/**", "**/common/**", "**/android/**", "**/mazha/**" }}
-    classpath = files(subprojects.collect {project -> project.sourceSets.main.compileClasspath})
-    destinationDir = new File(projectDir, 'build/docs')
-}
-
-// tasks below require the ghpages variable to be set
-if (project.hasProperty('ghpages')) {
-    task publishDocsVersioned(type: Sync, dependsOn: docs) {
-        from "build/docs"
-        into "$ghpages/docs/${rootProject.version}"
+            // For the subprojects we include all the javadoc from dependencies on other subprojects
+            // this produces a more standalone javadoc jar for each published artifact.
+            source getProjectDocSources(project).collect() { dsp ->
+                        dsp.sourceSets.main.allJava
+            }
+        }
     }
 
-    task publishDocsLatest(type: Sync, dependsOn: docs) {
-        from "build/docs"
-        into "$ghpages/docs/latest"
+    task javadocJar(type: Jar, dependsOn: javadoc) {
+        classifier = 'javadoc'
+        from new File(buildDir, 'docs')
     }
 
-    // Publish docs and maven artifacts to GH repo
-    task publishAll(dependsOn: [publishDocsVersioned, publishDocsLatest, subprojects.publish])
+    task sourcesJar(type: Jar, dependsOn: classes) {
+        classifier = 'sources'
+        sourceSets.all {
+            into(name + "/java", { from allJava })
+            into(name + "/resources", { from resources })
+        }
+    }
+
+    artifacts {
+        archives sourcesJar, javadocJar
+    }
+
+    uploadArchives {
+        ext.ossrhUsername = System.properties.ossrhUsername
+        ext.ossrhPassword = System.properties.ossrhPassword
+
+        doFirst {
+            // If the OSSRH credentials are not available, then fail the build
+            if (ossrhUsername == null || ossrhPassword == null) {
+                throw new GradleException('OSSRH credentials properties (ossrhUsername & ' +
+                        'ossrhPassword) are required to upload archives.')
+            }
+        }
+
+        repositories {
+            mavenDeployer {
+                //when publishing sign the pom
+                beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+
+                repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
+                    authentication(userName: ossrhUsername, password: ossrhPassword)
+                }
+
+                snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
+                    authentication(userName: ossrhUsername, password: ossrhPassword)
+                }
+
+                //augment the pom with additional information
+                pom.project {
+                    packaging 'jar'
+                    inceptionYear '2013'
+                    url 'https://cloudant.com'
+                    licenses {
+                        license {
+                            name 'The Apache Software License, Version 2.0'
+                            url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                            distribution 'repo'
+                        }
+                    }
+                    scm {
+                        connection 'scm:git:git://github.com/cloudant/sync-android.git'
+                        developerConnection 'scm:git:git@github.com/cloudant/sync-android.git'
+                        url 'https://java-cloudant@github.com/cloudant/sync-android.git'
+                    }
+                    properties {
+                        'project.build.sourceEncoding' 'UTF-8'
+                    }
+                    developers {
+                        developer {
+                            name 'IBM Cloudant'
+                            email 'support@cloudant.com'
+                            url 'https://cloudant.com'
+                            organization 'IBM'
+                            organizationUrl 'http://www.ibm.com'
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 task wrapper(type: Wrapper) {
     gradleVersion = '2.2.1'
+}
+
+signing {
+    // Only apply signing when it is a release and is being published
+    required {
+        isReleaseVersion && gradle.taskGraph.hasTask("uploadArchives")
+    }
+
+    // Load signing parameters from system properties
+    ['signing.keyId', 'signing.password', 'signing.secretKeyRingFile']
+            .each { propName ->
+        // Set a property with the given name if the system property is set
+        if (System.properties.(propName.toString()) != null) {
+            ext.(propName.toString()) = System.properties.(propName.toString())
+        }
+    }
+
+    // When signing, sign the archives
+    sign configurations.archives
+}
+
+// Function to get project doc sources (i.e. the project and all its dependent projects)
+def getProjectDocSources(project) {
+    // Get the compile time dependencies
+    def projectDependencies = project.configurations.compile.getAllDependencies().withType(ProjectDependency)
+    // Get the projects from the dependencies
+    def dependentProjects = projectDependencies*.dependencyProject
+    // Recurse
+    if (dependentProjects.size > 0) {
+    dependentProjects.each { dependentProjects += getProjectDocSources(it) }
+    }
+    // Finally add the original project
+    dependentProjects.add(project)
+    // Return without duplicates
+    return dependentProjects.unique()
 }

--- a/cloudant-sync-datastore-android-encryption/build.gradle
+++ b/cloudant-sync-datastore-android-encryption/build.gradle
@@ -29,40 +29,16 @@ test {
      exclude '**/**'
 }
 
-//
-// Publishing
-//
-
-publishing {
-    publications {
-        mavenJava(MavenPublication) {
-
-            from components.java
-
-            pom.withXml {
-                Node rootNode = asNode()
-
-                rootNode.appendNode('name', 'Cloudant Sync Datastore Android: Android Encryption components')
-                rootNode.appendNode('description', 'A JSON document datastore that syncs')
-                rootNode.appendNode('url', 'https://cloudant.com/')
-                rootNode.appendNode('packaging', 'jar')
-
-                Node scmNode = rootNode.appendNode('scm')
-                scmNode.appendNode('url', 'https://github.com/cloudant/sync-android')
-                scmNode.appendNode('connection', 'https://github.com/cloudant/sync-android.git')
-
-                Node licencesNode = rootNode.appendNode('licenses')
-                Node licenceNode = licencesNode.appendNode('license')
-                licenceNode.appendNode('name', 'The Apache Software License, Version 2.0')
-                licenceNode.appendNode('url', 'http://www.apache.org/licenses/LICENSE-2.0.txt')
-                licenceNode.appendNode('distribution', 'repo')
-            }
-        }
-    }
-
+uploadArchives {
     repositories {
-        maven {
-            url "$buildDir/repo"
+        mavenDeployer {
+
+            //augment the pom with additional information
+            pom.project {
+                name "cloudant-sync-datastore-android-encryption"
+                description 'Cloudant Sync Datastore for Android: Local Datastore Encryption'
+                inceptionYear '2015'
+            }
         }
     }
 }

--- a/cloudant-sync-datastore-android/build.gradle
+++ b/cloudant-sync-datastore-android/build.gradle
@@ -24,38 +24,19 @@ test {
 // Publishing
 //
 
-publishing {
-    publications {
-        mavenJava(MavenPublication) {
 
-            from components.java
+uploadArchives {
+    repositories {
+        mavenDeployer {
 
-            pom.withXml {
-                Node rootNode = asNode()
-
-                rootNode.appendNode('name', 'Cloudant Sync Datastore Android: Android components')
-                rootNode.appendNode('description', 'A JSON document datastore that syncs')
-                rootNode.appendNode('url', 'https://cloudant.com/')
-                rootNode.appendNode('packaging', 'jar')
-
-                Node scmNode = rootNode.appendNode('scm')
-                scmNode.appendNode('url', 'https://github.com/cloudant/sync-android')
-                scmNode.appendNode('connection', 'https://github.com/cloudant/sync-android.git')
-
-                Node licencesNode = rootNode.appendNode('licenses')
-                Node licenceNode = licencesNode.appendNode('license')
-                licenceNode.appendNode('name', 'The Apache Software License, Version 2.0')
-                licenceNode.appendNode('url', 'http://www.apache.org/licenses/LICENSE-2.0.txt')
-                licenceNode.appendNode('distribution', 'repo')
+            //augment the pom with additional information
+            pom.project {
+                name "cloudant-sync-datastore-android"
+                description 'Cloudant Sync Datastore for Android'
             }
         }
     }
-
-    repositories {
-        maven {
-            url "$buildDir/repo"
-        }
-    }
 }
+
 
 

--- a/cloudant-sync-datastore-core/build.gradle
+++ b/cloudant-sync-datastore-core/build.gradle
@@ -92,49 +92,22 @@ task unreliableNetworkTest(type: Test, dependsOn: testClasses) {
     }
 }
 
-
-//
-// Publishing
-//
-
-publishing {
-    publications {
-        mavenJava(MavenPublication) {
-
-            from components.java
-
-            pom.withXml {
-                Node rootNode = asNode()
-
-                rootNode.appendNode('name', 'Cloudant Sync Datastore Android: core components')
-                rootNode.appendNode('description', 'A JSON document datastore that syncs')
-                rootNode.appendNode('url', 'https://cloudant.com/')
-                rootNode.appendNode('packaging', 'jar')
-
-                Node scmNode = rootNode.appendNode('scm')
-                scmNode.appendNode('url', 'https://github.com/cloudant/sync-android')
-                scmNode.appendNode('connection', 'https://github.com/cloudant/sync-android.git')
-
-                Node licencesNode = rootNode.appendNode('licenses')
-                Node licenceNode = licencesNode.appendNode('license')
-                licenceNode.appendNode('name', 'The Apache Software License, Version 2.0')
-                licenceNode.appendNode('url', 'http://www.apache.org/licenses/LICENSE-2.0.txt')
-                licenceNode.appendNode('distribution', 'repo')
-            }
-        }
-    }
-
-    repositories {
-        maven {
-            url "$buildDir/repo"
-        }
-    }
-}
-
 //for Ant filter for "processResources" task
 import org.apache.tools.ant.filters.ReplaceTokens
 processResources {
     filter ReplaceTokens, tokens: [
         "version": project.version
     ]
+}
+
+uploadArchives {
+    repositories {
+        mavenDeployer {
+            //augment the pom with additional information
+            pom.project {
+                name "cloudant-sync-datastore-core"
+                description 'Cloudant Sync Datastore Core Package'
+            }
+        }
+    }
 }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/mazha/GetOpenRevisionsResponse.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/mazha/GetOpenRevisionsResponse.java
@@ -25,9 +25,12 @@ import java.util.List;
 import java.util.Map;
 
 /**
+ * <p>
  * Convenience class to access the response of GET document request with open revision options. An example response
  * is following:
- * <p/>
+ * </p>
+ * <pre>
+ * {@code 
  * [{
  *     "ok" : {
  *         "_id" : "c3fe5bfdee767fa3d51717bb8b2a9349",
@@ -62,7 +65,8 @@ import java.util.Map;
  * {
  *     "missing" : "2-a63239adb4844666a48e070b64c1f965bad"
  * }]
- * <p/>
+ * }
+ * </pre>
  *
  * The response firstly is convert to a <code>List</code> of <code>Map</code>, which could be used to construct
  * and <code>GetOpenRevisionsResponse</code> object.

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/sqlite/SQLDatabase.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/sqlite/SQLDatabase.java
@@ -102,13 +102,11 @@ public abstract class SQLDatabase {
      * For SQLite database, this is to call:
      *
      *         this.execSQL("VACUUM");
-     *
-     * @throws java.sql.SQLException
      */
     public abstract void compactDatabase();
 
     /**
-     * Gets the database version, and SQLDatabase's version is defined as:</p>
+     * <p>Gets the database version, and SQLDatabase's version is defined as:</p>
      *
      * <pre>    PRAGMA user_version;</pre>
      *

--- a/cloudant-sync-datastore-javase/build.gradle
+++ b/cloudant-sync-datastore-javase/build.gradle
@@ -17,42 +17,15 @@ tasks.withType(Test) {
     systemProperty "sqlite4java.library.path", "../native"
 }
 
-//
-// Publishing
-//
+uploadArchives {
+    repositories {
+        mavenDeployer {
 
-publishing {
-    publications {
-        mavenJava(MavenPublication) {
-            
-            from components.java
-            
-            pom.withXml {
-                Node rootNode = asNode()
-                
-                rootNode.appendNode('name', 'Cloudant Sync Datastore Android: Java SE components')
-                rootNode.appendNode('description', 'A JSON document datastore that syncs')
-                rootNode.appendNode('url', 'https://cloudant.com/')
-                rootNode.appendNode('packaging', 'jar')
-                
-                Node scmNode = rootNode.appendNode('scm')
-                scmNode.appendNode('url', 'https://github.com/cloudant/sync-android')
-                scmNode.appendNode('connection', 'https://github.com/cloudant/sync-android.git')
-                
-                Node licencesNode = rootNode.appendNode('licenses')
-                Node licenceNode = licencesNode.appendNode('license')
-                licenceNode.appendNode('name', 'The Apache Software License, Version 2.0')
-                licenceNode.appendNode('url', 'http://www.apache.org/licenses/LICENSE-2.0.txt')
-                licenceNode.appendNode('distribution', 'repo')
+            //augment the pom with additional information
+            pom.project {
+                name "cloudant-sync-datastore-javase"
+                description 'Cloudant Sync Datastore for Java SE'
             }
         }
     }
-
-    repositories {
-        maven {
-            url "$buildDir/repo"
-        }
-    }
 }
-
-

--- a/cloudant-sync-datastore-javase/src/main/java/com/cloudant/sync/sqlite/sqlite4java/SQLiteWrapper.java
+++ b/cloudant-sync-datastore-javase/src/main/java/com/cloudant/sync/sqlite/sqlite4java/SQLiteWrapper.java
@@ -30,13 +30,7 @@ import java.util.logging.Logger;
 
 
 /**
- * Very simple implementation of SQLDatabase backed by sqlite4java. This is mainly used for testing.
- *
- * Since sqlite4java's SQLiteConnection does not really support multi-threading, as a matter of face, the
- * SQLiteConnection can only be used by the thread create/open it, ThreadLocal<SQLiteConnection> is created, so that
- * each thread (if there is any) is using their own connection.
- *
- * All the connection are closed when displose() is called.
+ * Implementation of SQLDatabase backed by sqlite4java.
  */
 public class SQLiteWrapper extends SQLDatabase {
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Jan 07 14:07:38 GMT 2015
+#Fri Dec 18 10:33:15 GMT 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip


### PR DESCRIPTION
## What

Move to using Maven Central to publish sync-android packages,

## How
- Remove GH Pages publishing gradle code
- Add maven central publishing code heavily inspired from [java-cloudant build.gradle](https://github.com/cloudant/java-cloudant/blob/82491d83f1dada6d7b0d2e542c182118a8af8352/build.gradle)

## Testing
Manually run upload task and snapshots will appear in https://oss.sonatype.org/content/repositories/snapshots/com/cloudant/ 

## Reviewers
reviewer @ricellis 
reviewer @tomblench 
reviewer @rhyshort
