### PR TITLE
Use SQLDatabaseQueue instead of an executor service directly

### DIFF
--- a/cloudant-sync-datastore-android-encryption/src/test/java/com/cloudant/sync/datastore/encryption/EndToEndEncryptionTest.java
+++ b/cloudant-sync-datastore-android-encryption/src/test/java/com/cloudant/sync/datastore/encryption/EndToEndEncryptionTest.java
@@ -128,8 +128,11 @@ public class EndToEndEncryptionTest {
         // it.
 
         IndexManager im = new IndexManager(this.datastore);
-        im.ensureIndexed(Arrays.<Object>asList("name", "age"));
-
+        try {
+            im.ensureIndexed(Arrays.<Object>asList("name", "age"));
+        } finally {
+            im.close();
+        }
 
         InputStream in = new FileInputStream(jsonDatabase);
         byte[] magicBytesBuffer = new byte[sqlCipherMagicBytes.length];
@@ -137,7 +140,7 @@ public class EndToEndEncryptionTest {
 
         assertEquals("Didn't read full buffer", magicBytesBuffer.length, readLength);
 
-        if(dataShouldBeEncrypted) {
+        if (dataShouldBeEncrypted) {
             assertThat("SQLite magic bytes found in file that should be encrypted",
                     sqlCipherMagicBytes, IsNot.not(IsEqual.equalTo(magicBytesBuffer)));
         } else {
@@ -150,7 +153,11 @@ public class EndToEndEncryptionTest {
     public void indexDataEncrypted() throws IOException {
 
         IndexManager im = new IndexManager(this.datastore);
-        im.ensureIndexed(Arrays.<Object>asList("name", "age"));
+        try {
+            im.ensureIndexed(Arrays.<Object>asList("name", "age"));
+        } finally {
+            im.close();
+        }
 
         File jsonDatabase = new File(datastoreManagerDir
                 + File.separator + "EndToEndEncryptionTest"
@@ -164,7 +171,7 @@ public class EndToEndEncryptionTest {
 
         assertEquals("Didn't read full buffer", magicBytesBuffer.length, readLength);
 
-        if(dataShouldBeEncrypted) {
+        if (dataShouldBeEncrypted) {
             assertThat("SQLite magic bytes found in file that should be encrypted",
                     sqlCipherMagicBytes, IsNot.not(IsEqual.equalTo(magicBytesBuffer)));
         } else {
@@ -293,12 +300,17 @@ public class EndToEndEncryptionTest {
 
         // perform a query to ensure we can use special chars
         IndexManager indexManager = new IndexManager(datastore);
-        assertNotNull(indexManager.ensureIndexed(Arrays.<Object>asList("name","pet"),"my index"));
-        // query for the name fred and check that docs are returned.
-        Map<String,Object> selector = new HashMap<String, Object>();
-        selector.put("name","fred");
-        QueryResult queryResult = indexManager.find(selector);
-        assertNotNull(queryResult);
+        try {
+            assertNotNull(indexManager.ensureIndexed(Arrays.<Object>asList("name", "pet"), "my index"));
+
+            // query for the name fred and check that docs are returned.
+            Map<String, Object> selector = new HashMap<String, Object>();
+            selector.put("name", "fred");
+            QueryResult queryResult = indexManager.find(selector);
+            assertNotNull(queryResult);
+        } finally {
+            indexManager.close();
+        }
         // Delete
         try {
             datastore.deleteDocumentFromRevision(saved);

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/QueryException.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/QueryException.java
@@ -12,4 +12,8 @@ public class QueryException extends RuntimeException {
     public QueryException(Exception causedBy){
         super(causedBy);
     }
+
+    public QueryException(String messaage){
+        super(messaage);
+    }
 }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/QueryExecutor.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/QueryExecutor.java
@@ -15,6 +15,8 @@ package com.cloudant.sync.query;
 import com.cloudant.sync.datastore.Datastore;
 import com.cloudant.sync.sqlite.Cursor;
 import com.cloudant.sync.sqlite.SQLDatabase;
+import com.cloudant.sync.sqlite.SQLDatabaseQueue;
+import com.cloudant.sync.sqlite.SQLQueueCallable;
 import com.cloudant.sync.util.DatabaseUtils;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Sets;
@@ -37,9 +39,8 @@ import java.util.logging.Logger;
  */
 class QueryExecutor {
 
-    private final SQLDatabase database;
     private final Datastore datastore;
-    private final ExecutorService queue;
+    private final SQLDatabaseQueue queue;
 
     private static final Logger logger = Logger.getLogger(QueryExecutor.class.getName());
 
@@ -49,8 +50,7 @@ class QueryExecutor {
      *  Constructs a new QueryExecutor using the indexes in 'database' to find documents from
      *  'datastore'.
      */
-    QueryExecutor(SQLDatabase database, Datastore datastore, ExecutorService queue) {
-        this.database = database;
+    QueryExecutor(Datastore datastore, SQLDatabaseQueue queue) {
         this.datastore = datastore;
         this.queue = queue;
     }
@@ -108,9 +108,9 @@ class QueryExecutor {
             return null;
         }
 
-        Future<List<String>> result = queue.submit(new Callable<List<String>>() {
+        Future<List<String>> result = queue.submit(new SQLQueueCallable<List<String>>() {
             @Override
-            public List<String> call() throws Exception {
+            public List<String> call(SQLDatabase database) throws Exception {
                 Set<String> docIdSet = executeQueryTree(root, database);
                 List<String> docIdList;
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/AbstractQueryTestBase.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/AbstractQueryTestBase.java
@@ -21,6 +21,7 @@ import com.cloudant.sync.datastore.DatastoreManager;
 import com.cloudant.sync.datastore.DocumentBodyFactory;
 import com.cloudant.sync.datastore.DocumentRevision;
 import com.cloudant.sync.sqlite.SQLDatabase;
+import com.cloudant.sync.sqlite.SQLDatabaseQueue;
 import com.cloudant.sync.util.TestUtils;
 
 import org.junit.After;
@@ -47,7 +48,7 @@ public abstract class AbstractQueryTestBase {
     DatastoreManager factory = null;
     DatastoreImpl ds = null;
     IndexManager im = null;
-    SQLDatabase db = null;
+    SQLDatabaseQueue indexManagerDatabaseQueue;
 
     @Before
     public void setUp() throws Exception {
@@ -61,14 +62,12 @@ public abstract class AbstractQueryTestBase {
     }
 
     @After
-    public void tearDown() {
+    public void tearDown() throws Exception {
         im.close();
-        assertThat(im.getQueue().isShutdown(), is(true));
+        assertThat(indexManagerDatabaseQueue.isShutdown(), is(true));
         ds.close();
-        TestUtils.deleteDatabaseQuietly(db);
         TestUtils.deleteTempTestingDir(factoryPath);
 
-        db = null;
         im = null;
         ds = null;
         factory = null;

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/MockMatcherIndexManager.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/MockMatcherIndexManager.java
@@ -13,6 +13,7 @@
 package com.cloudant.sync.query;
 
 import com.cloudant.sync.datastore.Datastore;
+import com.cloudant.sync.util.TestUtils;
 
 import java.util.List;
 import java.util.Map;
@@ -46,9 +47,13 @@ public class MockMatcherIndexManager extends IndexManager {
             return null;
         }
 
-        MockMatcherQueryExecutor queryExecutor = new MockMatcherQueryExecutor(getDatabase(),
-                                                                              getDatastore(),
-                                                                              getQueue());
+        MockMatcherQueryExecutor queryExecutor = null;
+        try {
+            queryExecutor = new MockMatcherQueryExecutor(getDatastore(),
+                    TestUtils.getDBQueue(this));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
         Map<String, Object> indexes = listIndexes();
         return queryExecutor.find(query, indexes, skip, limit, fields, sortDocument);
     }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/MockMatcherQueryExecutor.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/MockMatcherQueryExecutor.java
@@ -15,6 +15,7 @@ package com.cloudant.sync.query;
 import com.cloudant.sync.datastore.Datastore;
 import com.cloudant.sync.sqlite.Cursor;
 import com.cloudant.sync.sqlite.SQLDatabase;
+import com.cloudant.sync.sqlite.SQLDatabaseQueue;
 import com.cloudant.sync.util.DatabaseUtils;
 
 import java.sql.SQLException;
@@ -38,8 +39,8 @@ public class MockMatcherQueryExecutor extends QueryExecutor{
 
     private final Set<String> docIds;
 
-    MockMatcherQueryExecutor(SQLDatabase database, Datastore datastore, ExecutorService queue) {
-        super(database, datastore, queue);
+    MockMatcherQueryExecutor(Datastore datastore, SQLDatabaseQueue queue) {
+        super(datastore, queue);
         docIds = new HashSet<String>(datastore.getAllDocumentIds());
     }
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/MockSQLOnlyIndexManager.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/MockSQLOnlyIndexManager.java
@@ -13,6 +13,7 @@
 package com.cloudant.sync.query;
 
 import com.cloudant.sync.datastore.Datastore;
+import com.cloudant.sync.util.TestUtils;
 
 import java.util.List;
 import java.util.Map;
@@ -46,9 +47,13 @@ public class MockSQLOnlyIndexManager extends IndexManager {
             return null;
         }
 
-        MockSQLOnlyQueryExecutor queryExecutor = new MockSQLOnlyQueryExecutor(getDatabase(),
-                                                                              getDatastore(),
-                                                                              getQueue());
+        MockSQLOnlyQueryExecutor queryExecutor = null;
+        try {
+            queryExecutor = new MockSQLOnlyQueryExecutor(getDatastore(),
+                    TestUtils.getDBQueue(this));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
         Map<String, Object> indexes = listIndexes();
         return queryExecutor.find(query, indexes, skip, limit, fields, sortDocument);
     }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/MockSQLOnlyQueryExecutor.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/MockSQLOnlyQueryExecutor.java
@@ -14,6 +14,7 @@ package com.cloudant.sync.query;
 
 import com.cloudant.sync.datastore.Datastore;
 import com.cloudant.sync.sqlite.SQLDatabase;
+import com.cloudant.sync.sqlite.SQLDatabaseQueue;
 
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -29,8 +30,8 @@ import java.util.concurrent.ExecutorService;
  */
 public class MockSQLOnlyQueryExecutor extends QueryExecutor{
 
-    MockSQLOnlyQueryExecutor(SQLDatabase database, Datastore datastore, ExecutorService queue) {
-        super(database, datastore, queue);
+    MockSQLOnlyQueryExecutor(Datastore datastore, SQLDatabaseQueue queue) {
+        super(datastore, queue);
     }
 
     @Override

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryCoveringIndexesTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryCoveringIndexesTest.java
@@ -84,12 +84,11 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         } else if (testType.equals(STANDARD_EXECUTION)) {
             im = new IndexManager(ds);
         }
+        indexManagerDatabaseQueue = TestUtils.getDBQueue(im);
         assertThat(im, is(notNullValue()));
-        db = TestUtils.getDatabaseConnectionToExistingDb(im.getDatabase());
-        assertThat(db, is(notNullValue()));
-        assertThat(im.getQueue(), is(notNullValue()));
+        assertThat(indexManagerDatabaseQueue, is(notNullValue()));
         String[] metadataTableList = new String[] { IndexManager.INDEX_METADATA_TABLE_NAME };
-        SQLDatabaseTestUtils.assertTablesExist(db, metadataTableList);
+        SQLDatabaseTestUtils.assertTablesExist(TestUtils.getDBQueue(im), metadataTableList);
     }
 
     // When executing AND queries

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryFilterFieldsTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryFilterFieldsTest.java
@@ -42,12 +42,11 @@ public class QueryFilterFieldsTest extends AbstractQueryTestBase {
     public void setUp() throws Exception {
         super.setUp();
         im = new IndexManager(ds);
+        indexManagerDatabaseQueue = TestUtils.getDBQueue(im);
         assertThat(im, is(notNullValue()));
-        db = TestUtils.getDatabaseConnectionToExistingDb(im.getDatabase());
-        assertThat(db, is(notNullValue()));
-        assertThat(im.getQueue(), is(notNullValue()));
+        assertThat(indexManagerDatabaseQueue, is(notNullValue()));
         String[] metadataTableList = new String[] { IndexManager.INDEX_METADATA_TABLE_NAME };
-        SQLDatabaseTestUtils.assertTablesExist(db, metadataTableList);
+        SQLDatabaseTestUtils.assertTablesExist(indexManagerDatabaseQueue, metadataTableList);
 
         setUpBasicQueryData();
     }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryResultTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryResultTest.java
@@ -41,12 +41,11 @@ public class QueryResultTest extends AbstractQueryTestBase {
     public void setUp() throws Exception {
         super.setUp();
         im = new IndexManager(ds);
+        indexManagerDatabaseQueue = TestUtils.getDBQueue(im);
         assertThat(im, is(notNullValue()));
-        db = TestUtils.getDatabaseConnectionToExistingDb(im.getDatabase());
-        assertThat(db, is(notNullValue()));
-        assertThat(im.getQueue(), is(notNullValue()));
+        assertThat(indexManagerDatabaseQueue, is(notNullValue()));
         String[] metadataTableList = new String[]{IndexManager.INDEX_METADATA_TABLE_NAME};
-        SQLDatabaseTestUtils.assertTablesExist(db, metadataTableList);
+        SQLDatabaseTestUtils.assertTablesExist(indexManagerDatabaseQueue, metadataTableList);
 
         queue = new SQLDatabaseQueue(factoryPath + "/" + factory.listAllDatastores().get(0) +
             "/db.sync", new NullKeyProvider());

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QuerySortTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QuerySortTest.java
@@ -42,12 +42,11 @@ public class QuerySortTest extends AbstractQueryTestBase {
     public void setUp() throws Exception {
         super.setUp();
         im = new IndexManager(ds);
+        indexManagerDatabaseQueue = TestUtils.getDBQueue(im);
         assertThat(im, is(notNullValue()));
-        db = TestUtils.getDatabaseConnectionToExistingDb(im.getDatabase());
-        assertThat(db, is(notNullValue()));
-        assertThat(im.getQueue(), is(notNullValue()));
+        assertThat(TestUtils.getDBQueue(im), is(notNullValue()));
         String[] metadataTableList = new String[] { IndexManager.INDEX_METADATA_TABLE_NAME };
-        SQLDatabaseTestUtils.assertTablesExist(db, metadataTableList);
+        SQLDatabaseTestUtils.assertTablesExist(indexManagerDatabaseQueue, metadataTableList);
 
         Map<String, Object> indexA = new HashMap<String, Object>();
         indexA.put("name", "a");

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryTextSearchTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryTextSearchTest.java
@@ -43,12 +43,11 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
     public void setUp() throws Exception {
         super.setUp();
         im = new IndexManager(ds);
+        indexManagerDatabaseQueue = TestUtils.getDBQueue(im);
         assertThat(im, is(notNullValue()));
-        db = TestUtils.getDatabaseConnectionToExistingDb(im.getDatabase());
-        assertThat(db, is(notNullValue()));
-        assertThat(im.getQueue(), is(notNullValue()));
+        assertThat(indexManagerDatabaseQueue, is(notNullValue()));
         String[] metadataTableList = new String[] { IndexManager.INDEX_METADATA_TABLE_NAME };
-        SQLDatabaseTestUtils.assertTablesExist(db, metadataTableList);
+        SQLDatabaseTestUtils.assertTablesExist(indexManagerDatabaseQueue, metadataTableList);
 
         DocumentRevision rev = new DocumentRevision("mike12");
         Map<String, Object> bodyMap = new HashMap<String, Object>();
@@ -304,7 +303,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
     @Test
     public void canQueryUsingEnhancedQuerySyntaxNOT() throws Exception{
         // Only execute this test if SQLite enhanced query syntax is enabled
-        Set<String> compileOptions = SQLDatabaseTestUtils.getCompileOptions(db);
+        Set<String> compileOptions = SQLDatabaseTestUtils.getCompileOptions(indexManagerDatabaseQueue);
         if (compileOptions.containsAll(Arrays.asList("ENABLE_FTS3", "ENABLE_FTS3_PARENTHESIS"))) {
             List<Object> fields = Collections.<Object>singletonList("comment");
             assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
@@ -325,7 +324,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
     @Test
     public void canQueryUsingEnhancedQuerySyntaxParentheses() throws Exception{
         // Only execute this test if SQLite enhanced query syntax is enabled
-        Set<String> compileOptions = SQLDatabaseTestUtils.getCompileOptions(db);
+        Set<String> compileOptions = SQLDatabaseTestUtils.getCompileOptions(indexManagerDatabaseQueue);
         if (compileOptions.containsAll(Arrays.asList("ENABLE_FTS3", "ENABLE_FTS3_PARENTHESIS"))) {
             List<Object> fields = Collections.<Object>singletonList("comment");
             assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryWithoutCoveringIndexesTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryWithoutCoveringIndexesTest.java
@@ -81,12 +81,11 @@ public class QueryWithoutCoveringIndexesTest extends AbstractQueryTestBase {
         } else if (testType.equals(STANDARD_EXECUTION)) {
             im = new IndexManager(ds);
         }
+        indexManagerDatabaseQueue = TestUtils.getDBQueue(im);
         assertThat(im, is(notNullValue()));
-        db = TestUtils.getDatabaseConnectionToExistingDb(im.getDatabase());
-        assertThat(db, is(notNullValue()));
-        assertThat(im.getQueue(), is(notNullValue()));
+        assertThat(indexManagerDatabaseQueue, is(notNullValue()));
         String[] metadataTableList = new String[] { IndexManager.INDEX_METADATA_TABLE_NAME };
-        SQLDatabaseTestUtils.assertTablesExist(db, metadataTableList);
+        SQLDatabaseTestUtils.assertTablesExist(indexManagerDatabaseQueue, metadataTableList);
     }
 
     // When executing AND queries

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/util/TestUtils.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/util/TestUtils.java
@@ -17,11 +17,14 @@ package com.cloudant.sync.util;
 import com.cloudant.sync.datastore.DocumentBody;
 import com.cloudant.sync.datastore.DocumentBodyFactory;
 import com.cloudant.sync.datastore.encryption.NullKeyProvider;
+import com.cloudant.sync.query.IndexManager;
 import com.cloudant.sync.sqlite.SQLDatabase;
 import com.cloudant.sync.sqlite.SQLDatabaseFactory;
+import com.cloudant.sync.sqlite.SQLDatabaseQueue;
 
 import org.apache.commons.io.FileUtils;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
@@ -56,6 +59,13 @@ public class TestUtils {
             }
         } catch (Exception e) {
         }
+    }
+
+    public static SQLDatabaseQueue getDBQueue(IndexManager indexManager) throws Exception {
+        Class clazz =  IndexManager.class;
+        Field dbQueue = clazz.getDeclaredField("dbQueue");
+        dbQueue.setAccessible(true);
+        return (SQLDatabaseQueue) dbQueue.get(indexManager);
     }
 
     public static String createTempTestingDir(String dirPrefix) {
@@ -147,23 +157,5 @@ public class TestUtils {
 
        }
    }
-
-   public static SQLDatabase getDatabaseConnectionToExistingDb(SQLDatabase db){
-       if(Misc.isRunningOnAndroid())
-           return db;
-
-       try {
-           String filePath = (String) db.getClass()
-                   .getMethod("getDatabaseFile")
-                   .invoke(db);
-           return SQLDatabaseFactory.openSqlDatabase(filePath,
-                   new NullKeyProvider());
-       } catch (Exception e) {
-           e.printStackTrace();
-       }
-
-       return null;
-   }
-
 
 }


### PR DESCRIPTION
## What

Use `SQLDatabaseQueue` instead of an `ExecutorService` and `SQLDatabse` directly.

## How

Swap out the `SQLDatabase` and `ExecutorService` with `SQLDatabaseQueue`

## Testing

All tests pass, however some have been reworked slightly so they run on the queue rather than on the main test thread.

## Issues

Resolves #286