### PR TITLE
Increase diagnostics

### DIFF
--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/DatastoreImpl.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/DatastoreImpl.java
@@ -510,7 +510,7 @@ public class DatastoreImpl implements Datastore {
            logger.log(Level.SEVERE, "Failed to get changes",e);
             if(e.getCause()!= null){
                 if(e.getCause() instanceof IllegalStateException) {
-                    throw (IllegalStateException) e.getCause();
+                    throw new IllegalStateException(e);
                 }
             }
         }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/DatastoreImpl.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/DatastoreImpl.java
@@ -61,6 +61,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -492,8 +493,12 @@ public class DatastoreImpl implements Datastore {
                         }
                         List<DocumentRevision> results = getDocumentsWithInternalIdsInQueue(db, ids);
                         if(results.size() != ids.size()) {
-                            throw new IllegalStateException(String.format("The number of documents %d does not match number of ids %d, " +
-                                    "something must be wrong here.", results.size(), ids.size()));
+                            throw new IllegalStateException(String.format(Locale.ENGLISH,
+                                    "The number of documents does not match number of ids, " +
+                                    "something must be wrong here. Number of IDs: %s, number of documents: %s",
+                                    ids.size(),
+                                    results.size()
+                                    ));
                         }
 
                         return new Changes(lastSequence, results);
@@ -508,11 +513,9 @@ public class DatastoreImpl implements Datastore {
             logger.log(Level.SEVERE, "Failed to get changes",e);
         } catch (ExecutionException e) {
            logger.log(Level.SEVERE, "Failed to get changes",e);
-            if(e.getCause()!= null){
                 if(e.getCause() instanceof IllegalStateException) {
-                    throw new IllegalStateException(e);
+                    throw new IllegalStateException("Failed to get changes, SQLite version: "+queue.getSQLiteVersion(),e);
                 }
-            }
         }
 
         return null;

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/GetRevisionTaskThreaded.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/GetRevisionTaskThreaded.java
@@ -28,6 +28,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -123,7 +124,12 @@ class GetRevisionTaskThreaded implements Iterable<DocumentRevsList> {
             @Override
             public DocumentRevsList executeRequest(BulkGetRequest request) {
                 // since this is part of a thread pool, we'll rename each thread as it takes a task.
-                Thread.currentThread().setName("GetRevisionThread: "+GetRevisionTaskThreaded.this.sourceDb.getIdentifier());
+                try {
+                    Thread.currentThread().setName("GetRevisionThread: " + GetRevisionTaskThreaded.this.sourceDb.getIdentifier());
+
+                } catch (SecurityException e){
+                    logger.log(Level.WARNING, "Could not rename pull strategy pool thread", e);
+                }
                 return new DocumentRevsList(GetRevisionTaskThreaded.this.sourceDb.getRevisions
                         (request.id, request.revs, request.atts_since,
                                 GetRevisionTaskThreaded.this.pullAttachmentsInline));

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/GetRevisionTaskThreaded.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/GetRevisionTaskThreaded.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
@@ -121,6 +122,8 @@ class GetRevisionTaskThreaded implements Iterable<DocumentRevsList> {
                 DocumentRevsList>(executorService, this.requests, threads + 1) {
             @Override
             public DocumentRevsList executeRequest(BulkGetRequest request) {
+                // since this is part of a thread pool, we'll rename each thread as it takes a task.
+                Thread.currentThread().setName("GetRevisionThread: "+GetRevisionTaskThreaded.this.sourceDb.getIdentifier());
                 return new DocumentRevsList(GetRevisionTaskThreaded.this.sourceDb.getRevisions
                         (request.id, request.revs, request.atts_since,
                                 GetRevisionTaskThreaded.this.pullAttachmentsInline));

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/PullStrategy.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/PullStrategy.java
@@ -488,4 +488,9 @@ class PullStrategy implements ReplicationStrategy {
     public EventBus getEventBus() {
         return eventBus;
     }
+
+    @Override
+    public String getRemote() {
+        return this.sourceDb.getIdentifier();
+    }
 }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/PushStrategy.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/PushStrategy.java
@@ -459,4 +459,8 @@ class PushStrategy implements ReplicationStrategy {
         return eventBus;
     }
 
+    @Override
+    public String getRemote() {
+        return this.targetDb.getIdentifier();
+    }
 }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ReplicationStrategy.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ReplicationStrategy.java
@@ -32,4 +32,6 @@ interface ReplicationStrategy extends Runnable {
 
     int getBatchCounter();
 
+    String getRemote();
+
 }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ReplicatorImpl.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ReplicatorImpl.java
@@ -20,6 +20,8 @@ import com.cloudant.sync.notifications.ReplicationCompleted;
 import com.cloudant.sync.notifications.ReplicationErrored;
 import com.google.common.base.Preconditions;
 
+import java.util.Locale;
+
 /**
  * This class is not intended as API, it is public for EventBus access only.
  * @api_private
@@ -62,7 +64,11 @@ public class ReplicatorImpl implements Replicator {
                 // complete/stopped/error -> started: (re)start replication for nth time
                 // we assume register() is idempotent
                 this.strategy.getEventBus().register(this);
-                this.strategyThread = new Thread(this.strategy);
+                String replicatorThreadName = String.format(Locale.ENGLISH,
+                        "Replicator: %s - %s",
+                        this.strategy.getClass().getSimpleName(),
+                        this.strategy.getRemote());
+                this.strategyThread = new Thread(this.strategy, replicatorThreadName);
                 this.strategyThread.start();
                 this.state = State.STARTED;
                 break;


### PR DESCRIPTION
## What

Increase the ability to diagnose problems when the changes feed throws an `IllegalStateException`.

## How

- Name threads created by thread pools for SQLDatabaseQueue and for pull replications.
- Name the ReplicatorThread
- Provide the SQLite version and include it in the IllegalState thrown by the changes feed.

## Tests

No new tests, manually checked that the threads get renamed using the debugger in idea.