### PR TITLE
2nd attempt at 'less database traffic' PR

### DIFF
--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/BasicDatastore.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/BasicDatastore.java
@@ -28,6 +28,7 @@ import com.cloudant.sync.datastore.migrations.MigrateDatabase6To100;
 import com.cloudant.sync.notifications.DatabaseClosed;
 import com.cloudant.sync.notifications.DocumentCreated;
 import com.cloudant.sync.notifications.DocumentDeleted;
+import com.cloudant.sync.notifications.DocumentModified;
 import com.cloudant.sync.notifications.DocumentUpdated;
 import com.cloudant.sync.sqlite.ContentValues;
 import com.cloudant.sync.sqlite.Cursor;
@@ -58,6 +59,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -72,16 +74,43 @@ class BasicDatastore implements Datastore, DatastoreExtended {
 
     private static final String FULL_DOCUMENT_COLS = "docs.docid, docs.doc_id, revid, sequence, json, current, deleted, parent";
 
+    private static final String GET_DOC_NUMERIC_ID =
+            "SELECT doc_id from docs WHERE docid=?";
+
+    // get all document columns for current ("winning") revision of a given doc id
     private static final String GET_DOCUMENT_CURRENT_REVISION =
             "SELECT " + FULL_DOCUMENT_COLS + " FROM revs, docs WHERE docs.docid=? AND revs.doc_id=docs.doc_id " +
                     "AND current=1 ORDER BY revid DESC LIMIT 1";
 
+    // get sequence number for current ("winning") revision of a given doc id
+    private static final String GET_SEQUENCE_CURRENT_REVISION =
+            "SELECT revs.sequence FROM revs, docs WHERE docs.docid=? AND revs.doc_id=docs.doc_id " +
+                    "AND current=1 ORDER BY revid DESC LIMIT 1";
+
+    // get all document columns for a given revision and doc id
     private static final String GET_DOCUMENT_GIVEN_REVISION =
             "SELECT " + FULL_DOCUMENT_COLS + " FROM revs, docs WHERE docs.docid=? AND revs.doc_id=docs.doc_id " +
                     "AND revid=? LIMIT 1";
 
+    // get sequence number for a given revision and doc id
+    private static final String GET_SEQUENCE_GIVEN_REVISION =
+            "SELECT revs.sequence FROM revs, docs WHERE docs.docid=? AND revs.doc_id=docs.doc_id " +
+                    "AND revid=? LIMIT 1";
+
     public static final String SQL_CHANGE_IDS_SINCE_LIMIT = "SELECT doc_id, max(sequence) FROM revs " +
             "WHERE sequence > ? AND sequence <= ? GROUP BY doc_id ";
+
+    // get all non-deleted leaf rev ids for a given doc id
+    public static final String GET_NON_DELETED_LEAFS = "SELECT revs.revid FROM revs " +
+            "WHERE revs.doc_id = ? " +
+            "AND revs.deleted = 0 AND revs.sequence NOT IN " +
+            "(SELECT DISTINCT parent FROM revs WHERE parent NOT NULL) ";
+
+    // get all leaf rev ids for a given doc id
+    public static final String GET_ALL_LEAFS = "SELECT revs.revid FROM revs " +
+            "WHERE revs.doc_id = ? " +
+            "AND revs.sequence NOT IN " +
+            "(SELECT DISTINCT parent FROM revs WHERE parent NOT NULL) ";
 
     // Limit of parameters (placeholders) one query can have.
     // SQLite has limit on the number of placeholders on a single query, default 999.
@@ -276,6 +305,47 @@ class BasicDatastore implements Datastore, DatastoreExtended {
     public BasicDocumentRevision getDocument(String id) throws DocumentNotFoundException {
         Preconditions.checkState(this.isOpen(), "Database is closed");
         return getDocument(id, null);
+    }
+
+    private long getSequenceInQueue(SQLDatabase db, String id, String rev)
+            throws DatastoreException {
+        Cursor cursor = null;
+        try {
+            String[] args = (rev == null) ? new String[]{id} : new String[]{id, rev};
+            String sql = (rev == null) ? GET_SEQUENCE_CURRENT_REVISION : GET_SEQUENCE_GIVEN_REVISION;
+            cursor = db.rawQuery(sql, args);
+            if (cursor.moveToFirst()) {
+                long sequence = cursor.getLong(0);
+                return sequence;
+            } else {
+                return -1;
+            }
+        } catch (SQLException e) {
+            logger.log(Level.SEVERE,"Error sequence with id: " + id + "and rev " + rev,e);
+            throw new DatastoreException(String.format("Could not find sequence with id %s at revision %s",id,rev),e);
+        } finally {
+            DatabaseUtils.closeCursorQuietly(cursor);
+        }
+    }
+
+    private long getNumericIdInQueue(SQLDatabase db, String id)
+            throws AttachmentException, DocumentNotFoundException, DatastoreException {
+        Cursor cursor = null;
+        try {
+            String sql = GET_DOC_NUMERIC_ID;
+            cursor = db.rawQuery(sql, new String[]{id});
+            if (cursor.moveToFirst()) {
+                long sequence = cursor.getLong(0);
+                return sequence;
+            } else {
+                return -1;
+            }
+        } catch (SQLException e) {
+            logger.log(Level.SEVERE,"Error sequence with id: " + id);
+            throw new DatastoreException(String.format("Could not find sequence with id %s",id),e);
+        } finally {
+            DatabaseUtils.closeCursorQuietly(cursor);
+        }
     }
 
     /**
@@ -490,10 +560,11 @@ class BasicDatastore implements Datastore, DatastoreExtended {
         // outside the sqlDb as we're batching requests.
         Collections.sort(result, new Comparator<BasicDocumentRevision>() {
             @Override
-            public int compare(BasicDocumentRevision documentRevision, BasicDocumentRevision documentRevision2) {
+            public int compare(BasicDocumentRevision documentRevision, BasicDocumentRevision
+                    documentRevision2) {
                 long a = documentRevision.getSequence();
                 long b = documentRevision2.getSequence();
-                return (int)(a - b);
+                return (int) (a - b);
             }
         });
 
@@ -934,69 +1005,72 @@ class BasicDatastore implements Datastore, DatastoreExtended {
         }
     }
 
-
     @Override
     public void forceInsert(final BasicDocumentRevision rev,
                             final List<String> revisionHistory,
                             final Map<String, Object> attachments,
                             final Map<String[],List<PreparedAttachment>>preparedAttachments,
                             final boolean pullAttachmentsInline) throws DocumentException {
-        Preconditions.checkState(this.isOpen(), "Database is closed");
-        Preconditions.checkNotNull(rev, "Input document revision can not be null");
-        Preconditions.checkNotNull(revisionHistory, "Input revision history must not be null");
-        Preconditions.checkArgument(revisionHistory.size() > 0, "Input revision history must not be empty");
-        Preconditions.checkArgument(checkCurrentRevisionIsInRevisionHistory(rev, revisionHistory),
-                "Current revision must exist in revision history.");
-        Preconditions.checkArgument(checkRevisionIsInCorrectOrder(revisionHistory),
-                "Revision history must be in right order.");
-        CouchUtils.validateDocumentId(rev.getId());
-        CouchUtils.validateRevisionId(rev.getRevision());
+        forceInsert(Collections.singletonList(new ForceInsertItem(rev, revisionHistory,
+                attachments, preparedAttachments, pullAttachmentsInline)));
+    }
 
-        logger.finer("forceInsert(): " + rev.toString() + ",\n" + JSONUtils.toPrettyJson
-                (revisionHistory));
+    @Override
+    public void forceInsert(final List<ForceInsertItem> items) throws DocumentException {
+        Preconditions.checkState(this.isOpen(), "Database is closed");
+
+        for (ForceInsertItem item : items) {
+            Preconditions.checkNotNull(item.rev, "Input document revision can not be null");
+            Preconditions.checkNotNull(item.revisionHistory, "Input revision history must not be null");
+            Preconditions.checkArgument(item.revisionHistory.size() > 0, "Input revision history must not be empty");
+
+            Preconditions.checkArgument(checkCurrentRevisionIsInRevisionHistory(item.rev, item.revisionHistory),
+                    "Current revision must exist in revision history.");
+            Preconditions.checkArgument(checkRevisionIsInCorrectOrder(item.revisionHistory),
+                    "Revision history must be in right order.");
+            CouchUtils.validateDocumentId(item.rev.getId());
+            CouchUtils.validateRevisionId(item.rev.getRevision());
+        }
+
+        // for raising events after completing database transaction
+        final List<DocumentModified> events = new LinkedList<DocumentModified>();
 
         try {
-            Object event = queue.submitTransaction(new SQLQueueCallable<Object>(){
+            queue.submitTransaction(new SQLQueueCallable<Object>() {
                 @Override
-                public Object call(SQLDatabase db) throws Exception{
-                    DocumentCreated documentCreated = null;
-                    DocumentUpdated documentUpdated = null;
+                public Object call(SQLDatabase db) throws Exception {
+                    for (ForceInsertItem item : items) {
 
-                    boolean ok = true;
+                        logger.finer("forceInsert(): " + item.rev.toString());
 
-                    long seq = 0;
+                        DocumentCreated documentCreated = null;
+                        DocumentUpdated documentUpdated = null;
 
+                        boolean ok = true;
 
-                    // sequence here is -1, but we need it to insert the attachment - also might
-                    // be wanted by subscribers
-                    BasicDocumentRevision revisionFromDB = null;
-                    try {
-                        revisionFromDB = getDocumentInQueue(db,rev.getId(),null);
-                    } catch (DocumentNotFoundException e){
-                        // this is expected since this method is normally used by replication
-                        // we may be missing the document from our copy
-                    }
+                        long docNumericId = getNumericIdInQueue(db, item.rev.getId());
+                        long seq = 0;
 
-                    if (revisionFromDB != null) {
-                        seq = doForceInsertExistingDocumentWithHistory(db, rev, revisionHistory,
-                                attachments);
-                        rev.initialiseSequence(seq);
-                        // TODO fetch the parent doc?
-                        documentUpdated = new DocumentUpdated(null, rev);
-                    } else {
-                        seq = doForceInsertNewDocumentWithHistory(db, rev, revisionHistory);
-                        rev.initialiseSequence(seq);
-                        documentCreated = new DocumentCreated(rev);
-                    }
+                        if (docNumericId != -1) {
+                            seq = doForceInsertExistingDocumentWithHistory(db, item.rev, docNumericId, item.revisionHistory,
+                                    item.attachments);
+                            item.rev.initialiseSequence(seq);
+                            // TODO fetch the parent doc?
+                            documentUpdated = new DocumentUpdated(null, item.rev);
+                        } else {
+                            seq = doForceInsertNewDocumentWithHistory(db, item.rev, item.revisionHistory);
+                            item.rev.initialiseSequence(seq);
+                            documentCreated = new DocumentCreated(item.rev);
+                        }
 
-                    // now deal with any attachments
-                    if (pullAttachmentsInline) {
-                        if (attachments != null) {
-                            for (String att : attachments.keySet()) {
-                                Map attachmentMetadata = (Map)attachments.get(att);
-                                Boolean stub = (Boolean) attachmentMetadata.get("stub");
+                        // now deal with any attachments
+                        if (item.pullAttachmentsInline) {
+                            if (item.attachments != null) {
+                                for (String att : item.attachments.keySet()) {
+                                    Map attachmentMetadata = (Map) item.attachments.get(att);
+                                    Boolean stub = (Boolean) attachmentMetadata.get("stub");
 
-                                if (stub != null && stub) {
+                                    if (stub != null && stub) {
                                     // stubs get copied forward at the end of
                                     // insertDocumentHistoryIntoExistingTree - nothing to do here
                                     continue;
@@ -1009,36 +1083,36 @@ class BasicDatastore implements Datastore, DatastoreExtended {
                                 // so we don't have to worry about that
                                 UnsavedStreamAttachment usa = new UnsavedStreamAttachment(is,
                                         att, type);
-                                try {
-                                    PreparedAttachment pa = AttachmentManager.prepareAttachment(
-                                            attachmentsDir, attachmentStreamFactory, usa);
-                                    AttachmentManager.addAttachment(db, attachmentsDir, rev, pa);
-                                } catch (Exception e) {
-                                    logger.log(Level.SEVERE, "There was a problem adding the " +
-                                                    "attachment "
-                                                    + usa + "to the datastore for document " + rev,
-                                            e);
-                                    throw e;
-                                }
+                                    try {
+                                        PreparedAttachment pa = AttachmentManager.prepareAttachment(
+                                                attachmentsDir, attachmentStreamFactory, usa);
+                                        AttachmentManager.addAttachment(db, attachmentsDir, item.rev, pa);
+                                    } catch (Exception e) {
+                                        logger.log(Level.SEVERE, "There was a problem adding the " +
+                                                        "attachment "
+                                                        + usa + "to the datastore for document " + item.rev,
+                                                e);
+                                        throw e;
+                                    }
                             }
                         }
-                    } else {
+                        } else {
 
-                        try {
-                            if (preparedAttachments != null) {
-                                for (String[] key : preparedAttachments.keySet()) {
-                                    String id = key[0];
-                                    String rev = key[1];
-                                    try {
-                                        BasicDocumentRevision doc = getDocumentInQueue(db, id, rev);
-                                        if (doc != null) {
-                                            AttachmentManager.addAttachmentsToRevision(db,
-                                                    attachmentsDir, doc, preparedAttachments.get(key));
-                                        }
-                                    } catch (DocumentNotFoundException e){
-                                        //safe to continue, previously getDocumentInQueue could return
-                                        // null and this was deemed safe and expected behaviour
-                                        // DocumentNotFoundException is thrown instead of returning
+                            try {
+                                if (item.preparedAttachments != null) {
+                                    for (String[] key : item.preparedAttachments.keySet()) {
+                                        String id = key[0];
+                                        String rev = key[1];
+                                        try {
+                                            BasicDocumentRevision doc = getDocumentInQueue(db, id, rev);
+                                            if (doc != null) {
+                                                AttachmentManager.addAttachmentsToRevision(db,
+                                                        attachmentsDir, doc, item.preparedAttachments.get(key));
+                                            }
+                                        } catch (DocumentNotFoundException e) {
+                                            //safe to continue, previously getDocumentInQueue could return
+                                            // null and this was deemed safe and expected behaviour
+                                            // DocumentNotFoundException is thrown instead of returning
                                         // null now.
                                         continue;
                                     }
@@ -1050,23 +1124,26 @@ class BasicDatastore implements Datastore, DatastoreExtended {
                             throw e;
                         }
 
-                    }
-                    if (ok) {
-                        logger.log(Level.FINER, "Inserted revision: %s", rev);
-                        if (documentCreated != null) {
-                            return documentCreated;
-                        } else if (documentUpdated != null) {
-                            return documentUpdated;
+
+                        }
+                        if (ok) {
+                            logger.log(Level.FINER, "Inserted revision: %s", item.rev);
+                            if (documentCreated != null) {
+                                events.add(documentCreated);
+                            } else if (documentUpdated != null) {
+                                events.add(documentUpdated);
+                            }
                         }
                     }
                     return null;
                 }
             }).get();
 
-            if(event != null) {
+            // if we got here, everything got written to the database successfully
+            // now raise any events we stored up
+            for(DocumentModified event : events) {
                 eventBus.post(event);
             }
-
 
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
@@ -1105,6 +1182,7 @@ class BasicDatastore implements Datastore, DatastoreExtended {
      *                    as well) sorted in ascending order.
      */
     private long doForceInsertExistingDocumentWithHistory(SQLDatabase db,BasicDocumentRevision newRevision,
+                                                          long docNumericId,
                                                           List<String> revisions,
                                                           Map<String, Object> attachments)
             throws AttachmentException, DocumentNotFoundException, DatastoreException {
@@ -1116,89 +1194,57 @@ class BasicDatastore implements Datastore, DatastoreExtended {
         Preconditions.checkNotNull(revisions, "Revision history should not be null.");
         Preconditions.checkArgument(revisions.size() > 0, "Revision history should have at least one revision." );
 
-        // First look up all locally-known revisions of this document:
-
-        DocumentRevisionTree localRevs;
-        try {
-            localRevs = getAllRevisionsOfDocumentInQueue(db, newRevision.getId());
-        } catch (DocumentNotFoundException e){
-            //this shouldn't be thrown since from the checkArugment above call we know the document
-            //exists so it should have a revision history
-            throw new RuntimeException(String.format("Error getting all revisions of document" +
-                    " with id %s even though revision exists",newRevision.getId()), e);
-        }
-
-        assert localRevs != null;
+        // do we have a common ancestor?
+        long ancestorSequence = getSequenceInQueue(db, newRevision.getId(), revisions.get(0));
 
         long sequence;
 
-        BasicDocumentRevision parent = localRevs.lookup(newRevision.getId(), revisions.get(0));
-        if(parent == null) {
-            sequence = insertDocumentHistoryToNewTree(db,newRevision, revisions, localRevs.getDocumentNumericId(), localRevs);
+        if(ancestorSequence == -1) {
+            sequence = insertDocumentHistoryToNewTree(db,newRevision, revisions, docNumericId);
         } else {
-            sequence = insertDocumentHistoryIntoExistingTree(db,newRevision, revisions, localRevs.getDocumentNumericId(), localRevs, attachments);
+            sequence = insertDocumentHistoryIntoExistingTree(db,newRevision, revisions, docNumericId, attachments);
         }
         return sequence;
     }
 
     private long insertDocumentHistoryIntoExistingTree(SQLDatabase db, BasicDocumentRevision newRevision, List<String> revisions,
-                                                       Long docNumericID, DocumentRevisionTree localRevs,
+                                                       Long docNumericID,
                                                        Map<String, Object> attachments)
             throws AttachmentException, DocumentNotFoundException, DatastoreException {
-        BasicDocumentRevision parent = localRevs.lookup(newRevision.getId(), revisions.get(0));
-        Preconditions.checkNotNull(parent, "Parent must not be null");
-        BasicDocumentRevision previousLeaf = localRevs.getCurrentRevision();
 
+        // get info about previous "winning" rev
+        long previousLeafSeq = getSequenceInQueue(db, newRevision.getId(), null);
+        Preconditions.checkArgument(previousLeafSeq > 0, "Parent revision must exist");
 
-        // Walk through the remote history in chronological order, matching each revision ID to
-        // a local revision. When the list diverges, start creating blank local revisions to fill
-        // in the local history
-        int i ;
-        for (i = 1; i < revisions.size(); i++) {
-            BasicDocumentRevision nextNode = localRevs.lookupChildByRevId(parent, revisions.get(i));
-            if (nextNode == null) {
-                break;
-            } else {
-                parent = nextNode;
+        // Insert the new stub revisions, going down the tree
+        // at the end of the loop, parentSeq will be the parent of our doc to insert
+        long parentSeq = 0L;
+        for (int i=0; i<revisions.size()-1; i++) {
+            String revId = revisions.get(i);
+            long seq = getSequenceInQueue(db, newRevision.getId(), revId);
+            if (seq == -1) {
+                seq = insertStubRevision(db,docNumericID, revId, parentSeq);
+                this.changeDocumentToBeNotCurrent(db, parentSeq);
             }
-        }
-
-        if (i >= revisions.size()) {
-            logger.finer("All revision are in local sqlDatabase already, no new revision inserted.");
-            return -1;
-        }
-
-        // Insert the new stub revisions
-        for (; i < revisions.size() - 1; i++) {
-            logger.finer("Inserting new stub revision, id: " + docNumericID + ", rev: " + revisions.get(i));
-            this.changeDocumentToBeNotCurrent(db,parent.getSequence());
-            insertStubRevision(db,docNumericID, revisions.get(i), parent.getSequence());
-            parent = getDocumentInQueue(db, newRevision.getId(), revisions.get(i));
-            localRevs.add(parent);
+            parentSeq = seq;
         }
 
         // Insert the new leaf revision
-        logger.finer("Inserting new revision, id: " + docNumericID + ", rev: " + revisions.get(i));
-        String newRevisionId = revisions.get(revisions.size() - 1);
-        this.changeDocumentToBeNotCurrent(db,parent.getSequence());
+        String newLeafRev = revisions.get(revisions.size() - 1);
+        logger.finer("Inserting new revision, id: " + docNumericID + ", rev: " + newLeafRev);
+        this.changeDocumentToBeNotCurrent(db,parentSeq);
         // don't copy over attachments
         InsertRevisionCallable callable = new InsertRevisionCallable();
         callable.docNumericId = docNumericID;
-        callable.revId = newRevisionId;
-        callable.parentSequence = parent.getSequence();
+        callable.revId = newLeafRev;
+        callable.parentSequence = parentSeq;
         callable.deleted = newRevision.isDeleted();
         callable.current = false; // we'll call pickWinnerOfConflicts to set this if it needs it
         callable.data = newRevision.asBytes();
         callable.available = true;
-        long sequence = callable.call(db);
+        long newLeafSeq = callable.call(db);
 
-        BasicDocumentRevision newLeaf = getDocumentInQueue(db, newRevision.getId(), newRevisionId);
-        localRevs.add(newLeaf);
-
-        // Refresh previous leaf in case it is changed in sqlDb but not in memory
-        previousLeaf = getDocumentInQueue(db, previousLeaf.getId(), previousLeaf.getRevision());
-
-        pickWinnerOfConflicts(db,previousLeaf,localRevs);
+        pickWinnerOfConflicts(db, docNumericID, newRevision.getId(), previousLeafSeq);
 
         // copy stubbed attachments forward from last real revision to this revision
         if (attachments != null) {
@@ -1206,7 +1252,7 @@ class BasicDatastore implements Datastore, DatastoreExtended {
                 Boolean stub = ((Map<String, Boolean>) attachments.get(att)).get("stub");
                 if (stub != null && stub.booleanValue()) {
                     try {
-                        AttachmentManager.copyAttachment(db,previousLeaf.getSequence(), sequence, att);
+                        AttachmentManager.copyAttachment(db, previousLeafSeq, newLeafSeq, att);
                     } catch (SQLException sqe) {
                         logger.log(Level.SEVERE, "Error copying stubbed attachments", sqe);
                         throw new DatastoreException("Error copying stubbed attachments",sqe);
@@ -1215,18 +1261,18 @@ class BasicDatastore implements Datastore, DatastoreExtended {
             }
         }
 
-        return sequence;
+        return newLeafSeq;
     }
 
     private long insertDocumentHistoryToNewTree(SQLDatabase db, BasicDocumentRevision newRevision,
                                                 List<String> revisions,
-                                                Long docNumericID,
-                                                DocumentRevisionTree localRevs)
+                                                Long docNumericID)
             throws AttachmentException, DocumentNotFoundException, DatastoreException {
         Preconditions.checkArgument(checkCurrentRevisionIsInRevisionHistory(newRevision, revisions),
                 "Current revision must exist in revision history.");
 
-        BasicDocumentRevision previousWinner = localRevs.getCurrentRevision();
+        // get info about previous "winning" rev
+        long previousLeafSeq = getSequenceInQueue(db, newRevision.getId(), null);
 
         // Adding a brand new tree
         logger.finer("Inserting a brand new tree for an existing document.");
@@ -1234,31 +1280,28 @@ class BasicDatastore implements Datastore, DatastoreExtended {
         for(int i = 0 ; i < revisions.size() - 1 ; i ++) {
             //we copy attachments here so allow the exception to propagate
             parentSequence = insertStubRevision(db,docNumericID, revisions.get(i), parentSequence);
-            BasicDocumentRevision newNode = this.getDocumentInQueue(db, newRevision.getId(),
-                    revisions.get(i));
-            localRevs.add(newNode);
         }
         // don't copy attachments
+        String newLeafRev = newRevision.getRevision();
         InsertRevisionCallable callable = new InsertRevisionCallable();
         callable.docNumericId = docNumericID;
-        callable.revId = newRevision.getRevision();
+        callable.revId = newLeafRev;
         callable.parentSequence = parentSequence;
         callable.deleted = newRevision.isDeleted();
         callable.current = false; // we'll call pickWinnerOfConflicts to set this if it needs it
         callable.data = newRevision.asBytes();
         callable.available = !newRevision.isDeleted();
-        long sequence = callable.call(db);
-        BasicDocumentRevision newLeaf = getDocumentInQueue(db, newRevision.getId(), newRevision.getRevision());
-        localRevs.add(newLeaf);
+        long newLeafSeq = callable.call(db);
 
-        // No need to refresh the previousWinner since we are inserting a new tree,
-        // and nothing on the old tree should be touched.
-        pickWinnerOfConflicts(db,previousWinner,localRevs);
-        return sequence;
+        pickWinnerOfConflicts(db, docNumericID, newRevision.getId(), previousLeafSeq);
+        return newLeafSeq;
     }
 
 
-    private void pickWinnerOfConflicts(SQLDatabase db, BasicDocumentRevision previousWinner, DocumentRevisionTree objectTree) {
+    private void pickWinnerOfConflicts(SQLDatabase db,
+                                       long docNumericId,
+                                       String docId,
+                                       long previousWinnerSeq) throws DatastoreException {
 
         /*
          Pick winner and mark the appropriate revision with the 'current' flag set
@@ -1275,29 +1318,54 @@ class BasicDatastore implements Datastore, DatastoreExtended {
          */
 
         // first get all non-deleted leafs
-        List<BasicDocumentRevision> leafs = objectTree.leafRevisions(true);
-        if (leafs.size() == 0) {
-            // all deleted, apply the normal rules to all the leafs
-            leafs = objectTree.leafRevisions();
+        List<String> leafs = new ArrayList<String>();
+        Cursor cursor = null;
+        try {
+            cursor = db.rawQuery(GET_NON_DELETED_LEAFS, new String[]{Long.toString(docNumericId)});
+            while (cursor.moveToNext()) {
+                leafs.add(cursor.getString(0));
+            }
+        } catch (SQLException sqe) {
+            throw new DatastoreException("Exception thrown whilst trying to fetch non-deleted leaf nodes in pickWinnerOfConflicts", sqe);
+        } finally {
+            DatabaseUtils.closeCursorQuietly(cursor);
         }
 
-        Collections.sort(leafs, new Comparator<BasicDocumentRevision>() {
+        // this is a corner case - all leaf nodes are deleted
+        // re-get with the same query but without the revs.delete clause
+        if (leafs.size() == 0) {
+            try {
+                cursor = db.rawQuery(GET_ALL_LEAFS, new String[]{Long.toString(docNumericId)});
+                while (cursor.moveToNext()) {
+                    leafs.add(cursor.getString(0));
+                }
+            } catch (SQLException sqe) {
+                throw new DatastoreException("Exception thrown whilst trying to fetch all leaf nodes in pickWinnerOfConflicts", sqe);
+            } finally {
+                DatabaseUtils.closeCursorQuietly(cursor);
+            }
+        }
+
+        Collections.sort(leafs, new Comparator<String>() {
             @Override
-            public int compare(BasicDocumentRevision r1, BasicDocumentRevision r2) {
-                int generationCompare = r1.getGeneration() - r2.getGeneration();
+            public int compare(String r1, String r2) {
+                int generationCompare = CouchUtils.generationFromRevId(r1) -
+                        CouchUtils.generationFromRevId(r2);
                 // note that the return statements have a unary minus since we are reverse sorting
                 if (generationCompare != 0) {
                     return -generationCompare;
                 } else {
-                    return -r1.getRevision().compareTo(r2.getRevision());
+                    return -CouchUtils.getRevisionIdSuffix(r1).compareTo(CouchUtils
+                            .getRevisionIdSuffix(r2));
                 }
             }
         });
         // new winner will be at the top of the list
-        BasicDocumentRevision leaf = leafs.get(0);
-        if (previousWinner.getSequence() != leaf.getSequence()) {
-            this.changeDocumentToBeNotCurrent(db, previousWinner.getSequence());
-            this.changeDocumentToBeCurrent(db, leaf.getSequence());
+        String leaf = leafs.get(0);
+        long newWinnerSeq = getSequenceInQueue(db, docId, leaf);
+        if (previousWinnerSeq != newWinnerSeq) {
+            this.changeDocumentToBeNotCurrent(db, previousWinnerSeq);
+            this.changeDocumentToBeCurrent(db, newWinnerSeq);
         }
     }
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/DatastoreExtended.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/DatastoreExtended.java
@@ -81,61 +81,73 @@ public interface DatastoreExtended extends Datastore {
     DocumentRevisionTree getAllRevisionsOfDocument(String documentId);
 
     /**
-     * <p>Inserts a revision of a document with an existing revision ID and
-     * revision history.</p>
-     *
-     * <p>This method inserts a revision into the document tree for an existing
-     * document. It checks every revision in the revision history, and adds
-     * {@code rev} is it isn't already present in the datastore.</p>
-     *
-     * <p>Here is an example of revHistory:</p>
-     *
-     * <pre>
-     * [
-     *     "1-421ff3d58df47ea6c5e83ca65efb2fa9",
-     *     "2-74e0572530e3b4cd4776616d2f591a96",
-     *     "3-d8e1fb8127d8dd732d9ae46a6c38ae3c",
-     *     "4-47d7102726fc89914431cb217ab7bace"
-     * ]
-     * </pre>
-     *
-     * <p>This method should only be called by the replicator. It's designed
-     * to allow revisions from different datastores to be added to this
-     * datastore during the replication process, when we wouldn't want to
-     * create new revision IDs (as if we did, we wouldn't know that we already
-     * had a particular revision from a previous replication).</p>
-     *
-     * <p>The {@code revisionHistory} is required so that we know whether
-     * the {@code rev} is part of the existing document tree, so we can see
-     * whether it's a conflict which needs to be grafted to the tree or
-     * whether it's a newer version of the same branch we already have.</p>
-     *
-     * <p>If the document was successfully inserted, a
+     * <p>
+     * Inserts one or more revisions of a document into the database. For efficiency, this is
+     * performed as one database transaction.
+     * </p>
+     * <p>
+     * Each revision is inserted at a point in the tree expressed by the path described in the
+     * {@code revisionHistory} field. If any non-leaf revisions do not exist locally, then they are
+     * created as "stub" revisions.
+     * </p>
+     * <p>
+     * This method should only be called by the replicator. It is designed
+     * to allow revisions from remote databases to be added to this
+     * database during the replication process: the documents in the remote database already have
+     * revision IDs that need to be preserved for the two databases to be in sync (otherwise it
+     * would not be possible to tell that the two represent the same revision). This is analogous to
+     * using the _new_edits false option in CouchDB
+     * (see <a href="https://wiki.apache.org/couchdb/HTTP_Bulk_Document_API#Posting_Existing_Revisions">
+     * the CouchDB wiki</a> for more detail).
+     * <p>
+     * If the document was successfully inserted, a
      * {@link com.cloudant.sync.notifications.DocumentCreated DocumentCreated},
      * {@link com.cloudant.sync.notifications.DocumentModified DocumentModified}, or
      * {@link com.cloudant.sync.notifications.DocumentDeleted DocumentDeleted}
      * event is posted on the event bus. The event will depend on the nature
-     * of the update made.</p>
+     * of the update made.
+     * </p>
      *
-     * @param rev A {@code DocumentRevision} containing the information for a revision
-     *            from a remote datastore.
-     * @param revisionHistory The history of the revision being inserted,
-     *                        including the rev ID of {@code rev}. This list
-     *                        needs to be sorted in ascending order
-     * @param attachments Attachments metadata and optionally data if {@code pullAttachmentsInline} true
-     * @param preparedAttachments Non-empty if {@code pullAttachmentsInline} false.
-     *                            Attachments that have already been prepared, this is a
-     *                            Map of String[docId,revId] → list of attachments
-     * @param pullAttachmentsInline If true, use {@code attachments} metadata and data directly
-     *                              from received JSON to add new attachments for this revision.
-     *                              Else use {@code preparedAttachments} which were previously
-     *                              downloaded and prepared by processOneChangesBatch in
-     *                              BasicPullStrategy
+     *
+     * @param items one or more revisions to insert. Each {@code ForceInsertItem} consists of:
+     * <ul>
+     * <li>
+     * <b>rev</b> A {@code DocumentRevision} containing the information for a revision
+     * from a remote datastore.
+     * </li>
+     * <li>
+     * <b>revisionHistory</b> The history of the revision being inserted,
+     * including the rev ID of {@code rev}. This list
+     * needs to be sorted in ascending order
+     * </li>
+     * <li>
+     * <b>attachments</b> Attachments metadata and optionally data if {@code pullAttachmentsInline} true
+     * </li>
+     * <li>
+     * <b>preparedAttachments</b> Non-empty if {@code pullAttachmentsInline} false.
+     * Attachments that have already been prepared, this is a
+     * Map of String[docId,revId] → list of attachments
+     * </li>
+     * <li>
+     * <b>pullAttachmentsInline</b> If true, use {@code attachments} metadata and data directly
+     * from received JSON to add new attachments for this revision.
+     * Else use {@code preparedAttachments} which were previously
+     * downloaded and prepared by processOneChangesBatch in
+     * BasicPullStrategy
+     * </li>
+     * </ul>
      *
      * @see Datastore#getEventBus()
      * @throws DocumentException if there was an error inserting the revision or its attachments
      * into the database
      */
+    void forceInsert(final List<ForceInsertItem> items) throws DocumentException;
+
+    /**
+     * This method has been deprecated and should not be used.
+     * @see #forceInsert(List)
+     */
+    @Deprecated
     void forceInsert(BasicDocumentRevision rev,
                             List<String> revisionHistory,
                             Map<String, Object> attachments,

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/ForceInsertItem.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/ForceInsertItem.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.datastore;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Created by tomblench on 22/01/16.
+ */
+public class ForceInsertItem {
+    public BasicDocumentRevision rev;
+    public List<String> revisionHistory;
+    public Map<String, Object> attachments;
+    public Map<String[],List<PreparedAttachment>>preparedAttachments;
+    public boolean pullAttachmentsInline;
+
+    public ForceInsertItem(BasicDocumentRevision rev, List<String> revisionHistory,
+                           Map<String, Object> attachments, Map<String[],
+            List<PreparedAttachment>> preparedAttachments, boolean pullAttachmentsInline) {
+        this.rev = rev;
+        this.revisionHistory = revisionHistory;
+        this.attachments = attachments;
+        this.preparedAttachments = preparedAttachments;
+        this.pullAttachmentsInline = pullAttachmentsInline;
+    }
+}

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/BasicPullStrategy.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/BasicPullStrategy.java
@@ -268,6 +268,18 @@ class BasicPullStrategy implements ReplicationStrategy {
         logger.info(msg);
     }
 
+    public class BatchItem {
+
+        public BatchItem(DocumentRevsList revsList,
+                         HashMap<String[], List<PreparedAttachment>> attachments) {
+            this.revsList = revsList;
+            this.attachments = attachments;
+        }
+
+        public HashMap<String[], List<PreparedAttachment>> attachments;
+        public DocumentRevsList revsList;
+    }
+
     private int processOneChangesBatch(ChangesResultWrapper changeFeeds)
             throws ExecutionException, InterruptedException, DocumentException {
         String feed = String.format(
@@ -285,7 +297,11 @@ class BasicPullStrategy implements ReplicationStrategy {
         // Process the changes in batches
         List<String> ids = Lists.newArrayList(missingRevisions.keySet());
         List<List<String>> batches = Lists.partition(ids, this.insertBatchSize);
+
+
         for (List<String> batch : batches) {
+
+            List<BatchItem> batchesToInsert = new ArrayList<BatchItem>();
 
             if (this.state.cancel) { break; }
 
@@ -374,9 +390,10 @@ class BasicPullStrategy implements ReplicationStrategy {
                     if (this.state.cancel)
                         break;
 
-                    this.targetDb.bulkInsert(revsList, atts, this.pullAttachmentsInline);
+                    batchesToInsert.add(new BatchItem(revsList, atts));
                     changesProcessed++;
                 }
+                this.targetDb.bulkInsert(batchesToInsert, this.pullAttachmentsInline);
             } catch (Exception e) {
                 throw new ExecutionException(e);
             }


### PR DESCRIPTION
Remove calls like getAllRevisionsOfDocumentInQueue and
getDocumentInQueue which incur an un-necessarily large overhead by
retrieving more data than is needed (especially document bodies) and
building temporary objects which contain large amounts of data which
are never used.

Instead we make direct SQL lookups on the data needed which is quicker
and also makes the code more compact.

reviewer @rhyshort