### PR TITLE
Add cookie auth on all replications

### DIFF
--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/PullReplicatorTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/PullReplicatorTest.java
@@ -207,4 +207,36 @@ public class PullReplicatorTest extends ReplicationTestBase {
         Assert.assertEquals(3, this.datastore.getDocumentCount());
     }
 
+    @Test
+    public void replicatorBuilderAddsCookieInterceptorCustomPort() throws Exception {
+        ReplicatorBuilder.Pull p = ReplicatorBuilder.pull().
+                from(new URI("http://🍶:🍶@some-host:123/path%2Fsome-path-日本")).
+                to(datastore);
+        BasicReplicator r = (BasicReplicator)p.build();
+        // check that user/pass has been removed
+        Assert.assertEquals("http://some-host:123/path%2Fsome-path-日本",
+                (((CouchClientWrapper)(((BasicPullStrategy)r.strategy).sourceDb)).
+                        getCouchClient().
+                        getRootUri()).
+                        toString()
+                );
+        assertCookieInterceptorPresent(p, "name=%F0%9F%8D%B6&password=%F0%9F%8D%B6");
+    }
+
+    @Test
+    public void replicatorBuilderAddsCookieInterceptorDefaultPort() throws Exception {
+        ReplicatorBuilder.Pull p = ReplicatorBuilder.pull().
+                from(new URI("http://🍶:🍶@some-host/path%2Fsome-path-日本")).
+                to(datastore);
+        BasicReplicator r = (BasicReplicator)p.build();
+        // check that user/pass has been removed
+        Assert.assertEquals("http://some-host:80/path%2Fsome-path-日本",
+                (((CouchClientWrapper) (((BasicPullStrategy) r.strategy).sourceDb)).
+                        getCouchClient().
+                        getRootUri()).
+                        toString()
+        );
+       assertCookieInterceptorPresent(p, "name=%F0%9F%8D%B6&password=%F0%9F%8D%B6");
+    }
+
 }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/PushReplicatorTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/PushReplicatorTest.java
@@ -21,6 +21,8 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import java.net.URI;
+
 @Category(RequireRunningCouchDB.class)
 public class PushReplicatorTest extends ReplicationTestBase {
 
@@ -148,6 +150,40 @@ public class PushReplicatorTest extends ReplicationTestBase {
         // check document counter has been reset since last replication and incremented
         Assert.assertEquals(1, replicationStrategy2.getDocumentCounter());
         Assert.assertEquals(3, remoteDb.couchClient.getDbInfo().getDocCount());
+    }
+
+
+    @Test
+    public void replicatorBuilderAddsCookieInterceptorCustomPort() throws Exception {
+        ReplicatorBuilder.Push p = ReplicatorBuilder.push().
+                from(datastore).
+                to(new URI("http://🍶:🍶@some-host:123/path%2Fsome-path-日本"));
+        BasicReplicator r = (BasicReplicator)p.build();
+        // check that user/pass has been removed
+        Assert.assertEquals("http://some-host:123/path%2Fsome-path-日本",
+                (((CouchClientWrapper) (((BasicPushStrategy) r.strategy).targetDb)).
+                        getCouchClient().
+                        getRootUri()).
+                        toString()
+        );
+        assertCookieInterceptorPresent(p, "name=%F0%9F%8D%B6&password=%F0%9F%8D%B6");
+    }
+
+    @Test
+    public void replicatorBuilderAddsCookieInterceptorDefaultPort() throws Exception {
+        ReplicatorBuilder.Push p = ReplicatorBuilder.push().
+                from(datastore).
+                to(new URI("http://🍶:🍶@some-host/path%2Fsome-path-日本"));
+        BasicReplicator r = (BasicReplicator)p.build();
+        // check that user/pass has been removed
+        Assert.assertEquals("http://some-host:80/path%2Fsome-path-日本",
+                (((CouchClientWrapper)(((BasicPushStrategy)r.strategy).targetDb)).
+                        getCouchClient().
+                        getRootUri()).
+                        toString()
+        );
+        assertCookieInterceptorPresent(p, "name=%F0%9F%8D%B6&password=%F0%9F%8D%B6");
+
     }
 
 


### PR DESCRIPTION
FB 51076

If username and password are specified in URL for ReplicatorBuilder, then add a CookieInterceptor and remove these credentials from the URL.

reviewer @brynh 
reviewer @alfinkel 