### PR TITLE
Small attachments unnecessarily base64 encoded

### DIFF
--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/MultipartAttachmentWriter.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/MultipartAttachmentWriter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014 Cloudant, Inc. All rights reserved.
+ * Copyright (c) 2014, 2016 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -57,7 +57,7 @@ import java.util.Map;
  * <p>
  * The stream consists of a first MIME body which is the JSON document itself, which needs to have
  * the <code>_attachments</code> object correctly populated. This is currently done by
- * {@link com.cloudant.sync.datastore.RevisionHistoryHelper#addAttachments(java.util.List, java.util.Map, com.cloudant.sync.replication.PushAttachmentsInline, int)}
+ * {@link com.cloudant.sync.datastore.RevisionHistoryHelper#addAttachments(java.util.List, java.util.Map, boolean, int)}
  * </p>
  *
  * <p>
@@ -66,7 +66,7 @@ import java.util.Map;
  * </p>
  *
  * @see com.cloudant.mazha.CouchClient#putMultipart(MultipartAttachmentWriter)
- * @see com.cloudant.sync.datastore.RevisionHistoryHelper#addAttachments(java.util.List, java.util.Map, com.cloudant.sync.replication.PushAttachmentsInline, int)
+ * @see com.cloudant.sync.datastore.RevisionHistoryHelper#addAttachments(java.util.List, java.util.Map, boolean, int)
  * @see <a href=http://couchdb.readthedocs.org/en/latest/api/document/common.html#creating-multiple-attachments>Creating Multiple Attachments</a>
  * @see <a href=http://tools.ietf.org/html/rfc2387>RFC 2387</a>
  *

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/PushAttachmentsInline.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/PushAttachmentsInline.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 Cloudant, Inc. All rights reserved.
+ * Copyright (c) 2015, 2016 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -14,17 +14,28 @@
 
 package com.cloudant.sync.replication;
 
+import java.util.List;
+
 /**
  * <p>
  * Strategy to decide whether to push attachments inline:
  * </p>
  *
  * <ul>
- *     <li>False: Always push attachments separately as an HTTP binary PUT</li>
+ *     <li>False: Always push attachments separately from JSON body, via multipart/related</li>
  *     <li>Small: Push small attachments inline, and large attachments separately.
  *         Uses SavedAttachment.isLarge() to determine whether attachment is small or large.</li>
- *     <li>True: Always push attachments inline as a base64-encoded string.</li>
+ *     <li>True: Always push attachments inline in JSON body, as a base64-encoded string.</li>
  * </ul>
+ *
+ * <p>
+ * Note that all attachments belonging to a pushed revision are either sent via multipart/related,
+ * or all inline in JSON body, as a base64-encoded string.
+ * Further details of this can be found at
+ * {@link com.cloudant.sync.datastore.RevisionHistoryHelper#shouldInline(List, PushAttachmentsInline, int)}
+ * </p>
+ *
+ * @see com.cloudant.sync.datastore.RevisionHistoryHelper
  *
  * @api_public
  */

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/PushStrategy.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/PushStrategy.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013 Cloudant, Inc. All rights reserved.
+ * Copyright (c) 2013, 2016 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -398,15 +398,19 @@ class PushStrategy implements ReplicationStrategy {
                     }
                 }
 
+                // do we inline all attachments as base64 or send them all via multipart writer?
+                boolean shouldInline = RevisionHistoryHelper.shouldInline(atts,
+                        this.pushAttachmentsInline,
+                        minRevPos);
                 // get the json, and inline any small attachments
                 Map<String, Object> json = RevisionHistoryHelper.revisionHistoryToJson(path,
                         atts,
-                        this.pushAttachmentsInline,
+                        shouldInline,
                         minRevPos);
                 // if there are any large atts we will get a multipart writer, otherwise null
                 MultipartAttachmentWriter mpw = RevisionHistoryHelper.createMultipartWriter(json,
                         atts,
-                        this.pushAttachmentsInline,
+                        shouldInline,
                         minRevPos);
 
                 // now we will have either a multipart or a plain doc


### PR DESCRIPTION
_What_: If we decide to send attachments via multipart/related, then all attachments should be sent as additional body parts even if they were previous determined as being too small to send as body parts. Put another way, either all attachments are sent as inline base64 in the json body, or they are sent as body parts.

_Why_: The previous behaviour was slightly inefficient. Once we switched to the multipart/related method, it's wasteful to base64 encode some attachments.

_Testing_: Additional tests pass, added new test `pushBigAndSmallAttachmentsTest` and verified correct behaviour via wireshark.

GitHub issue: #276 