### PR TITLE
Use enum for `indexType` parameters in Public API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,10 @@
   to be updated to use the `DocumentRevision` class. See the updated
   [CRUD guide](https://github.com/cloudant/sync-android/blob/master/doc/crud.md)
   for examples of how to use this class.
+- [BREAKING CHANGE] Index type is now defined as the IndexType enum this effects
+ the following APIs:
+  - Index#getInstance
+  - IndexManger#ensureIndexed
 
 # 0.15.5 (2016-02-25)
 - [FIXED] Issue where `java.lang.RuntimeException: Offer timed out` could be thrown 5 minutes after

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/Index.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/Index.java
@@ -31,12 +31,6 @@ class Index {
 
     private static final Logger logger = Logger.getLogger(Index.class.getCanonicalName());
 
-    public static final String JSON_TYPE = "json";
-
-    public static final String TEXT_TYPE = "text";
-
-    private static final List<String> validTypes = Arrays.asList(JSON_TYPE, TEXT_TYPE);
-
     private static final String TEXT_TOKENIZE = "tokenize";
 
     private static final String TEXT_DEFAULT_TOKENIZER = "simple";
@@ -47,7 +41,7 @@ class Index {
 
     protected final String indexName;
 
-    protected final String indexType;
+    protected final IndexType indexType;
 
     protected final Map<String, String> indexSettings;
 
@@ -55,7 +49,7 @@ class Index {
 
     private Index(List<Object> fieldNames,
                   String indexName,
-                  String indexType,
+                  IndexType indexType,
                   Map<String, String> indexSettings) {
         this.fieldNames = fieldNames;
         this.indexName = indexName;
@@ -71,10 +65,10 @@ class Index {
      * @return the Index object or null if arguments passed in were invalid.
      */
     public static Index getInstance(List<Object> fieldNames, String indexName) {
-        return getInstance(fieldNames, indexName, JSON_TYPE);
+        return getInstance(fieldNames, indexName, IndexType.JSON);
     }
 
-    public static Index getInstance(List<Object> fieldNames, String indexName, String indexType) {
+    public static Index getInstance(List<Object> fieldNames, String indexName, IndexType indexType) {
         return getInstance(fieldNames, indexName, indexType, null);
     }
 
@@ -91,7 +85,7 @@ class Index {
      */
     public static Index getInstance(List<Object> fieldNames,
                               String indexName,
-                              String indexType,
+                              IndexType indexType,
                               Map<String, String> indexSettings) {
         if (fieldNames == null || fieldNames.isEmpty()) {
             logger.log(Level.SEVERE, "No field names were provided.");
@@ -103,22 +97,12 @@ class Index {
             return null;
         }
 
-        if (indexType == null || indexType.isEmpty()) {
-            logger.log(Level.SEVERE, "No index type was provided.");
-            return null;
-        }
-
-        if (!validTypes.contains(indexType.toLowerCase())) {
-            logger.log(Level.SEVERE, String.format("Invalid index type %s.", indexType));
-            return null;
-        }
-
-        if (indexType.equalsIgnoreCase(JSON_TYPE) && indexSettings != null) {
+        if (indexType == IndexType.JSON && indexSettings != null) {
             logger.log(Level.WARNING, String.format("Index type is %s, index settings %s ignored.",
                                                     indexType,
                                                     indexSettings.toString()));
             indexSettings = null;
-        } else if (indexType.equalsIgnoreCase(TEXT_TYPE)) {
+        } else if (indexType == IndexType.TEXT) {
             if (indexSettings == null) {
                 indexSettings = new HashMap<String, String>();
                 indexSettings.put(TEXT_TOKENIZE, TEXT_DEFAULT_TOKENIZER);
@@ -148,8 +132,8 @@ class Index {
      * @param indexSettings the indexSettings to compare to
      * @return true/false - whether there is a match
      */
-    protected boolean compareIndexTypeTo(String indexType, String indexSettings) {
-        if (!this.indexType.equalsIgnoreCase(indexType)) {
+    protected boolean compareIndexTypeTo(IndexType indexType, String indexSettings) {
+        if (this.indexType != indexType) {
             return false;
         }
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexCreator.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexCreator.java
@@ -72,7 +72,7 @@ class IndexCreator {
             return null;
         }
 
-        if (index.indexType.equalsIgnoreCase("text")) {
+        if (index.indexType == IndexType.TEXT) {
             if (!IndexManager.ftsAvailable(queue, database)) {
                 logger.log(Level.SEVERE, "Text search not supported.  To add support for text " +
                                          "search, enable FTS compile options in SQLite.");
@@ -120,7 +120,7 @@ class IndexCreator {
             if (existingIndexes != null && existingIndexes.get(index.indexName) != null) {
                 Map<String, Object> existingIndex =
                         (Map<String, Object>) existingIndexes.get(index.indexName);
-                String existingType = (String) existingIndex.get("type");
+                IndexType existingType = (IndexType) existingIndex.get("type");
                 String existingSettings = (String) existingIndex.get("settings");
                 List<String> existingFieldsList = (List<String>) existingIndex.get("fields");
                 Set<String> existingFields = new HashSet<String>(existingFieldsList);
@@ -153,7 +153,7 @@ class IndexCreator {
                 for (String fieldName: fieldNamesList) {
                     ContentValues parameters = new ContentValues();
                     parameters.put("index_name", index.indexName);
-                    parameters.put("index_type", index.indexType);
+                    parameters.put("index_type", index.indexType.toString());
                     parameters.put("index_settings", index.settingsAsJSON());
                     parameters.put("field_name", fieldName);
                     parameters.put("last_sequence", 0);
@@ -174,7 +174,7 @@ class IndexCreator {
                 }
 
                 List<String> statements = new ArrayList<String>();
-                if (index.indexType.equalsIgnoreCase(Index.TEXT_TYPE)) {
+                if (index.indexType == IndexType.TEXT) {
                     List<String> settingsList = new ArrayList<String>();
                     // Add text settings
                     for (String key : index.indexSettings.keySet()) {
@@ -284,11 +284,11 @@ class IndexCreator {
      */
     @SuppressWarnings("unchecked")
     protected static boolean indexLimitReached(Index index, Map<String, Object> existingIndexes) {
-        if (index.indexType.equalsIgnoreCase(Index.TEXT_TYPE)) {
+        if (index.indexType == IndexType.TEXT) {
             for (String name : existingIndexes.keySet()) {
                 Map<String, Object> existingIndex = (Map<String, Object>) existingIndexes.get(name);
-                String type = (String) existingIndex.get("type");
-                if (type.equalsIgnoreCase(Index.TEXT_TYPE) &&
+                IndexType type = (IndexType) existingIndex.get("type");
+                if (type == IndexType.TEXT &&
                     !name.equalsIgnoreCase(index.indexName)) {
                     logger.log(Level.SEVERE,
                             String.format("The text index %s already exists.  ", name) +

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexManager.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexManager.java
@@ -188,7 +188,7 @@ public class IndexManager {
             indexes = new HashMap<String, Object>();
             while (cursor.moveToNext()) {
                 String rowIndex = cursor.getString(0);
-                String rowType = cursor.getString(1);
+                IndexType rowType = IndexType.enumValue(cursor.getString(1));
                 String rowField = cursor.getString(2);
                 String rowSettings = cursor.getString(3);
                 if (!indexes.containsKey(rowIndex)) {
@@ -255,7 +255,7 @@ public class IndexManager {
      *  @param indexType The type of index (json or text currently supported)
      *  @return name of created index
      */
-    public String ensureIndexed(List<Object> fieldNames, String indexName, String indexType) {
+    public String ensureIndexed(List<Object> fieldNames, String indexName, IndexType indexType) {
         return ensureIndexed(fieldNames, indexName, indexType, null);
     }
 
@@ -273,7 +273,7 @@ public class IndexManager {
      */
     public String ensureIndexed(List<Object> fieldNames,
                                 String indexName,
-                                String indexType,
+                                IndexType indexType,
                                 Map<String, String> indexSettings) {
         return IndexCreator.ensureIndexed(Index.getInstance(fieldNames,
                                                             indexName,

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexType.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexType.java
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (c) 2016 IBM Corp. All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ *  except in compliance with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under the
+ *   License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ *  either express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+package com.cloudant.sync.query;
+
+/**
+ * Denotes the type for an Query Index.
+ */
+public enum IndexType {
+
+    /**
+     * JSON Index
+     */
+    JSON,
+    /**
+     * Text Index
+     */
+    TEXT;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        return super.toString().toLowerCase();
+    }
+
+    /**
+     * Converts a string to its Enum value.
+     * @param value The string to convert to an enum
+     * @return The enum value for the String or {@code null}
+     */
+    public static IndexType enumValue(String value){
+        if(value.equals(IndexType.JSON.toString())){
+            return IndexType.JSON;
+        } else if (value.equals(IndexType.TEXT.toString())){
+            return IndexType.TEXT;
+        }
+        return null;
+    }
+
+}

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/QuerySqlTranslator.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/QuerySqlTranslator.java
@@ -393,8 +393,8 @@ class QuerySqlTranslator {
             Map<String, Object> indexDefinition = (Map<String, Object>) indexes.get(indexName);
 
             // Don't choose a text index for a non-text query clause
-            String indexType = (String) indexDefinition.get("type");
-            if (indexType.equalsIgnoreCase("text")) {
+            IndexType indexType = (IndexType) indexDefinition.get("type");
+            if (indexType == IndexType.TEXT) {
                 continue;
             }
 
@@ -414,8 +414,8 @@ class QuerySqlTranslator {
         String textIndex = null;
         for (String indexName: indexes.keySet()) {
             Map<String, Object> indexDefinition = (Map<String, Object>) indexes.get(indexName);
-            String indexType = (String) indexDefinition.get("type");
-            if (indexType.equalsIgnoreCase("text")) {
+            IndexType indexType = (IndexType) indexDefinition.get("type");
+            if (indexType == IndexType.TEXT) {
                 textIndex = indexName;
             }
         }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexCreatorTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexCreatorTest.java
@@ -194,13 +194,13 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
         // supports using the json type
         String indexName = im.ensureIndexed(Arrays.<Object>asList(nameField, ageField),
                                             "basic",
-                                            "json");
+                                            IndexType.JSON);
         assertThat(indexName, is("basic"));
         Map<String, Object> indexes = im.listIndexes();
         assertThat(indexes.size(), is(1));
         @SuppressWarnings("unchecked")
         Map<String, Object> index = (Map<String, Object>) indexes.get("basic");
-        assertThat((String) index.get("type"), is("json"));
+        assertThat((IndexType) index.get("type"), is(IndexType.JSON));
         assertThat(index.get("settings"), is(nullValue()));
     }
 
@@ -213,13 +213,13 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
 
         String indexName = im.ensureIndexed(Arrays.<Object>asList(nameField, ageField),
                                             "basic",
-                                            "text");
+                                            IndexType.TEXT);
         assertThat(indexName, is("basic"));
         Map<String, Object> indexes = im.listIndexes();
         assertThat(indexes.size(), is(1));
         @SuppressWarnings("unchecked")
         Map<String, Object> index = (Map<String, Object>) indexes.get("basic");
-        assertThat((String) index.get("type"), is("text"));
+        assertThat((IndexType) index.get("type"), is(IndexType.TEXT));
         assertThat((String) index.get("settings"), is("{\"tokenize\":\"simple\"}"));
     }
 
@@ -228,15 +228,15 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
         Map<String, String> settings = new HashMap<String, String>();
         settings.put("tokenize", "porter");
         String indexName = im.ensureIndexed(Arrays.<Object>asList("name", "age"),
-                                            "basic",
-                                            "text",
-                                             settings);
+                "basic",
+                IndexType.TEXT,
+                settings);
         assertThat(indexName, is("basic"));
         Map<String, Object> indexes = im.listIndexes();
         assertThat(indexes.size(), is(1));
         @SuppressWarnings("unchecked")
         Map<String, Object> index = (Map<String, Object>) indexes.get("basic");
-        assertThat((String) index.get("type"), is("text"));
+        assertThat((IndexType) index.get("type"), is(IndexType.TEXT));
         assertThat((String) index.get("settings"), is("{\"tokenize\":\"porter\"}"));
     }
 
@@ -246,7 +246,7 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
         settings.put("tokenize", "porter");
         String indexName = im.ensureIndexed(Arrays.<Object>asList("name", "age"),
                                             "textIndex",
-                                            "text",
+                                            IndexType.TEXT,
                                             settings);
         assertThat(indexName, is("textIndex"));
         indexName = im.ensureIndexed(Arrays.<Object>asList("name", "age"), "jsonIndex");
@@ -257,37 +257,9 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
 
     @Test
     public void correctlyLimitsTextIndexesToOne() {
-        String indexName = im.ensureIndexed(Arrays.<Object>asList("name", "age"), "basic", "text");
+        String indexName = im.ensureIndexed(Arrays.<Object>asList("name", "age"), "basic", IndexType.TEXT);
         assertThat(indexName, is("basic"));
-        indexName = im.ensureIndexed(Arrays.<Object>asList("name", "age"), "anotherIndex", "text");
-        assertThat(indexName, is(nullValue()));
-    }
-
-    @Test
-    public void createIndexWithGeoType() {
-        HashMap<String, String> nameField = new HashMap<String, String>();
-        nameField.put("name", "asc");
-        HashMap<String, String> ageField = new HashMap<String, String>();
-        ageField.put("age", "desc");
-
-        // doesn't support using the geo type
-        String indexName = im.ensureIndexed(Arrays.<Object>asList(nameField, ageField),
-                                            "basic",
-                                            "geo");
-        assertThat(indexName, is(nullValue()));
-    }
-
-    @Test
-    public void createIndexWithUnplannedType() {
-        HashMap<String, String> nameField = new HashMap<String, String>();
-        nameField.put("name", "asc");
-        HashMap<String, String> ageField = new HashMap<String, String>();
-        ageField.put("age", "desc");
-
-        // doesn't support using the unplanned type
-        String indexName = im.ensureIndexed(Arrays.<Object>asList(nameField, ageField),
-                                            "basic",
-                                            "frog");
+        indexName = im.ensureIndexed(Arrays.<Object>asList("name", "age"), "anotherIndex", IndexType.TEXT);
         assertThat(indexName, is(nullValue()));
     }
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexManagerTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexManagerTest.java
@@ -15,7 +15,6 @@ package com.cloudant.sync.query;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -136,7 +135,7 @@ public class IndexManagerTest extends AbstractIndexTestBase {
             ds.createDocumentFromRevision(rev);
         }
 
-        im.ensureIndexed(Arrays.<Object>asList("name", "address"), "basic", "text");
+        im.ensureIndexed(Arrays.<Object>asList("name", "address"), "basic", IndexType.TEXT);
         assertThat(im.listIndexes().keySet(), contains("basic"));
 
         assertThat(im.deleteIndexNamed("basic"), is(true));

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexTest.java
@@ -42,16 +42,16 @@ public class IndexTest {
         Index index = Index.getInstance(fieldNames, indexName);
         assertThat(index.indexName, is("basic"));
         assertThat(index.fieldNames, is(Arrays.<Object>asList("name", "age")));
-        assertThat(index.indexType, is("json"));
+        assertThat(index.indexType, is(IndexType.JSON));
         assertThat(index.indexSettings, is(nullValue()));
     }
 
     @Test
     public void constructsIndexWithTextTypeDefaultSettings() {
-        Index index = Index.getInstance(fieldNames, indexName, "text");
+        Index index = Index.getInstance(fieldNames, indexName, IndexType.TEXT);
         assertThat(index.indexName, is("basic"));
         assertThat(index.fieldNames, is(Arrays.<Object>asList("name", "age")));
-        assertThat(index.indexType, is("text"));
+        assertThat(index.indexType, is(IndexType.TEXT));
         assertThat(index.indexSettings.size(), is(1));
         assertThat(index.indexSettings.get("tokenize"), is("simple"));
     }
@@ -75,25 +75,10 @@ public class IndexTest {
     }
 
     @Test
-    public void returnsNullWhenNoIndexType() {
-        Index index = Index.getInstance(fieldNames, indexName, null);
-        assertThat(index, is(nullValue()));
-
-        index = Index.getInstance(fieldNames, indexName, "");
-        assertThat(index, is(nullValue()));
-    }
-
-    @Test
-    public void returnsNullWhenInvalidIndexType() {
-        Index index = Index.getInstance(fieldNames, indexName, "blah");
-        assertThat(index, is(nullValue()));
-    }
-
-    @Test
     public void returnsNullWhenInvalidIndexSettings() {
         Map<String, String> indexSettings = new HashMap<String, String>();
         indexSettings.put("foo", "bar");
-        Index index = Index.getInstance(fieldNames, indexName, "text", indexSettings);
+        Index index = Index.getInstance(fieldNames, indexName, IndexType.TEXT, indexSettings);
         assertThat(index, is(nullValue()));
     }
 
@@ -102,7 +87,7 @@ public class IndexTest {
         Map<String, String> indexSettings = new HashMap<String, String>();
         indexSettings.put("tokenize", "porter");
         // json indexes do not support index settings.  Index settings will be ignored.
-        Index index = Index.getInstance(fieldNames, indexName, "json", indexSettings);
+        Index index = Index.getInstance(fieldNames, indexName, IndexType.JSON, indexSettings);
         assertThat(index.indexSettings, is(nullValue()));
     }
 
@@ -111,7 +96,7 @@ public class IndexTest {
         Map<String, String> indexSettings = new HashMap<String, String>();
         indexSettings.put("tokenize", "porter");
         // text indexes support the tokenize setting.
-        Index index = Index.getInstance(fieldNames, indexName, "text", indexSettings);
+        Index index = Index.getInstance(fieldNames, indexName, IndexType.TEXT, indexSettings);
         assertThat(index.indexSettings.size(), is(1));
         assertThat(index.indexSettings.get("tokenize"), is("porter"));
     }
@@ -119,30 +104,30 @@ public class IndexTest {
     @Test
     public void comparesIndexTypeAndReturnsInEquality() {
         Index index = Index.getInstance(fieldNames, indexName);
-        assertThat(index.compareIndexTypeTo("text", null), is(false));
+        assertThat(index.compareIndexTypeTo(IndexType.TEXT, null), is(false));
     }
 
     @Test
     public void comparesIndexTypeAndReturnsEquality() {
         Index index = Index.getInstance(fieldNames, indexName);
-        assertThat(index.compareIndexTypeTo("json", null), is(true));
+        assertThat(index.compareIndexTypeTo(IndexType.JSON, null), is(true));
     }
 
     @Test
     public void comparesIndexSettingsAndReturnsInEquality() {
-        Index index = Index.getInstance(fieldNames, indexName, "text");
-        assertThat(index.compareIndexTypeTo("text", "{\"tokenize\":\"porter\"}"), is(false));
+        Index index = Index.getInstance(fieldNames, indexName, IndexType.TEXT);
+        assertThat(index.compareIndexTypeTo(IndexType.TEXT, "{\"tokenize\":\"porter\"}"), is(false));
     }
 
     @Test
     public void comparesIndexSettingsAndReturnsEquality() {
-        Index index = Index.getInstance(fieldNames, indexName, "text");
-        assertThat(index.compareIndexTypeTo("text", "{\"tokenize\":\"simple\"}"), is(true));
+        Index index = Index.getInstance(fieldNames, indexName, IndexType.TEXT);
+        assertThat(index.compareIndexTypeTo(IndexType.TEXT, "{\"tokenize\":\"simple\"}"), is(true));
     }
 
     @Test
     public void returnsIndexSettingsAsAString() {
-        Index index = Index.getInstance(fieldNames, indexName, "text");
+        Index index = Index.getInstance(fieldNames, indexName, IndexType.TEXT);
         assertThat(index.settingsAsJSON(), is("{\"tokenize\":\"simple\"}"));
     }
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexUpdaterTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexUpdaterTest.java
@@ -20,7 +20,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
-import com.cloudant.sync.datastore.DocumentBody;
 import com.cloudant.sync.datastore.DocumentBodyFactory;
 import com.cloudant.sync.datastore.DocumentException;
 import com.cloudant.sync.datastore.DocumentRevision;
@@ -841,11 +840,11 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         // Test index updates for multiple json indexes as well as
         // index updates for co-existing json and text indexes.
         if (testType.equals(TEXT_INDEX_EXECUTION)) {
-            createIndex("basic", Arrays.<Object>asList("age", "pet", "name"), "text");
+            createIndex("basic", Arrays.<Object>asList("age", "pet", "name"), IndexType.TEXT);
         } else {
-            createIndex("basic", Arrays.<Object>asList("age", "pet", "name"), "json");
+            createIndex("basic", Arrays.<Object>asList("age", "pet", "name"), IndexType.JSON);
         }
-        createIndex("basicName", Arrays.<Object>asList("name"), "json");
+        createIndex("basicName", Arrays.<Object>asList("name"), IndexType.JSON);
 
         im.updateAllIndexes();
 
@@ -959,14 +958,14 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
 
     private void createIndex(String indexName, List<Object> fieldNames) {
         if (testType.equals(TEXT_INDEX_EXECUTION)) {
-            createIndex(indexName, fieldNames, "text");
+            createIndex(indexName, fieldNames, IndexType.TEXT);
         } else {
-            createIndex(indexName, fieldNames, "json");
+            createIndex(indexName, fieldNames, IndexType.JSON);
         }
     }
 
     @SuppressWarnings("unchecked")
-    private void createIndex(String indexName, List<Object> fieldNames, String indexType) {
+    private void createIndex(String indexName, List<Object> fieldNames, IndexType indexType) {
         assertThat(im.ensureIndexed(fieldNames, indexName, indexType), is(indexName));
 
         Map<String, Object> indexes = im.listIndexes();

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryResultTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryResultTest.java
@@ -12,6 +12,10 @@
 
 package com.cloudant.sync.query;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
 import com.cloudant.sync.datastore.encryption.NullKeyProvider;
 import com.cloudant.sync.sqlite.SQLDatabase;
 import com.cloudant.sync.sqlite.SQLDatabaseQueue;
@@ -27,10 +31,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
 
 public class QueryResultTest extends AbstractQueryTestBase {
 
@@ -61,7 +61,7 @@ public class QueryResultTest extends AbstractQueryTestBase {
     public void testQueryGetDocumentsWithIdsFails() throws InterruptedException,
         ExecutionException {
         List<Object> fields = Collections.<Object>singletonList("pet");
-        assertThat(im.ensureIndexed(fields, "basic_text", "text"), is("basic_text"));
+        assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
 
         // query - { "$text" : { "$search" : "cat" } }
         Map<String, Object> search = new HashMap<String, Object>();

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QuerySqlTranslatorTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QuerySqlTranslatorTest.java
@@ -45,7 +45,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         super.setUp();
         indexName = im.ensureIndexed(Arrays.<Object>asList("name", "age", "pet"), "basic");
         assertThat(indexName, is("basic"));
-        textIndexName = im.ensureIndexed(Arrays.<Object>asList("comments"), "basic_text", "text");
+        textIndexName = im.ensureIndexed(Arrays.<Object>asList("comments"), "basic_text", IndexType.TEXT);
         assertThat(textIndexName, is("basic_text"));
         indexes = im.listIndexes();
         assertThat(indexes.size(), is(2));
@@ -494,7 +494,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         Map<String, Object> indexes = new HashMap<String, Object>();
         Map<String, Object> index = new HashMap<String, Object>();
         index.put("name", "named");
-        index.put("type", "json");
+        index.put("type", IndexType.JSON);
         index.put("fields", Arrays.<Object>asList("name"));
         indexes.put("named", index);
 
@@ -512,7 +512,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         Map<String, Object> indexes = new HashMap<String, Object>();
         Map<String, Object> index = new HashMap<String, Object>();
         index.put("name", "named");
-        index.put("type", "json");
+        index.put("type", IndexType.JSON);
         index.put("fields", Arrays.<Object>asList("name", "age", "pet"));
         indexes.put("named", index);
 
@@ -532,17 +532,17 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
 
         Map<String, Object> named = new HashMap<String, Object>();
         named.put("name", "named");
-        named.put("type", "json");
+        named.put("type", IndexType.JSON);
         named.put("fields", Arrays.<Object>asList("name", "age", "pet"));
 
         Map<String, Object> bopped = new HashMap<String, Object>();
         bopped.put("name", "bopped");
-        bopped.put("type", "json");
+        bopped.put("type", IndexType.JSON);
         bopped.put("fields", Arrays.<Object>asList("house_number", "pet"));
 
         Map<String, Object> unsuitable = new HashMap<String, Object>();
         unsuitable.put("name", "unsuitable");
-        unsuitable.put("type", "json");
+        unsuitable.put("type", IndexType.JSON);
         unsuitable.put("fields", Arrays.<Object>asList("name"));
 
         indexes.put("named", named);
@@ -565,7 +565,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
 
         Map<String, Object> named = new HashMap<String, Object>();
         named.put("name", "named");
-        named.put("type", "json");
+        named.put("type", IndexType.JSON);
         named.put("fields", Arrays.<Object>asList("name", "age", "pet"));
 
         Map<String, Object> bopped = new HashMap<String, Object>();
@@ -575,12 +575,12 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
 
         Map<String, Object> manyField = new HashMap<String, Object>();
         manyField.put("name", "manyField");
-        manyField.put("type", "json");
+        manyField.put("type", IndexType.JSON);
         manyField.put("fields", Arrays.<Object>asList("name", "age", "pet"));
 
         Map<String, Object> unsuitable = new HashMap<String, Object>();
         unsuitable.put("name", "unsuitable");
-        unsuitable.put("type", "json");
+        unsuitable.put("type", IndexType.JSON);
         unsuitable.put("fields", Arrays.<Object>asList("name"));
 
         indexes.put("named", named);
@@ -604,12 +604,12 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
 
         Map<String, Object> named = new HashMap<String, Object>();
         named.put("name", "named");
-        named.put("type", "json");
+        named.put("type", IndexType.JSON);
         named.put("fields", Arrays.<Object>asList("name", "age"));
 
         Map<String, Object> unsuitable = new HashMap<String, Object>();
         unsuitable.put("name", "unsuitable");
-        unsuitable.put("type", "json");
+        unsuitable.put("type", IndexType.JSON);
         unsuitable.put("fields", Arrays.<Object>asList("name"));
 
         indexes.put("named", named);

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryTextSearchTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryTextSearchTest.java
@@ -108,7 +108,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
 
     @Test
     public void canMakeAQueryConsistingOfASingleTextSearch() {
-        assertThat(im.ensureIndexed(Arrays.<Object>asList("comment"), "basic_text", "text"),
+        assertThat(im.ensureIndexed(Arrays.<Object>asList("comment"), "basic_text", IndexType.TEXT),
                                     is("basic_text"));
 
         // query - { "$text" : { "$search" : "lives in Bristol" } }
@@ -122,7 +122,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
 
     @Test
     public void canMakeAPhraseSearch() {
-        assertThat(im.ensureIndexed(Arrays.<Object>asList("comment"), "basic_text", "text"),
+        assertThat(im.ensureIndexed(Arrays.<Object>asList("comment"), "basic_text", IndexType.TEXT),
                                     is("basic_text"));
 
         // query - { "$text" : { "$search" : "\"lives in Bristol\"" } }
@@ -136,7 +136,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
 
     @Test
     public void canMakeAQueryTextSearchContainingAnApostrophe() {
-        assertThat(im.ensureIndexed(Arrays.<Object>asList("comment"), "basic_text", "text"),
+        assertThat(im.ensureIndexed(Arrays.<Object>asList("comment"), "basic_text", IndexType.TEXT),
                                     is("basic_text"));
 
         // query - { "$text" : { "$search" : "He's retired" } }
@@ -150,7 +150,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
 
     @Test
     public void canMakeAQueryConsistingOfASingleTextSearchWithASort() {
-        assertThat(im.ensureIndexed(Arrays.<Object>asList("name", "comment"), "basic_text", "text"),
+        assertThat(im.ensureIndexed(Arrays.<Object>asList("name", "comment"), "basic_text", IndexType.TEXT),
                                     is("basic_text"));
 
         // query - { "$text" : { "$search" : "best friend" } }
@@ -171,7 +171,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
     @Test
     public void canMakeANDCompoundQueryWithATextSearch() {
         assertThat(im.ensureIndexed(Arrays.<Object>asList("name"), "basic"), is("basic"));
-        assertThat(im.ensureIndexed(Arrays.<Object>asList("name", "comment"), "basic_text", "text"),
+        assertThat(im.ensureIndexed(Arrays.<Object>asList("name", "comment"), "basic_text", IndexType.TEXT),
                    is("basic_text"));
 
         // query - { "name" : "mike", "$text" : { "$search" : "best friend" } }
@@ -187,7 +187,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
     @Test
     public void canMakeORCompoundQueryWithATextSearch() {
         assertThat(im.ensureIndexed(Arrays.<Object>asList("name"), "basic"), is("basic"));
-        assertThat(im.ensureIndexed(Arrays.<Object>asList("comment"), "basic_text", "text"),
+        assertThat(im.ensureIndexed(Arrays.<Object>asList("comment"), "basic_text", IndexType.TEXT),
                    is("basic_text"));
 
         // query - { "$or" : [ { "name" : "mike" }, { "$text" : { "$search" : "best friend" } } ] }
@@ -226,7 +226,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
         // So even though "name" exists in the text index, the clause that { "name" : "mike" }
         // expects a JSON index that contains the "name" field.  Since, this query includes a
         // text search clause then all clauses of the query must be satisfied by existing indexes.
-        assertThat(im.ensureIndexed(Arrays.<Object>asList("name", "comment"), "basic_text", "text"),
+        assertThat(im.ensureIndexed(Arrays.<Object>asList("name", "comment"), "basic_text", IndexType.TEXT),
                    is("basic_text"));
 
         // query - { "$or" : [ { "name" : "mike" }, { "$text" : { "$search" : "best friend" } } ] }
@@ -245,7 +245,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
     @Test
     public void canMakeATextSearchUsingNonAsciiValues() {
         List<Object> fields = Collections.<Object>singletonList("comment");
-        assertThat(im.ensureIndexed(fields, "basic_text", "text"), is("basic_text"));
+        assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
 
         // query - { "$text" : { "$search" : "\"صديق له هو\"" } }
         Map<String, Object> search = new HashMap<String, Object>();
@@ -259,7 +259,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
     @Test
     public void returnsEmptyResultSetForUnmatchedPhraseSearch() {
         List<Object> fields = Collections.<Object>singletonList("comment");
-        assertThat(im.ensureIndexed(fields, "basic_text", "text"), is("basic_text"));
+        assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
 
         // query - { "$text" : { "$search" : "\"Remus Romulus\"" } }
         Map<String, Object> search = new HashMap<String, Object>();
@@ -273,7 +273,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
     @Test
     public void returnsCorrectResultSetForNonContiguousWordSearch() {
         List<Object> fields = Collections.<Object>singletonList("comment");
-        assertThat(im.ensureIndexed(fields, "basic_text", "text"), is("basic_text"));
+        assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
 
         // query - { "$text" : { "$search" : "Remus Romulus" } }
         // - The search predicate "Remus Romulus" normalizes to "Remus AND Romulus" in SQLite
@@ -288,7 +288,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
     @Test
     public void canQueryUsingEnhancedQuerySyntaxOR() {
         List<Object> fields = Collections.<Object>singletonList("comment");
-        assertThat(im.ensureIndexed(fields, "basic_text", "text"), is("basic_text"));
+        assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
 
         // query - { "$text" : { "$search" : "Remus OR Romulus" } }
         // - Enhanced Query Syntax - logical operators must be uppercase otherwise they will
@@ -307,7 +307,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
         Set<String> compileOptions = SQLDatabaseTestUtils.getCompileOptions(db);
         if (compileOptions.containsAll(Arrays.asList("ENABLE_FTS3", "ENABLE_FTS3_PARENTHESIS"))) {
             List<Object> fields = Collections.<Object>singletonList("comment");
-            assertThat(im.ensureIndexed(fields, "basic_text", "text"), is("basic_text"));
+            assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
 
             // query - { "$text" : { "$search" : "Remus NOT Romulus" } }
             // - Enhanced Query Syntax - logical operators must be uppercase otherwise they will
@@ -328,7 +328,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
         Set<String> compileOptions = SQLDatabaseTestUtils.getCompileOptions(db);
         if (compileOptions.containsAll(Arrays.asList("ENABLE_FTS3", "ENABLE_FTS3_PARENTHESIS"))) {
             List<Object> fields = Collections.<Object>singletonList("comment");
-            assertThat(im.ensureIndexed(fields, "basic_text", "text"), is("basic_text"));
+            assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
 
             // query - { "$text" : { "$search" : "(Remus OR Romulus) AND \"lives next door\"" } }
             // - Parentheses are used to override SQLite enhanced query syntax operator precedence
@@ -345,7 +345,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
     @Test
     public void canQueryUsingNEAR() {
         List<Object> fields = Collections.<Object>singletonList("comment");
-        assertThat(im.ensureIndexed(fields, "basic_text", "text"), is("basic_text"));
+        assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
 
         // query - { "$text" : { "$search" : "\"he lives\" NEAR/2 Bristol" } }
         // - NEAR provides the ability to search for terms/phrases in proximity to each other
@@ -362,7 +362,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
     @Test
     public void ignoresCapitalizationUsingDefaultTokenizer() {
         List<Object> fields = Collections.<Object>singletonList("comment");
-        assertThat(im.ensureIndexed(fields, "basic_text", "text"), is("basic_text"));
+        assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
 
         // query - { "$text" : { "$search" : "rEmUs RoMuLuS" } }
         // - Search is generally case-insensitive unless a custom tokenizer is provided
@@ -378,7 +378,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
     public void queriesNonStringFieldAsAString() {
         // Text index on age field
         List<Object> fields = Collections.<Object>singletonList("age");
-        assertThat(im.ensureIndexed(fields, "basic_text", "text"), is("basic_text"));
+        assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
 
         // query - { "$text" : { "$search" : "12" } }
         Map<String, Object> search = new HashMap<String, Object>();
@@ -393,7 +393,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
     public void returnsNullWhenSearchCriteriaNotAString() {
         // Text index on age field
         List<Object> fields = Collections.<Object>singletonList("age");
-        assertThat(im.ensureIndexed(fields, "basic_text", "text"), is("basic_text"));
+        assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
 
         // query - { "$text" : { "$search" : 12 } }
         Map<String, Object> search = new HashMap<String, Object>();
@@ -408,7 +408,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
     public void canQueryAcrossMultipleFields() {
         // Text index on name and comment fields
         List<Object> fields = Arrays.<Object>asList("name", "comment");
-        assertThat(im.ensureIndexed(fields, "basic_text", "text"), is("basic_text"));
+        assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
 
         // query - { "$text" : { "$search" : "Fred" } }
         //       - Will find both fred12 and fred34 as well as mike12 since Fred is mentioned
@@ -425,7 +425,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
     public void canQueryTargetingSpecificFields() {
         // Text index on name and comment fields
         List<Object> fields = Arrays.<Object>asList("name", "comment");
-        assertThat(im.ensureIndexed(fields, "basic_text", "text"), is("basic_text"));
+        assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
 
         // query - { "$text" : { "$search" : "name:fred comment:lives in Bristol" } }
         //       - Will only find fred12 since he is the only named fred who's comment
@@ -441,7 +441,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
     @Test
     public void canQueryUsingPrefixSearches() {
         List<Object> fields = Collections.<Object>singletonList("comment");
-        assertThat(im.ensureIndexed(fields, "basic_text", "text"), is("basic_text"));
+        assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
 
         // query - { "$text" : { "$search" : "liv* riv*" } }
         Map<String, Object> search = new HashMap<String, Object>();
@@ -455,7 +455,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
     @Test
     public void returnsEmptyResultSetWhenPrefixSearchesMissingWildcards() {
         List<Object> fields = Collections.<Object>singletonList("comment");
-        assertThat(im.ensureIndexed(fields, "basic_text", "text"), is("basic_text"));
+        assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
 
         // query - { "$text" : { "$search" : "liv riv" } }
         Map<String, Object> search = new HashMap<String, Object>();
@@ -469,7 +469,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
     @Test
     public void canQueryUsingID() {
         List<Object> fields = Collections.<Object>singletonList("comment");
-        assertThat(im.ensureIndexed(fields, "basic_text", "text"), is("basic_text"));
+        assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
 
         // query - { "$text" : { "$search" : "_id:mike*" } }
         Map<String, Object> search = new HashMap<String, Object>();
@@ -485,7 +485,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
         List<Object> fields = Collections.<Object>singletonList("comment");
         Map<String, String> indexSettings = new HashMap<String, String>();
         indexSettings.put("tokenize", "porter");
-        assertThat(im.ensureIndexed(fields, "basic_text", "text", indexSettings), is("basic_text"));
+        assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT, indexSettings), is("basic_text"));
 
         // query - { "$text" : { "$search" : "live" } }
         Map<String, Object> search = new HashMap<String, Object>();
@@ -499,7 +499,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
     @Test
     public void returnsEmptyResultSetUsingDefaultTokenizerStemmer() {
         List<Object> fields = Collections.<Object>singletonList("comment");
-        assertThat(im.ensureIndexed(fields, "basic_text", "text"), is("basic_text"));
+        assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
 
         // query - { "$text" : { "$search" : "live" } }
         Map<String, Object> search = new HashMap<String, Object>();
@@ -513,7 +513,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
     @Test
     public void canQueryUsingAnApostrophe() {
         List<Object> fields = Collections.<Object>singletonList("comment");
-        assertThat(im.ensureIndexed(fields, "basic_text", "text"), is("basic_text"));
+        assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
 
         // query - { "$text" : { "$search" : "He's retired" } }
         Map<String, Object> search = new HashMap<String, Object>();

--- a/doc/query.md
+++ b/doc/query.md
@@ -44,18 +44,18 @@ The `IndexManager` object provides the ability to manage query indexes and execu
 Secondly, these documents are in the datastore:
 
 ```java
-{ "name": "mike", 
-  "age": 12, 
+{ "name": "mike",
+  "age": 12,
   "pet": {"species": "cat"},
   "comment": "Mike goes to middle school and likes reading books." };
 
-{ "name": "mike", 
-  "age": 34, 
+{ "name": "mike",
+  "age": 34,
   "pet": {"species": "dog"},
   "comment": "Mike is a doctor and likes reading books." };
 
-{ "name": "fred", 
-  "age": 23, 
+{ "name": "fred",
+  "age": 23,
   "pet": {"species": "cat"},
   "comment": "Fred works for a startup out of his home office." };
 ```
@@ -74,28 +74,28 @@ Basic querying of fields benefits but does _not require_ a JSON index. For examp
 Use the following methods to create a JSON index:
 
 ```
-ensureIndexed(List<Object> fieldNames, 
+ensureIndexed(List<Object> fieldNames,
               String indexName)
 ```
 
 Use either of the following methods to create a TEXT index:
 
 ```
-ensureIndexed(List<Object> fieldNames, 
-              String indexName, 
-              String indexType)
+ensureIndexed(List<Object> fieldNames,
+              String indexName,
+              IndexType indexType)
 
-// or 
+// or
 
-ensureIndexed(List<Object> fieldNames, 
-              String indexName, 
-              String indexType, 
+ensureIndexed(List<Object> fieldNames,
+              String indexName,
+              IndexType indexType,
               Map<String, String> indexSettings)
-``` 
+```
 
 These indexes are persistent across application restarts as they are saved to disk. They are kept up to date as documents change; there's no need to call the `ensureIndexed(...)` method each time your applications starts, though there is no harm in doing so.
 
-The first argument, `fieldNames` is a list of fields to put into the index. The second argument, `indexName` is a name for the index. This is used to delete indexes at a later stage and appears when you list the indexes in the database.  The third argument, `indexType` defines what type of index to create.  Valid index types are `json` and `text`.  If not provided, the index type defaults to `json`.  The fourth argument, `indexSettings` is comprised of index parameters and their values.  Currently the only valid index setting is `tokenize` and it can only apply to a TEXT index.  If index settings are not provided for a TEXT index, the `tokenize` parameter defaults to the value `simple`.
+The first argument, `fieldNames` is a list of fields to put into the index. The second argument, `indexName` is a name for the index. This is used to delete indexes at a later stage and appears when you list the indexes in the database.  The third argument, `indexType` defines what type of index to create. If not provided, the index type defaults to `JSON`.  The fourth argument, `indexSettings` is comprised of index parameters and their values.  Currently the only valid index setting is `tokenize` and it can only apply to a TEXT index.  If index settings are not provided for a TEXT index, the `tokenize` parameter defaults to the value `simple`.
 
 A field can appear in more than one index. The query engine will select an appropriate index to use for a given query. However, the more indexes you have, the more disk space they will use and the greater the overhead in keeping them up to date.
 
@@ -103,7 +103,7 @@ To index values in sub-documents, use _dotted notation_. This notation puts the 
 
 ```java
 // Create an index over the name, age, and species fields.
-String name = im.ensureIndexed(Arrays.<Object>asList("name", "age", "pet.species"), 
+String name = im.ensureIndexed(Arrays.<Object>asList("name", "age", "pet.species"),
                                "basic");
 if (name == null) {
     // there was an error creating the index
@@ -112,7 +112,7 @@ if (name == null) {
 
 ####Indexing for text search
 
-Since text search relies on SQLite FTS which is a compile time option, we must ensure that SQLite FTS is infact available.  To verify that text search is enabled and that a text index can be created use `isTextSearchEnabled()` before attempting to create a text index.  If text search is not enabled see [compiling and enabling SQLite FTS][enableFTS] and [SQLite Android Bindings][androidBind] for details. 
+Since text search relies on SQLite FTS which is a compile time option, we must ensure that SQLite FTS is infact available.  To verify that text search is enabled and that a text index can be created use `isTextSearchEnabled()` before attempting to create a text index.  If text search is not enabled see [compiling and enabling SQLite FTS][enableFTS] and [SQLite Android Bindings][androidBind] for details.
 
 [enableFTS]: http://www.sqlite.org/fts3.html#section_2
 [androidBind]: https://www.sqlite.org/android/doc/trunk/www/index.wiki
@@ -120,9 +120,9 @@ Since text search relies on SQLite FTS which is a compile time option, we must e
 ```java
 if (im.isTextSearchEnabled()) {
     // Create a text index over the name and comment fields.
-    String name = im.ensureIndexed(Arrays.<Object>asList("name", "comment"), 
-                                   "basic_text_index", 
-                                   "text");
+    String name = im.ensureIndexed(Arrays.<Object>asList("name", "comment"),
+                                   "basic_text_index",
+                                   IndexType.TEXT);
     if (name == null) {
         // there was an error creating the index
     }
@@ -140,9 +140,9 @@ if (im.isTextSearchEnabled()) {
     Map<String, String> settings = new HashMap<String, String>();
     settings.add("tokenize", "porter");
     // Create a text index over the name and comment fields.
-    String name = im.ensureIndexed(Arrays.<Object>asList("name", "comment"), 
-                                   "basic_text_index", 
-                                   "text",
+    String name = im.ensureIndexed(Arrays.<Object>asList("name", "comment"),
+                                   "basic_text_index",
+                                   IndexType.TEXT,
                                    settings);
     if (name == null) {
         // there was an error creating the index
@@ -163,7 +163,7 @@ If an index needs to be changed, first delete the existing index by calling `del
 
 #### Indexing document metadata (_id and _rev)
 
-The document ID and revision ID are automatically indexed under `_id` and `_rev` 
+The document ID and revision ID are automatically indexed under `_id` and `_rev`
 respectively. If you need to query on document ID or document revision ID,
 use these field names.
 
@@ -248,8 +248,8 @@ query.put("$text", search);
 This query will match the following document because both `doctor` and `books` are found in its comment field.
 
 ```
-{ "name": "mike", 
-  "age": 34, 
+{ "name": "mike",
+  "age": 34,
   "pet": {"species": "dog"},
   "comment": "Mike is a doctor and likes reading books." };
 ```
@@ -267,8 +267,8 @@ query.put("$text", search);
 This query will match the following document because the phrase `is a doctor` is found in its comment field.
 
 ```
-{ "name": "mike", 
-  "age": 34, 
+{ "name": "mike",
+  "age": 34,
   "pet": {"species": "dog"},
   "comment": "Mike is a doctor and likes reading books." };
 ```
@@ -286,8 +286,8 @@ query.put("$text", search);
 This query will match the following document because the prefix `doc` followed by the `*` wildcard matches `doctor` found in its comment field.
 
 ```
-{ "name": "mike", 
-  "age": 34, 
+{ "name": "mike",
+  "age": 34,
   "pet": {"species": "dog"},
   "comment": "Mike is a doctor and likes reading books." };
 ```
@@ -314,7 +314,7 @@ Use `$or` to find documents where just one of the clauses match.
 To find all people with a `dog` who are under thirty:
 
 ```java
-// query: { "$or": [ { "pet.species": { "$eq": "dog" } }, 
+// query: { "$or": [ { "pet.species": { "$eq": "dog" } },
 //                   { "age": { "$lt": 30 } }
 //                 ]}
 Map<String, Object> query = new HashMap<String, Object>();
@@ -337,7 +337,7 @@ This selects documents where _either_ the person has a pet `dog` _or_ they are
 both over thirty _and_ named `mike`:
 
 ```java
-// query: { "$or": [ { "pet.species": { "$eq": "dog" } }, 
+// query: { "$or": [ { "pet.species": { "$eq": "dog" } },
 //                   { "$and": [ { "age": { "$gt": 30 } },
 //                               { "name": { "$eq": "mike" } }
 //                             ] }
@@ -380,7 +380,7 @@ There is an extended version of the `find` method which supports:
 - Skipping results.
 - Limiting the number of results returned.
 
-For any of these, use 
+For any of these, use
 
 ```java
 find(Map<String, Object> query,
@@ -392,7 +392,7 @@ find(Map<String, Object> query,
 
 #### Sorting
 
-Provide a sort document to the extended version of the `find` method to sort the results of a query. 
+Provide a sort document to the extended version of the `find` method to sort the results of a query.
 
 The sort document is a list of fields to sort by. Each field is represented by a map specifying the name of the field to sort by and the direction to sort.
 
@@ -480,7 +480,7 @@ Take this document as an example:
 You can create an index over the `pet` field:
 
 ```java
-String name = im.ensureIndexed(Arrays.<Object>asList("name", "age", "pet"), 
+String name = im.ensureIndexed(Arrays.<Object>asList("name", "age", "pet"),
                                "basic");
 ```
 
@@ -521,7 +521,7 @@ successful.
 However, if there was one index with `pet` in and another with `name` in, like this:
 
 ```java
-String indexOne = im.ensureIndexed(Arrays.<Object>asList("name", "age"), 
+String indexOne = im.ensureIndexed(Arrays.<Object>asList("name", "age"),
                                    "index_one");
 String indexTwo = im.ensureIndexed(Arrays.<Object>asList("age", "pet"),
                                    "index_two");
@@ -548,7 +548,7 @@ Right now the list of supported features is:
 - Skipping results.
 - Queries can include unindexed fields.
 - Queries can include a text search clause, although if they do no unindexed fields may be used.
-      
+
 Selectors -> combination
 
 - `$and`
@@ -603,7 +603,7 @@ the commit log :)
 
 Overall restrictions:
 
-- Cannot use covering indexes with projection (`fields`) to avoid loading 
+- Cannot use covering indexes with projection (`fields`) to avoid loading
   documents from the datastore.
 
 #### Query syntax
@@ -655,27 +655,27 @@ Here:
 * Quotes enclose literal string values.
 
 <pre>
-<em>query</em> := 
+<em>query</em> :=
     <strong>{ }</strong>
     <strong>{</strong> <em>many-expressions</em> <strong>}</strong>
 
 <em>many-expressions</em> := <em>expression</em> (&quot;,&quot; <em>expression</em>)*
 
-<em>expression</em> := 
+<em>expression</em> :=
     <em>compound-expression</em>
     <em>comparison-expression</em>
     <em>text-search-expression</em>
 
-<em>compound-expression</em> := 
+<em>compound-expression</em> :=
     <strong>{</strong> (&quot;$and&quot; | &quot;$nor&quot; | &quot;$or&quot;) <strong>:</strong> <strong>[</strong> <em>many-expressions</em> <strong>] }</strong>  // nor not implemented
-    
+
 <em>comparison-expression</em> :=
     <strong>{</strong> <em>field</em> <strong>:</strong> <strong>{</strong> <em>operator-expression</em> <strong>} }</strong>
 
-<em>negation-expression</em> := 
+<em>negation-expression</em> :=
     <strong>{</strong> &quot;$not&quot; <strong>:</strong> <strong>{</strong> <em>operator-expression</em> <strong>} }</strong>
 
-<em>operator-expression</em> := 
+<em>operator-expression</em> :=
     <em>negation-expression</em>
     <strong>{</strong> <em>operator</em> <strong>:</strong> <em>simple-value</em> <strong>}</strong>
     <strong>{</strong> &quot;$regex&quot; <strong>:</strong> <em>Pattern</em> <strong>}</strong>  // not implemented


### PR DESCRIPTION
## What
Use a enum instead of strings for index type parameters

## Why
Users have been confused with the index type parameter and have been using their own, restricting this to an enum will make the API easier to understand.

## How
- Created `IndexType` enum
- Change the parameter of type of `indexType` from `String` to `IndexType`

## Tests

No additional tests have been added, however some tests were removed as they are no longer needed.

## Reviewers 

reviewer @tomblench 
reviewer @alfinkel 

## Issues

Fixes: #246