### PR TITLE
Additional test output and bump JVM version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 script: "./gradlew check integrationTest"
 
 jdk:
-  - openjdk7
+  - oraclejdk8
 
 services:
   - couchdb

--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,16 @@ subprojects {
         configurations.testCompile.each { File file -> println file.name }
     }
 
+    tasks.withType(Test) {
+        testLogging {
+            // Get full exception info for test failures
+            exceptionFormat = 'full'
+            showExceptions = true
+            showCauses = true
+            showStackTraces = true
+        }
+    }
+
     //findbugs
     apply plugin: 'findbugs'
     findbugs {


### PR DESCRIPTION
*What*

Updated JVM to 8.
Added additional test output.

*Testing*

No new tests, enables more exception output for existing tests.

*Issues*

Probably fixes #337 if that was being caused by the JVM version. Otherwise it will give us more information to address that intermittent failure.