### PR TITLE
Added additional database close calls.

### DIFF
--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/BasicDBCoreObservableTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/BasicDBCoreObservableTest.java
@@ -46,8 +46,8 @@ public class BasicDBCoreObservableTest {
 
     @After
     public void tearDown() {
-        TestUtils.deleteTempTestingDir(this.database_dir);
         core.close();
+        TestUtils.deleteTempTestingDir(this.database_dir);
     }
 
     @Test

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/SQLDatabaseFactoryTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/SQLDatabaseFactoryTest.java
@@ -63,6 +63,7 @@ public class SQLDatabaseFactoryTest {
 
     @After
     public void tearDown() throws Exception {
+        database.close();
         TestUtils.deleteDatabaseQuietly(database);
         TestUtils.deleteTempTestingDir(database_dir);
     }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/util/TestUtils.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/util/TestUtils.java
@@ -55,6 +55,9 @@ public class TestUtils {
     public static void deleteDatabaseQuietly(SQLDatabase database) {
         try {
             if (database != null) {
+                if (database.isOpen()) {
+                    database.close(); // Close before deleting
+                }
                 FileUtils.deleteQuietly(new File(database.filename));
             }
         } catch (Exception e) {

--- a/cloudant-sync-datastore-javase/src/test/java/com/cloudant/sync/sqlite/sqlite4java/SQLiteWrapperTest.java
+++ b/cloudant-sync-datastore-javase/src/test/java/com/cloudant/sync/sqlite/sqlite4java/SQLiteWrapperTest.java
@@ -61,8 +61,9 @@ public class SQLiteWrapperTest {
 
     @After
     public void tearDown() throws Exception {
-        TestUtils.deleteTempTestingDir(database_dir);
+        database.close();
         TestUtils.deleteDatabaseQuietly(database);
+        TestUtils.deleteTempTestingDir(database_dir);
     }
 
     @Test


### PR DESCRIPTION
*What*

More places where `close()` was not being called by tests.

*How*

* Fixed ordering to call close before deleting temporary directory in teard down of `BasicDBCoreObservableTest`.
* Added close call in teardown in `SQLDatabaseFactoryTest`.
* Added a close before delete in `TestUtils.deleteDatabaseQuietly` if database was still open.
* Added close and fixed deletion ordering in tear down of `SQLiteWrapperTest`.

*Tests*

No new tests, this PR is for test fixes. Green CI. Connected check passes locally.

Fixes #323 