### PR TITLE
Implement ensureIndexed with index name generation

### DIFF
--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/Index.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/Index.java
@@ -61,7 +61,7 @@ class Index {
      * This method sets the index type to the default setting of "json"
      *
      * @param fieldNames the field names in the index
-     * @param indexName the index name
+     * @param indexName the index name or null
      * @return the Index object or null if arguments passed in were invalid.
      */
     public static Index getInstance(List<Object> fieldNames, String indexName) {
@@ -77,7 +77,7 @@ class Index {
      * Index object is valid.
      *
      * @param fieldNames the field names in the index
-     * @param indexName the index name
+     * @param indexName the index name or null
      * @param indexType the index type (json or text)
      * @param indexSettings the optional settings used to configure the index.
      *                      Only supported parameter is 'tokenize' for text indexes only.
@@ -92,8 +92,7 @@ class Index {
             return null;
         }
 
-        if (indexName == null || indexName.isEmpty()) {
-            logger.log(Level.SEVERE, "No index name was provided.");
+        if(indexName != null && indexName.isEmpty()){
             return null;
         }
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexManager.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexManager.java
@@ -224,9 +224,7 @@ public class IndexManager {
      *  @return name of created index
      */
     public String ensureIndexed(List<Object> fieldNames) {
-        logger.log(Level.SEVERE, "ensureIndexed(fieldNames) not implemented.");
-
-        return null;
+        return this.ensureIndexed(fieldNames, null);
     }
 
     /**
@@ -235,14 +233,14 @@ public class IndexManager {
      *  This function generates a name for the new index.
      *
      *  @param fieldNames List of field names in the sort format
-     *  @param indexName Name of index to create
+     *  @param indexName Name of index to create or null to generate an index name.
      *  @return name of created index
      */
     public String ensureIndexed(List<Object> fieldNames, String indexName) {
         return IndexCreator.ensureIndexed(Index.getInstance(fieldNames, indexName),
-                                          database,
-                                          datastore,
-                                          queue);
+                database,
+                datastore,
+                queue);
     }
 
     /**
@@ -251,7 +249,7 @@ public class IndexManager {
      *  This function generates a name for the new index.
      *
      *  @param fieldNames List of field names in the sort format
-     *  @param indexName Name of index to create
+     *  @param indexName Name of index to create or null to generate an index name.
      *  @param indexType The type of index (json or text currently supported)
      *  @return name of created index
      */
@@ -265,7 +263,7 @@ public class IndexManager {
      *  This function generates a name for the new index.
      *
      *  @param fieldNames List of field names in the sort format
-     *  @param indexName Name of index to create
+     *  @param indexName Name of index to create or null to generate an index name.
      *  @param indexType The type of index (json or text currently supported)
      *  @param indexSettings The optional settings to be applied to an index
      *                       Only text indexes support settings - Ex. { "tokenize" : "simple" }
@@ -276,12 +274,12 @@ public class IndexManager {
                                 IndexType indexType,
                                 Map<String, String> indexSettings) {
         return IndexCreator.ensureIndexed(Index.getInstance(fieldNames,
-                                                            indexName,
-                                                            indexType,
-                                                            indexSettings),
-                                          database,
-                                          datastore,
-                                          queue);
+                        indexName,
+                        indexType,
+                        indexSettings),
+                database,
+                datastore,
+                queue);
     }
 
     /**
@@ -442,8 +440,8 @@ public class IndexManager {
     public boolean isTextSearchEnabled() {
         if (!textSearchEnabled) {
             logger.log(Level.INFO, "Text search is currently not supported.  " +
-                                   "To enable text search recompile SQLite with " +
-                                   "the full text search compile options enabled.");
+                    "To enable text search recompile SQLite with " +
+                    "the full text search compile options enabled.");
         }
         return textSearchEnabled;
     }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexCreatorTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexCreatorTest.java
@@ -47,11 +47,6 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
         name = im.ensureIndexed(fieldNames, "basic");
         assertThat(name, is(nullValue()));
 
-        // doesn't create an index on null name
-        fieldNames = Arrays.<Object>asList("name");
-        name = im.ensureIndexed(fieldNames, null);
-        assertThat(name, is(nullValue()));
-
         // doesn't create an index without a name
         name = im.ensureIndexed(fieldNames, "");
         assertThat(name, is(nullValue()));

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexManagerTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexManagerTest.java
@@ -16,7 +16,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.notNullValue;
 
 import com.cloudant.sync.datastore.DocumentBodyFactory;
 import com.cloudant.sync.datastore.DocumentRevision;
@@ -30,8 +30,8 @@ import java.util.Map;
 public class IndexManagerTest extends AbstractIndexTestBase {
 
     @Test
-    public void unimplementedEnsureIndexed() {
-        assertThat(im.ensureIndexed(Arrays.<Object>asList("name")), is(nullValue()));
+    public void enusureIndexedGeneratesIndexName() {
+        assertThat(im.ensureIndexed(Arrays.<Object>asList("name")), is(notNullValue()));
     }
 
     @Test

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexTest.java
@@ -14,6 +14,7 @@ package com.cloudant.sync.query;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
 import org.junit.Before;
@@ -66,11 +67,14 @@ public class IndexTest {
     }
 
     @Test
-    public void returnsNullWhenNoIndexName() {
+    public void returnsValueWhenIndexNameIsNull(){
         Index index = Index.getInstance(fieldNames, null);
-        assertThat(index, is(nullValue()));
+        assertThat(index, is(notNullValue()));
+    }
 
-        index = Index.getInstance(fieldNames, "");
+    @Test
+    public void returnsNullWhenNoIndexName() {
+        Index index = Index.getInstance(fieldNames, "");
         assertThat(index, is(nullValue()));
     }
 


### PR DESCRIPTION
## What
Implement ensureIndex with index name generation.

## How
Generate a random index name when `ensureIndex(List<Object>)` is called.
The index name is generated with code inspired in the AttachmentManager
class which generates the attachment names. In the case of running out
of iterations before generating an unique attachment name, `null` is
returned. This causes ensureIndexed to behave as if it was passed a
`null` index name.

I'm unsure if asking the `IndexManager` for the current list of indexes for each iteration is a good 
idea some input on this specific point would be appreciated.

## Testing
A single test has been renamed and reworked to expect that the index name returned is not `null`

## Reviewers

reviewer @mikerhodes

## Issues

Fixes #245