### PR TITLE
Device tests

### DIFF
--- a/AndroidTest/app/build.gradle
+++ b/AndroidTest/app/build.gradle
@@ -69,7 +69,7 @@ android {
     }
 
     adbOptions {
-        timeOutInMs 30*1000 // 30 seconds in ms.
+        timeOutInMs 3*60*1000 // 3 minutes in ms.
     }
 
 }

--- a/AndroidTest/app/build.gradle
+++ b/AndroidTest/app/build.gradle
@@ -125,7 +125,7 @@ task(pullDeviceLog, type: AndroidExec) {
     doFirst {
         standardOutput = new FileOutputStream(new File(reportsDir, "logcat.log"), false)
     }
-    commandLine "adb","logcat", "-d"
+    commandLine "adb","logcat", "-d", "-v", "threadtime"
 }
 
 tasks.withType(com.android.build.gradle.internal.tasks.AndroidTestTask) {

--- a/cloudant-sync-datastore-android-encryption/src/test/java/com/cloudant/sync/datastore/encryption/EndToEndEncryptionTest.java
+++ b/cloudant-sync-datastore-android-encryption/src/test/java/com/cloudant/sync/datastore/encryption/EndToEndEncryptionTest.java
@@ -113,6 +113,7 @@ public class EndToEndEncryptionTest {
 
     @After
     public void tearDown() {
+        datastore.close();
         TestUtils.deleteTempTestingDir(datastoreManagerDir);
     }
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/DatastoreImplCRUDTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/DatastoreImplCRUDTest.java
@@ -568,11 +568,14 @@ public class DatastoreImplCRUDTest extends BasicDatastoreTestBase {
     @Test
     public void createDbWithSlashAndCreateDocument() throws Exception {
         Datastore datastore = datastoreManager.openDatastore("dbwith/aslash");
-        DocumentRevision rev = new DocumentRevision();
-        rev.setBody(bodyOne);
-        DocumentRevision doc = datastore.createDocumentFromRevision(rev);
-        validateNewlyCreatedDocument(doc);
-        datastore.close();
+        try {
+            DocumentRevision rev = new DocumentRevision();
+            rev.setBody(bodyOne);
+            DocumentRevision doc = datastore.createDocumentFromRevision(rev);
+            validateNewlyCreatedDocument(doc);
+        } finally {
+            datastore.close();
+        }
     }
 
     private void getAllDocuments_testCountAndOffset(int objectCount, List<DocumentRevision> expectedDocumentRevisions, boolean descending) {

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/DatastoreSchemaTests.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/DatastoreSchemaTests.java
@@ -192,18 +192,19 @@ public class DatastoreSchemaTests {
                 new File(temp_folder, "datastores").getAbsolutePath())
                 .openDatastore("testdb");
 
-        // Check migration worked
-        datastore.runOnDbQueue(new SQLQueueCallable<Object>() {
-            @Override
-            public Object call(SQLDatabase db) throws Exception {
-                Assert.assertTrue("DB version should be 100 or more", db.getVersion() >= 100);
-                return null;
-            }
-        }).get();
-
-        datastore.close();
-
-        TestUtils.deleteTempTestingDir(temp_folder.getAbsolutePath());
+        try {
+            // Check migration worked
+            datastore.runOnDbQueue(new SQLQueueCallable<Object>() {
+                @Override
+                public Object call(SQLDatabase db) throws Exception {
+                    Assert.assertTrue("DB version should be 100 or more", db.getVersion() >= 100);
+                    return null;
+                }
+            }).get();
+        } finally {
+            datastore.close();
+            TestUtils.deleteTempTestingDir(temp_folder.getAbsolutePath());
+        }
     }
 
     @SuppressWarnings("ResultOfMethodCallIgnored")  // mkdirs result should be fine

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/DatastoreTestBase.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/DatastoreTestBase.java
@@ -39,6 +39,7 @@ public abstract class DatastoreTestBase {
 
     @After
     public void testDown() {
+        datastore.close();
         TestUtils.deleteTempTestingDir(datastore_manager_dir);
     }
 }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/AbstractIndexTestBase.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/AbstractIndexTestBase.java
@@ -55,8 +55,8 @@ public abstract class AbstractIndexTestBase {
     public void tearDown() {
         im.close();
         assertThat(im.getQueue().isShutdown(), is(true));
-        TestUtils.deleteDatabaseQuietly(db);
         ds.close();
+        TestUtils.deleteDatabaseQuietly(db);
         TestUtils.deleteTempTestingDir(factoryPath);
 
         db = null;

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/AbstractQueryTestBase.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/AbstractQueryTestBase.java
@@ -64,8 +64,8 @@ public abstract class AbstractQueryTestBase {
     public void tearDown() {
         im.close();
         assertThat(im.getQueue().isShutdown(), is(true));
-        TestUtils.deleteDatabaseQuietly(db);
         ds.close();
+        TestUtils.deleteDatabaseQuietly(db);
         TestUtils.deleteTempTestingDir(factoryPath);
 
         db = null;

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryResultTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryResultTest.java
@@ -23,6 +23,7 @@ import com.cloudant.sync.sqlite.SQLQueueCallable;
 import com.cloudant.sync.util.SQLDatabaseTestUtils;
 import com.cloudant.sync.util.TestUtils;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -52,6 +53,12 @@ public class QueryResultTest extends AbstractQueryTestBase {
 
         setUpBasicQueryData();
     }
+
+    @After
+    public void shutdownQueue() throws Exception {
+        queue.shutdown();
+    }
+
 
     /*
      * Perform a simple query then drop the revs table from the database before attempting

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/AttachmentsConflictsTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/AttachmentsConflictsTest.java
@@ -69,17 +69,23 @@ public class AttachmentsConflictsTest extends ReplicationTestBase {
 
         this.datastoreManager.deleteDatastore(this.datastore.getDatastoreName());
         this.datastore = (DatastoreImpl)this.datastoreManager.openDatastore("foo-bar-baz");
-        this.pull();
+        try {
+            this.pull();
 
-        DocumentRevision gotRev = this.datastore.getDocument("doc-a");
+            DocumentRevision gotRev = this.datastore.getDocument("doc-a");
 
-        Assert.assertEquals(gotRev.getAttachments().size(), 1);
-        // local one is guaranteed to be winner because its revision tree is longer
-        Assert.assertEquals(gotRev.getBody().asMap().get("foo"), "local");
-        Assert.assertFalse(TestUtils.streamsEqual(gotRev.getAttachments().get("att1").getInputStream(),
-                new ByteArrayInputStream("hello".getBytes())));
-        Assert.assertTrue(TestUtils.streamsEqual(gotRev.getAttachments().get("att1").getInputStream(),
-                new ByteArrayInputStream("hello universe".getBytes())));
+            Assert.assertEquals(gotRev.getAttachments().size(), 1);
+            // local one is guaranteed to be winner because its revision tree is longer
+            Assert.assertEquals(gotRev.getBody().asMap().get("foo"), "local");
+            Assert.assertFalse(TestUtils.streamsEqual(gotRev.getAttachments().get("att1").getInputStream(),
+
+                    new ByteArrayInputStream("hello".getBytes())));
+            Assert.assertTrue(TestUtils.streamsEqual(gotRev.getAttachments().get("att1")
+                    .getInputStream(),
+                    new ByteArrayInputStream("hello universe".getBytes())));
+        } finally {
+            this.datastore.close();
+        }
     }
 
     // test that we can correctly pull attachments for a resolved remote db
@@ -119,10 +125,14 @@ public class AttachmentsConflictsTest extends ReplicationTestBase {
 
         this.datastoreManager.deleteDatastore(this.datastore.getDatastoreName());
         this.datastore = (DatastoreImpl)this.datastoreManager.openDatastore("foo-bar-baz");
-        this.pull();
+        try {
+            this.pull();
 
-        DocumentRevision gotRev = this.datastore.getDocument("doc-a");
-        Assert.assertEquals(gotRev.getAttachments().size(), 1);
+            DocumentRevision gotRev = this.datastore.getDocument("doc-a");
+            Assert.assertEquals(gotRev.getAttachments().size(), 1);
+        } finally {
+            this.datastore.close();
+        }
     }
 
 }


### PR DESCRIPTION
*What*

Fixed remaining issues causing on device tests to fail.

*How*

* Added `threadtime` formatting to logcat to assist debugging from tests.
* Fixed tests not closing databases
    * Fixed order of close and deletion in `AbstractQueryTestBase` and `AbstractIndexTestBase`.
    * Added close to `DatastoreTestBase`.
    * Closed datastores in remaining tests that didn't close them: `EndToEndEncryptionTest`, `DatastoreImplCRUDTest`, `DatastoreSchemaTests`,  and `AttachmentsConflictsTest`.
    * Ensured queue is shutdown in `QueryResultTest`.
* Increased adb timeout to 3 minutes (from 30 seconds) - some tests create a lot of local documents, which can take some time (particularly with heavy GC on device). Increasing the adb test timeout allows these tests to run to completion.

*Tests*

All tests now pass on Nexus 7 device.