### PR TITLE
Address FB 61611

### DIFF
--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/BasicDatastore.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/BasicDatastore.java
@@ -615,7 +615,8 @@ class BasicDatastore implements Datastore, DatastoreExtended {
     }
 
     @Override
-    public List<DocumentRevision> getDocumentsWithIds(final List<String> docIds) {
+    public List<DocumentRevision> getDocumentsWithIds(final List<String> docIds)  throws
+            DocumentException {
         Preconditions.checkState(this.isOpen(), "Database is closed");
         Preconditions.checkNotNull(docIds, "Input document id list cannot be null");
         try {
@@ -632,13 +633,12 @@ class BasicDatastore implements Datastore, DatastoreExtended {
                 }
             }).get();
         } catch (InterruptedException e) {
-            logger.log(Level.SEVERE,"Failed to get documents with ids",e);
+            logger.log(Level.SEVERE, "Failed to get documents with ids", e);
+            throw new DocumentException("Failed to get documents with ids", e);
         } catch (ExecutionException e) {
             logger.log(Level.SEVERE, "Failed to get documents with ids", e);
+            throw new DocumentException("Failed to get documents with ids", e);
         }
-
-        return null;
-
     }
 
     @Override

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/Datastore.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/Datastore.java
@@ -20,7 +20,6 @@ package com.cloudant.sync.datastore;
 import com.cloudant.sync.datastore.encryption.KeyProvider;
 import com.google.common.eventbus.EventBus;
 
-import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 
@@ -170,8 +169,10 @@ public interface Datastore {
      *
      * @param documentIds list of document id
      * @return list of {@code DocumentRevision} objects.
+     * @throws com.cloudant.sync.datastore.DocumentException if there was an error retrieving the
+     * documents.
      */
-    List<DocumentRevision> getDocumentsWithIds(List<String> documentIds);
+    List<DocumentRevision> getDocumentsWithIds(List<String> documentIds) throws DocumentException;
 
     /**
      * <p>Retrieves the datastore's current sequence number.</p>

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/QueryException.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/QueryException.java
@@ -1,0 +1,13 @@
+package com.cloudant.sync.query;
+
+/**
+ * This unchecked exception is used to wrap another exception so
+ * we can pass meaningful exception traces over the {@link QueryResult#iterator()}
+ * boundary as we can't change the signature of {@link QueryResult#iterator} to
+ * add a checked exception.
+ */
+public class QueryException extends RuntimeException {
+    public QueryException(Exception causedBy){
+        super(causedBy);
+    }
+}

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryResultTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryResultTest.java
@@ -1,0 +1,85 @@
+//  Copyright (c) 2016 IBM Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+package com.cloudant.sync.query;
+
+import com.cloudant.sync.datastore.encryption.NullKeyProvider;
+import com.cloudant.sync.sqlite.SQLDatabase;
+import com.cloudant.sync.sqlite.SQLDatabaseQueue;
+import com.cloudant.sync.sqlite.SQLQueueCallable;
+import com.cloudant.sync.util.SQLDatabaseTestUtils;
+import com.cloudant.sync.util.TestUtils;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class QueryResultTest extends AbstractQueryTestBase {
+
+    SQLDatabaseQueue queue;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        im = new IndexManager(ds);
+        assertThat(im, is(notNullValue()));
+        db = TestUtils.getDatabaseConnectionToExistingDb(im.getDatabase());
+        assertThat(db, is(notNullValue()));
+        assertThat(im.getQueue(), is(notNullValue()));
+        String[] metadataTableList = new String[]{IndexManager.INDEX_METADATA_TABLE_NAME};
+        SQLDatabaseTestUtils.assertTablesExist(db, metadataTableList);
+
+        queue = new SQLDatabaseQueue(factoryPath + "/" + factory.listAllDatastores().get(0) +
+            "/db.sync", new NullKeyProvider());
+
+        setUpBasicQueryData();
+    }
+
+    /*
+     * Perform a simple query then drop the revs table from the database before attempting
+     * to get the document ids from the QueryResult.
+     */
+    @Test(expected = QueryException.class)
+    public void testQueryGetDocumentsWithIdsFails() throws InterruptedException,
+        ExecutionException {
+        List<Object> fields = Collections.<Object>singletonList("pet");
+        assertThat(im.ensureIndexed(fields, "basic_text", "text"), is("basic_text"));
+
+        // query - { "$text" : { "$search" : "cat" } }
+        Map<String, Object> search = new HashMap<String, Object>();
+        search.put("$search", "cat");
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("$text", search);
+        QueryResult queryResult = im.find(query);
+
+        queue.submit(new SQLQueueCallable<Void>() {
+            @Override
+            public Void call(SQLDatabase db) throws Exception {
+                db.execSQL("DROP TABLE IF EXISTS revs");
+                return null;
+            }
+        }).get();
+
+        // Attempt to retrieve the document ids. This should fail with an
+        // UncheckedDocumentException because the revs table has been dropped.
+        queryResult.documentIds();
+    }
+}


### PR DESCRIPTION
_What?_
Add test to reproduce a scenario similar to the crash reported in FB 61535. Update the code to throw an unchecked exception so that  further diagnostic information may be obtained on the underlying cause of FB 61535.

_Why?_
FB 61535 caused a crash for MIA. The underlying cause of the crash is not clear and is likely masked by the fact `Datastore.getDocumentsWithIds()` returns `null` in case of failure, which then leads to an NPE elsewhere.

How?
A test has been added to cause a failure in `Datastore.getDocumentsWithIds()` such that the existing code would have returned `null`. `Datastore.getDocumentsWithIds()` has been updated to throw a `DocumentException` retaining the details of the exception that caused it. Because `QueryResult.iterator()` implements the `Iterable` interface, we can't pass a `DocumentException` through that interface, so we encapsulate the `DocumentException` in an unchecked exception `UncheckedDocumentException` so that it can be thrown by `QueryResult.iterator()`. For further discussion of this, see FB 61611.

reviewer @mikerhodes
reviewer @rhyshort