### PR TITLE
Enable Filtering of Push Replication

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
   "Private" for each class. See
   [the last paragraph of this section of the README](https://github.com/cloudant/sync-android/blob/master/README.md#overview-of-the-library)
   for more details.
+- [NEW] Added filtering for push replications.
 - [BREAKING CHANGE] The `EventBus` APIs have been changed from the Google Guava
   (`com.google.common.eventbus`) to our own `com.cloudant.sync.event` API. The new implementation
   has increased restrictions on visibility of `@Subscribe` annotated methods. See the

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/PushFilter.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/PushFilter.java
@@ -1,0 +1,57 @@
+/*
+ *  Copyright (c) 2016 IBM Corp. All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ *  except in compliance with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under the
+ *   License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ *  either express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+package com.cloudant.sync.replication;
+
+import com.cloudant.sync.datastore.DocumentRevision;
+/*
+ * Created by Rhys Short on 31/03/2016.
+ */
+
+/**
+ * <P>
+ * Interface for filtering documents during a push replication.
+ * </P>
+ * <P>
+ * Example usage - a filter for replicating only documents with an ID beginning with the letter a:
+ * </P>
+ * <pre>
+ * <code>
+ * replicatorBuilder.filter(new PushFilter(){
+ *             {@literal @}Override
+ *              public boolean shouldReplicateDocument(DocumentRevision revision) {
+ *                  if (revision.getId().startsWith("a") {
+ *                      return true;
+ *                  } else {
+ *                      return false;
+ *                  }
+ *              }
+ *     });
+ * </code>
+ * </pre>
+ *
+ * @api_public
+ * @see com.cloudant.sync.replication.ReplicatorBuilder.Push#filter(PushFilter)
+ */
+public interface PushFilter {
+
+    /**
+     * Determines if a DocumentRevision should be replicated to the remote database
+     *
+     * @param revision the DocumentRevision under consideration for replication
+     * @return true if the DocumentRevision should be replicated.
+     */
+    boolean shouldReplicateDocument(DocumentRevision revision);
+
+}

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ReplicatorBuilder.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ReplicatorBuilder.java
@@ -94,6 +94,8 @@ public abstract class ReplicatorBuilder<S, T, E> {
 
         private PushAttachmentsInline pushAttachmentsInline = PushAttachmentsInline.Small;
 
+        private PushFilter pushFilter = null;
+
         @Override
         public Replicator build() {
 
@@ -113,8 +115,19 @@ public abstract class ReplicatorBuilder<S, T, E> {
             pushStrategy.batchLimitPerRun = batchLimitPerRun;
             pushStrategy.bulkInsertSize = bulkInsertSize;
             pushStrategy.pushAttachmentsInline = pushAttachmentsInline;
+            pushStrategy.filter = pushFilter;
 
             return new ReplicatorImpl(pushStrategy, super.id);
+        }
+
+        /**
+         *  Sets the filter to use for this replication
+         * @param filter the filter to use for this replication
+         * @return This instance of {@link ReplicatorBuilder}
+         */
+        public Push filter(PushFilter filter){
+            this.pushFilter = filter;
+            return this;
         }
 
         /**


### PR DESCRIPTION
## What
Make it possible to filter push replications.

## Why
This feature was requested by a user and brings sync-android closer to feature parity with CDTDatastore.

## How
- Added a new option to `ReplicatorBuilder`, to add filters to push replications.
- Added a new interface to be the integration point for user filter functions.

The replicator will write a checkpoint in the case where the changes feed had at least 1 change (even if that change was filtered out and therefore not pushed). This means that replications will not rewind in the event that a batch of changes are completely filtered out. If there were no changes at all then no checkpoint will be written.
The replication will complete when there are no more unfiltered changes.

## Reviewers
reviewer @ricellis
reviewer @tomblench 
reviewer @rhyshort - can you look over my modifications to your original

## Issues
- #214