### PR TITLE
Allow Queries which include booleans to execute

### DIFF
--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/QuerySqlTranslator.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/QuerySqlTranslator.java
@@ -484,7 +484,17 @@ class QuerySqlTranslator {
         // [ { "fieldName":  "mike"}, ...]
 
         List<String> whereClauses = new ArrayList<String>();
-        List<Object> sqlParameters = new ArrayList<Object>();
+        List<Object> sqlParameters = new ArrayList<Object>() {
+            @Override
+            public boolean add(Object o) {
+                if (o instanceof Boolean){
+                    Boolean bool = (Boolean) o;
+                    return super.add(bool ? "1" : "0");
+                } else {
+                    return super.add(String.valueOf(o));
+                }
+            }
+        };
 
         Map<String, String> operatorMap = new HashMap<String, String>();
         operatorMap.put(EQ, "=");
@@ -558,11 +568,14 @@ class QuerySqlTranslator {
                         sqlParameters.add(modulus.get(1));
                     } else {
                         // The predicate map value must be either a
-                        // String or a non-Float Number here.
+                        // String, a non-Float Number or Boolean here.
                         // This was validated during normalization.
+                        // Boolean values need to be converted into 1 or 0
+                        // to match SQLite expected values.
                         predicateValue = negatedPredicate.get(operator);
                         placeholder = "?";
-                        sqlParameters.add(String.valueOf(predicateValue));
+                        sqlParameters.add(predicateValue);
+
                     }
 
                     whereClause = whereClauseForNot(fieldName, sqlOperator, tableName, placeholder);
@@ -592,11 +605,13 @@ class QuerySqlTranslator {
                         sqlParameters.add(modulus.get(1));
                     } else {
                         // The predicate map value must be either a
-                        // String or a non-Float Number here.
+                        // String, a non-Float Number or Boolean here.
                         // This was validated during normalization.
+                        // Boolean values need to be converted into 1 or 0
+                        // to match SQLite expected values.
                         Object predicateValue = predicate.get(operator);
                         placeholder = "?";
-                        sqlParameters.add(String.valueOf(predicateValue));
+                        sqlParameters.add(predicateValue);
                     }
 
                     whereClause = String.format("\"%s\" %s %s", fieldName,

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/QueryValidator.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/QueryValidator.java
@@ -587,7 +587,7 @@ class QueryValidator {
         } else if (operator.equals(MOD)) {
             return validateModArgument(predicateValue);
         } else if (validateNotAFloat(predicateValue)) {
-            return (predicateValue instanceof String || predicateValue instanceof Number);
+            return (predicateValue instanceof String || predicateValue instanceof Number || predicateValue instanceof Boolean);
         }
 
         return false;

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryCoveringIndexesTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryCoveringIndexesTest.java
@@ -116,6 +116,28 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
     }
 
     @Test
+    public void returnsDocForQueryWithBool() throws Exception {
+        setUpBasicQueryData();
+        DocumentRevision rev = new DocumentRevision("marriedMike");
+        Map<String, Object> bodyMap = new HashMap<String, Object>();
+        bodyMap.put("name", "mike");
+        bodyMap.put("age", 12);
+        bodyMap.put("pet", "cat");
+        bodyMap.put("married", true);
+        rev.setBody(DocumentBodyFactory.create(bodyMap));
+        ds.createDocumentFromRevision(rev);
+        assertThat(im.ensureIndexed(Arrays.<Object>asList("name", "age", "married"), "married"), is("married"));
+        // query - { "married" : { "eq" : true } }
+        Map<String, Object> marriedOperator = new HashMap<String, Object>();
+        marriedOperator.put("$eq", true);
+        Map<String, Object> query = new HashMap<String, Object>();
+        query.put("married", marriedOperator);
+        QueryResult result = im.find(query);
+        assertThat(result, is(notNullValue()));
+        assertThat(result.documentIds().size(), is(1));
+    }
+
+    @Test
     public void returnsDocForQueryAgainstIndexWithSpecialChar() throws Exception {
         DocumentRevision rev = new DocumentRevision("mike12");
         Map<String, Object> bodyMap = new HashMap<String, Object>();

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryValidatorTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryValidatorTest.java
@@ -672,4 +672,22 @@ public class QueryValidatorTest {
         assertThat(normalizedQuery, is(nullValue()));
     }
 
+    @Test
+    public void normalizesQueryWithEQOperator() {
+        Map<String, Object> query = new HashMap<String, Object>();
+
+        // query - { "animal" : true }
+        query.put("animal", Boolean.TRUE);
+        Map<String, Object> normalizedQuery = QueryValidator.normaliseAndValidateQuery(query);
+
+        // normalized query - { "$and" : [ { "animal" : { "$eq" : true } } ] }
+        Map<String, Object> c1op = new HashMap<String, Object>();
+        c1op.put("$eq", Boolean.TRUE);
+        Map<String, Object> c1 = new HashMap<String, Object>();
+        c1.put("animal", c1op);
+        Map<String, Object> expected = new LinkedHashMap<String, Object>();
+        expected.put("$and", Arrays.<Object>asList(c1));
+        assertThat(normalizedQuery, is(expected));
+    }
+
 }


### PR DESCRIPTION
## What
Allow Queries which include booleans to execute, for example:
`{ "married" : { "$eq" : true } }` previously these would be marked
incorrectly as invalid during the normalization and validation phase.

## How
- Update validation logic to include a boolean as an acceptable value.
- Correctly transform a boolean value into `1` or `0` to be used with SQLite queries.

## Testing
- New test added to check validation
- New test to make sure `QueryValidator` correctly normalises the  an `$eq` query with a boolean value.

## Issues

Fixes #273