### PR TITLE
Allow Special Characters in Query Index Names

### DIFF
--- a/cloudant-sync-datastore-android-encryption/src/main/java/com/cloudant/sync/sqlite/android/AndroidSQLCipherSQLite.java
+++ b/cloudant-sync-datastore-android-encryption/src/main/java/com/cloudant/sync/sqlite/android/AndroidSQLCipherSQLite.java
@@ -136,7 +136,7 @@ public class AndroidSQLCipherSQLite extends SQLDatabase {
 
     @Override
     public int update(String table, ContentValues args, String whereClause, String[] whereArgs) {
-        return this.database.update(table, this.createAndroidContentValues(args), whereClause, whereArgs);
+        return this.database.update("\""+table+"\"", this.createAndroidContentValues(args), whereClause, whereArgs);
     }
 
     @Override
@@ -146,7 +146,7 @@ public class AndroidSQLCipherSQLite extends SQLDatabase {
 
     @Override
     public int delete(String table, String whereClause, String[] whereArgs) {
-        return this.database.delete(table, whereClause, whereArgs);
+        return this.database.delete("\""+table+"\"", whereClause, whereArgs);
     }
 
     @Override
@@ -159,7 +159,7 @@ public class AndroidSQLCipherSQLite extends SQLDatabase {
         //android DB will thrown an exception rather than return a -1 row id if there is a failure
         // so we catch constraintException and return -1
         try {
-            return this.database.insertWithOnConflict(table, null,
+            return this.database.insertWithOnConflict("\""+table+"\"", null,
                     createAndroidContentValues(initialValues), conflictAlgorithm);
         } catch (SQLiteConstraintException sqlce){
             return -1;

--- a/cloudant-sync-datastore-android-encryption/src/test/java/com/cloudant/sync/datastore/encryption/EndToEndEncryptionTest.java
+++ b/cloudant-sync-datastore-android-encryption/src/test/java/com/cloudant/sync/datastore/encryption/EndToEndEncryptionTest.java
@@ -14,6 +14,13 @@
 
 package com.cloudant.sync.datastore.encryption;
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import com.cloudant.sync.datastore.Attachment;
 import com.cloudant.sync.datastore.ConflictException;
 import com.cloudant.sync.datastore.Datastore;
@@ -25,9 +32,11 @@ import com.cloudant.sync.datastore.DocumentRevision;
 import com.cloudant.sync.datastore.UnsavedFileAttachment;
 import com.cloudant.sync.datastore.UnsavedStreamAttachment;
 import com.cloudant.sync.query.IndexManager;
+import com.cloudant.sync.query.QueryResult;
 import com.cloudant.sync.util.TestUtils;
 
 import net.sqlcipher.database.SQLiteDatabase;
+
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.io.IOUtils;
@@ -49,13 +58,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 
 
 /**
@@ -288,6 +290,14 @@ public class EndToEndEncryptionTest {
         assertTrue("Saved attachment did not read correctly",
                 IOUtils.contentEquals(new ByteArrayInputStream(nonAsciiText.getBytes()), in));
 
+        // perform a query to ensure we can use special chars
+        IndexManager indexManager = new IndexManager(datastore);
+        assertNotNull(indexManager.ensureIndexed(Arrays.<Object>asList("name","pet"),"my index"));
+        // query for the name fred and check that docs are returned.
+        Map<String,Object> selector = new HashMap<String, Object>();
+        selector.put("name","fred");
+        QueryResult queryResult = indexManager.find(selector);
+        assertNotNull(queryResult);
         // Delete
         try {
             datastore.deleteDocumentFromRevision(saved);

--- a/cloudant-sync-datastore-android/src/main/java/com/cloudant/sync/sqlite/android/AndroidSQLite.java
+++ b/cloudant-sync-datastore-android/src/main/java/com/cloudant/sync/sqlite/android/AndroidSQLite.java
@@ -99,7 +99,7 @@ public class AndroidSQLite extends SQLDatabase {
 
     @Override
     public int update(String table, ContentValues args, String whereClause, String[] whereArgs) {
-        return this.database.update(table, this.createAndroidContentValues(args), whereClause, whereArgs);
+        return this.database.update("\""+table+"\"", this.createAndroidContentValues(args), whereClause, whereArgs);
     }
 
     @Override
@@ -109,7 +109,7 @@ public class AndroidSQLite extends SQLDatabase {
 
     @Override
     public int delete(String table, String whereClause, String[] whereArgs) {
-        return this.database.delete(table, whereClause, whereArgs);
+        return this.database.delete("\""+table+"\"", whereClause, whereArgs);
     }
 
     @Override
@@ -122,7 +122,7 @@ public class AndroidSQLite extends SQLDatabase {
         //android DB will thrown an exception rather than return a -1 row id if there is a failure
         // so we catch constraintException and return -1
         try {
-        return this.database.insertWithOnConflict(table, null,
+        return this.database.insertWithOnConflict("\""+table+"\"", null,
                 createAndroidContentValues(initialValues), conflictAlgorithm);
         } catch (SQLiteConstraintException sqlce){
             return -1;

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexCreator.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexCreator.java
@@ -24,6 +24,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
@@ -338,7 +339,7 @@ class IndexCreator {
     }
 
     private String createIndexTableStatementForIndex(String indexName, List<String> columns) {
-        String tableName = IndexManager.tableNameForIndex(indexName);
+        String tableName = String.format(Locale.ENGLISH, "\"%s\"", IndexManager.tableNameForIndex(indexName));
         Joiner joiner = Joiner.on(" NONE,").skipNulls();
         String cols = joiner.join(columns);
 
@@ -351,7 +352,7 @@ class IndexCreator {
         Joiner joiner = Joiner.on(",").skipNulls();
         String cols = joiner.join(columns);
 
-        return String.format("CREATE INDEX %s ON %s ( %s )", sqlIndexName, tableName, cols);
+        return String.format(Locale.ENGLISH, "CREATE INDEX \"%s\" ON \"%s\" ( %s )", sqlIndexName, tableName, cols);
     }
 
     /**
@@ -368,7 +369,8 @@ class IndexCreator {
     private String createVirtualTableStatementForIndex(String indexName,
                                                        List<String> columns,
                                                        List<String> indexSettings) {
-        String tableName = IndexManager.tableNameForIndex(indexName);
+        String tableName = String.format(Locale.ENGLISH, "\"%s\"", IndexManager
+                .tableNameForIndex(indexName));
         Joiner joiner = Joiner.on(",").skipNulls();
         String cols = joiner.join(columns);
         String settings = joiner.join(indexSettings);

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/QuerySqlTranslator.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/QuerySqlTranslator.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
@@ -128,7 +129,7 @@ class QuerySqlTranslator {
 
             if (allDocsIndex != null && !allDocsIndex.isEmpty()) {
                 String tableName = IndexManager.tableNameForIndex(allDocsIndex);
-                String sql = String.format("SELECT _id FROM %s", tableName);
+                String sql = String.format(Locale.ENGLISH, "SELECT _id FROM \"%s\"", tableName);
                 sqlNode.sql = SqlParts.partsForSql(sql, new String[]{});
             }
 
@@ -441,7 +442,8 @@ class QuerySqlTranslator {
 
         String tableName = IndexManager.tableNameForIndex(indexName);
 
-        String sql = String.format("SELECT _id FROM %s WHERE %s",
+        String sql = String.format(Locale.ENGLISH,
+                                   "SELECT _id FROM \"%s\" WHERE %s",
                                    tableName,
                                    where.sqlWithPlaceHolders);
         return SqlParts.partsForSql(sql, where.placeHolderValues);
@@ -469,7 +471,7 @@ class QuerySqlTranslator {
         String search = searchClause.get(SEARCH);
         search = search.replace("'", "''");
 
-        String sql = String.format("SELECT _id FROM %s WHERE %s MATCH ?", tableName, tableName);
+        String sql = String.format(Locale.ENGLISH, "SELECT _id FROM \"%s\" WHERE \"%s\" MATCH ?", tableName, tableName);
         return SqlParts.partsForSql(sql, new String[]{ search });
     }
 
@@ -643,8 +645,8 @@ class QuerySqlTranslator {
                                             String sqlOperator,
                                             String tableName,
                                             String operand) {
-        String whereForSubSelect = String.format("\"%s\" %s %s", fieldName, sqlOperator, operand);
-        String subSelect = String.format("SELECT _id FROM %s WHERE %s",
+        String whereForSubSelect = String.format(Locale.ENGLISH, "\"%s\" %s %s", fieldName, sqlOperator, operand);
+        String subSelect = String.format(Locale.ENGLISH, "SELECT _id FROM \"%s\" WHERE %s",
                                          tableName,
                                          whereForSubSelect);
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/sqlite/sqlite4java/QueryBuilder.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/sqlite/sqlite4java/QueryBuilder.java
@@ -29,7 +29,9 @@ public class QueryBuilder {
 
         StringBuilder query = new StringBuilder(120);
         query.append("UPDATE ")
+                .append("\"")
                 .append(table)
+                .append("\"")
                 .append(" SET ");
 
         int i = 0;
@@ -66,8 +68,9 @@ public class QueryBuilder {
 
     public static String buildSelectCountQuery(String table, String where) {
         StringBuilder query = new StringBuilder(120);
-        query.append("SELECT count(*) FROM ");
+        query.append("SELECT count(*) FROM \"");
         query.append(table);
+        query.append("\"");
         if(where != null) {
             appendClause(query, " WHERE ", where);
         }
@@ -93,8 +96,10 @@ public class QueryBuilder {
         } else {
             query.append("* ");
         }
-        query.append("FROM ");
-        query.append(table);
+        query.append("FROM ")
+                .append("\"")
+                .append(table)
+                .append("\"");
 
         if(where != null) {
             appendClause(query, " WHERE ", where);
@@ -129,9 +134,10 @@ public class QueryBuilder {
             String column = columns[i];
             if (column != null) {
                 if (i > 0) {
-                    s.append(", ");
+                    s.append(", \"");
                 }
                 s.append(column);
+                s.append("\"");
             }
         }
         s.append(' ');

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexManagerTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexManagerTest.java
@@ -56,6 +56,38 @@ public class IndexManagerTest extends AbstractIndexTestBase {
     }
 
     @Test
+    public void createIndexWithSpaceInName() {
+        im.ensureIndexed(Arrays.<Object>asList("name", "address"), "basic index");
+        assertThat(im.listIndexes().keySet(), contains("basic index"));
+    }
+
+    @Test
+         public void createIndexWithSingleQuoteInName() {
+        im.ensureIndexed(Arrays.<Object>asList("name", "address"), "basic'index");
+        assertThat(im.listIndexes().keySet(), contains("basic'index"));
+    }
+
+    @Test
+    public void createIndexWithSemiColonQuoteInName() {
+        im.ensureIndexed(Arrays.<Object>asList("name", "address"), "basic;index");
+        assertThat(im.listIndexes().keySet(), contains("basic;index"));
+    }
+
+    @Test
+    public void createIndexWithBracketsInName() {
+        im.ensureIndexed(Arrays.<Object>asList("name", "address"), "basic(index)");
+        assertThat(im.listIndexes().keySet(), contains("basic(index)"));
+    }
+
+    @Test
+    public void createIndexWithKeyWordName() {
+        im.ensureIndexed(Arrays.<Object>asList("name", "address"), "INSERT INDEX");
+        assertThat(im.listIndexes().keySet(), contains("INSERT INDEX"));
+    }
+
+
+
+    @Test
      public void deleteEmptyIndex() {
         im.ensureIndexed(Arrays.<Object>asList("name", "address"), "basic");
         assertThat(im.listIndexes().keySet(), contains("basic"));

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QuerySqlTranslatorTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QuerySqlTranslatorTest.java
@@ -72,7 +72,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         SqlQueryNode sqlNode = (SqlQueryNode) andNode.children.get(0);
         String sql = sqlNode.sql.sqlWithPlaceHolders;
         String[] placeHolderValues = sqlNode.sql.placeHolderValues;
-        String select = "SELECT _id FROM _t_cloudant_sync_query_index_basic";
+        String select = "SELECT _id FROM \"_t_cloudant_sync_query_index_basic\"";
         assertThat(sql, is(select));
         assertThat(placeHolderValues, is(emptyArray()));
     }
@@ -92,7 +92,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         SqlQueryNode sqlNode = (SqlQueryNode) andNode.children.get(0);
         String sql = sqlNode.sql.sqlWithPlaceHolders;
         String[] placeHolderValues = sqlNode.sql.placeHolderValues;
-        String select = "SELECT _id FROM _t_cloudant_sync_query_index_basic";
+        String select = "SELECT _id FROM \"_t_cloudant_sync_query_index_basic\"";
         String where = " WHERE \"name\" = ?";
         assertThat(sql, is(String.format("%s%s", select, where)));
         assertThat(placeHolderValues, is(arrayContaining("mike")));
@@ -114,7 +114,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         SqlQueryNode sqlNode = (SqlQueryNode) andNode.children.get(0);
         String sql = sqlNode.sql.sqlWithPlaceHolders;
         String[] placeHolderValues = sqlNode.sql.placeHolderValues;
-        String select = "SELECT _id FROM _t_cloudant_sync_query_index_basic";
+        String select = "SELECT _id FROM \"_t_cloudant_sync_query_index_basic\"";
         String where = " WHERE \"name\" = ? AND \"pet\" = ?";
         assertThat(sql, is(String.format("%s%s", select, where)));
         assertThat(placeHolderValues, is(arrayContainingInAnyOrder("mike", "cat")));
@@ -140,7 +140,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         SqlQueryNode sqlNode = (SqlQueryNode) andNode.children.get(0);
         String sql = sqlNode.sql.sqlWithPlaceHolders;
         String[] placeHolderValues = sqlNode.sql.placeHolderValues;
-        String select = "SELECT _id FROM _t_cloudant_sync_query_index_basic";
+        String select = "SELECT _id FROM \"_t_cloudant_sync_query_index_basic\"";
         String where = " WHERE \"name\" = ? AND \"pet\" = ?";
         assertThat(sql, is(String.format("%s%s", select, where)));
         assertThat(placeHolderValues, is(arrayContainingInAnyOrder("mike", "cat")));
@@ -174,7 +174,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         AndQueryNode andNode = (AndQueryNode) node;
         assertThat(andNode.children.size(), is(2));
 
-        String select = "SELECT _id FROM _t_cloudant_sync_query_index_basic";
+        String select = "SELECT _id FROM \"_t_cloudant_sync_query_index_basic\"";
         String where = " WHERE \"name\" = ? AND \"pet\" = ?";
         String sql = String.format("%s%s", select, where);
 
@@ -218,7 +218,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         AndQueryNode andNode = (AndQueryNode) node;
         assertThat(andNode.children.size(), is(2));
 
-        String select = "SELECT _id FROM _t_cloudant_sync_query_index_basic";
+        String select = "SELECT _id FROM \"_t_cloudant_sync_query_index_basic\"";
         String where = " WHERE \"name\" = ? AND \"pet\" = ?";
         String sql = String.format("%s%s", select, where);
 
@@ -256,7 +256,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         OrQueryNode orNode = (OrQueryNode) node;
         assertThat(orNode.children.size(), is(2));
 
-        String select = "SELECT _id FROM _t_cloudant_sync_query_index_basic";
+        String select = "SELECT _id FROM \"_t_cloudant_sync_query_index_basic\"";
         String whereLeft = " WHERE \"name\" = ?";
         String whereRight = " WHERE \"pet\" = ?";
         String sqlLeft = String.format("%s%s", select, whereLeft);
@@ -299,7 +299,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         OrQueryNode orNode = (OrQueryNode) node;
         assertThat(orNode.children.size(), is(3));
 
-        String select = "SELECT _id FROM _t_cloudant_sync_query_index_basic";
+        String select = "SELECT _id FROM \"_t_cloudant_sync_query_index_basic\"";
         String whereLeft = " WHERE \"name\" = ?";
         String whereRight = " WHERE \"pet\" = ?";
         String sqlLeft = String.format("%s%s", select, whereLeft);
@@ -357,7 +357,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         OrQueryNode orNode = (OrQueryNode) node;
         assertThat(orNode.children.size(), is(4));
 
-        String select = "SELECT _id FROM _t_cloudant_sync_query_index_basic";
+        String select = "SELECT _id FROM \"_t_cloudant_sync_query_index_basic\"";
         String whereLeft = " WHERE \"name\" = ?";
         String whereRight = " WHERE \"pet\" = ?";
         String whereAnd = " WHERE \"name\" = ? AND \"pet\" = ?";
@@ -431,7 +431,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         OrQueryNode orNode = (OrQueryNode) node;
         assertThat(orNode.children.size(), is(3));
 
-        String select = "SELECT _id FROM _t_cloudant_sync_query_index_basic";
+        String select = "SELECT _id FROM \"_t_cloudant_sync_query_index_basic\"";
         String whereLeft = " WHERE \"name\" = ?";
         String whereRight = " WHERE \"pet\" = ?";
         String whereAnd = " WHERE \"name\" = ? AND \"pet\" = ?";
@@ -836,7 +836,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         name.put("name", not);
         SqlParts where = QuerySqlTranslator.whereSqlForAndClause(Arrays.<Object>asList(name),
                                                                  indexName);
-        String expected = String.format("_id NOT IN (SELECT _id FROM %s WHERE \"name\" = ?)",
+        String expected = String.format("_id NOT IN (SELECT _id FROM \"%s\" WHERE \"name\" = ?)",
                                         indexTable);
         assertThat(where.sqlWithPlaceHolders, is(expected));
         assertThat(where.placeHolderValues, is(arrayContaining("mike")));
@@ -866,10 +866,10 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         List<Object> clauses = Arrays.<Object>asList(name, age, pet);
         SqlParts where = QuerySqlTranslator.whereSqlForAndClause(clauses, indexName);
 
-        String expectedName = String.format("_id NOT IN (SELECT _id FROM %s WHERE \"name\" = ?)",
+        String expectedName = String.format("_id NOT IN (SELECT _id FROM \"%s\" WHERE \"name\" = ?)",
                                             indexTable);
         String expectedAge = "\"age\" = ?";
-        String expectedPet = String.format("_id NOT IN (SELECT _id FROM %s WHERE \"pet\" = ?)",
+        String expectedPet = String.format("_id NOT IN (SELECT _id FROM \"%s\" WHERE \"pet\" = ?)",
                                            indexTable);
         String expected = String.format("%s AND %s AND %s", expectedName, expectedAge, expectedPet);
 
@@ -888,7 +888,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
 
         SqlParts where = QuerySqlTranslator.whereSqlForAndClause(Arrays.<Object>asList(name),
                                                                  indexName);
-        String expected = String.format("_id NOT IN (SELECT _id FROM %s WHERE \"name\" > ?)",
+        String expected = String.format("_id NOT IN (SELECT _id FROM \"%s\" WHERE \"name\" > ?)",
                                         indexTable);
         assertThat(where.sqlWithPlaceHolders, is(expected));
         assertThat(where.placeHolderValues, is(arrayContaining("mike")));
@@ -905,7 +905,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
 
         SqlParts where = QuerySqlTranslator.whereSqlForAndClause(Arrays.<Object>asList(name),
                                                                  indexName);
-        String expected = String.format("_id NOT IN (SELECT _id FROM %s WHERE \"name\" >= ?)",
+        String expected = String.format("_id NOT IN (SELECT _id FROM \"%s\" WHERE \"name\" >= ?)",
                                         indexTable);
         assertThat(where.sqlWithPlaceHolders, is(expected));
         assertThat(where.placeHolderValues, is(arrayContaining("mike")));
@@ -922,7 +922,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
 
         SqlParts where = QuerySqlTranslator.whereSqlForAndClause(Arrays.<Object>asList(name),
                                                                  indexName);
-        String expected = String.format("_id NOT IN (SELECT _id FROM %s WHERE \"name\" < ?)",
+        String expected = String.format("_id NOT IN (SELECT _id FROM \"%s\" WHERE \"name\" < ?)",
                                         indexTable);
         assertThat(where.sqlWithPlaceHolders, is(expected));
         assertThat(where.placeHolderValues, is(arrayContaining("mike")));
@@ -939,7 +939,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
 
         SqlParts where = QuerySqlTranslator.whereSqlForAndClause(Arrays.<Object>asList(name),
                                                                  indexName);
-        String expected = String.format("_id NOT IN (SELECT _id FROM %s WHERE \"name\" <= ?)",
+        String expected = String.format("_id NOT IN (SELECT _id FROM \"%s\" WHERE \"name\" <= ?)",
                                         indexTable);
         assertThat(where.sqlWithPlaceHolders, is(expected));
         assertThat(where.placeHolderValues, is(arrayContaining("mike")));
@@ -956,7 +956,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
 
         SqlParts where = QuerySqlTranslator.whereSqlForAndClause(Arrays.<Object>asList(name),
                                                                  indexName);
-        String expected = String.format("_id NOT IN (SELECT _id FROM %s %s)",
+        String expected = String.format("_id NOT IN (SELECT _id FROM \"%s\" %s)",
                                         indexTable,
                                         "WHERE \"name\" IN ( ?, ? )");
         assertThat(where.sqlWithPlaceHolders, is(expected));
@@ -978,7 +978,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
 
         SqlParts where = QuerySqlTranslator.whereSqlForAndClause(Arrays.<Object>asList(c1, c2),
                                                                  indexName);
-        String notEqName = String.format("_id NOT IN (SELECT _id FROM %s WHERE \"name\" = ?)",
+        String notEqName = String.format("_id NOT IN (SELECT _id FROM \"%s\" WHERE \"name\" = ?)",
                                          indexTable);
         String eqName = "\"name\" = ?";
         String expected = String.format("%s AND %s", notEqName, eqName);
@@ -1016,7 +1016,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         String ageGt = "\"age\" > ?";
         String ageLte = "\"age\" <= ?";
         String nameEq = "\"name\" = ?";
-        String ageNe = String.format("_id NOT IN (SELECT _id FROM %s WHERE \"age\" = ?)",
+        String ageNe = String.format("_id NOT IN (SELECT _id FROM \"%s\" WHERE \"age\" = ?)",
                                      indexTable);
         String ageEq = "\"age\" = ?";
         String expected = String.format("%s AND %s AND %s AND %s AND %s",
@@ -1042,7 +1042,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
                 QuerySqlTranslator.whereSqlForAndClause(Collections.<Object>singletonList(age),
                                                         indexName);
         String expected = String.format("_id NOT IN " +
-                                        "(SELECT _id FROM %s" +
+                                        "(SELECT _id FROM \"%s\"" +
                                         " WHERE \"age\" %% ? = CAST(? AS INTEGER))",
                                         indexTable);
         assertThat(where.sqlWithPlaceHolders, is(expected));
@@ -1078,7 +1078,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         name.put("name", eq);
         List<Object> clause = Arrays.<Object>asList(name);
         SqlParts sql = QuerySqlTranslator.selectStatementForAndClause(clause, "anIndex");
-        String expected = "SELECT _id FROM _t_cloudant_sync_query_index_anIndex WHERE \"name\" = ?";
+        String expected = "SELECT _id FROM \"_t_cloudant_sync_query_index_anIndex\" WHERE \"name\" = ?";
         assertThat(sql.sqlWithPlaceHolders, is(expected));
         assertThat(sql.placeHolderValues, is(arrayContaining("mike")));
     }
@@ -1102,7 +1102,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
 
         List<Object> clause = Arrays.<Object>asList(name, age, pet);
         SqlParts sql = QuerySqlTranslator.selectStatementForAndClause(clause, "anIndex");
-        String select = "SELECT _id FROM _t_cloudant_sync_query_index_anIndex";
+        String select = "SELECT _id FROM \"_t_cloudant_sync_query_index_anIndex\"";
         String where = " WHERE \"name\" = ? AND \"age\" = ? AND \"pet\" = ?";
         String expected = String.format("%s%s", select, where);
         assertThat(sql.sqlWithPlaceHolders, is(expected));
@@ -1135,8 +1135,8 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         String sql = sqlNode.sql.sqlWithPlaceHolders;
         String[] placeHolderValues = sqlNode.sql.placeHolderValues;
 
-        String select = "SELECT _id FROM _t_cloudant_sync_query_index_basic_text";
-        String where = " WHERE _t_cloudant_sync_query_index_basic_text MATCH ?";
+        String select = "SELECT _id FROM \"_t_cloudant_sync_query_index_basic_text\"";
+        String where = " WHERE \"_t_cloudant_sync_query_index_basic_text\" MATCH ?";
         assertThat(sql, is(String.format("%s%s", select, where)));
         assertThat(placeHolderValues, is(arrayContainingInAnyOrder("foo bar baz")));
     }
@@ -1169,7 +1169,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         String sql = sqlNode.sql.sqlWithPlaceHolders;
         String[] placeHolderValues = sqlNode.sql.placeHolderValues;
 
-        String select = "SELECT _id FROM _t_cloudant_sync_query_index_basic";
+        String select = "SELECT _id FROM \"_t_cloudant_sync_query_index_basic\"";
         String where = " WHERE \"name\" = ?";
         assertThat(sql, is(String.format("%s%s", select, where)));
         assertThat(placeHolderValues, is(arrayContainingInAnyOrder("mike")));
@@ -1178,8 +1178,8 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         sql = sqlNode.sql.sqlWithPlaceHolders;
         placeHolderValues = sqlNode.sql.placeHolderValues;
 
-        select = "SELECT _id FROM _t_cloudant_sync_query_index_basic_text";
-        where = " WHERE _t_cloudant_sync_query_index_basic_text MATCH ?";
+        select = "SELECT _id FROM \"_t_cloudant_sync_query_index_basic_text\"";
+        where = " WHERE \"_t_cloudant_sync_query_index_basic_text\" MATCH ?";
         assertThat(sql, is(String.format("%s%s", select, where)));
         assertThat(placeHolderValues, is(arrayContainingInAnyOrder("foo bar baz")));
     }
@@ -1208,12 +1208,12 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         OrQueryNode orNode = (OrQueryNode) node;
         assertThat(orNode.children.size(), is(2));
 
-        String selectLeft = "SELECT _id FROM _t_cloudant_sync_query_index_basic";
+        String selectLeft = "SELECT _id FROM \"_t_cloudant_sync_query_index_basic\"";
         String whereLeft = " WHERE \"name\" = ?";
         String sqlLeft = String.format("%s%s", selectLeft, whereLeft);
 
-        String selectRight = "SELECT _id FROM _t_cloudant_sync_query_index_basic_text";
-        String whereRight = " WHERE _t_cloudant_sync_query_index_basic_text MATCH ?";
+        String selectRight = "SELECT _id FROM \"_t_cloudant_sync_query_index_basic_text\"";
+        String whereRight = " WHERE \"_t_cloudant_sync_query_index_basic_text\" MATCH ?";
         String sqlRight = String.format("%s%s", selectRight, whereRight);
 
         SqlQueryNode sqlNode = (SqlQueryNode) orNode.children.get(0);

--- a/cloudant-sync-datastore-javase/src/main/java/com/cloudant/sync/sqlite/sqlite4java/SQLiteWrapper.java
+++ b/cloudant-sync-datastore-javase/src/main/java/com/cloudant/sync/sqlite/sqlite4java/SQLiteWrapper.java
@@ -263,8 +263,9 @@ public class SQLiteWrapper extends SQLDatabase {
     @Override
     public int delete(String table, String whereClause, String[] whereArgs) {
         try {
-            String sql = new StringBuilder("DELETE FROM ")
+            String sql = new StringBuilder("DELETE FROM \"")
                     .append(table)
+                    .append("\"")
                     .append(!Strings.isNullOrEmpty(whereClause) ? " WHERE " +
                             whereClause : "")
                     .toString();
@@ -288,8 +289,9 @@ public class SQLiteWrapper extends SQLDatabase {
             StringBuilder sql = new StringBuilder();
             sql.append("INSERT ");
             sql.append(CONFLICT_VALUES[conflictAlgorithm]);
-            sql.append(" INTO ");
+            sql.append(" INTO \"");
             sql.append(table);
+            sql.append("\"");
             sql.append('(');
 
 


### PR DESCRIPTION
## What

Allow special characters in Query Index Names

## How
Surround  SQLite Identifier names with `"` to escape characters like \` \`

## Testing 

Added new Tests for IndexCreator, IndexManager and extended End to End test for Encryption to verify it works for encrypted databases.

## Reviewers

reviewer @brynh
reviewer @emlaver 

## Issues
#244 