### PR TITLE
Throw Exception instead of returning null

### DIFF
--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/sqlite/SQLDatabaseFactory.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/sqlite/SQLDatabaseFactory.java
@@ -46,8 +46,9 @@ public class SQLDatabaseFactory {
      * @return {@code SQLDatabase} for the given filename
      * @throws IOException if the file does not exists, and also
      *         can not be created
+     * @throws SQLException if the database cannot be opened.
      */
-    public static SQLDatabase createSQLDatabase(String dbFilename, KeyProvider provider) throws IOException {
+    public static SQLDatabase createSQLDatabase(String dbFilename, KeyProvider provider) throws IOException, SQLException {
 
         boolean runningOnAndroid =  Misc.isRunningOnAndroid();
         boolean useSqlCipher = (provider.getEncryptionKey() != null);
@@ -78,7 +79,7 @@ public class SQLDatabaseFactory {
 
         } catch (Exception e) {
             logger.log(Level.SEVERE, "Failed to load database module", e);
-            return null;
+            throw new SQLException("Failed to load database module", e);
         }
 
     }
@@ -91,8 +92,9 @@ public class SQLDatabaseFactory {
      * @return {@code SQLDatabase} for the given filename
      * @throws IOException if the file does not exists, and also
      *         can not be created
+     * @throws SQLException If the database could not be opened.
      */
-    public static SQLDatabase openSqlDatabase(String dbFilename, KeyProvider provider) throws IOException {
+    public static SQLDatabase openSqlDatabase(String dbFilename, KeyProvider provider) throws IOException, SQLException {
 
         boolean runningOnAndroid =  Misc.isRunningOnAndroid();
         boolean useSqlCipher = (provider.getEncryptionKey() != null);
@@ -110,7 +112,7 @@ public class SQLDatabaseFactory {
                     if (validateOpenedDatabase(result)) {
                         return result;
                     } else {
-                        return null;
+                        throw new SQLException("Database could not be opened, invalid key.");
                     }
                 } else {
                     return (SQLDatabase) Class.forName("com.cloudant.sync.sqlite.android.AndroidSQLite")
@@ -129,7 +131,7 @@ public class SQLDatabaseFactory {
 
         } catch (Exception e) {
             logger.log(Level.SEVERE, "Failed to load database module", e);
-            return null;
+            throw new SQLException("Failed to load database module", e);
         }
     }
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/sqlite/SQLDatabaseQueue.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/sqlite/SQLDatabaseQueue.java
@@ -47,8 +47,9 @@ public class SQLDatabaseQueue {
      * Creates an SQLQueue for the database specified.
      * @param filename The file where the database is located
      * @throws IOException If an problem is encountered creating the DB
+     * @throws SQLException If the database cannot be opened.
      */
-    public SQLDatabaseQueue(String filename) throws IOException {
+    public SQLDatabaseQueue(String filename) throws IOException, SQLException {
         this(filename, new NullKeyProvider());
     }
 
@@ -58,8 +59,9 @@ public class SQLDatabaseQueue {
      * @param provider The key provider object that contains the user-defined SQLCipher key.
      *                 Supply a NullKeyProvider to use a non-encrypted database.
      * @throws IOException If a problem occurs creating the database
+     * @throws SQLException If the database cannot be opened.
      */
-    public SQLDatabaseQueue(String filename, KeyProvider provider) throws IOException {
+    public SQLDatabaseQueue(String filename, KeyProvider provider) throws IOException, SQLException {
         this.db = SQLDatabaseFactory.createSQLDatabase(filename, provider);
         queue.submit(new Runnable() {
             @Override

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/DatastoreSchemaTests.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/DatastoreSchemaTests.java
@@ -77,8 +77,7 @@ public class DatastoreSchemaTests {
      * fixture/datastores-user_version6.zip contains a known database, at version 6 and
      * with two attachments.
      */
-    public void migrateVersion6To100() throws DatastoreNotCreatedException, ExecutionException,
-            InterruptedException, IOException {
+    public void migrateVersion6To100() throws Exception {
         // Extract database to temp folder
         File temp_folder = new File(TestUtils.createTempTestingDir(this.getClass().getName()));
         File zippedVersion6 = f("fixture/datastores-user_version6.zip");

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/util/TestUtils.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/util/TestUtils.java
@@ -158,13 +158,7 @@ public class TestUtils {
                    .invoke(db);
            return SQLDatabaseFactory.openSqlDatabase(filePath,
                    new NullKeyProvider());
-       } catch (IllegalAccessException e) {
-           e.printStackTrace();
-       } catch (InvocationTargetException e) {
-           e.printStackTrace();
-       } catch (NoSuchMethodException e) {
-           e.printStackTrace();
-       } catch (IOException e) {
+       } catch (Exception e) {
            e.printStackTrace();
        }
 


### PR DESCRIPTION
## What

Do not return null when the database can not be opened

## How

Throw SQLDatabaseException instead of returning null when the database
cannot be opened.

## Tests

No additional tests, all current tests pass.

## Issues

Fixes #320