### PR TITLE
313 force insert failure

### DIFF
--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/DatastoreImplForceInsertTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/DatastoreImplForceInsertTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013 Cloudant, Inc. All rights reserved.
+ * Copyright (C) 2013, 2016 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -63,6 +63,7 @@ public class DatastoreImplForceInsertTest {
 
     @After
     public void tearDown() throws Exception {
+        datastore.close();
         TestUtils.deleteDatabaseQuietly(database);
         TestUtils.deleteTempTestingDir(database_dir);
     }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/DatastoreManagerTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/DatastoreManagerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013 Cloudant, Inc. All rights reserved.
+ * Copyright (C) 2013, 2016 IBM Corp. All rights reserved.
  * <p/>
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -226,8 +226,15 @@ public class DatastoreManagerTest {
             @Override
             protected void doAssertions() throws Exception {
                 Datastore ds0 = results.get(0);
-                for (Datastore ds : results) {
-                    Assert.assertSame("The datastore instances should all be the same", ds0, ds);
+                try {
+                    for (Datastore ds : results) {
+                        Assert.assertSame("The datastore instances should all be the same", ds0, ds);
+
+                    }
+                } finally {
+                    for (Datastore ds : results) {
+                        if (ds != null) ds.close();
+                    }
                 }
             }
 
@@ -246,10 +253,18 @@ public class DatastoreManagerTest {
 
     @Test
     public void datastoreInstanceNotReusedAfterClose() throws Exception {
-        Datastore ds1 = manager.openDatastore("ds1");
-        ds1.close();
-        Datastore ds2 = manager.openDatastore("ds1");
-        Assert.assertNotSame("The Datastore instances should not be the same.", ds1, ds2);
+        Datastore ds1 = null, ds2 = null;
+        try {
+            ds1 = manager.openDatastore("ds1");
+        } finally {
+            if (ds1 != null) ds1.close();
+        }
+        try {
+            ds2 = manager.openDatastore("ds1");
+            Assert.assertNotSame("The Datastore instances should not be the same.", ds1, ds2);
+        } finally {
+            if (ds2 != null) ds2.close();
+        }
     }
 
     @Test


### PR DESCRIPTION
*What*

Closed datastores left open in `DatastoreImplForceInsertTest`.

*Why*

Leaving the datastores open could lead to leaked connections and later thread deaths from `udpateSchema` failures e.g.
>E/AndroidRuntime(21513): android.database.sqlite.SQLiteException: cannot rollback - no transaction is active (code 1)
...
com.cloudant.sync.sqlite.android.AndroidSQLite.endTransaction(AndroidSQLite.java:76)
E/AndroidRuntime(21513): 	at com.cloudant.sync.sqlite.SQLDatabaseFactory.updateSchema(SQLDatabaseFactory.java:206)

*How*

Added `datastore.close()` call to test teardown. This exposed some other tests failing to close datastores correctly, namely:
`DatastoreManagerTest`

and an issue where calling `close` more than once on the same `Datastore` resulted in a `RejectedExecutionException`.

*Test*

This is mainly changes to existing tests to close datatstores opened by the tests. 