### PR TITLE
326 pick winner

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@
 - [DEPRECATED] `DatastoreManager` constructors. Use `DatastoreManager.getInstance` factory methods
   instead to guarantee only a single `DatastoreManager` instance is created for a given storage
   directory path in the scope of the `DatastoreManager` class.
+- [FIX] Corrected a case where two root nodes with identical revision IDs prevented selection of the
+  correct new winning revision.
 
 # 1.0.0 (2016-05-03)
 - [NOTE] This library follows the

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/DatastoreImpl.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/DatastoreImpl.java
@@ -104,12 +104,14 @@ public class DatastoreImpl implements Datastore {
             "WHERE sequence > ? AND sequence <= ? GROUP BY doc_id ";
 
     // get all non-deleted leaf rev ids for a given doc id
+    // gets all revs whose sequence is not a parent of another rev and the rev isn't deleted
     public static final String GET_NON_DELETED_LEAFS = "SELECT revs.revid FROM revs " +
             "WHERE revs.doc_id = ? " +
             "AND revs.deleted = 0 AND revs.sequence NOT IN " +
             "(SELECT DISTINCT parent FROM revs WHERE parent NOT NULL) ";
 
     // get all leaf rev ids for a given doc id
+    // gets all revs whose sequence is not a parent of another rev
     public static final String GET_ALL_LEAFS = "SELECT revs.revid FROM revs " +
             "WHERE revs.doc_id = ? " +
             "AND revs.sequence NOT IN " +
@@ -483,8 +485,8 @@ public class DatastoreImpl implements Datastore {
                         }
                         List<DocumentRevision> results = getDocumentsWithInternalIdsInQueue(db, ids);
                         if(results.size() != ids.size()) {
-                            throw new IllegalStateException("The number of document does not match number of ids, " +
-                                    "something must be wrong here.");
+                            throw new IllegalStateException(String.format("The number of documents %d does not match number of ids %d, " +
+                                    "something must be wrong here.", results.size(), ids.size()));
                         }
 
                         return new Changes(lastSequence, results);

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/DatastoreImpl.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/DatastoreImpl.java
@@ -92,15 +92,15 @@ public class DatastoreImpl implements Datastore {
             "SELECT revs.sequence FROM revs, docs WHERE docs.docid=? AND revs.doc_id=docs.doc_id " +
                     "AND current=1 ORDER BY revid DESC LIMIT 1";
 
-    // get all document columns for a given revision and doc id
+    // get all document columns for a given revision and doc id† (see below)
     private static final String GET_DOCUMENT_GIVEN_REVISION =
-            "SELECT " + FULL_DOCUMENT_COLS + " FROM revs, docs WHERE docs.docid=? AND revs.doc_id=docs.doc_id " +
-                    "AND revid=? LIMIT 1";
+            "SELECT " + FULL_DOCUMENT_COLS + " FROM revs, docs WHERE docs.docid=? AND revs" +
+                    ".doc_id=docs.doc_id AND revid=? ORDER BY revs.sequence LIMIT 1";
 
-    // get sequence number for a given revision and doc id
+    // get sequence number for a given revision and doc id† (see below)
     private static final String GET_SEQUENCE_GIVEN_REVISION =
             "SELECT revs.sequence FROM revs, docs WHERE docs.docid=? AND revs.doc_id=docs.doc_id " +
-                    "AND revid=? LIMIT 1";
+                    "AND revid=? ORDER BY revs.sequence LIMIT 1";
 
     public static final String SQL_CHANGE_IDS_SINCE_LIMIT = "SELECT doc_id, max(sequence) FROM revs " +
             "WHERE sequence > ? AND sequence <= ? GROUP BY doc_id ";
@@ -118,6 +118,11 @@ public class DatastoreImpl implements Datastore {
             "WHERE revs.doc_id = ? " +
             "AND revs.sequence NOT IN " +
             "(SELECT DISTINCT parent FROM revs WHERE parent NOT NULL) ";
+
+    // † N.B. whilst there should only ever be a single result bugs have resulted in duplicate
+    // revision IDs in the tree. Whilst it appears that the lowest sequence number is always
+    // returned by these queries we use ORDER BY sequence to guarantee that and lock down a
+    // behaviour for any future occurrences of duplicate revs in a tree.
 
     // Limit of parameters (placeholders) one query can have.
     // SQLite has limit on the number of placeholders on a single query, default 999.

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/DatastoreImplForceInsertTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/DatastoreImplForceInsertTest.java
@@ -18,7 +18,9 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 
+import com.cloudant.android.ContentValues;
 import com.cloudant.sync.sqlite.SQLDatabase;
+import com.cloudant.sync.sqlite.SQLQueueCallable;
 import com.cloudant.sync.util.CouchUtils;
 import com.cloudant.sync.util.JSONUtils;
 import com.cloudant.sync.util.TestUtils;
@@ -502,6 +504,63 @@ public class DatastoreImplForceInsertTest {
         datastore.forceInsert(rev2_alt, "1-x", "2-y");
 
         Assert.assertEquals(datastore.getDocument(OBJECT_ID).getRevision(), "2-y");
+    }
+
+    /**
+     * <p>
+     * This test is for https://github.com/cloudant/sync-android/issues/326. The test nefariously
+     * creates a tree with two roots with identical revision IDs (replicating the type of tree
+     * created by a bug with parallel replications and force insert). The two revisions have
+     * different bodies to help us assert easily which is which (note that revision IDs were not
+     * calculated based on body content in this library at the time this test was created).
+     * </p>
+     * <p>
+     * Once those two revisions are in place a deletion of the revision ID is force inserted as would
+     * happen during a replication. When the bug was in place pickWinner did not choose a new winner
+     * and the tree was left without a current winner revision for the document. The correct
+     * behaviour is for the non-deleted duplicate revision to win.
+     * </p>
+     *
+     * @throws Exception
+     */
+    @Test
+    public void forceInsert_pickWinnerOfConflicts_TwoOfSameRoot_OneDeleted() throws Exception {
+        DocumentRevision rev1a = createDbObject("1-x", bodyOne);
+        DocumentRevision rev2 = createDbObjectDeleted("2-x");
+
+        // Insert the same document twice, so we have two identical roots
+        // We give them different bodies so we can tell them apart
+
+        //Force insert the first
+        datastore.forceInsert(rev1a, "1-x");
+
+        // Now insert a duplicate (don't use forceInsert because that will protect against
+        // duplicate entries).
+        datastore.runOnDbQueue(new SQLQueueCallable<Long>() {
+            @Override
+            public Long call(SQLDatabase db) throws Exception {
+                ContentValues args = new ContentValues();
+                args.put("doc_id", 1l);
+                args.put("revid", "1-x");
+                args.put("json", bodyTwo.asBytes());
+                return db.insert("revs", args);
+            }
+        });
+
+        // Now force insert the deleted
+        datastore.forceInsert(rev2, "1-x", "2-x");
+
+        // Get the document
+        DocumentRevision doc = datastore.getDocument(OBJECT_ID);
+        // If there is no winner an exception would be thrown.
+
+        // We favour non-deleted nodes so the winner should be a 1-x
+        Assert.assertEquals("The document winner should be the expected revision", "1-x", doc
+                .getRevision());
+        // The winner should be the one with body two because the 2-x deleted revision should graft
+        // onto the lowest seq of the two identical 1-x revisions.
+        Assert.assertEquals("The document winner should have the expected body", bodyTwo.asMap(),
+                doc.getBody().asMap());
     }
 
     @Test


### PR DESCRIPTION
*What*

Corrected selection of winner when multiple root nodes have identical revisions - fixes #326 

*How*

Added sequence to information returned from `GET_NON_DELETED_LEAFS` and  `GET_ALL_LEAFS` SQL queries and stored query results in a `SortedMap`.

*Test*
Added test `forceInsert_pickWinnerOfConflicts_TwoOfSameRoot_OneDeleted`.