### PR TITLE
Move most SQL code out of DatastoreImpl

### DIFF
--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/library/LibraryVersion.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/library/LibraryVersion.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2016 IBM Corp. All rights reserved.
+ *  Copyright (C) 2016 IBM Corp. All rights reserved.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  *  except in compliance with the License. You may obtain a copy of the License at

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/AttachmentManager.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/AttachmentManager.java
@@ -50,11 +50,11 @@ import java.util.logging.Logger;
  *
  * @api_private
  */
-class AttachmentManager {
+public class AttachmentManager {
 
     private static final Logger logger = Logger.getLogger(AttachmentManager.class.getCanonicalName());
 
-    private static final String SQL_ATTACHMENTS_SELECT = "SELECT sequence, " +
+    public static final String SQL_ATTACHMENTS_SELECT = "SELECT sequence, " +
             "filename, " +
             "key, " +
             "type, " +
@@ -65,7 +65,7 @@ class AttachmentManager {
             "FROM attachments " +
             "WHERE filename = ? and sequence = ?";
 
-    private static final String SQL_ATTACHMENTS_SELECT_ALL = "SELECT sequence, " +
+    public static final String SQL_ATTACHMENTS_SELECT_ALL = "SELECT sequence, " +
             "filename, " +
             "key, " +
             "type, " +
@@ -492,7 +492,7 @@ class AttachmentManager {
      * @throws AttachmentException if a mapping doesn't exist and {@code allowCreateName} is
      *          false or if the name generation process fails.
      */
-    static File fileFromKey(SQLDatabase db, byte[] key, String attachmentsDir,
+    public static File fileFromKey(SQLDatabase db, byte[] key, String attachmentsDir,
                             boolean allowCreateName)
             throws AttachmentException {
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/AttachmentStreamFactory.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/AttachmentStreamFactory.java
@@ -116,7 +116,7 @@ public class AttachmentStreamFactory {
     /**
      * Get stream for writing attachment data to disk.
      *
-     * Opens the output stream using {@see FileUtils#openOutputStream(File)}.
+     * Opens the output stream using {@link FileUtils#openOutputStream(File)}.
      *
      * Data should be written to the stream unencoded, unencrypted.
      *
@@ -125,6 +125,7 @@ public class AttachmentStreamFactory {
      * @return Stream for writing.
      * @throws IOException if there's a problem writing to disk, including issues with
      *      encryption (bad key length and other key issues).
+     * @see FileUtils#openOutputStream(File)
      */
     public OutputStream getOutputStream(File file, Attachment.Encoding encoding) throws
             IOException {

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/AttachmentStreamFactory.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/AttachmentStreamFactory.java
@@ -45,7 +45,7 @@ import java.util.zip.GZIPOutputStream;
  *
  * @api_private
  */
-class AttachmentStreamFactory {
+public class AttachmentStreamFactory {
 
     /**
      * Byte array if there is a valid AES key, null if attachments

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/DocumentRevision.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/DocumentRevision.java
@@ -108,8 +108,6 @@ public class DocumentRevision implements Comparable<DocumentRevision> {
         }
     }
 
-
-
     /**
      * @return the unique identifier of the document
      */

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/ForceInsertItem.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/ForceInsertItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 IBM Corp. All rights reserved.
+ * Copyright (C) 2016 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/SavedAttachment.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/SavedAttachment.java
@@ -28,9 +28,9 @@ import java.util.logging.Logger;
 /**
  * An Attachment which has been retrieved from the Database
  *
- * @api_public
+ * @api_private
  */
-class SavedAttachment extends Attachment {
+public class SavedAttachment extends Attachment {
 
     // how many bytes should an attachment be to be considered large?
     static final int largeSizeBytes = 65536;
@@ -57,7 +57,7 @@ class SavedAttachment extends Attachment {
     private final File file;
     private final AttachmentStreamFactory attachmentStreamFactory;
 
-    protected SavedAttachment(long seq, String name, byte[] key, String type, Encoding encoding,
+    public SavedAttachment(long seq, String name, byte[] key, String type, Encoding encoding,
                               long length, long encodedLength, long revpos, File file,
                               AttachmentStreamFactory asf) {
         super(name, type, encoding);

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/AttachmentsForRevisionCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/AttachmentsForRevisionCallable.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.datastore.callables;
+
+import com.cloudant.sync.datastore.Attachment;
+import com.cloudant.sync.datastore.AttachmentException;
+import com.cloudant.sync.datastore.AttachmentManager;
+import com.cloudant.sync.datastore.AttachmentStreamFactory;
+import com.cloudant.sync.datastore.DatastoreImpl;
+import com.cloudant.sync.datastore.SavedAttachment;
+import com.cloudant.sync.sqlite.Cursor;
+import com.cloudant.sync.sqlite.SQLCallable;
+import com.cloudant.sync.sqlite.SQLDatabase;
+import com.cloudant.sync.util.DatabaseUtils;
+
+import java.io.File;
+import java.sql.SQLException;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Get all Attachments for a given internal sequence number
+ *
+ * @api_private
+ */
+public class AttachmentsForRevisionCallable implements SQLCallable<List<? extends Attachment>> {
+
+    private String attachmentsDir;
+    private AttachmentStreamFactory attachmentStreamFactory;
+    private long sequence;
+
+    private static final Logger logger = Logger.getLogger(DatastoreImpl.class.getCanonicalName());
+
+    /**
+     * @param attachmentsDir          Location of attachments
+     * @param attachmentStreamFactory Factory to manage access to attachment streams
+     * @param sequence Internal sequence number of Revision with which these Attachments are associated
+     */
+    public AttachmentsForRevisionCallable(String attachmentsDir, AttachmentStreamFactory
+            attachmentStreamFactory, long sequence) {
+        this.attachmentsDir = attachmentsDir;
+        this.attachmentStreamFactory = attachmentStreamFactory;
+        this.sequence = sequence;
+    }
+
+
+    public List<? extends Attachment> call(SQLDatabase db) throws AttachmentException {
+
+        Cursor c = null;
+        try {
+            LinkedList<SavedAttachment> atts = new LinkedList<SavedAttachment>();
+            c = db.rawQuery(AttachmentManager.SQL_ATTACHMENTS_SELECT_ALL,
+                    new String[]{String.valueOf(sequence)});
+            while (c.moveToNext()) {
+                String filename = c.getString(c.getColumnIndex("filename"));
+                byte[] key = c.getBlob(c.getColumnIndex("key"));
+                String type = c.getString(c.getColumnIndex("type"));
+                int encoding = c.getInt(c.getColumnIndex("encoding"));
+                long length = c.getInt(c.getColumnIndex("length"));
+                long encodedLength = c.getInt(c.getColumnIndex("encoded_length"));
+                int revpos = c.getInt(c.getColumnIndex("revpos"));
+                File file = AttachmentManager.fileFromKey(db, key, attachmentsDir, false);
+
+                atts.add(new SavedAttachment(sequence, filename, key, type, Attachment.Encoding
+                        .values()[encoding], length, encodedLength, revpos, file,
+                        attachmentStreamFactory));
+            }
+            return atts;
+        } catch (SQLException e) {
+            logger.log(Level.SEVERE, "Failed to get attachments", e);
+            throw new AttachmentException(e);
+        } finally {
+            DatabaseUtils.closeCursorQuietly(c);
+        }
+    }
+
+}

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/DeleteDocumentCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/DeleteDocumentCallable.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.datastore.callables;
+
+import com.cloudant.sync.datastore.ConflictException;
+import com.cloudant.sync.datastore.DatastoreException;
+import com.cloudant.sync.datastore.DatastoreImpl;
+import com.cloudant.sync.datastore.DocumentBodyFactory;
+import com.cloudant.sync.datastore.DocumentNotFoundException;
+import com.cloudant.sync.datastore.DocumentRevision;
+import com.cloudant.sync.datastore.DocumentRevisionBuilder;
+import com.cloudant.sync.sqlite.Cursor;
+import com.cloudant.sync.sqlite.SQLCallable;
+import com.cloudant.sync.sqlite.SQLDatabase;
+import com.cloudant.sync.util.CouchUtils;
+import com.cloudant.sync.util.DatabaseUtils;
+import com.cloudant.sync.util.JSONUtils;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+
+import java.sql.SQLException;
+
+/**
+ * Delete a Document for given Document ID and Revision ID.
+ *
+ * In the same manner as CouchDB, a new leaf Revision which is marked as deleted is created and made
+ * the child Revision of the Revision to be deleted.
+ *
+ * @api_private
+ */
+public class DeleteDocumentCallable implements SQLCallable<DocumentRevision> {
+
+    String docId;
+    String prevRevId;
+
+    /**
+     * @param docId     The Document ID of the Revision to be deleted
+     * @param prevRevId The Revision ID of the Revision to be deleted
+     */
+    public DeleteDocumentCallable(String docId, String prevRevId) {
+        this.docId = docId;
+        this.prevRevId = prevRevId;
+    }
+
+    public DocumentRevision call(SQLDatabase db) throws ConflictException, DocumentNotFoundException, DatastoreException {
+
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(docId),
+                "Input document id cannot be empty");
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(prevRevId),
+                "Input previous revision id cannot be empty");
+
+        CouchUtils.validateRevisionId(prevRevId);
+
+        // get the sequence, numeric document id, current flag for the given revision - if it's a non-deleted leaf
+        Cursor c = null;
+        long sequence;
+        long docNumericId;
+        boolean current;
+        try {
+            // first check if it exists
+            c = db.rawQuery(DatastoreImpl.GET_METADATA_GIVEN_REVISION, new String[]{docId, prevRevId});
+            boolean exists = c.moveToFirst();
+            if (!exists) {
+                throw new DocumentNotFoundException();
+            }
+            // now check it's a leaf revision
+            String leafQuery = "SELECT " + DatastoreImpl.METADATA_COLS + " FROM revs, docs WHERE " +
+                    "docs.docid=? AND revs.doc_id=docs.doc_id AND revid=? AND revs.sequence NOT " +
+                    "IN (SELECT DISTINCT parent FROM revs WHERE parent NOT NULL) ";
+            c = db.rawQuery(leafQuery, new String[]{docId, prevRevId});
+            boolean isLeaf = c.moveToFirst();
+            if (!isLeaf) {
+                throw new ConflictException("Document has newer revisions than the revision " +
+                        "passed to delete; get the newest revision of the document and try again.");
+            }
+            boolean isDeleted = c.getInt(c.getColumnIndex("deleted")) != 0;
+            if (isDeleted) {
+                throw new DocumentNotFoundException("Previous Revision is already deleted");
+            }
+            sequence = c.getLong(c.getColumnIndex("sequence"));
+            docNumericId = c.getLong(c.getColumnIndex("doc_id"));
+            current = c.getInt(c.getColumnIndex("current")) != 0;
+        } catch (SQLException sqe) {
+            throw new DatastoreException(sqe);
+        } finally {
+            DatabaseUtils.closeCursorQuietly(c);
+        }
+
+        new SetCurrentCallable(sequence, false).call(db);
+        String newRevisionId = CouchUtils.generateNextRevisionId(prevRevId);
+        // Previous revision to be deleted could be winner revision ("current" == true),
+        // or a non-winner leaf revision ("current" == false), the new inserted
+        // revision must have the same flag as it previous revision.
+        // Deletion of non-winner leaf revision is mainly used when resolving
+        // conflicts.
+        InsertRevisionCallable callable = new InsertRevisionCallable();
+
+        callable.docNumericId = docNumericId;
+        callable.revId = newRevisionId;
+        callable.parentSequence = sequence;
+        callable.deleted = true;
+        callable.current = current;
+        callable.data = JSONUtils.emptyJSONObjectAsBytes();
+        callable.available = false;
+        long newSequence = callable.call(db);
+
+        // build up the document to return to the caller - it's quicker than re-querying the database
+        // and we know all the values we need
+        return new DocumentRevisionBuilder().setInternalId(docNumericId).setDocId(docId).setRevId(newRevisionId).setParent(sequence).
+                setDeleted(true).setCurrent(current).setBody(DocumentBodyFactory.create(JSONUtils.emptyJSONObjectAsBytes())).
+                setSequence(newSequence).build();
+    }
+
+}

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/GetAllRevisionsOfDocumentCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/GetAllRevisionsOfDocumentCallable.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.datastore.callables;
+
+import com.cloudant.sync.datastore.Attachment;
+import com.cloudant.sync.datastore.AttachmentException;
+import com.cloudant.sync.datastore.AttachmentManager;
+import com.cloudant.sync.datastore.AttachmentStreamFactory;
+import com.cloudant.sync.datastore.DatastoreException;
+import com.cloudant.sync.datastore.DatastoreImpl;
+import com.cloudant.sync.datastore.DocumentRevision;
+import com.cloudant.sync.datastore.DocumentRevisionTree;
+import com.cloudant.sync.sqlite.Cursor;
+import com.cloudant.sync.sqlite.SQLCallable;
+import com.cloudant.sync.sqlite.SQLDatabase;
+import com.cloudant.sync.util.DatabaseUtils;
+
+import java.sql.SQLException;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Get all Revisions for a given Document ID, in the form of a {@code DocumentRevisionTree}
+ *
+ * @see DocumentRevisionTree
+ *
+ * @api_private
+ */
+public class GetAllRevisionsOfDocumentCallable implements SQLCallable<DocumentRevisionTree> {
+
+
+    private String docId;
+    private String attachmentsDir;
+    private AttachmentStreamFactory attachmentStreamFactory;
+
+    private static final Logger logger = Logger.getLogger(DatastoreImpl.class.getCanonicalName());
+
+    /**
+     * @param docId                   The Document ID to get the Document for
+     * @param attachmentsDir          Location of attachments
+     * @param attachmentStreamFactory Factory to manage access to attachment streams
+     */
+    public GetAllRevisionsOfDocumentCallable(String docId, String attachmentsDir,
+                                             AttachmentStreamFactory attachmentStreamFactory) {
+        this.docId = docId;
+        this.attachmentsDir = attachmentsDir;
+        this.attachmentStreamFactory = attachmentStreamFactory;
+    }
+
+    public DocumentRevisionTree call(SQLDatabase db) throws DatastoreException, AttachmentException {
+        String sql = "SELECT " + DatastoreImpl.FULL_DOCUMENT_COLS + " FROM revs, docs " +
+                "WHERE docs.docid=? AND revs.doc_id = docs.doc_id ORDER BY sequence ASC";
+
+        String[] args = {docId};
+        Cursor cursor = null;
+
+        try {
+            DocumentRevisionTree tree = new DocumentRevisionTree();
+            cursor = db.rawQuery(sql, args);
+            while (cursor.moveToNext()) {
+                long sequence = cursor.getLong(3);
+                List<? extends Attachment> atts = new AttachmentsForRevisionCallable(
+                        this.attachmentsDir, this.attachmentStreamFactory, sequence).call(db);
+                DocumentRevision rev = DatastoreImpl.getFullRevisionFromCurrentCursor(cursor, atts);
+                logger.finer("Rev: " + rev);
+                tree.add(rev);
+            }
+            return tree;
+        } catch (SQLException e) {
+            logger.log(Level.SEVERE, "Error getting all revisions of document", e);
+            throw new DatastoreException("DocumentRevisionTree not found with id: " + docId, e);
+        } finally {
+            DatabaseUtils.closeCursorQuietly(cursor);
+        }
+
+    }
+}

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/GetDocumentCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/GetDocumentCallable.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.datastore.callables;
+
+import com.cloudant.sync.datastore.Attachment;
+import com.cloudant.sync.datastore.AttachmentException;
+import com.cloudant.sync.datastore.AttachmentManager;
+import com.cloudant.sync.datastore.AttachmentStreamFactory;
+import com.cloudant.sync.datastore.Datastore;
+import com.cloudant.sync.datastore.DatastoreException;
+import com.cloudant.sync.datastore.DatastoreImpl;
+import com.cloudant.sync.datastore.DocumentNotFoundException;
+import com.cloudant.sync.datastore.DocumentRevision;
+import com.cloudant.sync.sqlite.Cursor;
+import com.cloudant.sync.sqlite.SQLCallable;
+import com.cloudant.sync.sqlite.SQLDatabase;
+import com.cloudant.sync.util.DatabaseUtils;
+
+import java.sql.SQLException;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Get the Document for a given Document ID and Revision ID
+ *
+ * @api_private
+ */
+public class GetDocumentCallable implements SQLCallable<DocumentRevision> {
+
+    String id;
+    String rev;
+
+    String attachmentsDir;
+    AttachmentStreamFactory attachmentStreamFactory;
+
+    /**
+     * @param id                      The Document ID to get the Document for
+     * @param rev                     The Revision ID to get the Document for
+     * @param attachmentsDir          Location of attachments
+     * @param attachmentStreamFactory Factory to manage access to attachment streams
+     */
+    public GetDocumentCallable(String id, String rev, String attachmentsDir,
+                               AttachmentStreamFactory attachmentStreamFactory) {
+        this.id = id;
+        this.rev = rev;
+        this.attachmentsDir = attachmentsDir;
+        this.attachmentStreamFactory = attachmentStreamFactory;
+    }
+
+    private static final Logger logger = Logger.getLogger(DatastoreImpl.class.getCanonicalName());
+
+
+    public DocumentRevision call(SQLDatabase db) throws DocumentNotFoundException, AttachmentException, DatastoreException{
+
+        Cursor cursor = null;
+        try {
+            String[] args = (rev == null) ? new String[]{id} : new String[]{id, rev};
+            String sql = (rev == null) ? DatastoreImpl.GET_DOCUMENT_CURRENT_REVISION :
+                    DatastoreImpl.GET_DOCUMENT_GIVEN_REVISION;
+            cursor = db.rawQuery(sql, args);
+            if (cursor.moveToFirst()) {
+                long sequence = cursor.getLong(3);
+                List<? extends Attachment> atts = new AttachmentsForRevisionCallable(
+                        this.attachmentsDir, this.attachmentStreamFactory, sequence).call(db);
+                return DatastoreImpl.getFullRevisionFromCurrentCursor(cursor, atts);
+            } else {
+                throw new DocumentNotFoundException(id, rev);
+            }
+        } catch (SQLException e) {
+            logger.log(Level.SEVERE, "Error getting document with id: " + id + "and rev " + rev, e);
+            throw new DatastoreException(String.format("Could not find document with id %s at " +
+                    "revision %s", id, rev), e);
+        } finally {
+            DatabaseUtils.closeCursorQuietly(cursor);
+        }
+    }
+
+}

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/GetDocumentCountCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/GetDocumentCountCallable.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.datastore.callables;
+
+import com.cloudant.sync.datastore.DatastoreException;
+import com.cloudant.sync.datastore.DatastoreImpl;
+import com.cloudant.sync.sqlite.Cursor;
+import com.cloudant.sync.sqlite.SQLCallable;
+import com.cloudant.sync.sqlite.SQLDatabase;
+import com.cloudant.sync.util.DatabaseUtils;
+
+import java.sql.SQLException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Get the total number of Documents in the database.
+ *
+ * Documents where all revisions are deleted are not counted.
+ *
+ * @api_private
+ */
+public class GetDocumentCountCallable implements SQLCallable<Integer> {
+
+    private static final Logger logger = Logger.getLogger(DatastoreImpl.class.getCanonicalName());
+
+    @Override
+    public Integer call(SQLDatabase db) throws Exception {
+        String sql = "SELECT COUNT(DISTINCT doc_id) FROM revs WHERE current=1 AND deleted=0";
+        Cursor cursor = null;
+        int result = 0;
+        try {
+            cursor = db.rawQuery(sql, null);
+            if (cursor.moveToFirst()) {
+                result = cursor.getInt(0);
+            }
+        } catch (SQLException e) {
+            logger.log(Level.SEVERE, "Error getting document count", e);
+            throw new DatastoreException(e);
+        } finally {
+            DatabaseUtils.closeCursorQuietly(cursor);
+        }
+        return result;
+    }
+
+}

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/GetDocumentsWithInternalIdsCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/GetDocumentsWithInternalIdsCallable.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.datastore.callables;
+
+import com.cloudant.sync.datastore.AttachmentStreamFactory;
+import com.cloudant.sync.datastore.DatastoreException;
+import com.cloudant.sync.datastore.DatastoreImpl;
+import com.cloudant.sync.datastore.DocumentException;
+import com.cloudant.sync.datastore.DocumentRevision;
+import com.cloudant.sync.sqlite.SQLCallable;
+import com.cloudant.sync.sqlite.SQLDatabase;
+import com.cloudant.sync.util.DatabaseUtils;
+import com.google.common.collect.Lists;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Get a list of the winning (current) Revisions matching a list of internal (numeric) Document IDs
+ * @api_private
+ */
+public class GetDocumentsWithInternalIdsCallable implements SQLCallable<List<DocumentRevision>> {
+
+    private List<Long> docIds;
+    private String attachmentsDir;
+    private AttachmentStreamFactory attachmentStreamFactory;
+
+    /**
+     * @param docIds                  List of internal (numeric) Document IDs
+     * @param attachmentsDir          Location of attachments
+     * @param attachmentStreamFactory Factory to manage access to attachment streams
+     */
+    public GetDocumentsWithInternalIdsCallable(List<Long> docIds, String attachmentsDir,
+                                               AttachmentStreamFactory attachmentStreamFactory) {
+        this.docIds = docIds;
+        this.attachmentsDir = attachmentsDir;
+        this.attachmentStreamFactory = attachmentStreamFactory;
+    }
+
+    public List<DocumentRevision> call(SQLDatabase db) throws DatastoreException, DocumentException {
+
+        if (docIds.size() == 0) {
+            return Collections.emptyList();
+        }
+
+        final String GET_DOCUMENTS_BY_INTERNAL_IDS = "SELECT " + DatastoreImpl.FULL_DOCUMENT_COLS + " FROM " +
+                "revs, docs " +
+                "WHERE revs.doc_id IN ( %s ) AND current = 1 AND docs.doc_id = revs.doc_id";
+
+        // Split into batches because SQLite has a limit on the number
+        // of placeholders we can use in a single query. 999 is the default
+        // value, but it can be lower. It's hard to find this out from Java,
+        // so we use a value much lower.
+        List<DocumentRevision> result = new ArrayList<DocumentRevision>(docIds.size());
+
+        List<List<Long>> batches = Lists.partition(docIds, DatastoreImpl.SQLITE_QUERY_PLACEHOLDERS_LIMIT);
+        for (List<Long> batch : batches) {
+            String sql = String.format(
+                    GET_DOCUMENTS_BY_INTERNAL_IDS,
+                    DatabaseUtils.makePlaceholders(batch.size())
+            );
+            String[] args = new String[batch.size()];
+            for (int i = 0; i < batch.size(); i++) {
+                args[i] = Long.toString(batch.get(i));
+            }
+            result.addAll(DatastoreImpl.getRevisionsFromRawQuery(db, sql, args, attachmentsDir, attachmentStreamFactory));
+        }
+
+        // Contract is to sort by sequence number, which we need to do
+        // outside the sqlDb as we're batching requests.
+        Collections.sort(result, new Comparator<DocumentRevision>() {
+            @Override
+            public int compare(DocumentRevision documentRevision, DocumentRevision
+                    documentRevision2) {
+                long a = documentRevision.getSequence();
+                long b = documentRevision2.getSequence();
+                return (int) (a - b);
+            }
+        });
+
+        return result;
+    }
+
+}

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/GetLastSequenceCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/GetLastSequenceCallable.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.datastore.callables;
+
+import com.cloudant.sync.datastore.Datastore;
+import com.cloudant.sync.datastore.DatastoreException;
+import com.cloudant.sync.datastore.DatastoreImpl;
+import com.cloudant.sync.sqlite.Cursor;
+import com.cloudant.sync.sqlite.SQLCallable;
+import com.cloudant.sync.sqlite.SQLDatabase;
+import com.cloudant.sync.util.DatabaseUtils;
+
+import java.sql.SQLException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Get the most recent (highest) sequence number for the database
+ *
+ * @api_private
+ */
+public class GetLastSequenceCallable implements SQLCallable<Long> {
+
+    private static final Logger logger = Logger.getLogger(DatastoreImpl.class.getCanonicalName());
+
+    @Override
+    public Long call(SQLDatabase db) throws Exception {
+        String sql = "SELECT MAX(sequence) FROM revs";
+        Cursor cursor = null;
+        long result = 0;
+        try {
+            cursor = db.rawQuery(sql, null);
+            if (cursor.moveToFirst()) {
+                if (cursor.columnType(0) == Cursor.FIELD_TYPE_INTEGER) {
+                    result = cursor.getLong(0);
+                } else if (cursor.columnType(0) == Cursor.FIELD_TYPE_NULL) {
+                    result = Datastore.SEQUENCE_NUMBER_START;
+                } else {
+                    throw new IllegalStateException("SQLite return an unexpected value.");
+                }
+            }
+        } catch (SQLException e) {
+            logger.log(Level.SEVERE, "Error getting last sequence", e);
+            throw new DatastoreException(e);
+        } finally {
+            DatabaseUtils.closeCursorQuietly(cursor);
+        }
+        return result;
+    }
+
+}

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/GetLocalDocumentCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/GetLocalDocumentCallable.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.datastore.callables;
+
+import com.cloudant.sync.datastore.DatastoreException;
+import com.cloudant.sync.datastore.DatastoreImpl;
+import com.cloudant.sync.datastore.DocumentBodyFactory;
+import com.cloudant.sync.datastore.DocumentNotFoundException;
+import com.cloudant.sync.datastore.LocalDocument;
+import com.cloudant.sync.sqlite.Cursor;
+import com.cloudant.sync.sqlite.SQLCallable;
+import com.cloudant.sync.sqlite.SQLDatabase;
+import com.cloudant.sync.util.DatabaseUtils;
+
+import java.sql.SQLException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Get the local Document for a given Document ID
+ *
+ * @api_private
+ */
+public class GetLocalDocumentCallable implements SQLCallable<LocalDocument> {
+
+    private String docId;
+
+    private static final Logger logger = Logger.getLogger(DatastoreImpl.class.getCanonicalName());
+
+    /**
+     * @param docId Document to fetch the local Document for
+     */
+    public GetLocalDocumentCallable(String docId) {
+        this.docId = docId;
+    }
+
+    @Override
+    public LocalDocument call(SQLDatabase database) throws Exception {
+        Cursor cursor = null;
+        try {
+            String[] args = {docId};
+            cursor = database.rawQuery("SELECT json FROM localdocs WHERE docid=?", args);
+            if (cursor.moveToFirst()) {
+                byte[] json = cursor.getBlob(0);
+
+                return new LocalDocument(docId, DocumentBodyFactory.create(json));
+            } else {
+                throw new DocumentNotFoundException(String.format("No local document found with " +
+                        "id: %s", docId));
+            }
+        } catch (SQLException e) {
+            logger.log(Level.SEVERE, String.format("Error getting local document with id: %s",
+                    docId), e);
+            throw new DatastoreException("Error getting local document with id: " + docId, e);
+        } finally {
+            DatabaseUtils.closeCursorQuietly(cursor);
+        }
+
+    }
+}

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/GetNumericIdCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/GetNumericIdCallable.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.datastore.callables;
+
+import com.cloudant.sync.datastore.DatastoreException;
+import com.cloudant.sync.datastore.DatastoreImpl;
+import com.cloudant.sync.sqlite.Cursor;
+import com.cloudant.sync.sqlite.SQLCallable;
+import com.cloudant.sync.sqlite.SQLDatabase;
+import com.cloudant.sync.util.DatabaseUtils;
+
+import java.sql.SQLException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Get the internal numeric ID for a given Document ID
+ *
+ * @api_private
+ */
+public class GetNumericIdCallable implements SQLCallable<Long> {
+
+    private String id;
+
+    private static final Logger logger = Logger.getLogger(DatastoreImpl.class.getCanonicalName());
+
+    /**
+     * @param id Document ID to fetch the internal numeric ID for
+     */
+    public GetNumericIdCallable(String id) {
+        this.id = id;
+    }
+
+    public Long call(SQLDatabase db) throws DatastoreException {
+        Cursor cursor = null;
+        try {
+            String sql = DatastoreImpl.GET_DOC_NUMERIC_ID;
+            cursor = db.rawQuery(sql, new String[]{id});
+            if (cursor.moveToFirst()) {
+                long sequence = cursor.getLong(0);
+                return sequence;
+            } else {
+                return -1L;
+            }
+        } catch (SQLException e) {
+            logger.log(Level.SEVERE, "Error sequence with id: " + id);
+            throw new DatastoreException(String.format("Could not find sequence with id %s", id),
+                    e);
+        } finally {
+            DatabaseUtils.closeCursorQuietly(cursor);
+        }
+    }
+}

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/GetSequenceCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/GetSequenceCallable.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.datastore.callables;
+
+import com.cloudant.sync.datastore.DatastoreException;
+import com.cloudant.sync.datastore.DatastoreImpl;
+import com.cloudant.sync.sqlite.Cursor;
+import com.cloudant.sync.sqlite.SQLCallable;
+import com.cloudant.sync.sqlite.SQLDatabase;
+import com.cloudant.sync.util.DatabaseUtils;
+
+import java.sql.SQLException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Get the internal sequence number for a given a revision
+ *
+ * @api_private
+ */
+public class GetSequenceCallable implements SQLCallable<Long> {
+
+    private String id;
+    private String rev;
+
+    private static final Logger logger = Logger.getLogger(DatastoreImpl.class.getCanonicalName());
+
+    /**
+     * @param id  Document ID of the revision to fetch the sequence for
+     * @param rev Revision ID of the revision to fetch the sequence for
+     */
+    public GetSequenceCallable(String id, String rev) {
+        this.id = id;
+        this.rev = rev;
+    }
+
+    public Long call(SQLDatabase db) throws DatastoreException {
+        Cursor cursor = null;
+        try {
+            String[] args = (rev == null) ? new String[]{id} : new String[]{id, rev};
+            String sql = (rev == null) ? DatastoreImpl.GET_METADATA_CURRENT_REVISION :
+                    DatastoreImpl.GET_METADATA_GIVEN_REVISION;
+            cursor = db.rawQuery(sql, args);
+            if (cursor.moveToFirst()) {
+                long sequence = cursor.getLong(cursor.getColumnIndex("sequence"));
+                return sequence;
+            } else {
+                return -1L;
+            }
+        } catch (SQLException e) {
+            logger.log(Level.SEVERE, "Error sequence with id: " + id + "and rev " + rev, e);
+            throw new DatastoreException(String.format("Could not find sequence with id %s at " +
+                    "revision %s", id, rev), e);
+        } finally {
+            DatabaseUtils.closeCursorQuietly(cursor);
+        }
+    }
+}

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/SetCurrentCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/SetCurrentCallable.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.datastore.callables;
+
+import com.cloudant.android.ContentValues;
+import com.cloudant.sync.datastore.DatastoreException;
+import com.cloudant.sync.sqlite.SQLCallable;
+import com.cloudant.sync.sqlite.SQLDatabase;
+
+/**
+ * <p>
+ *     Set the {@code current} field in the revs table to true or false.
+ * </p>
+ * <p>
+ *     The {@code current} field is used to track the "current" or "winning" revision in the
+ *     case of conflicted document trees. This is updated according to the standard couch
+ *     algorithm.
+ * </p>
+ *
+ * @api_private
+ */
+
+public class SetCurrentCallable implements SQLCallable<Void> {
+
+    private long sequence;
+    private boolean valueOfCurrent;
+
+    /**
+     * @param sequence       Sequence number of revision
+     * @param valueOfCurrent New value of {@code current} (true/false)
+     *
+     * @see com.cloudant.sync.datastore.DatastoreImpl#pickWinnerOfConflicts(long)
+     */
+    public SetCurrentCallable(long sequence, boolean valueOfCurrent) {
+        this.sequence = sequence;
+        this.valueOfCurrent = valueOfCurrent;
+    }
+
+    @Override
+    public Void call(SQLDatabase db) throws DatastoreException {
+        ContentValues updateContent = new ContentValues();
+        updateContent.put("current", valueOfCurrent ? 1 : 0);
+        String[] whereArgs = new String[]{String.valueOf(sequence)};
+        db.update("revs", updateContent, "sequence=?", whereArgs);
+        return null;
+    }
+}

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/event/EventBus.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/event/EventBus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 IBM Corp. All rights reserved.
+ * Copyright (C) 2016 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/event/Subscribe.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/event/Subscribe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 IBM Corp. All rights reserved.
+ * Copyright (C) 2016 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexType.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexType.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2016 IBM Corp. All rights reserved.
+ *  Copyright (C) 2016 IBM Corp. All rights reserved.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  *  except in compliance with the License. You may obtain a copy of the License at

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/PushFilter.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/PushFilter.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2016 IBM Corp. All rights reserved.
+ *  Copyright (C) 2016 IBM Corp. All rights reserved.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  *  except in compliance with the License. You may obtain a copy of the License at

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/QueuingExecutorCompletionService.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/QueuingExecutorCompletionService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 IBM Corp. All rights reserved.
+ * Copyright (C) 2016 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryResultTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryResultTest.java
@@ -1,4 +1,4 @@
-//  Copyright (c) 2016 IBM Cloudant. All rights reserved.
+//  Copyright (C) 2016 IBM Cloudant. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
 //  except in compliance with the License. You may obtain a copy of the License at

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/PullReplicationTerminationTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/PullReplicationTerminationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 IBM Corp. All rights reserved.
+ * Copyright (C) 2016 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/ReplicationThreadpoolTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/ReplicationThreadpoolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 IBM Corp. All rights reserved.
+ * Copyright (C) 2016 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/util/MultiThreadedTestHelper.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/util/MultiThreadedTestHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 IBM Corp. All rights reserved.
+ * Copyright (C) 2016 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at


### PR DESCRIPTION
This is achieved by moving the SQL code out of the various `*InQueue`
methods or methods in anonymous classes. Instead each 'operation'
becomes a `*Callable` class which overrides the `call()` method.

This change widens access of some fields and methods from
package-private to public, due to the fact that callables live in their
own package. This may not be entirely desirable and other work-arounds
could be considered.