### PR TITLE
60490 policies remote config

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@
  the following APIs:
   - Index#getInstance
   - IndexManger#ensureIndexed
+- [BREAKING CHANGE] Made it easier to create replication policies where credentials for replicators
+  need to be retrieved asynchronously.
 
 # 0.15.5 (2016-02-25)
 - [FIXED] Issue where `java.lang.RuntimeException: Offer timed out` could be thrown 5 minutes after
@@ -61,7 +63,7 @@
   for a code sample which shows how to add custom request headers
   using an HTTP Request Interceptor.
 - [NEW] Added replication policies, allowing users to easily create policies such as "Replicate
-   every 2 hours, only when on Wifi". See the [Replication Policies User Guide](REPLICATION_POLICIES.md).
+   every 2 hours, only when on Wifi". See the [Replication Policies User Guide](doc/replication-policies.md).
 - [IMPROVED] Replication reliability when transferring data over unreliable
   networks.
 

--- a/cloudant-sync-datastore-android/src/test/java/com/cloudant/android/TestReplicationService.java
+++ b/cloudant-sync-datastore-android/src/test/java/com/cloudant/android/TestReplicationService.java
@@ -37,31 +37,6 @@ public class TestReplicationService extends PeriodicReplicationService {
         attachBaseContext(baseContext);
     }
 
-    protected Replicator[] getReplicators(Context context) {
-        try {
-            File path = context.getDir(
-                DATASTORE_MANGER_DIR,
-                Context.MODE_PRIVATE
-            );
-            DatastoreManager manager = new DatastoreManager(path.getAbsolutePath());
-            Datastore datastore = null;
-            try {
-                datastore = manager.openDatastore(TASKS_DATASTORE_NAME);
-            } catch (DatastoreNotCreatedException dnce) {
-                Log.e(TAG, "Unable to open Datastore", dnce);
-            }
-
-            // Set some arbitrary URI. Our tests use mocks, so we're not going to communicate with it anyway.
-            URI uri = new URI("https://test.cloudant.com");
-            Replicator pullReplicator = ReplicatorBuilder.pull().from(uri).to(datastore).withId(0).build();
-            return new Replicator[] {pullReplicator};
-        } catch (URISyntaxException e) {
-            e.printStackTrace();
-        }
-
-        return null;
-    }
-
     protected int getBoundIntervalInSeconds() {
         return 60;
     }

--- a/cloudant-sync-datastore-android/src/test/java/com/cloudant/sync/replication/WifiPeriodicReplicationReceiverTest.java
+++ b/cloudant-sync-datastore-android/src/test/java/com/cloudant/sync/replication/WifiPeriodicReplicationReceiverTest.java
@@ -75,10 +75,6 @@ public class WifiPeriodicReplicationReceiverTest extends AndroidTestCase {
             super(Receiver.class);
         }
         @Override
-        protected Replicator[] getReplicators(Context context) {
-            return null;
-        }
-        @Override
         protected int getBoundIntervalInSeconds() {
             return 20;
         }


### PR DESCRIPTION
*What*
Make Android replication policies easier to use when getting credentials for replication from a remote service.

*How*
The previous implementation required that the `getReplicators()` method was overridden in the concrete implementation to retrieve `Replicator` objects configured to perform the desired replications. It was always assumed this could be called from the `ReplicationService.onCreate()` method, which causes issues when an asynchronous call is required to get credentials in order to setup the `Replicator` objects. The new implementation removes the abstract `getReplicators()` method from the interface and instead requires the user to call `setReplicators(Replicator[])` before the service will respond to commands sent to it via the `Intent` mechanism. Any commands sent to the `ReplicationService` prior to `setReplicators(Replicator[])` being called will be queued and only processed once `setReplicators(Replicator[])` has been called. If consecutive identical commands are sent to the `ReplicationService` before `setReplicators(Replicator[])` has been called, the duplicates will be ignored.

*Testing*
New tests have been added to ensure that commands sent to the `ReplicationService` are not processed before `setReplicators(Replicator[])` has been called and that the queuing mechanism works as described above.

reviewer @ricellis
reviewer @alfinkel