### PR TITLE
Update build.gradle to use Maven Central

### DIFF
--- a/sample/todo-sync/build.gradle
+++ b/sample/todo-sync/build.gradle
@@ -11,15 +11,11 @@ apply plugin: 'idea'
 
 repositories {
     mavenLocal()
-
-    maven { url "http://cloudant.github.io/cloudant-sync-eap/repository" }
-
     mavenCentral()
 }
 
 dependencies {
     compile(group: 'com.cloudant', name: 'cloudant-sync-datastore-android', version:'latest.release')
-    compile(group: 'com.cloudant', name: 'cloudant-sync-datastore-core', version:'latest.release')
 }
 
 android {


### PR DESCRIPTION
Update build.gradle to use Maven Central to pull sync-android jars.

See: https://groups.google.com/forum/#!topic/cloudant-sync/pNgi2qtL5MQ