### PR TITLE
Perf findbugs medium

### DIFF
--- a/cloudant-sync-datastore-android/src/main/java/com/cloudant/sync/replication/PeriodicReplicationService.java
+++ b/cloudant-sync-datastore-android/src/main/java/com/cloudant/sync/replication/PeriodicReplicationService.java
@@ -81,7 +81,8 @@ public abstract class PeriodicReplicationService<T extends PeriodicReplicationRe
                     resetAlarmDueTimesOnReboot();
                     break;
                 default:
-                    //do nothing
+                    // Do nothing
+                    break;
             }
 
             super.handleMessage(msg);

--- a/cloudant-sync-datastore-android/src/main/java/com/cloudant/sync/replication/ReplicationService.java
+++ b/cloudant-sync-datastore-android/src/main/java/com/cloudant/sync/replication/ReplicationService.java
@@ -124,7 +124,8 @@ public abstract class ReplicationService extends Service
                         stopReplications();
                         break;
                     default:
-                        //do nothing
+                        // Do nothing
+                        break;
                 }
             } finally {
                 // Get the Intent used to start the service and release the WakeLock if there is one.

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/BasicDatastore.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/BasicDatastore.java
@@ -1248,14 +1248,15 @@ class BasicDatastore implements Datastore, DatastoreExtended {
 
         // copy stubbed attachments forward from last real revision to this revision
         if (attachments != null) {
-            for (String att : attachments.keySet()) {
-                Boolean stub = ((Map<String, Boolean>) attachments.get(att)).get("stub");
+            for (Map.Entry<String, Object> att : attachments.entrySet()) {
+                Boolean stub = ((Map<String, Boolean>) att.getValue()).get("stub");
                 if (stub != null && stub.booleanValue()) {
                     try {
-                        AttachmentManager.copyAttachment(db, previousLeafSeq, newLeafSeq, att);
+                        AttachmentManager.copyAttachment(db, previousLeafSeq, newLeafSeq, att
+                                .getKey());
                     } catch (SQLException sqe) {
                         logger.log(Level.SEVERE, "Error copying stubbed attachments", sqe);
-                        throw new DatastoreException("Error copying stubbed attachments",sqe);
+                        throw new DatastoreException("Error copying stubbed attachments", sqe);
                     }
                 }
             }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexCreator.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexCreator.java
@@ -308,8 +308,9 @@ class IndexCreator {
     @SuppressWarnings("unchecked")
     protected static boolean indexLimitReached(Index index, Map<String, Object> existingIndexes) {
         if (index.indexType == IndexType.TEXT) {
-            for (String name : existingIndexes.keySet()) {
-                Map<String, Object> existingIndex = (Map<String, Object>) existingIndexes.get(name);
+            for (Map.Entry<String, Object> entry : existingIndexes.entrySet()) {
+                String name = entry.getKey();
+                Map<String, Object> existingIndex = (Map<String, Object>) entry.getValue();
                 IndexType type = (IndexType) existingIndex.get("type");
                 if (type == IndexType.TEXT &&
                     !name.equalsIgnoreCase(index.indexName)) {

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexUpdater.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexUpdater.java
@@ -100,10 +100,10 @@ class IndexUpdater {
     private boolean updateAllIndexes(Map<String, Object> indexes) {
         boolean success = true;
 
-        for (String indexName: indexes.keySet()) {
-            Map<String, Object> index = (Map<String, Object>) indexes.get(indexName);
+        for (Map.Entry<String, Object> entry: indexes.entrySet()) {
+            Map<String, Object> index = (Map<String, Object>) entry.getValue();
             List<String> fields = (ArrayList<String>) index.get("fields");
-            success = updateIndex(indexName, fields);
+            success = updateIndex(entry.getKey(), fields);
             if (!success) {
                 break;
             }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/QueryExecutor.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/QueryExecutor.java
@@ -418,11 +418,11 @@ class QueryExecutor {
         }
 
         String chosenIndex = null;
-        for (String indexName : indexes.keySet()) {
-            Map<String, Object> index = (Map<String, Object>) indexes.get(indexName);
+        for (Map.Entry<String, Object> entry : indexes.entrySet()) {
+            Map<String, Object> index = (Map<String, Object>) entry.getValue();
             Set<String> providedFields = new HashSet<String>((List<String>) index.get("fields"));
             if (providedFields.containsAll(neededFields)) {
-                chosenIndex = indexName;
+                chosenIndex = entry.getKey();
                 break;
             }
         }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/QueryResult.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/QueryResult.java
@@ -192,9 +192,9 @@ public class QueryResult implements Iterable<DocumentRevision> {
         // grab the map filter fields and rebuild object
         Map<String, Object> originalBody = rev.getBody().asMap();
         Map<String, Object> body = new HashMap<String, Object>();
-        for (String key : originalBody.keySet()) {
-            if (fields.contains(key)) {
-                body.put(key, originalBody.get(key));
+        for (Map.Entry<String, Object> entry : originalBody.entrySet()) {
+            if (fields.contains(entry.getKey())) {
+                body.put(entry.getKey(), entry.getValue());
             }
         }
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/QuerySqlTranslator.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/QuerySqlTranslator.java
@@ -389,8 +389,8 @@ class QuerySqlTranslator {
     protected static String chooseIndexForFields(Set<String> neededFields,
                                                  Map<String, Object> indexes) {
         String chosenIndex = null;
-        for (String indexName: indexes.keySet()) {
-            Map<String, Object> indexDefinition = (Map<String, Object>) indexes.get(indexName);
+        for (Map.Entry<String, Object> entry: indexes.entrySet()) {
+            Map<String, Object> indexDefinition = (Map<String, Object>) entry.getValue();
 
             // Don't choose a text index for a non-text query clause
             IndexType indexType = (IndexType) indexDefinition.get("type");
@@ -401,7 +401,7 @@ class QuerySqlTranslator {
             List<String> fieldList = (List<String>) indexDefinition.get("fields");
             Set<String> providedFields = new HashSet<String>(fieldList);
             if (providedFields.containsAll(neededFields)) {
-                chosenIndex = indexName;
+                chosenIndex = entry.getKey();
                 break;
             }
         }
@@ -412,11 +412,11 @@ class QuerySqlTranslator {
     @SuppressWarnings("unchecked")
     private static String getTextIndex(Map<String, Object> indexes) {
         String textIndex = null;
-        for (String indexName: indexes.keySet()) {
-            Map<String, Object> indexDefinition = (Map<String, Object>) indexes.get(indexName);
+        for (Map.Entry<String, Object> entry: indexes.entrySet()) {
+            Map<String, Object> indexDefinition = (Map<String, Object>) entry.getValue();
             IndexType indexType = (IndexType) indexDefinition.get("type");
             if (indexType == IndexType.TEXT) {
-                textIndex = indexName;
+                textIndex = entry.getKey();
             }
         }
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/QueryValidator.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/QueryValidator.java
@@ -119,10 +119,10 @@ class QueryValidator {
             //     [ {"field1": "mike"}, ... ]
             //     [ {"field1": [ "mike", "bob" ]}, ... ]
             List<Object> andClause = new ArrayList<Object>();
-            for (String k: query.keySet()) {
-                Object predicate = query.get(k);
+            for (Map.Entry<String, Object> entry: query.entrySet()) {
+                Object predicate = entry.getValue();
                 Map<String, Object> element = new HashMap<String, Object>();
-                element.put(k, predicate);
+                element.put(entry.getKey(), predicate);
                 andClause.add(element);
             }
             query.clear();

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/BasicPullStrategy.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/BasicPullStrategy.java
@@ -341,8 +341,8 @@ class BasicPullStrategy implements ReplicationStrategy {
                                 atts.put(new String[]{documentRevs.getId(), documentRevs.getRev()
                                 }, preparedAtts);
 
-                                for (String attachmentName : attachments.keySet()) {
-                                    Map attachmentMetadata = (Map) attachments.get(attachmentName);
+                                for (Map.Entry<String, Object> entry : attachments.entrySet()) {
+                                    Map attachmentMetadata = (Map) entry.getValue();
                                     int revpos = (Integer) attachmentMetadata.get("revpos");
                                     String contentType = (String) attachmentMetadata.get
                                             ("content_type");
@@ -367,7 +367,7 @@ class BasicPullStrategy implements ReplicationStrategy {
 
                                         Attachment a = this.targetDb.getDbCore()
                                                 .getAttachment(documentRevs.getId(), revId,
-                                                        attachmentName);
+                                                        entry.getKey());
                                         if (a != null) {
                                             // skip attachment, already got it
                                             continue;
@@ -376,7 +376,7 @@ class BasicPullStrategy implements ReplicationStrategy {
                                     }
                                     UnsavedStreamAttachment usa = this.sourceDb
                                             .getAttachmentStream(documentRevs.getId(),
-                                                    documentRevs.getRev(), attachmentName,
+                                                    documentRevs.getRev(), entry.getKey(),
                                                     contentType, encoding);
 
                                     // by preparing the attachment here, it is downloaded outside


### PR DESCRIPTION
*What*
Fix the remaining performance issues highlighted by the medium level findbugs report.

*How*
Replaced uses of `keySet` with `entrySet` when both keys and values are needed.
Added break statements to the `default:` cases in `switch` to protect against accidentally falling through if new cases are added later.

*Testing*
No new tests added, existing tests pass (on Travis!).

*Reviewers*

reviewer @mikerhodes