### PR TITLE
EventBus API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,9 @@
 # 1.0.0 (Unreleased)
+- [BREAKING CHANGE] The `EventBus` APIs have been changed from the Google Guava
+  (`com.google.common.eventbus`) to our own `com.cloudant.sync.event` API. The new implementation
+  has increased restrictions on visibility of `@Subscribe` annotated methods. See the
+  [Event guide](https://github.com/cloudant/sync-android/blob/master/doc/event.md) and javadoc for
+  details.
 - [BREAKING CHANGE] The `BasicDocumentRevision` and
   `MutableDocumentRevision` classes have been removed, in order to
   simplify use of API methods. All code using this library will need

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/BasicDatastore.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/BasicDatastore.java
@@ -26,6 +26,7 @@ import com.cloudant.sync.datastore.encryption.KeyProvider;
 import com.cloudant.sync.datastore.encryption.NullKeyProvider;
 import com.cloudant.sync.datastore.migrations.MigrateDatabase6To100;
 import com.cloudant.sync.datastore.migrations.SchemaOnlyMigration;
+import com.cloudant.sync.event.EventBus;
 import com.cloudant.sync.notifications.DatabaseClosed;
 import com.cloudant.sync.notifications.DocumentCreated;
 import com.cloudant.sync.notifications.DocumentDeleted;
@@ -44,7 +45,6 @@ import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
-import com.google.common.eventbus.EventBus;
 
 import org.apache.commons.io.FilenameUtils;
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/Datastore.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/Datastore.java
@@ -18,7 +18,7 @@
 package com.cloudant.sync.datastore;
 
 import com.cloudant.sync.datastore.encryption.KeyProvider;
-import com.google.common.eventbus.EventBus;
+import com.cloudant.sync.event.EventBus;
 
 import java.util.Iterator;
 import java.util.List;

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/DatastoreManager.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/DatastoreManager.java
@@ -19,13 +19,13 @@ package com.cloudant.sync.datastore;
 
 import com.cloudant.sync.datastore.encryption.KeyProvider;
 import com.cloudant.sync.datastore.encryption.NullKeyProvider;
+import com.cloudant.sync.event.EventBus;
+import com.cloudant.sync.event.Subscribe;
 import com.cloudant.sync.notifications.DatabaseClosed;
 import com.cloudant.sync.notifications.DatabaseCreated;
 import com.cloudant.sync.notifications.DatabaseDeleted;
 import com.cloudant.sync.notifications.DatabaseOpened;
 import com.google.common.base.Preconditions;
-import com.google.common.eventbus.EventBus;
-import com.google.common.eventbus.Subscribe;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/event/EventBus.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/event/EventBus.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.event;
+
+import com.google.common.eventbus.Subscribe;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * A publish/subscribe event bus for sync notifications.
+ * <p>
+ * This class provides methods for registering and un-registering event subscribers as well as a
+ * method for posting an event to the bus. Events are isolated to each specific instance of this
+ * class.
+ * </p>
+ */
+public class EventBus {
+
+    // The Guava EventBus that this class delegates to.
+    private final com.google.common.eventbus.EventBus eventBus = new com.google.common.eventbus
+            .EventBus();
+    // A map of listeners to their Guava bus proxies.
+    private final Map<Object, BusProxy> listeners = new ConcurrentHashMap
+            <Object, BusProxy>();
+
+    /**
+     * Post an event to the bus. All subscribers to the event class type posted will be notified.
+     *
+     * @param event to post to subscribers
+     */
+    public void post(Object event) {
+        eventBus.post(event);
+    }
+
+    /**
+     * Register an instance containing one or more subscriber methods to receive events.
+     * <p>
+     * To receive events the instance must have 1 or more methods annotated with
+     * {@link com.cloudant.sync.event.Subscribe}.
+     * </p>
+     *
+     * @param object the instance that will be notified when an event is posted
+     */
+    public void register(Object object) {
+        BusProxy proxy = new BusProxy(object);
+        BusProxy existingProxy = listeners.put(object, proxy);
+        if (existingProxy != null) {
+            // If the same object was registered twice unregister the previous proxy from the Guava
+            // bus to prevent double notifications.
+            eventBus.unregister(existingProxy);
+        }
+        eventBus.register(proxy);
+    }
+
+    /**
+     * Deregister a previously registered instance with subscriber methods.
+     *
+     * @param object the instance that will no longer be notified of events
+     */
+    public void unregister(Object object) {
+        BusProxy proxy = listeners.remove(object);
+        if (proxy != null) {
+            eventBus.unregister(proxy);
+        }
+    }
+
+    /**
+     * This class serves as a proxy for any listener registered with the sync EventBus. The proxy is
+     * registered with the Guava EventBus (using an Object event type to receive all events).
+     * The proxy then filters events as appropriate before passing them on to the methods that were
+     * subscribed using the sync {@link com.cloudant.sync.event.Subscribe} annotation.
+     * <p>
+     * Instances of this class are registered on the Guava event bus for each listener registered on
+     * the sync EventBus class.
+     * </p>
+     */
+    private static final class BusProxy {
+
+        // The instance registered wiht the sync EventBus
+        private final Object listener;
+        // The list of methods in that instance that were annotated with @Subscribe
+        private final List<SubscriberMethod> methods = new ArrayList<SubscriberMethod>();
+
+        // Constructor that reflectively identifies the @Subscribe annotated methods
+        BusProxy(Object listener) {
+            this.listener = listener;
+            Class<?> listenerClass = listener.getClass();
+            // Do loop to traverse the class hierarchy looking for @Subscribe methods. Using
+            // listenerClass.getMethods() seems preferable as it should include inherited public
+            // methods, but it does not seem to work for some of the mock(listener) types used in
+            // the tests (e.g. mock(StrategyListener.class)).
+            do {
+                for (Method m : listenerClass.getDeclaredMethods()) {
+                    if (m.isAnnotationPresent(com.cloudant.sync.event.Subscribe.class)) {
+                        Class[] params = m.getParameterTypes();
+                        if (params.length == 1) {
+                            methods.add(new SubscriberMethod(m, params[0]));
+                        }
+                    }
+                }
+            } while ((listenerClass = listenerClass.getSuperclass()) != null);
+        }
+
+        /**
+         * This method is annotated with Guava's @Subscribe annotation and uses an Object type so it
+         * receives all notifications. It performs an instance check on received events and
+         * invokes the appropriate proxy subscriber methods.
+         *
+         * @param o
+         */
+        @Subscribe
+        public void onEvent(Object o) {
+            for (SubscriberMethod method : methods) {
+                if (method.eventTypeToInvokeOn.isInstance(o)) {
+                    try {
+                        method.methodToInvokeOnEvent.invoke(listener, o);
+                    } catch (InvocationTargetException e) {
+                        throw new RuntimeException(EventBus.class.getName() + " could not invoke " +
+                                "subscriber " + method.toString(), e);
+                    } catch (IllegalAccessException e) {
+                        throw new RuntimeException(EventBus.class.getName() + " could not access " +
+                                "subscriber " + method.toString(), e);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Class that encapsulates a {@link com.cloudant.sync.event.Subscribe} annotated method and the
+     * type of event it is subscribed to (as discovered from its single parameter type).
+     */
+    private static final class SubscriberMethod {
+        private final Method methodToInvokeOnEvent;
+        private final Class<?> eventTypeToInvokeOn;
+
+        private SubscriberMethod(Method methodToInvokeOnEvent, Class<?> eventTypeToInvokeOn) {
+            this.methodToInvokeOnEvent = methodToInvokeOnEvent;
+            this.eventTypeToInvokeOn = eventTypeToInvokeOn;
+        }
+    }
+}

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/event/Subscribe.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/event/Subscribe.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.event;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to indicate a method should be subscribed to events posted to the {@link EventBus} on
+ * which the method's owning instance is registered.
+ * <p>
+ * Methods using this annotation must have only a single parameter and must be visible to the
+ * EventBus (i.e. the owning class and method itself must be public). The parameter type of the
+ * annotated method is of the type of event that notifications will be received for.
+ * </p>
+ * <p>
+ * Subscribers are called synchronously so methods using this annotation must not perform long
+ * running operations and should spawn a separate thread if needed.
+ * </p>
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Subscribe {
+}

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/BasicPullStrategy.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/BasicPullStrategy.java
@@ -27,11 +27,11 @@ import com.cloudant.sync.datastore.DocumentException;
 import com.cloudant.sync.datastore.DocumentRevsList;
 import com.cloudant.sync.datastore.PreparedAttachment;
 import com.cloudant.sync.datastore.UnsavedStreamAttachment;
+import com.cloudant.sync.event.EventBus;
 import com.cloudant.sync.util.JSONUtils;
 import com.cloudant.sync.util.Misc;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
-import com.google.common.eventbus.EventBus;
 
 import org.apache.commons.codec.binary.Hex;
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/BasicPushStrategy.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/BasicPushStrategy.java
@@ -28,11 +28,11 @@ import com.cloudant.sync.datastore.DocumentRevision;
 import com.cloudant.sync.datastore.DocumentRevisionTree;
 import com.cloudant.sync.datastore.MultipartAttachmentWriter;
 import com.cloudant.sync.datastore.RevisionHistoryHelper;
+import com.cloudant.sync.event.EventBus;
 import com.cloudant.sync.util.JSONUtils;
 import com.cloudant.sync.util.Misc;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
-import com.google.common.eventbus.EventBus;
 
 import org.apache.commons.codec.binary.Hex;
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/BasicReplicator.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/BasicReplicator.java
@@ -14,13 +14,16 @@
 
 package com.cloudant.sync.replication;
 
+import com.cloudant.sync.event.EventBus;
+import com.cloudant.sync.event.Subscribe;
 import com.cloudant.sync.notifications.ReplicationCompleted;
 import com.cloudant.sync.notifications.ReplicationErrored;
 import com.google.common.base.Preconditions;
-import com.google.common.eventbus.EventBus;
-import com.google.common.eventbus.Subscribe;
 
-class BasicReplicator implements Replicator {
+/**
+ * This class is not intended as API, it is public for EventBus access only.
+ */
+public class BasicReplicator implements Replicator {
 
     public static final int NULL_ID = -1;
     protected Thread strategyThread;

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ReplicationPolicyManager.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ReplicationPolicyManager.java
@@ -1,12 +1,11 @@
 package com.cloudant.sync.replication;
 
+import com.cloudant.sync.event.Subscribe;
 import com.cloudant.sync.notifications.ReplicationCompleted;
 import com.cloudant.sync.notifications.ReplicationErrored;
-import com.google.common.eventbus.Subscribe;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -25,7 +24,10 @@ public class ReplicationPolicyManager {
         void replicationErrored(int id);
     }
 
-    private class ReplicationListener {
+    /**
+     * This class is not intended as API, it is public for EventBus access only.
+     */
+    public class ReplicationListener {
 
         Set<Replicator> replicatorsInProgress;
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ReplicationStrategy.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ReplicationStrategy.java
@@ -15,7 +15,8 @@
 package com.cloudant.sync.replication;
 
 import com.cloudant.sync.datastore.DatastoreException;
-import com.google.common.eventbus.EventBus;
+import com.cloudant.sync.event.EventBus;
+
 
 interface ReplicationStrategy extends Runnable {
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/Replicator.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/Replicator.java
@@ -14,7 +14,7 @@
 
 package com.cloudant.sync.replication;
 
-import com.google.common.eventbus.EventBus;
+import com.cloudant.sync.event.EventBus;
 
 /**
  * <p>Manages replication between a local

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/BasicDBCoreObservableTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/BasicDBCoreObservableTest.java
@@ -14,16 +14,16 @@
 
 package com.cloudant.sync.datastore;
 
+import com.cloudant.sync.event.Subscribe;
+import com.cloudant.sync.notifications.DocumentModified;
 import com.cloudant.sync.sqlite.SQLDatabase;
 import com.cloudant.sync.util.TestUtils;
+
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-
-import com.cloudant.sync.notifications.DocumentModified;
-import com.google.common.eventbus.Subscribe;
 
 public class BasicDBCoreObservableTest {
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/DatabaseNotificationsMoreTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/DatabaseNotificationsMoreTest.java
@@ -14,11 +14,14 @@
 
 package com.cloudant.sync.datastore;
 
+import static org.hamcrest.Matchers.hasSize;
+
+import com.cloudant.sync.event.Subscribe;
 import com.cloudant.sync.notifications.DatabaseClosed;
 import com.cloudant.sync.notifications.DatabaseCreated;
 import com.cloudant.sync.notifications.DatabaseOpened;
 import com.cloudant.sync.util.TestUtils;
-import com.google.common.eventbus.Subscribe;
+
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -26,8 +29,6 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import static org.hamcrest.Matchers.hasSize;
 
 /**
  * Uses pattern called EventRecorder to assert certain and only certain

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/DatabaseNotificationsTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/DatabaseNotificationsTest.java
@@ -14,22 +14,20 @@
 
 package com.cloudant.sync.datastore;
 
-import java.io.IOException;
-import java.util.concurrent.CountDownLatch;
-
+import com.cloudant.sync.event.Subscribe;
 import com.cloudant.sync.notifications.DatabaseClosed;
 import com.cloudant.sync.notifications.DatabaseCreated;
+import com.cloudant.sync.notifications.DatabaseDeleted;
+import com.cloudant.sync.notifications.DatabaseOpened;
+import com.cloudant.sync.util.TestUtils;
+
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
-import com.cloudant.sync.notifications.DatabaseOpened;
-import com.cloudant.sync.notifications.DatabaseDeleted;
-import com.cloudant.sync.util.TestUtils;
-import com.google.common.eventbus.Subscribe;
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
 
 public class DatabaseNotificationsTest {
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/DocumentNotificationsTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/DocumentNotificationsTest.java
@@ -14,16 +14,16 @@
 
 package com.cloudant.sync.datastore;
 
-import java.util.concurrent.CountDownLatch;
+import com.cloudant.sync.event.Subscribe;
+import com.cloudant.sync.notifications.DocumentCreated;
+import com.cloudant.sync.notifications.DocumentDeleted;
+import com.cloudant.sync.notifications.DocumentUpdated;
 
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.cloudant.sync.notifications.DocumentCreated;
-import com.cloudant.sync.notifications.DocumentDeleted;
-import com.cloudant.sync.notifications.DocumentUpdated;
-import com.google.common.eventbus.Subscribe;
+import java.util.concurrent.CountDownLatch;
 
 public class DocumentNotificationsTest extends BasicDatastoreTestBase {
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/ForceInsertTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/ForceInsertTest.java
@@ -14,9 +14,9 @@
 
 package com.cloudant.sync.datastore;
 
+import com.cloudant.sync.event.Subscribe;
 import com.cloudant.sync.notifications.DocumentCreated;
 import com.cloudant.sync.notifications.DocumentUpdated;
-import com.google.common.eventbus.Subscribe;
 
 import org.apache.commons.codec.binary.Base64;
 import org.junit.Assert;

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/BasicPullStrategyMockTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/BasicPullStrategyMockTest.java
@@ -14,6 +14,15 @@
 
 package com.cloudant.sync.replication;
 
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.cloudant.common.RequireRunningCouchDB;
 import com.cloudant.mazha.ChangesResult;
 import com.cloudant.mazha.DocumentRevs;
@@ -21,13 +30,11 @@ import com.cloudant.mazha.OkOpenRevision;
 import com.cloudant.mazha.OpenRevision;
 import com.cloudant.mazha.json.JSONHelper;
 import com.cloudant.sync.datastore.DocumentRevsList;
+import com.cloudant.sync.event.Subscribe;
 import com.cloudant.sync.util.TestUtils;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.google.common.eventbus.Subscribe;
 
-import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.mockito.invocation.InvocationOnMock;
@@ -39,11 +46,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
-
-import static org.mockito.Mockito.*;
 
 @Category(RequireRunningCouchDB.class)
 public class BasicPullStrategyMockTest extends ReplicationTestBase {

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/BasicPushStrategyMockTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/BasicPushStrategyMockTest.java
@@ -14,9 +14,19 @@
 
 package com.cloudant.sync.replication;
 
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.argThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.cloudant.common.RequireRunningCouchDB;
 import com.cloudant.mazha.CouchClient;
-import com.google.common.eventbus.Subscribe;
+import com.cloudant.sync.event.Subscribe;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -25,8 +35,6 @@ import org.mockito.ArgumentMatcher;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static org.mockito.Mockito.*;
 
 @Category(RequireRunningCouchDB.class)
 public class BasicPushStrategyMockTest extends ReplicationTestBase {

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/BasicReplicatorMockTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/BasicReplicatorMockTest.java
@@ -14,11 +14,22 @@
 
 package com.cloudant.sync.replication;
 
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
 import com.cloudant.sync.datastore.DatastoreExtended;
+import com.cloudant.sync.event.EventBus;
+import com.cloudant.sync.event.Subscribe;
 import com.cloudant.sync.notifications.ReplicationCompleted;
 import com.cloudant.sync.notifications.ReplicationErrored;
-import com.google.common.eventbus.EventBus;
-import com.google.common.eventbus.Subscribe;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -27,8 +38,6 @@ import org.mockito.stubbing.Answer;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-
-import static org.mockito.Mockito.*;
 
 public class BasicReplicatorMockTest {
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/ReplicationPolicyManagerTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/ReplicationPolicyManagerTest.java
@@ -1,20 +1,20 @@
 package com.cloudant.sync.replication;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.cloudant.sync.event.EventBus;
 import com.cloudant.sync.notifications.ReplicationCompleted;
 import com.cloudant.sync.notifications.ReplicationErrored;
-import com.google.common.eventbus.EventBus;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.net.URI;
-
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public class ReplicationPolicyManagerTest extends ReplicationTestBase {
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/TestReplicationListener.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/TestReplicationListener.java
@@ -14,9 +14,9 @@
 
 package com.cloudant.sync.replication;
 
+import com.cloudant.sync.event.Subscribe;
 import com.cloudant.sync.notifications.ReplicationCompleted;
 import com.cloudant.sync.notifications.ReplicationErrored;
-import com.google.common.eventbus.Subscribe;
 
 public class TestReplicationListener {
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/TestStrategyListener.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/TestStrategyListener.java
@@ -14,9 +14,7 @@
 
 package com.cloudant.sync.replication;
 
-import com.cloudant.sync.notifications.ReplicationCompleted;
-import com.cloudant.sync.notifications.ReplicationErrored;
-import com.google.common.eventbus.Subscribe;
+import com.cloudant.sync.event.Subscribe;
 
 /**
  * Simple implementation of <code>StrategyListener</code>. It can be checked if the complete() or

--- a/doc/events.md
+++ b/doc/events.md
@@ -1,9 +1,12 @@
 # Events
 
 _This functionality is available in versions 0.3.0 and up._
+Note that prior to version 1.0.0 the Google Guava EventBus (`com.google.common.eventbus` package)
+API was used, but now there is an API provided in the `com.cloudant.sync.event` package. To migrate
+your code you will need to adjust your imports accordingly.
 
-Cloudant Sync uses [EventBus](https://code.google.com/p/guava-libraries/wiki/EventBusExplained) from
-the Google Guava library to post events to interested parties in a publish and subscribe fashion.
+Cloudant Sync uses an `EventBus` to post events to interested parties in a publish and subscribe
+fashion.
 
 The `Datastore` class posts events about Documents:
 
@@ -18,7 +21,12 @@ The `DatastoreManager` class posts events about Databases:
 * `DatabaseDeleted`
 * `DatabaseOpened`.
 
-There are also generic `Modified` events for each class (more about these later).
+There are also generic `Modified` events for each class: `DocumentModified` and `DatabaseModified`
+ (more about these later).
+
+There are also events posted about replications:
+`ReplicationCompleted`
+`ReplicationErrored`
 
 To subscribe to an event, first register the object whose methods you want to be called (in this
 case, an instance of `DocumentNotificationClient`):
@@ -31,7 +39,7 @@ eventBus.register(dnc);
 ```
 
 Next, add the methods you want to be called when each event occurs and decorate them with the
-`@Subscribe` annotation.
+`@Subscribe` annotation. These methods must be visible to the EventBus class.
 
 Here the `DocumentNotificationClient` is subscribing to the `DocumentCreated` event. Because the
 events are just classes, they obey the type hierarchy. This means that it is also possible to
@@ -47,7 +55,7 @@ public class DocumentNotificationClient {
 }
 ```
 
-For `DatastoreManger` events there is a similar superclass: `DatabaseChanged`.
+For `DatastoreManger` events there is a similar superclass: `DatabaseModified`.
 
 Whether to use these generic events or one method per event type is simply a matter of style.
 

--- a/doc/replication.md
+++ b/doc/replication.md
@@ -81,7 +81,7 @@ replication finishes so we can wait for a replication to finish without
 needing to poll:
 
 ```java
-import com.google.common.eventbus.Subscribe;
+import com.cloudant.sync.event.Subscribe;
 import java.util.concurrent.CountDownLatch;
 import com.cloudant.sync.notifications.ReplicationCompleted;
 import com.cloudant.sync.notifications.ReplicationErrored;

--- a/sample/todo-sync/src/com/cloudant/todo/TasksModel.java
+++ b/sample/todo-sync/src/com/cloudant/todo/TasksModel.java
@@ -28,11 +28,11 @@ import com.cloudant.sync.datastore.DatastoreNotCreatedException;
 import com.cloudant.sync.datastore.DocumentBodyFactory;
 import com.cloudant.sync.datastore.DocumentException;
 import com.cloudant.sync.datastore.DocumentRevision;
+import com.cloudant.sync.event.Subscribe;
 import com.cloudant.sync.notifications.ReplicationCompleted;
 import com.cloudant.sync.notifications.ReplicationErrored;
 import com.cloudant.sync.replication.Replicator;
 import com.cloudant.sync.replication.ReplicatorBuilder;
-import com.google.common.eventbus.Subscribe;
 
 import java.io.File;
 import java.net.URI;


### PR DESCRIPTION
#*What*

Remove Guava `EventBus` from the API to allow potential future removal of the (large) Guava dependency.

*How*

Added new `EventBus` class and `@Subscribe` annotation. Scan for subscriber methods and register a proxy on the Guava bus to invoke the subscribers.
Replace existing `EventBus` uses with new API, including some visibility changes since the new API invokes only visible methods (using `setAccessible` is not desirable

*Testing*

The notifications framework is covered in many existing tests notably:
`com/cloudant/sync/datastore/DatabaseNotificationsMoreTest.java`
`com/cloudant/sync/datastore/DatabaseNotificationsTest.java`
`com/cloudant/sync/datastore/DocumentNotificationsTest.java`
and many of the replication tests.
Whilst the new delegating `EventBus` could potentially use some unit tests, I expect us to remove it in the medium future and I don't think any unit tests would expose any problems not already found by the existing integration tests.

*Reviewers*

Thoughts on whether the new `EventBus` and `@Subscribe` should be in the existing `com.cloudant.sync.notifications` package - I put them in their own package since everything in notificaitons was a type you could subscribe to, but I'm still not sure it is worth isolating them.

reviewer @tomblench 
reviewer @rhyshort