### PR TITLE
DatastoreManager uniqueness

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# Unreleased
+- [DEPRECATED] `DatastoreManager` constructors. Use `DatastoreManager.getInstance` factory methods
+  instead to guarantee only a single `DatastoreManager` instance is created for a given storage
+  directory path in the scope of the `DatastoreManager` class.
+
 # 1.0.0 (2016-05-03)
 - [NOTE] This library follows the
   [Semantic Versioning 2.0.0 specification](http://semver.org). To

--- a/cloudant-sync-datastore-android-encryption/src/test/java/com/cloudant/sync/datastore/encryption/EndToEndEncryptionTest.java
+++ b/cloudant-sync-datastore-android-encryption/src/test/java/com/cloudant/sync/datastore/encryption/EndToEndEncryptionTest.java
@@ -101,7 +101,7 @@ public class EndToEndEncryptionTest {
     @Before
     public void setUp() throws DatastoreNotCreatedException {
         datastoreManagerDir = TestUtils.createTempTestingDir(this.getClass().getName());
-        datastoreManager = new DatastoreManager(this.datastoreManagerDir);
+        datastoreManager = DatastoreManager.getInstance(this.datastoreManagerDir);
 
         if(dataShouldBeEncrypted) {
             this.datastore = this.datastoreManager.openDatastore(getClass().getSimpleName(),

--- a/cloudant-sync-datastore-core/findbugs_excludes.xml
+++ b/cloudant-sync-datastore-core/findbugs_excludes.xml
@@ -19,16 +19,8 @@ A list of known findbugs issues that we cannot fix at this time.
 
     <Match>
         <Bug code="RV" pattern="RV_RETURN_VALUE_IGNORED_BAD_PRACTICE" />
-        <Or >
-            <And>
-                <Class name="com.cloudant.sync.datastore.AttachmentManager"/>
-                <Method name="addAttachment" />
-            </And>
-            <And>
-                <Class name="com.cloudant.sync.datastore.DatastoreManager"/>
-                <Method name="&lt;init&gt;" />
-            </And>
-        </Or>
+        <Class name="com.cloudant.sync.datastore.AttachmentManager"/>
+        <Method name="addAttachment" />
     </Match>
     <Match>
         <Bug code="RV" pattern="RV_NEGATING_RESULT_OF_COMPARETO" />

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/DatastoreManager.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/DatastoreManager.java
@@ -37,6 +37,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.logging.Logger;
 
 /**
@@ -56,6 +58,10 @@ import java.util.logging.Logger;
  */
 public class DatastoreManager {
 
+    // Static map to manage DatastoreManager instances (one per directory path)
+    private static final ConcurrentMap<File, DatastoreManager> datastoreManagers = new
+            ConcurrentHashMap<File, DatastoreManager>();
+
     private final static String LOG_TAG = "DatastoreManager";
     private final static Logger logger = Logger.getLogger(DatastoreManager.class.getCanonicalName());
 
@@ -73,17 +79,17 @@ public class DatastoreManager {
 
     /**
      * <p>Constructs a {@code DatastoreManager} to manage a directory.</p>
-     *
      * <p>Datastores are created within the {@code directoryPath} directory.
      * In general, this folder should be under the control of, and only used
      * by, a single {@code DatastoreManager} object at any time.</p>
      *
      * @param directoryPath root directory to manage
-     *
      * @see DatastoreManager#DatastoreManager(java.io.File)
+     * @deprecated Use {@link DatastoreManager#getInstance(String)} to guarantee only a
+     * single DatastoreManager instance is created per storage path.
      */
     public DatastoreManager(String directoryPath) {
-        this(new File(directoryPath));
+        this(new File(directoryPath), false);
     }
 
     /**
@@ -97,8 +103,32 @@ public class DatastoreManager {
      *
      * @throws IllegalArgumentException if the {@code directoryPath} is not a
      *          directory or isn't writable.
+     *
+     * @deprecated Use {@link DatastoreManager#getInstance(File)} to guarantee only a single
+     * DatastoreManager instance is created per storage path.
      */
     public DatastoreManager(File directoryPath) {
+        this(directoryPath, false);
+    }
+
+    /**
+     * <p>Constructs a {@code DatastoreManager} to manage a directory.</p>
+     *
+     * <p>Datastores are created within the {@code directoryPath} directory.
+     * In general, this folder should be under the control of, and only used
+     * by, a single {@code DatastoreManager} object at any time.</p>
+     *<P>
+     * Internal use only, external callers should use DatastoreManager.getInstance().
+     *</P>
+     * @param directoryPath root directory to manage
+     * @param unused parameter to distinguish the private constructor from the deprecated public one
+     *               to be removed when deprecated constructors are removed.
+     *
+     * @throws IllegalArgumentException if the {@code directoryPath} is not a
+     *          directory or isn't writable.
+     *
+     */
+    private DatastoreManager(File directoryPath, boolean unused) {
         logger.fine("Datastore path: " + directoryPath);
 
         if(!directoryPath.exists()){
@@ -111,6 +141,43 @@ public class DatastoreManager {
             throw new IllegalArgumentException("Datastore directory is not writable");
         }
         this.path = directoryPath.getAbsolutePath();
+    }
+
+    /**
+     * <P>Gets a {@code DatastoreManager} to manage the specified directory of datastores.</P>
+     *
+     * @param directoryPath root directory to manage
+     * @see DatastoreManager#getInstance(File)
+     * @return a new or existing DatastoreManager instance for the specified directory.
+     */
+    public static DatastoreManager getInstance(String directoryPath) {
+        return DatastoreManager.getInstance(new File(directoryPath));
+    }
+
+    /**
+     * <P>Gets a {@code DatastoreManager} to manage the specified directory of datastores.</P>
+     * <P>This folder should be under the control of, and only used by, a single
+     * {@code DatastoreManager} instance at any time.
+     * </P>
+     * <P>accessing a DatastoreManager via this method guarantees that only a single
+     * DatastoreManager instance exists for the specified path within the static scope of this
+     * DatastoreManager class.
+     * </P>
+     * <P>
+     * This method is thread safe and it is acceptable to repeatedly call this method to re-obtain
+     * the same DatastoreManager instance.
+     * </P>
+     *
+     * @param directoryPath root directory to manage
+     * @return a new or existing DatastoreManager instance for the specified directory.
+     * @throws IllegalArgumentException if the {@code directoryPath} is not a
+     *                                  directory or isn't writable.
+     */
+    public static DatastoreManager getInstance(File directoryPath) {
+        // Uses the deprecated public constructor until we can change it to a private constructor.
+        DatastoreManager manager = new DatastoreManager(directoryPath, false);
+        DatastoreManager existingManager = datastoreManagers.putIfAbsent(directoryPath, manager);
+        return (existingManager == null) ? manager : existingManager;
     }
 
     /**

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/DatabaseNotificationsMoreTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/DatabaseNotificationsMoreTest.java
@@ -52,7 +52,7 @@ public class DatabaseNotificationsMoreTest {
     public void setUp() throws Exception {
         datastoreManagerDir = TestUtils
                 .createTempTestingDir(DatabaseNotificationsMoreTest.class.getName());
-        datastoreManager = new DatastoreManager(datastoreManagerDir);
+        datastoreManager = DatastoreManager.getInstance(datastoreManagerDir);
         datastoreManager.getEventBus().register(this);
         this.clearAllEventList();
     }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/DatabaseNotificationsTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/DatabaseNotificationsTest.java
@@ -39,7 +39,7 @@ public class DatabaseNotificationsTest {
     public void setUpClass() throws Exception {
         datastoreManagerDir = TestUtils
                 .createTempTestingDir(DatabaseNotificationsTest.class.getName());
-        datastoreManager = new DatastoreManager(datastoreManagerDir);
+        datastoreManager = DatastoreManager.getInstance(datastoreManagerDir);
         datastoreManager.getEventBus().register(this);
     }
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/DatastoreManagerTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/DatastoreManagerTest.java
@@ -14,6 +14,8 @@
 
 package com.cloudant.sync.datastore;
 
+import com.cloudant.sync.util.MultiThreadedTestHelper;
+
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Assert;
@@ -23,12 +25,10 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.Callable;
 
 public class DatastoreManagerTest {
 
@@ -40,7 +40,7 @@ public class DatastoreManagerTest {
         TEST_PATH = FileUtils.getTempDirectory().getAbsolutePath() + File.separator +
                 "DatastoreManagerTest";
         new File(TEST_PATH).mkdirs();
-        manager = new DatastoreManager(TEST_PATH);
+        manager = DatastoreManager.getInstance(TEST_PATH);
     }
 
     @After
@@ -54,7 +54,7 @@ public class DatastoreManagerTest {
         try {
             f.mkdir();
             f.setReadOnly();
-            manager = new DatastoreManager(f.getAbsolutePath());
+            manager = DatastoreManager.getInstance(f.getAbsolutePath());
         } finally {
             f.setWritable(true);
             f.delete();
@@ -65,7 +65,7 @@ public class DatastoreManagerTest {
     public void createFailsIfMissingIntermediates(){
         File f = new File(TEST_PATH, "missing_inter/missing_test");
         try {
-            manager = new DatastoreManager(f.getAbsolutePath());
+            manager = DatastoreManager.getInstance(f.getAbsolutePath());
         } finally {
             f.delete();
         }
@@ -75,7 +75,7 @@ public class DatastoreManagerTest {
     public void createDirectoryIfMissing(){
         File f = new File(TEST_PATH, "missing_test");
         try {
-            manager = new DatastoreManager(f.getAbsolutePath());
+            manager = DatastoreManager.getInstance(f.getAbsolutePath());
         } finally {
             f.delete();
         }
@@ -221,40 +221,27 @@ public class DatastoreManagerTest {
 
     @Test
     public void multithreadedDatastoreCreation() throws Exception {
-        int numberOfThreads = 25;
-        final List<Datastore> datastores = Collections.synchronizedList(new ArrayList<Datastore>());
-        final List<Throwable> exceptions = Collections.synchronizedList(new ArrayList<Throwable>());
-        final CountDownLatch latch = new CountDownLatch(1);
-        List<Thread> threads = new ArrayList<Thread>(numberOfThreads);
-        for (int i = 0; i < numberOfThreads; i++) {
-            threads.add(new Thread(new Runnable() {
-                @Override
-                public void run() {
-                    try {
-                        latch.await(20, TimeUnit.SECONDS);
-                        Datastore ds = manager.openDatastore("sameDatastoreName");
-                        datastores.add(ds);
-                    } catch(Throwable e) {
-                        exceptions.add(e);
-                    }
+        new MultiThreadedTestHelper<Datastore>(25) {
+
+            @Override
+            protected void doAssertions() throws Exception {
+                Datastore ds0 = results.get(0);
+                for (Datastore ds : results) {
+                    Assert.assertSame("The datastore instances should all be the same", ds0, ds);
                 }
-            }));
-        }
-        for (Thread thread : threads) {
-            thread.start();
-        }
-        // Release many threads simultaneously
-        latch.countDown();
-        // Wait for all threads to finish
-        for (Thread thread : threads) {
-            thread.join();
-        }
-        Assert.assertTrue("There should be no exceptions.", exceptions.isEmpty());
-        Assert.assertEquals("There should be the correct number of datastores", numberOfThreads, datastores.size());
-        Datastore ds0 = datastores.get(0);
-        for (Datastore ds : datastores) {
-            Assert.assertSame("The datastore instances should all be the same", ds0, ds);
-        }
+            }
+
+            @Override
+            protected Callable<Datastore> getCallable() {
+                return new
+                        Callable<Datastore>() {
+                            @Override
+                            public Datastore call() throws Exception {
+                                return manager.openDatastore("sameDatastoreName");
+                            }
+                        };
+            }
+        }.run();
     }
 
     @Test
@@ -263,5 +250,42 @@ public class DatastoreManagerTest {
         ds1.close();
         Datastore ds2 = manager.openDatastore("ds1");
         Assert.assertNotSame("The Datastore instances should not be the same.", ds1, ds2);
+    }
+
+    @Test
+    public void assertFactoryReturnsSameInstanceString() throws Exception {
+        DatastoreManager manager2 = DatastoreManager.getInstance(manager.getPath());
+        Assert.assertSame("The DatastoreManager instances should be the same.", manager, manager2);
+    }
+
+    @Test
+    public void assertFactoryReturnsSameInstanceFile() throws Exception {
+        DatastoreManager manager2 = DatastoreManager.getInstance(new File(manager.getPath()));
+        Assert.assertSame("The DatastoreManager instances should be the same.", manager, manager2);
+    }
+
+    @Test
+    public void multithreadedDatastoreManagerAccess() throws Exception {
+        new MultiThreadedTestHelper<DatastoreManager>(25) {
+
+            @Override
+            protected void doAssertions() throws Exception {
+                for (DatastoreManager gotManager : results) {
+                    Assert.assertSame("The datastore manager instances should all be the same",
+                            manager, gotManager);
+                }
+            }
+
+            @Override
+            protected Callable<DatastoreManager> getCallable() {
+                return new
+                        Callable<DatastoreManager>() {
+                            @Override
+                            public DatastoreManager call() throws Exception {
+                                return DatastoreManager.getInstance(manager.getPath());
+                            }
+                        };
+            }
+        }.run();
     }
 }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/DatastoreSchemaTests.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/DatastoreSchemaTests.java
@@ -188,7 +188,7 @@ public class DatastoreSchemaTests {
         Assert.assertTrue(unzipToDirectory(zippedVersion6, temp_folder));
 
         // Datastore manager the temp folder
-        DatastoreImpl datastore = (DatastoreImpl) new DatastoreManager(
+        DatastoreImpl datastore = (DatastoreImpl) DatastoreManager.getInstance(
                 new File(temp_folder, "datastores").getAbsolutePath())
                 .openDatastore("testdb");
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/DatastoreTestBase.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/DatastoreTestBase.java
@@ -32,7 +32,7 @@ public abstract class DatastoreTestBase {
     @Before
     public void setUp() throws Exception {
         datastore_manager_dir = TestUtils.createTempTestingDir(this.getClass().getName());
-        datastoreManager = new DatastoreManager(this.datastore_manager_dir);
+        datastoreManager = DatastoreManager.getInstance(this.datastore_manager_dir);
         this.datastore = (DatastoreImpl) (this.datastoreManager.openDatastore(getClass().getSimpleName()));
 
     }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/MultipartAttachmentWriterTests.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/MultipartAttachmentWriterTests.java
@@ -60,7 +60,7 @@ public class MultipartAttachmentWriterTests {
     @Before
     public void setUp() throws Exception {
         datastore_manager_dir = TestUtils.createTempTestingDir(this.getClass().getName());
-        datastoreManager = new DatastoreManager(this.datastore_manager_dir);
+        datastoreManager = DatastoreManager.getInstance(this.datastore_manager_dir);
         datastore = (this.datastoreManager.openDatastore(getClass().getSimpleName()));
         jsonData = "{\"body\":\"This is a body.\"}".getBytes();
         bodyOne = DocumentBodyImpl.bodyWith(jsonData);

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/AbstractIndexTestBase.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/AbstractIndexTestBase.java
@@ -37,7 +37,7 @@ public abstract class AbstractIndexTestBase {
     public void setUp() throws Exception {
         factoryPath = TestUtils.createTempTestingDir(AbstractIndexTestBase.class.getName());
         assertThat(factoryPath, is(notNullValue()));
-        factory = new DatastoreManager(factoryPath);
+        factory = DatastoreManager.getInstance(factoryPath);
         assertThat(factory, is(notNullValue()));
         ds = (DatastoreImpl) factory.openDatastore(AbstractIndexTestBase.class.getSimpleName());
         assertThat(ds, is(notNullValue()));

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/AbstractQueryTestBase.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/AbstractQueryTestBase.java
@@ -53,7 +53,7 @@ public abstract class AbstractQueryTestBase {
     public void setUp() throws Exception {
         factoryPath = TestUtils.createTempTestingDir(AbstractQueryTestBase.class.getName());
         assertThat(factoryPath, is(notNullValue()));
-        factory = new DatastoreManager(factoryPath);
+        factory = DatastoreManager.getInstance(factoryPath);
         assertThat(factory, is(notNullValue()));
         String datastoreName = AbstractQueryTestBase.class.getSimpleName();
         ds = (DatastoreImpl) factory.openDatastore(datastoreName);

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/ReplicationTestBase.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/ReplicationTestBase.java
@@ -63,7 +63,7 @@ public abstract class ReplicationTestBase extends CouchTestBase {
 
     protected void createDatastore() throws Exception {
         datastoreManagerPath = TestUtils.createTempTestingDir(this.getClass().getName());
-        datastoreManager = new DatastoreManager(this.datastoreManagerPath);
+        datastoreManager = DatastoreManager.getInstance(this.datastoreManagerPath);
         datastore = (DatastoreImpl) datastoreManager.openDatastore(getClass().getSimpleName());
         datastoreWrapper = new DatastoreWrapper(datastore);
     }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/util/MultiThreadedTestHelper.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/util/MultiThreadedTestHelper.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * A simple test abstraction that executes a callable from the specified number of threads as close
+ * to simultaneously as possible. The callable is wrapped in a runnable and blocked behind a latch.
+ * The latch counts down as each thread is ready and then there is a final countdown to unlatch all
+ * the threads at once.
+ * <p>
+ * To use this class extend it specifying the number of threads and implementing getCallable.
+ * </p>
+ * <p>
+ * The default assertions include checking that all the threads executed and there were no
+ * exceptions and that the number of results were correct. Additional assertions are added by
+ * implementing the doAssertions method.
+ * </p>
+ * <p>
+ * Call run to start the test.
+ * </p>
+ *
+ * @param <T> the type of result from the Callable
+ */
+public abstract class MultiThreadedTestHelper<T> {
+
+    private final int numberOfThreads;
+    private final List<Thread> threads;
+    protected final List<T> results;
+    protected final List<Throwable> exceptions;
+    final AtomicBoolean failedToExecuteAllThreads = new AtomicBoolean(false);
+    final CountDownLatch latch;
+
+
+    public MultiThreadedTestHelper(int numberOfThreads) {
+        this.numberOfThreads = numberOfThreads;
+        this.latch = new CountDownLatch(numberOfThreads + 1);
+        this.threads = new ArrayList<Thread>(numberOfThreads);
+        this.results = Collections.synchronizedList(new ArrayList<T>(numberOfThreads));
+        this.exceptions = Collections.synchronizedList(new ArrayList<Throwable>(numberOfThreads));
+        for (int i = 0; i < numberOfThreads; i++) {
+            final Callable<T> callable = getCallable();
+            threads.add(new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        latch.countDown();
+                        // Wait for all the threads to be running before proceeding with the calls
+                        // we want them to happen as much at same time as possible.
+                        if (latch.await(20, TimeUnit.SECONDS)) {
+                            results.add(callable.call());
+                            return;
+                        }
+                    } catch (Throwable t) {
+                        exceptions.add(t);
+                    }
+                    // If we reached this we didn't execute the thread correctly
+                    failedToExecuteAllThreads.set(true);
+                }
+            }));
+        }
+    }
+
+    public void run() throws Exception {
+        for (Thread thread : threads) {
+            thread.start();
+        }
+        // Release many threads simultaneously
+        latch.countDown();
+        // Wait for all threads to finish
+        for (Thread thread : threads) {
+            thread.join();
+        }
+        defaultAssertions();
+        doAssertions();
+    }
+
+    protected void defaultAssertions() throws Exception {
+        assertFalse("All threads should have executed", failedToExecuteAllThreads.get());
+        assertTrue("There should be no exceptions.", exceptions.isEmpty());
+        assertEquals("There should be the correct number of results",
+                numberOfThreads, results.size());
+    }
+
+    protected abstract void doAssertions() throws Exception;
+
+    protected abstract Callable<T> getCallable();
+}

--- a/doc/crud.md
+++ b/doc/crud.md
@@ -21,7 +21,7 @@ import com.cloudant.sync.datastore.Datastore;
 
 // Create a DatastoreManager using application internal storage path
 File path = getApplicationContext().getDir("datastores");
-DatastoreManager manager = new DatastoreManager(path.getAbsolutePath());
+DatastoreManager manager = DatastoreManager.getInstance(path.getAbsolutePath());
 ```
 
 Once you've a manager set up, it's straightforward to create datastores:

--- a/doc/encryption.md
+++ b/doc/encryption.md
@@ -58,7 +58,7 @@ Once you've included the binaries in your app's build, you need to perform some 
     KeyProvider keyProvider = new SimpleKeyProvider(key); 
 
     File path = getApplicationContext().getDir("datastores", MODE_PRIVATE);
-    DatastoreManager manager = new DatastoreManager(path.getAbsolutePath()); 
+    DatastoreManager manager = DatastoreManager.getInstance(path.getAbsolutePath());
 
     Datastore ds = manager.openDatastore("my_datastore", keyProvider);
     ```
@@ -112,7 +112,7 @@ protected void onCreate(Bundle savedInstanceState) {
     KeyProvider keyProvider = 
             new SimpleKeyProvider("testAKeyPasswordtestAKeyPassword".getBytes());
  
-    DatastoreManager manager = new DatastoreManager(path.getAbsolutePath());
+    DatastoreManager manager = DatastoreManager.getInstance(path.getAbsolutePath());
  
     Datastore ds = null;
     try {

--- a/doc/query.md
+++ b/doc/query.md
@@ -34,7 +34,7 @@ import com.cloudant.sync.datastore.Datastore;
 import com.cloudant.sync.query.IndexManager;
 
 File path = getApplicationContext().getDir("datastores");
-DatastoreManager manager = new DatastoreManager(path.getAbsolutePath());
+DatastoreManager manager = DatastoreManager.getInstance(path.getAbsolutePath());
 Datastore ds = manager.openDatastore("my_datastore");
 IndexManager im = new IndexManager(ds);
 ```

--- a/doc/replication-policies.md
+++ b/doc/replication-policies.md
@@ -186,7 +186,7 @@ public class MyReplicationService extends PeriodicReplicationService {
                 Context.MODE_PRIVATE
             );
 
-            DatastoreManager manager = new DatastoreManager(path.getAbsolutePath());
+            DatastoreManager manager = DatastoreManager.getInstance(path.getAbsolutePath());
             Datastore datastore = null;
             try {
                 datastore = manager.openDatastore(TASKS_DATASTORE_NAME);

--- a/sample/todo-sync/src/com/cloudant/todo/TasksModel.java
+++ b/sample/todo-sync/src/com/cloudant/todo/TasksModel.java
@@ -70,7 +70,7 @@ class TasksModel {
                 DATASTORE_MANGER_DIR,
                 Context.MODE_PRIVATE
         );
-        DatastoreManager manager = new DatastoreManager(path.getAbsolutePath());
+        DatastoreManager manager = DatastoreManager.getInstance(path.getAbsolutePath());
         try {
             this.mDatastore = manager.openDatastore(TASKS_DATASTORE_NAME);
         } catch (DatastoreNotCreatedException dnce) {


### PR DESCRIPTION
*What*

Made it easier to obtain a singleton `DatastoreManager` for a storage path.

*Why*

The `DatastoreManager` expects to manage a storage location without anything else interfering with the files in that location. Exposing the constructor allows multiple `DatastoreManager` instances to be created for the same storage location. It is preferable to return a singleton instance for any given storage location (at least within the scope of the `DatastoreManager` class). This also has the advantage of allowing the same `DatastoreManager` instance to be retrieved in multiple places when the object cannot be passed around and only the path (string) is available (e.g. as used by the sync-android-p2p project).

*How*

Simplify locking for `Datastore` instance opening/creation/closing/deletion, removing double-lock pattern, which may have returned a `null` `Datastore` instance if `openDatastore` was called in parallel with a deletion.
Deprecate the public `DatastoreManager` constructors (leave them in place until the next major release for compatibility with existing code).
Added new static `getInstance` methods on `DatastoreManager` that create or return an existing `DatastoreManager` instance per storage path.

*Testing*

Added new tests:
* multithreadedDatastoreCreation
* datastoreInstanceNotReusedAfterClose
* assertFactoryReturnsSameInstanceString
* assertFactoryReturnsSameInstanceFile

Refactored existing test code to use `DatastoreManager.getInstance`.