### PR TITLE
333 add schema constraint

### DIFF
--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/DatastoreImpl.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/DatastoreImpl.java
@@ -187,7 +187,7 @@ public class DatastoreImpl implements Datastore {
         queue.updateSchema(new SchemaOnlyMigration(DatastoreConstants.getSchemaVersion5()), 5);
         queue.updateSchema(new SchemaOnlyMigration(DatastoreConstants.getSchemaVersion6()), 6);
         queue.updateSchema(new MigrateDatabase6To100(), 100);
-        queue.updateSchema(new MigrateDatabase100To200(), 200);
+        queue.updateSchema(new MigrateDatabase100To200(DatastoreConstants.getSchemaVersion200()), 200);
         this.eventBus = new EventBus();
 
         this.attachmentsDir = this.extensionDataFolder(ATTACHMENTS_EXTENSION_NAME);

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/DatastoreImplForceInsertTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/DatastoreImplForceInsertTest.java
@@ -506,63 +506,6 @@ public class DatastoreImplForceInsertTest {
         Assert.assertEquals(datastore.getDocument(OBJECT_ID).getRevision(), "2-y");
     }
 
-    /**
-     * <p>
-     * This test is for https://github.com/cloudant/sync-android/issues/326. The test nefariously
-     * creates a tree with two roots with identical revision IDs (replicating the type of tree
-     * created by a bug with parallel replications and force insert). The two revisions have
-     * different bodies to help us assert easily which is which (note that revision IDs were not
-     * calculated based on body content in this library at the time this test was created).
-     * </p>
-     * <p>
-     * Once those two revisions are in place a deletion of the revision ID is force inserted as would
-     * happen during a replication. When the bug was in place pickWinner did not choose a new winner
-     * and the tree was left without a current winner revision for the document. The correct
-     * behaviour is for the non-deleted duplicate revision to win.
-     * </p>
-     *
-     * @throws Exception
-     */
-    @Test
-    public void forceInsert_pickWinnerOfConflicts_TwoOfSameRoot_OneDeleted() throws Exception {
-        DocumentRevision rev1a = createDbObject("1-x", bodyOne);
-        DocumentRevision rev2 = createDbObjectDeleted("2-x");
-
-        // Insert the same document twice, so we have two identical roots
-        // We give them different bodies so we can tell them apart
-
-        //Force insert the first
-        datastore.forceInsert(rev1a, "1-x");
-
-        // Now insert a duplicate (don't use forceInsert because that will protect against
-        // duplicate entries).
-        datastore.runOnDbQueue(new SQLQueueCallable<Long>() {
-            @Override
-            public Long call(SQLDatabase db) throws Exception {
-                ContentValues args = new ContentValues();
-                args.put("doc_id", 1l);
-                args.put("revid", "1-x");
-                args.put("json", bodyTwo.asBytes());
-                return db.insert("revs", args);
-            }
-        });
-
-        // Now force insert the deleted
-        datastore.forceInsert(rev2, "1-x", "2-x");
-
-        // Get the document
-        DocumentRevision doc = datastore.getDocument(OBJECT_ID);
-        // If there is no winner an exception would be thrown.
-
-        // We favour non-deleted nodes so the winner should be a 1-x
-        Assert.assertEquals("The document winner should be the expected revision", "1-x", doc
-                .getRevision());
-        // The winner should be the one with body two because the 2-x deleted revision should graft
-        // onto the lowest seq of the two identical 1-x revisions.
-        Assert.assertEquals("The document winner should have the expected body", bodyTwo.asMap(),
-                doc.getBody().asMap());
-    }
-
     @Test
     public void forceInsert_pickWinnerOfConflicts_Complex() throws Exception {
 


### PR DESCRIPTION
_What_: Migrate schema version 200 to new tables for `revs` and `attachments`

_Why_: These schema constraints should have been in the original DDL to prevent duplicate revs and attachments (see also #329). Their omission means that certain logic errors were not caught by SQLite. By migrating to new tables with these constraints added (using the recipe outlined at https://www.sqlite.org/lang_altertable.html) we help to ensure the database can't get into an inconsistent state in the future.

_Testing_: Existing/updated tests pass