### PR TITLE
Misc test cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ build
 *.iws
 out
 local.gradle
-sync-core/fixture
+cloudant-sync-datastore-core/fixture
 **/.idea/*
 !**/.idea/codeStyleSettings.xml
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/CouchClientWrapperTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/CouchClientWrapperTest.java
@@ -14,12 +14,20 @@
 
 package com.cloudant.sync.replication;
 
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+
 import com.cloudant.common.CouchTestBase;
 import com.cloudant.common.RequireRunningCouchDB;
-import com.cloudant.mazha.*;
-import com.cloudant.sync.datastore.DocumentBodyFactory;
-import com.cloudant.sync.datastore.DocumentBody;
+import com.cloudant.mazha.ChangesResult;
+import com.cloudant.mazha.CouchConfig;
+import com.cloudant.mazha.DocumentRevs;
+import com.cloudant.mazha.NoResourceException;
+import com.cloudant.mazha.Response;
 import com.cloudant.sync.datastore.BasicDocumentRevision;
+import com.cloudant.sync.datastore.DocumentBody;
+import com.cloudant.sync.datastore.DocumentBodyFactory;
 import com.cloudant.sync.datastore.DocumentRevisionBuilder;
 import com.cloudant.sync.util.CouchUtils;
 import com.cloudant.sync.util.TestUtils;
@@ -36,8 +44,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
-
-import static org.hamcrest.CoreMatchers.*;
 
 @Category(RequireRunningCouchDB.class)
 public class CouchClientWrapperTest extends CouchTestBase {
@@ -316,14 +322,17 @@ public class CouchClientWrapperTest extends CouchTestBase {
     public void accessAndUpdateRemoteDbWithSlashInName() throws Exception {
         //do a little set up for this specific test
         CouchConfig config = super.getCouchConfig("myslash%2Fencoded_db");
-        remoteDb = new CouchClientWrapper(config.getRootUri(), config.getRequestInterceptors(),
+        CouchClientWrapper slashDb = new CouchClientWrapper(config.getRootUri(),
+                config.getRequestInterceptors(),
                 config.getResponseInterceptors());
-        CouchClientWrapperDbUtils.deleteDbQuietly(remoteDb);
-        remoteDb.createDatabase();
-        Bar bar1 = new Bar();
-        Response res1 = remoteDb.create(bar1);
-        Assert.assertNotNull(res1);
-        Assert.assertTrue(res1.getOk());
-
+        slashDb.createDatabase();
+        try {
+            Bar bar1 = new Bar();
+            Response res1 = slashDb.create(bar1);
+            Assert.assertNotNull(res1);
+            Assert.assertTrue(res1.getOk());
+        } finally {
+            CouchClientWrapperDbUtils.deleteDbQuietly(slashDb);
+        }
     }
 }


### PR DESCRIPTION
*What*
Fix some test cleanup/ignore issues.

*How*
The `CouchClientWrapperTest.accessAndUpdateRemoteDbWithSlashInName()` test set a new value to the `remoteDb` field during the test. This meant the DB that test created was cleaned up by the `teardown()` method, but the DB created by the `setup` and initially assigned to the `remoteDb` field was never removed.

Update the `.gitignore` naming for the copied test fixtures so that they don't show up as changes. This rename was missed as part of #193.

*Testing*
No new tests needed.

reviewer @rhyshort 