### PR TITLE
Upgrade cloudant-http to 2.5.1

### DIFF
--- a/AndroidTest/app/build.gradle
+++ b/AndroidTest/app/build.gradle
@@ -85,7 +85,7 @@ dependencies {
     compile 'commons-io:commons-io:2.4'
     compile 'commons-codec:commons-codec:1.9'
     compile 'org.apache.commons:commons-lang3:3.3.2'
-    compile group: 'com.cloudant', name: 'cloudant-http', version:'2.4.1'
+    compile group: 'com.cloudant', name: 'cloudant-http', version:'2.5.1'
     compile 'com.google.code.findbugs:jsr305:3.0.0' //this is needed for some versions of android
     compile files('../../cloudant-sync-datastore-android-encryption/libs/sqlcipher.jar') //required sqlcipher lib
     compile files('../../cloudant-sync-datastore-android/libs/android-support-v4.jar')

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,15 @@
 # Unreleased
+
+- [NEW] Updated to version 2.5.1 of the `cloudant-http` library. This
+  includes optional support for handling HTTP status code 429 `Too
+  Many Requests` with blocking backoff and retries. To enable the
+  backoff add an instance of a `Replay429Interceptor` with the desired
+  number of retries and initial backoff:
+  ```
+  builder.addResponseInterceptors(new Replay429Interceptor(retries, initialBackoff));
+  ```
+  A default instance is available using 3 retries and starting with a
+  250 ms backoff: `Replay429Interceptor.WITH_DEFAULTS`
 - [DEPRECATED] `DatastoreManager` constructors. Use `DatastoreManager.getInstance` factory methods
   instead to guarantee only a single `DatastoreManager` instance is created for a given storage
   directory path in the scope of the `DatastoreManager` class.

--- a/cloudant-sync-datastore-core/build.gradle
+++ b/cloudant-sync-datastore-core/build.gradle
@@ -3,7 +3,7 @@
 // ************ //
 dependencies {
 
-    compile group: 'com.cloudant', name: 'cloudant-http', version:'2.4.2'
+    compile group: 'com.cloudant', name: 'cloudant-http', version:'2.5.1'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version:'2.1.1'
     compile group: 'commons-codec', name: 'commons-codec', version:'1.10'
     compile group: 'com.google.guava', name: 'guava', version:'15.0'


### PR DESCRIPTION
_What/Why_: See #298 

_Testing_: `gradle clean integrationTest` passes