### PR TITLE
Create directory for datastore management

### DIFF
--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/DatastoreManager.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/DatastoreManager.java
@@ -98,6 +98,11 @@ public class DatastoreManager {
      */
     public DatastoreManager(File directoryPath) {
         logger.fine("Datastore path: " + directoryPath);
+
+        if(!directoryPath.exists()){
+            directoryPath.mkdir();
+        }
+
         if(!directoryPath.isDirectory() ) {
             throw new IllegalArgumentException("Input path is not a valid directory");
         } else if(!directoryPath.canWrite()) {

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/DatastoreManagerTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/DatastoreManagerTest.java
@@ -46,10 +46,31 @@ public class DatastoreManagerTest {
     public void nonWritableDatastoreManagerPathThrows() {
         File f = new File(TEST_PATH, "c_root_test");
         try {
+            f.mkdir();
             f.setReadOnly();
             manager = new DatastoreManager(f.getAbsolutePath());
         } finally {
             f.setWritable(true);
+            f.delete();
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void createFailsIfMissingIntermediates(){
+        File f = new File(TEST_PATH, "missing_inter/missing_test");
+        try {
+            manager = new DatastoreManager(f.getAbsolutePath());
+        } finally {
+            f.delete();
+        }
+    }
+
+    @Test
+    public void createDirectoryIfMissing(){
+        File f = new File(TEST_PATH, "missing_test");
+        try {
+            manager = new DatastoreManager(f.getAbsolutePath());
+        } finally {
             f.delete();
         }
     }


### PR DESCRIPTION
In order to make sync-android behave more like CDTDatastore,
create the directory to manage if it doesn't exist. This behaviour
should be the same as `mkdir`

reviewer @ricellis 