### PR TITLE
Collect logcat from device runs

### DIFF
--- a/AndroidExec.gradle
+++ b/AndroidExec.gradle
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+// Define AndroidExec as an external property for includers to be able to use it
+ext.AndroidExec = AndroidExec
+
+// A gradle Exec task that searches the Android tools locations for matching executables.
+// Tasks of this type can only execute if sdk.dir is set in local.properties or the ANDROID_HOME
+// environment variable is set. It will include the highest found version of the build-tools.
+public class AndroidExec extends Exec {
+
+    @Override
+    Task configure(Closure closure) {
+        Task toReturn = super.configure(closure)
+        String androidPath = null;
+        File localProperties = new File(getProject().getRootProject().getRootDir(), "local.properties")
+        if (localProperties.exists()) {
+            Properties properties = new Properties()
+            localProperties.withInputStream { instr ->
+                properties.load(instr)
+            }
+            androidPath = properties.getProperty('sdk.dir')
+        }
+
+        if(androidPath == null){
+            androidPath = System.env.ANDROID_HOME
+        }
+
+        if (androidPath != null) {
+            // Get the highest build tools version
+            def btv = Arrays.asList(new File(androidPath + File.separator + "build-tools").list())
+                    .sort().reverse().get(0)
+
+            String[] androidToolsPaths = ["tools", "build-tools" + File.separator + btv, "platform-tools"]
+            // Search the tools paths looking for a matching file to set as the executable
+            for (String androidToolsPath : androidToolsPaths) {
+                File toolsPath = new File(androidPath + File.separator + androidToolsPath);
+                // Search the android paths
+                String[] matchingExec = toolsPath.list(new FilenameFilter() {
+                    @Override
+                    boolean accept(File dir, String name) {
+                        return name.equals(getExecutable());
+                    }
+                })
+                if (matchingExec.length == 1) {
+                    setExecutable(new File(toolsPath, matchingExec[0]))
+                    break
+                }
+            }
+        } else {
+            doFirst {
+                throw new TaskInstantiationException("ANDROID_HOME environment variable or " +
+                        "local.properties sdk.dir definition did not exist. " +
+                        "Unable to run tasks of type AndroidExec without these properties.")
+            }
+        }
+        return toReturn
+    }
+}

--- a/AndroidTest/app/build.gradle
+++ b/AndroidTest/app/build.gradle
@@ -110,29 +110,11 @@ repositories {
     mavenCentral()
 }
 
-task(uploadFixtures,type:Exec) {
+task(uploadFixtures, type: AndroidExec) {
     // need to upload the fixtures to the device/emulator external storage
     // this will work irrespective of current working directory due to use of $scriptLocation
 
-    def rootDir = project.rootDir
-    def localProperties = new File(rootDir, "local.properties")
-    def androidPath = null;
-    if (localProperties.exists()) {
-        Properties properties = new Properties()
-        localProperties.withInputStream { instr ->
-            properties.load(instr)
-        }
-        androidPath = properties.getProperty('sdk.dir')
-    }
-
-    if(androidPath == null){
-         androidPath = System.env.ANDROID_HOME
-        if(androidPath == null){
-            throw new Exception("Couldn't find android sdk directory, set ANDROID_HOME or sdk.dir in local.properties");
-        }
-    }
-
-    commandLine "$androidPath/platform-tools/adb","push", "-p", "$scriptLocation/../../fixture", "/sdcard/fixture"
+    commandLine "adb","push", "-p", "$scriptLocation/../../fixture", "/sdcard/fixture"
 }
 
 def convertTestSysPropsToHash (){

--- a/AndroidTest/app/build.gradle
+++ b/AndroidTest/app/build.gradle
@@ -117,6 +117,22 @@ task(uploadFixtures, type: AndroidExec) {
     commandLine "adb","push", "-p", "$scriptLocation/../../fixture", "/sdcard/fixture"
 }
 
+task(clearDeviceLog, type: AndroidExec) {
+    commandLine "adb","logcat", "-c"
+}
+
+task(pullDeviceLog, type: AndroidExec) {
+    doFirst {
+        standardOutput = new FileOutputStream(new File(reportsDir, "logcat.log"), false)
+    }
+    commandLine "adb","logcat", "-d"
+}
+
+tasks.withType(com.android.build.gradle.internal.tasks.AndroidTestTask) {
+    dependsOn clearDeviceLog
+    finalizedBy pullDeviceLog
+}
+
 def convertTestSysPropsToHash (){
 
     return "{" +

--- a/AndroidTest/build.gradle
+++ b/AndroidTest/build.gradle
@@ -1,5 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
+apply from: '../AndroidExec.gradle'
+
 buildscript {
     repositories {
         jcenter()

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@
 apply plugin: 'java'
 apply plugin: 'maven'
 apply plugin: 'signing'
+apply from: 'AndroidExec.gradle'
 
 //
 // General settings
@@ -226,6 +227,7 @@ subprojects {
     File dexAllDir = new File(project.buildDir, "dex-all")
     File dexAllInputDir = new File(dexAllDir, "in")
     File dexAllOutputDir = new File(dexAllDir, "out")
+    File dexLog = new File(dexAllOutputDir, "dex.log")
     task copyDependencies(type: Copy) {
         from configurations.runtime
         into dexAllInputDir
@@ -239,64 +241,28 @@ subprojects {
     task dexAll(type: AndroidExec, dependsOn: [copyDependencies, copyLib]) {
         doFirst {
             dexAllOutputDir.mkdir()
+            dexLog.createNewFile()
             def writer = new PrintWriter(new File(dexAllOutputDir, "dexInputList.txt"))
             writer.println(dexAllInputDir.absolutePath)
             writer.close()
+            standardOutput = new FileOutputStream(dexLog, false)
+            errorOutput = standardOutput
+        }
+        doLast{
+            standardOutput.close()
         }
         inputs.dir dexAllInputDir
         outputs.dir dexAllOutputDir
         workingDir dexAllOutputDir
-        commandLine 'bash', '-e', '-c', """
-            dx --dex --statistics --num-threads=4 --core-library --output=all.dex --input-list=dexInputList.txt >dex.log 2>&1
-        """
+
+        commandLine 'dx', '--dex', '--statistics', '--num-threads=4', '--core-library',
+                '--output=all.dex', '--input-list=dexInputList.txt'
     }
 
     task methodCount(type: Exec, dependsOn: [dexAll]) {
         // Run this task to get the Android method counts.
         workingDir dexAllOutputDir
-        commandLine 'bash', '-e', '-c', """
-            grep 'method id:.*' dex.log
-        """
-    }
-}
-
-// A gradle Exec task that includes the Android tools on the path.
-// Tasks of this type can only execute if sdk.dir is set in local.properties or the ANDROID_HOME
-// environment variable is set. It will include the highest found version of the build-tools.
-class AndroidExec extends org.gradle.api.tasks.Exec {
-
-    @Override
-    Task configure(Closure closure) {
-        String androidPath = null;
-        File localProperties = new File(getProject().getRootProject().getRootDir(), "local.properties")
-        if (localProperties.exists()) {
-            Properties properties = new Properties()
-            localProperties.withInputStream { instr ->
-                properties.load(instr)
-            }
-            androidPath = properties.getProperty('sdk.dir')
-        }
-
-        if(androidPath == null){
-            androidPath = System.env.ANDROID_HOME
-        }
-
-        if (androidPath != null) {
-            // Get the highest build tools version
-            def btv = Arrays.asList(new File(androidPath + File.separator + "build-tools").list())
-                    .sort().reverse().get(0)
-
-            String[] androidPaths = ["tools", "build-tools" + File.separator + btv, "platform-tools"]
-            for (String aPath : androidPaths) {
-                environment("PATH", environment.PATH + File.pathSeparator + androidPath
-                        + File.separator + aPath)
-            }
-        } else {
-            doFirst { throw new TaskInstantiationException("ANDROID_HOME environment variable or " +
-                    "local.properties sdk.dir definition did not exist. " +
-                    "Unable to run tasks of type AndroidExec without these properties.")}
-        }
-        return super.configure(closure)
+        commandLine 'grep', 'method id:.*', dexLog
     }
 }
 


### PR DESCRIPTION
*What*

Collect logcat from device runs.

*Why*

Additional debug info is useful if tests fail on emulator or device.

*How*

Added `clearDeviceLog` and `pullDeviceLog` tasks to run either
side of tasks of type `AndroidTestTask`. It is annoying to reference that internal type, but I couldn't find a better way to get the dependency on the correct task.

Enabled the new tasks and `uploadFixtures` to use `AndroidExec` task type by:

* Moved `AndroidExec` task into a shareable build script.
* Made `AndroidExec` search paths for matching Android tools to execute as
environment variables required calling bash which wasn’t platform
independent (env only applies to the executed process not the search
for that executable).
* Imported shared script into build.gradle and AndroidTest/build.gradle.
* Refactored commandLine properties to suit AndroidExec without needing bash

*Test*

Running the `connectedCheck` produced output in `AndroidTest/app/build/reports/logcat.log`