### PR TITLE
Fixed pull replication bounded queue issues

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# Unreleased
+- [FIXED] Issue where `java.lang.RuntimeException: Offer timed out` could be thrown 5 minutes after
+  a replication error.
+
 # 0.15.4 (2016-02-22)
 - [IMPROVED] Optimise pull replication performance. This is achieved
   by reducing excessive database traffic and batching up insertions in

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/BasicPullStrategy.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/BasicPullStrategy.java
@@ -215,9 +215,6 @@ class BasicPullStrategy implements ReplicationStrategy {
         for (this.state.batchCounter = 1; this.state.batchCounter < this.batchLimitPerRun; this.state.batchCounter++) {
 
             if (this.state.cancel) {
-                for (GetRevisionTaskThreaded task : threadedTasks) {
-                    task.cancel();
-                }
                 return;
             }
 
@@ -439,8 +436,6 @@ class BasicPullStrategy implements ReplicationStrategy {
         return new ChangesResultWrapper(changeFeeds);
     }
 
-    private List<GetRevisionTaskThreaded> threadedTasks = new ArrayList<GetRevisionTaskThreaded>();
-
     public Iterable<DocumentRevsList> createTask(List<String> ids,
                                                  Map<String, Collection<String>> revisions) {
 
@@ -473,9 +468,7 @@ class BasicPullStrategy implements ReplicationStrategy {
         if (useBulkGet) {
             return new GetRevisionTaskBulk(this.sourceDb, requests, this.pullAttachmentsInline);
         } else {
-            GetRevisionTaskThreaded task = new GetRevisionTaskThreaded(this.sourceDb, requests, this.pullAttachmentsInline);
-            threadedTasks.add(task);
-            return task;
+            return new GetRevisionTaskThreaded(this.sourceDb, requests, this.pullAttachmentsInline);
         }
     }
     

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/QueuingExecutorCompletionService.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/QueuingExecutorCompletionService.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package com.cloudant.sync.replication;
+
+import java.util.Queue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Created by tomblench on 23/02/16.
+ */
+
+/**
+ * This class extends the ExecutorCompletionService using a Queue of requests to operate a policy of
+ * submitting a new request for execution after a previous request has completed. The number of
+ * concurrent requests allowed can be specified and that number of jobs will be submitted on
+ * construction after which the one complete, one submitted policy applies. This has the
+ * advantage of terminating submission of requests for execution if responses stop being retrieved
+ * from the CompletionService.
+ *
+ * @param <Q> reQuest type
+ * @param <R> Response type
+ */
+public abstract class QueuingExecutorCompletionService<Q, R> extends ExecutorCompletionService<R> {
+
+    private final Queue<Q> requests;
+    // A count of the number of requests that have been submitted for execution, but have either
+    // not yet executed or been retrieved from the CompletionService. Use of this object within this
+    // class should be synchronized.
+    private final AtomicInteger requestsOutstanding = new AtomicInteger();
+
+    /**
+     * @param executorService    the executor service to execute the requests
+     * @param requests           the Queue of requests to execute
+     * @param concurrentRequests the number of concurrent requests
+     */
+    public QueuingExecutorCompletionService(ExecutorService executorService,
+                                            final Queue<Q> requests,
+                                            int concurrentRequests) {
+        super(executorService);
+        this.requests = requests;
+        // We submit the first n jobs, corresponding to the number of concurrentRequests
+        for (int n = 0; n < concurrentRequests; n++) {
+            submitRequestInternal();
+        }
+        // Subsequent jobs are requested by completion
+    }
+
+    /**
+     * @return true if requests have been submitted that have not yet been retrieved from the
+     * CompletionService
+     */
+    public boolean hasRequestsOutstanding() {
+        synchronized (requestsOutstanding) {
+            return requestsOutstanding.get() != 0;
+        }
+    }
+
+    @Override
+    public Future<R> poll() {
+        Future<R> result = super.poll();
+        return submitNewOnCompletion(result);
+    }
+
+    @Override
+    public Future<R> poll(long timeout, TimeUnit unit) throws
+            InterruptedException {
+        Future<R> result = super.poll(timeout, unit);
+        return submitNewOnCompletion(result);
+    }
+
+    @Override
+    public Future<R> take() throws InterruptedException {
+        Future<R> result = super.take();
+        return submitNewOnCompletion(result);
+    }
+
+    private Future<R> submitNewOnCompletion(Future<R> f) {
+        if (f != null) {
+            // We lock on the requestsOutstanding so that both the decrement and (potential)
+            // increment happen before any subsequent check of the value of requestsOutstanding.
+            // This avoids any issues where a call in-between the decrement and increment could
+            // have returned false for a short duration while the next request was submitted.
+            synchronized (requestsOutstanding) {
+                requestsOutstanding.decrementAndGet();
+                submitRequestInternal();
+            }
+        }
+        return f;
+    }
+
+    private void submitRequestInternal() {
+        final Q request;
+        // We need to synchronize this poll, so that multiple threads performing the next submit
+        // do not duplicate requests.
+        synchronized (requests) {
+            request = requests.poll();
+        }
+        if (request != null) {
+            submit(new Callable<R>() {
+                @Override
+                public R call() throws Exception {
+                    return executeRequest(request);
+                }
+            });
+            synchronized (requestsOutstanding) {
+                requestsOutstanding.incrementAndGet();
+            }
+        }
+    }
+
+    /**
+     * Subclasses should override this method with the desired execution method, which will
+     * ultimately be wrapped in a Callable for submission to the ExecutorCompletionService.
+     *
+     * @param request
+     * @return response
+     */
+    public abstract R executeRequest(Q request);
+
+}

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/BasicPullStrategyTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/BasicPullStrategyTest.java
@@ -19,7 +19,6 @@ import static org.hamcrest.CoreMatchers.startsWith;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.cloudant.common.CouchUtils;
 import com.cloudant.common.RequireRunningCouchDB;
 import com.cloudant.mazha.AnimalDb;
 import com.cloudant.mazha.CouchClient;
@@ -35,15 +34,11 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
-import java.util.concurrent.TimeUnit;
 
 @Category(RequireRunningCouchDB.class)
 public class BasicPullStrategyTest extends ReplicationTestBase {
@@ -408,94 +403,6 @@ public class BasicPullStrategyTest extends ReplicationTestBase {
 
     }
 
-    /**
-     * Test that a replication can be stopped.
-     * Uses a lot of large-ish docs to ensure the replication takes some time.
-     *
-     * @throws Exception
-     */
-    @Test
-    public void stopRunningReplication() throws Exception {
-        // Create a lot of documents in the remote db
-        int createBatches = 3;
-        int numDocsPerBatch = 700;
-        Random r = new Random();
-        for (int batch = 0; batch < createBatches; batch++) {
-            List<Foo> docs = new ArrayList<Foo>(numDocsPerBatch);
-            for (int i = 0; i < numDocsPerBatch; i++) {
-                Foo f = new Foo();
-                String docPrefix = batch + "-" + i + "-";
-                f.setId(docPrefix + CouchUtils.generateDocumentId());
-                f.setRevision(CouchUtils.getFirstRevisionId());
-                byte[] bytes = new byte[512];
-                r.nextBytes(bytes);
-                f.setFoo("Foo " + docPrefix + " " + new String(bytes, "UTF-8"));
-                docs.add(f);
-            }
-            remoteDb.getCouchClient().bulkCreateDocs(docs);
-        }
 
-        // Start the replication
-        Replicator replicator = getPullBuilder().build();
-        replicator.start();
-
-        // Wait until the replicator is already started before stopping
-        do {
-            TimeUnit.MILLISECONDS.sleep(100);
-        } while (replicator.getState() == Replicator.State.PENDING);
-
-        // Assert that the replicator is started
-        Assert.assertEquals("The replicator should be started", Replicator.State.STARTED,
-                replicator.getState());
-
-        // Let the replicator run for a short time
-        TimeUnit.MILLISECONDS.sleep(500);
-
-        // This is horrible reflection to assert that no tasks have been left behind
-        // because of https://github.com/cloudant/sync-android/issues/232, it would otherwise take
-        // 5 minutes to see exceptions from tasks being left behind
-        BasicPullStrategy pullStrategy = getPrivateField(BasicReplicator.class, "strategy",
-                BasicPullStrategy.class, replicator);
-        List<GetRevisionTaskThreaded> tasks = getPrivateField(BasicPullStrategy.class,
-                "threadedTasks", List.class, pullStrategy);
-
-        // Assert that at least one task has been created before stopping the replicator
-        // Only applicable when not using bulk_get
-        if (!remoteDb.getCouchClient().isBulkSupported()) {
-            Assert.assertTrue("There should be at least one task created", tasks.size() >= 1);
-        }
-
-        // Now stop the replicator
-        replicator.stop();
-
-        // Wait until the replicator is stopped
-        do {
-            TimeUnit.MILLISECONDS.sleep(100);
-        } while (replicator.getState() == Replicator.State.STOPPING);
-
-        // Assert that the replicator stopped (not error/complete)
-        Assert.assertEquals("The replicator should be stopped", Replicator.State.STOPPED,
-                replicator.getState());
-
-        // Check that the tasks have no leftover jobs or responses
-        for (GetRevisionTaskThreaded task : tasks) {
-            Collection jobs = getPrivateField(GetRevisionTaskThreaded.class, "submittedJobs",
-                    Collection.class, task);
-            Assert.assertTrue("There should be no jobs left", jobs.isEmpty());
-            Collection responses = getPrivateField(GetRevisionTaskThreaded.class, "responses",
-                    Collection.class, task);
-            Assert.assertTrue("There should be no responses left", responses.isEmpty());
-        }
-    }
-
-    /**
-     * Set field as accessible and get the value
-     */
-    private <T> T getPrivateField(Class<?> sourceOfField, String fieldName, Class<T>
-            typeOfField, Object instanceOfField) throws Exception {
-        Field field = sourceOfField.getDeclaredField(fieldName);
-        field.setAccessible(true);
-        return (T) field.get(instanceOfField);
-    }
 
 }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/PullReplicationTerminationTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/PullReplicationTerminationTest.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright (c) 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package com.cloudant.sync.replication;
+
+import com.cloudant.common.CouchUtils;
+import com.cloudant.common.RequireRunningCouchDB;
+import com.cloudant.http.HttpConnectionInterceptorContext;
+import com.cloudant.http.HttpConnectionRequestInterceptor;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+@Category(RequireRunningCouchDB.class)
+public class PullReplicationTerminationTest extends ReplicationTestBase {
+
+    // Test configuration fields
+    private int docBatches = 3;
+    private int docsPerBatch = 700;
+    private int expectedDocs = docBatches * docsPerBatch;
+
+    // Test run fields
+    private Replicator replicator = null;
+    private ThrowingInterceptor throwingInterceptor = null;
+    private TestReplicationListener listener = null;
+
+    @Before
+    public void customizeReplicatorAndPopulateDb() throws Exception {
+        setupTerminationTestReplicator();
+        populateRemoteDb(docBatches, docsPerBatch, 512);
+    }
+
+    private void setupTerminationTestReplicator() {
+        replicator = getPullBuilder().addRequestInterceptors((throwingInterceptor = new
+                ThrowingInterceptor())).build();
+        replicator.getEventBus().register((listener = new TestReplicationListener()));
+    }
+
+    private void populateRemoteDb(int batches, int docsPerBatch, int contentSize) throws Exception {
+        // Create documents in the remote db
+        Random r = new Random();
+        for (int batch = 0; batch < batches; batch++) {
+            List<Foo> docs = new ArrayList<Foo>(docsPerBatch);
+            for (int i = 0; i < docsPerBatch; i++) {
+                Foo f = new Foo();
+                String docPrefix = batch + "-" + i + "-";
+                f.setId(docPrefix + CouchUtils.generateDocumentId());
+                f.setRevision(CouchUtils.getFirstRevisionId());
+                byte[] bytes = new byte[contentSize];
+                r.nextBytes(bytes);
+                f.setFoo("Foo " + docPrefix + " " + new String(bytes, "UTF-8"));
+                docs.add(f);
+            }
+            remoteDb.getCouchClient().bulkCreateDocs(docs);
+        }
+    }
+
+    /**
+     * Wait up to 1 minute for the replicator to reach the desired state and assert that it did.
+     *
+     * @param state
+     * @throws Exception
+     */
+    private void waitForReplicatorToReachState(Replicator.State state) throws Exception {
+        waitForReplicatorToReachState(state, 1, TimeUnit.MINUTES);
+    }
+
+    /**
+     * Wait for the replicator to reach the desired state
+     *
+     * @param state        the state to check for
+     * @param maxWait      the maximum time to wait
+     * @param maxWaitUnits the units of the wait time
+     * @throws Exception
+     */
+    private void waitForReplicatorToReachState(Replicator.State state, long maxWait, TimeUnit
+            maxWaitUnits) throws Exception {
+        long timeout = System.nanoTime() + TimeUnit.NANOSECONDS.convert(maxWait, maxWaitUnits);
+        while (replicator.getState() != state && System.nanoTime() - timeout < 0) {
+            TimeUnit.MILLISECONDS.sleep(100);
+        }
+        Assert.assertEquals("The replicator should have reached the state " + state.toString() +
+                        " within the timeout.", state,
+                replicator.getState());
+    }
+
+    private void startReplication() throws Exception {
+        // Start the replication
+        replicator.start();
+
+        // Wait until the replicator is already started before stopping
+        waitForReplicatorToReachState(Replicator.State.STARTED);
+
+        // Let the replicator run for a short time
+        TimeUnit.MILLISECONDS.sleep(500);
+    }
+
+    private void assertComplete() throws Exception {
+        // Now run the replicator to completion
+        waitForReplicatorToReachState(Replicator.State.COMPLETE, 5, TimeUnit.MINUTES);
+
+        // Validate that the local datastore contains all the documents
+        Assert.assertEquals("The local datastore should contain all the documents", expectedDocs,
+                datastore.getDocumentCount());
+
+        // Assert that the listener was called
+        Assert.assertTrue("The listener should have been called when the replication " +
+                        "completed.",
+                listener.finishCalled);
+    }
+
+    /**
+     * Interceptor that has a flag to enable throwing an exception from an HTTP request.
+     * Used for testing exception cases.
+     */
+    private static final class ThrowingInterceptor implements HttpConnectionRequestInterceptor {
+
+        volatile boolean shouldThrow = false;
+
+        @Override
+        public HttpConnectionInterceptorContext interceptRequest
+                (HttpConnectionInterceptorContext context) {
+            if (shouldThrow == true) {
+                throw new RuntimeException("Test exception");
+            } else {
+                return context;
+            }
+        }
+    }
+
+    /**
+     * Test that a replication can be stopped.
+     * Uses a lot of large-ish docs to ensure the replication takes some time.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void stopRunningReplication() throws Exception {
+
+        // Start the replication
+        startReplication();
+
+        // Now stop the replicator
+        replicator.stop();
+
+        // Wait until the replicator is stopped
+        waitForReplicatorToReachState(Replicator.State.STOPPED);
+
+        Assert.assertTrue("The listener should have been called when the replication stopped.",
+                listener.finishCalled);
+        // Record the number of docs written before stopping
+        int docs = listener.docs;
+
+        // Assert that the listener data matches the local datastore
+        Assert.assertEquals("The local datastore should contain the expected number of " +
+                "documents", docs, datastore.getDocumentCount());
+    }
+
+    /**
+     * Test that a replication can be stopped.
+     * Uses a lot of large-ish docs to ensure the replication takes some time.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void resumeStoppedReplication() throws Exception {
+
+        // Execute the same steps as stopping the replication
+        stopRunningReplication();
+
+        // Record the number of docs written at the time of the stop
+        int docs = listener.docs;
+
+        // Assert that the existing replicator is invalid
+        replicator.start();
+        // This should complete instantly
+        waitForReplicatorToReachState(Replicator.State.COMPLETE, 10, TimeUnit.SECONDS);
+        // Validate that the listener recorded 0 batches and docs
+        Assert.assertEquals("The listener should have recorded 0 batches", 0, listener.batches);
+        Assert.assertEquals("The listener should have recorded 0 docs", 0, listener.docs);
+
+        // Validate that no additional documents were added to the local datastore
+        Assert.assertEquals("The local datastore should contain all the documents", docs,
+                datastore.getDocumentCount());
+
+        // Now start a new replication
+        setupTerminationTestReplicator();
+        startReplication();
+
+        // Assert it completes and all docs present
+        assertComplete();
+    }
+
+    @Test
+    public void replicatorHttpException() throws Exception {
+
+        // Start the replication
+        startReplication();
+
+        // Set the interceptor to throw
+        throwingInterceptor.shouldThrow = true;
+
+        // Wait for the error state
+        waitForReplicatorToReachState(Replicator.State.ERROR);
+
+        Assert.assertTrue("The listener should have been called when the replication errored.",
+                listener.errorCalled);
+    }
+
+    @Test
+    public void resumeErroredReplication() throws Exception {
+
+        // Execute the same steps as the HttpException case
+        replicatorHttpException();
+
+        // Turn off the exception
+        throwingInterceptor.shouldThrow = false;
+
+        // Now start it again
+        startReplication();
+
+        // Assert it completes and all docs present
+        assertComplete();
+    }
+
+    @Test
+    public void runMultiBatchLargeReplicationToCompletion() throws Exception {
+        runReplicationUntilComplete(replicator);
+        assertComplete();
+    }
+}

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/ReplicationThreadpoolTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/ReplicationThreadpoolTest.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package com.cloudant.sync.replication;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class ReplicationThreadpoolTest {
+
+    /**
+     * This test validates that the type of ThreadPoolExecutor we use for GetRevisionTaskThreaded
+     * behaves as we expect in terms of generation and expiry of threads.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void threadpoolTest() throws Exception {
+
+        final CountDownLatch latch = new CountDownLatch(1);
+        int threads = 4;
+        ThreadPoolExecutor tpe = new ThreadPoolExecutor(threads, threads, 1,
+                TimeUnit.SECONDS, new LinkedBlockingQueue<Runnable>());
+        // Allowing core threads to timeout means we don't keep threads in memory except when
+        // tasks are running or for the configured amount of time afterwards.
+        tpe.allowCoreThreadTimeOut(true);
+
+        List<Future<?>> futures = new ArrayList<Future<?>>();
+
+        for (int i = 1; i < threads; i++) {
+            futures.add(tpe.submit(new LatchedRunnable(latch)));
+            Assert.assertEquals("The threadpool count should increase with tasks up to threads",
+                    i, tpe.getPoolSize());
+        }
+        futures.add(tpe.submit(new LatchedRunnable(latch)));
+        Assert.assertEquals("The threadpool count should be capped", threads, tpe.getPoolSize());
+
+        // Now countdown the latch to release the threads
+        latch.countDown();
+        // Ensure they are all completed
+        for (Future<?> f : futures) {
+            f.get();
+        }
+
+        // Sleep to allow the threads to expire (1 second expiry, but allow 2)
+        TimeUnit.SECONDS.sleep(2);
+        // Validate no threads remain
+        Assert.assertEquals("The threadpool should be empty", 0, tpe.getPoolSize());
+    }
+
+    /*
+     * Simple test to execute a method which adds numbers over a large number of threads
+     */
+    @Test
+    public void addServiceTest() {
+        Queue<AddRequest> requests = new LinkedBlockingQueue<AddRequest>();
+        int nRequests = 10000;
+        for (int i = 0; i < nRequests; i++) {
+            AddRequest request = new AddRequest();
+            request.x = i;
+            request.y = i * 2;
+            requests.add(request);
+        }
+        int threads = 50;
+        final AtomicInteger nResponses = new AtomicInteger();
+        QueuingExecutorCompletionService<AddRequest, AddResponse> service =
+                new QueuingExecutorCompletionService<AddRequest, AddResponse>(Executors
+                        .newFixedThreadPool(threads), requests, threads) {
+                    @Override
+                    public AddResponse executeRequest(AddRequest request) {
+                        AddResponse response = new AddResponse();
+                        response.x = request.x;
+                        response.y = request.y;
+                        response.z = request.x + request.y;
+                        return response;
+                    }
+                };
+        try {
+            Future<AddResponse> response;
+            while (service.hasRequestsOutstanding() && (response = service.take()) != null) {
+                Assert.assertEquals(response.get().x + response.get().y, response.get().z);
+                nResponses.incrementAndGet();
+            }
+        } catch (InterruptedException ie) {
+            Assert.fail(ie.getMessage());
+        } catch (ExecutionException ee) {
+            Assert.fail(ee.getMessage());
+        }
+        Assert.assertEquals(nRequests, nResponses.get());
+        Assert.assertFalse(service.hasRequestsOutstanding());
+    }
+
+    /*
+     * Only consume half of the results
+     * - we use a threadpool which times out quickly so we can assert that no threads are running
+     *   after only consuming half of the results
+     * - assert that the correct number of requests have been de-queued
+     */
+    @Test
+    public void stopConsumingTest() throws Exception {
+        Queue<AddRequest> requests = new LinkedBlockingQueue<AddRequest>();
+        int nRequests = 10000;
+        for (int i = 0; i < nRequests; i++) {
+            AddRequest request = new AddRequest();
+            request.x = i;
+            request.y = i * 2;
+            requests.add(request);
+        }
+        int threads = 50;
+        final AtomicInteger nResponses = new AtomicInteger();
+        ThreadPoolExecutor tpe = new ThreadPoolExecutor(threads, threads, 1,
+                TimeUnit.SECONDS, new LinkedBlockingQueue<Runnable>());
+        // Allowing core threads to timeout means we don't keep threads in memory except when
+        // tasks are running or for the configured amount of time afterwards.
+        tpe.allowCoreThreadTimeOut(true);
+
+        QueuingExecutorCompletionService<AddRequest, AddResponse> service =
+                new QueuingExecutorCompletionService<AddRequest, AddResponse>(tpe, requests,
+                        threads) {
+                    @Override
+                    public AddResponse executeRequest(AddRequest request) {
+                        AddResponse response = new AddResponse();
+                        response.x = request.x;
+                        response.y = request.y;
+                        response.z = request.x + request.y;
+                        return response;
+                    }
+                };
+        try {
+            for (int i = 0; i < nRequests / 2; i++) {
+                Future<AddResponse> response = service.take();
+                Assert.assertEquals(response.get().x + response.get().y, response.get().z);
+                nResponses.incrementAndGet();
+            }
+        } catch (InterruptedException ie) {
+            Assert.fail(ie.getMessage());
+        } catch (ExecutionException ee) {
+            Assert.fail(ee.getMessage());
+        }
+        // Sleep to allow the threads to expire (1 second expiry, but allow 2)
+        TimeUnit.SECONDS.sleep(2);
+        // Validate no threads remain
+        Assert.assertEquals("The threadpool should be empty", 0, tpe.getPoolSize());
+
+        // we should have half of the requests left in the request queue, minus one thread-pool's
+        // worth which was 'in flight'
+        Assert.assertEquals(nRequests / 2 - threads, requests.size());
+    }
+
+    /*
+     * Test for run() throwing an exception:
+     * - the result of take() throws an ExecutionException
+     * - the rest of the results can still be processed
+     * - we get the correct number of results (excluding the one which threw)
+     */
+    @Test
+    public void runnableThrowsTest() {
+        Queue<AddRequest> requests = new LinkedBlockingQueue<AddRequest>();
+        int nRequests = 1000;
+        for (int i = 0; i < nRequests; i++) {
+            AddRequest request = new AddRequest();
+            request.x = i;
+            request.y = i * 2;
+            requests.add(request);
+        }
+        int threads = 50;
+        final int evilNumber = 666; // throw exception on this one
+        final String evilMessage = "It went bang";
+        ExecutorService executor = Executors.newFixedThreadPool(threads);
+        final QueuingExecutorCompletionService<AddRequest, AddResponse> service =
+                new QueuingExecutorCompletionService<AddRequest, AddResponse>(executor, requests,
+                        threads) {
+                    @Override
+                    public AddResponse executeRequest(AddRequest request) {
+                        AddResponse response = new AddResponse();
+                        response.x = request.x;
+                        response.y = request.y;
+                        if (response.x == evilNumber) {
+                            throw new RuntimeException(evilMessage);
+                        }
+                        response.z = request.x + request.y;
+                        return response;
+                    }
+                };
+
+        int nResponses = 0;
+        try {
+            Future<AddResponse> response;
+            while (service.hasRequestsOutstanding() && (response = service.take()) != null) {
+                try {
+                    Assert.assertEquals(response.get().x + response.get().y, response.get().z);
+                    nResponses++;
+                } catch (ExecutionException ee) {
+                    if (ee.getMessage().contains(evilMessage)) {
+                        // we got the one with the exception, now drain the queue again and
+                        // ensure everything else processes OK
+                        System.out.println("Caught ex " + ee);
+                    } else {
+                        Assert.fail(ee.getMessage());
+                    }
+                }
+            }
+        } catch (InterruptedException ie) {
+            Assert.fail(ie.getMessage());
+        }
+        Assert.assertFalse(service.hasRequestsOutstanding());
+        Assert.assertEquals(nRequests - 1, nResponses);
+    }
+
+    // simple example of a request: x+y = z
+    private class AddRequest {
+        int x;
+        int y;
+    }
+
+    // simple example of a response: x+y = z
+    private class AddResponse {
+        int x;
+        int y;
+        int z;
+    }
+
+    private class LatchedRunnable implements Runnable {
+
+        private final CountDownLatch latch;
+
+        LatchedRunnable(CountDownLatch latch) {
+            this.latch = latch;
+        }
+
+        @Override
+        public void run() {
+            try {
+                latch.await();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+}

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/TestReplicationListener.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/TestReplicationListener.java
@@ -23,10 +23,14 @@ public class TestReplicationListener {
     public boolean errorCalled = false;
     public boolean finishCalled = false;
     public Throwable exception = null;
+    public int batches = 0;
+    public int docs = 0;
 
     @Subscribe
     public void complete(ReplicationCompleted rc) {
         finishCalled = true;
+        batches = rc.batchesReplicated;
+        docs = rc.documentsReplicated;
     }
 
     @Subscribe


### PR DESCRIPTION
*What*
Following on from #232 some other cases where a `RuntimeException: Offer timed out` were identified this fixes those issues by removing the timed `offer()`.

*Why*
The timed offer/bounded queue design was useful for managing the number of submitted tasks and avoiding the need to track/cancel tasks (as the fix for #232 did). Using a completion service to control the number of concurrent jobs maintains that benefit, whilst avoiding the issues seen with the bounded queue.

*How*
Changed to an executor with an unbounded queue `QueuingExecutorCompletionService` that submits new tasks on completion of old ones, maintaining an active number of concurrent jobs.
Changed to a static thread pool so it is shared between tasks
instead of creating new threadpools for each task.
Updated `CHANGES.md`

*Testing*
Added `PullReplicationTerminationTest` class with:
-`stopRunningReplication`
-`resumeStoppedReplication`
-`replicatorHttpException`
-`resumeErroredReplication`
-`runMultiBatchLargeReplicationToCompletion`
Added doc/batch count to `TestReplicationListener`.
Added tests for `QueuingExecutorCompletionService`.
Added test for static thread pool behaviour.

Reviewers:
@ricellis
@tomblench 
@alfinkel 