### PR TITLE
Removed Guava Lists usages

### DIFF
--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/DatastoreImpl.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/DatastoreImpl.java
@@ -40,6 +40,7 @@ import com.cloudant.sync.sqlite.Cursor;
 import com.cloudant.sync.sqlite.SQLCallable;
 import com.cloudant.sync.sqlite.SQLDatabase;
 import com.cloudant.sync.sqlite.SQLDatabaseQueue;
+import com.cloudant.sync.util.CollectionUtils;
 import com.cloudant.sync.util.CouchUtils;
 import com.cloudant.sync.util.DatabaseUtils;
 import com.cloudant.sync.util.JSONUtils;
@@ -47,7 +48,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 
 import org.apache.commons.io.FilenameUtils;
@@ -557,7 +557,7 @@ public class DatastoreImpl implements Datastore {
         // so we use a value much lower.
         List<DocumentRevision> result = new ArrayList<DocumentRevision>(docIds.size());
 
-        List<List<Long>> batches = Lists.partition(docIds, SQLITE_QUERY_PLACEHOLDERS_LIMIT);
+        List<List<Long>> batches = CollectionUtils.partition(docIds, SQLITE_QUERY_PLACEHOLDERS_LIMIT);
         for (List<Long> batch : batches) {
             String sql = String.format(
                     GET_DOCUMENTS_BY_INTERNAL_IDS,

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/QueryResult.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/QueryResult.java
@@ -18,7 +18,7 @@ import com.cloudant.sync.datastore.DocumentBodyFactory;
 import com.cloudant.sync.datastore.DocumentException;
 import com.cloudant.sync.datastore.DocumentRevision;
 import com.cloudant.sync.datastore.DocumentRevisionBuilder;
-import com.google.common.collect.Lists;
+import com.cloudant.sync.util.CollectionUtils;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -79,7 +79,7 @@ public class QueryResult implements Iterable<DocumentRevision> {
      */
     public List<String> documentIds() {
         List<String> documentIds = new ArrayList<String>();
-        List<DocumentRevision> docs = Lists.newArrayList(iterator());
+        List<DocumentRevision> docs = CollectionUtils.newArrayList(iterator());
         for (DocumentRevision doc : docs) {
             documentIds.add(doc.getId());
         }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ChangesResultWrapper.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ChangesResultWrapper.java
@@ -17,14 +17,10 @@ package com.cloudant.sync.replication;
 import com.cloudant.mazha.ChangesResult;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 /**

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/PullStrategy.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/PullStrategy.java
@@ -28,9 +28,9 @@ import com.cloudant.sync.datastore.DocumentRevsList;
 import com.cloudant.sync.datastore.PreparedAttachment;
 import com.cloudant.sync.datastore.UnsavedStreamAttachment;
 import com.cloudant.sync.event.EventBus;
+import com.cloudant.sync.util.CollectionUtils;
 import com.cloudant.sync.util.JSONUtils;
 import com.cloudant.sync.util.Misc;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 
 import org.apache.commons.codec.binary.Hex;
@@ -308,8 +308,8 @@ class PullStrategy implements ReplicationStrategy {
         int changesProcessed = 0;
 
         // Process the changes in batches
-        List<String> ids = Lists.newArrayList(missingRevisions.keySet());
-        List<List<String>> batches = Lists.partition(ids, this.insertBatchSize);
+        List<String> ids = new ArrayList<String>(missingRevisions.keySet());
+        List<List<String>> batches = CollectionUtils.partition(ids, this.insertBatchSize);
 
 
         for (List<String> batch : batches) {

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/PushStrategy.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/PushStrategy.java
@@ -29,10 +29,10 @@ import com.cloudant.sync.datastore.DocumentRevisionTree;
 import com.cloudant.sync.datastore.MultipartAttachmentWriter;
 import com.cloudant.sync.datastore.RevisionHistoryHelper;
 import com.cloudant.sync.event.EventBus;
+import com.cloudant.sync.util.CollectionUtils;
 import com.cloudant.sync.util.JSONUtils;
 import com.cloudant.sync.util.Misc;
 import com.google.common.base.Strings;
-import com.google.common.collect.Lists;
 
 import org.apache.commons.codec.binary.Hex;
 
@@ -328,7 +328,7 @@ class PushStrategy implements ReplicationStrategy {
 
         // Process the changes themselves in batches, where we post a batch
         // at a time to the remote database's _bulk_docs endpoint.
-        List<? extends List<DocumentRevision>> batches = Lists.partition(
+        List<? extends List<DocumentRevision>> batches = CollectionUtils.partition(
                 changes.getResults(),
                 this.bulkInsertSize
         );

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/util/CollectionUtils.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/util/CollectionUtils.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.util;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+public class CollectionUtils {
+
+    public static <E> List<List<E>> partition(List<E> list, int partitionSize) {
+        int subLists = (list.size() / partitionSize) + (list.size() % partitionSize == 0 ? 0 : 1);
+        ArrayList<List<E>> lists = new ArrayList<List<E>>(subLists);
+        for (int i = 0; i < subLists; i++) {
+            int minIndex = i * partitionSize;
+            int maxIndex = i * partitionSize + partitionSize;
+            maxIndex = (maxIndex < list.size()) ? maxIndex : list.size();
+            lists.add(Collections.unmodifiableList(list.subList(minIndex, maxIndex)));
+        }
+        return Collections.unmodifiableList(lists);
+    }
+
+    public static <E> List<E> newArrayList(Iterator<E> iterator) {
+        List<E> list = new ArrayList<E>();
+        while (iterator.hasNext()) {
+            list.add(iterator.next());
+        }
+        return list;
+    }
+}

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/DatastoreImplConflictsTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/DatastoreImplConflictsTest.java
@@ -18,8 +18,8 @@ import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 
+import com.cloudant.sync.util.CollectionUtils;
 import com.cloudant.sync.util.CouchUtils;
-import com.google.common.collect.Lists;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -39,7 +39,7 @@ public class DatastoreImplConflictsTest extends BasicDatastoreTestBase {
         DocumentRevision newRev = this.createDetachedDocumentRevision(rev.getId(), "1-rev", "Jerry");
         this.datastore.forceInsert(newRev, "1-rev");
         Iterator<String> iterator = this.datastore.getConflictedDocumentIds();
-        List<String> conflictedDocId = Lists.newArrayList(iterator);
+        List<String> conflictedDocId = CollectionUtils.newArrayList(iterator);
         Assert.assertThat(conflictedDocId, hasSize(1));
         Assert.assertThat(conflictedDocId, hasItems(rev.getId()));
     }
@@ -54,7 +54,7 @@ public class DatastoreImplConflictsTest extends BasicDatastoreTestBase {
         this.datastore.forceInsert(newRev2, "1-b", "2-b", "3-b");
 
         Iterator<String> iterator = this.datastore.getConflictedDocumentIds();
-        List<String> conflictedDocId = Lists.newArrayList(iterator);
+        List<String> conflictedDocId = CollectionUtils.newArrayList(iterator);
         Assert.assertThat(conflictedDocId, hasSize(1));
         Assert.assertThat(conflictedDocId, hasItems(rev.getId()));
     }
@@ -67,7 +67,7 @@ public class DatastoreImplConflictsTest extends BasicDatastoreTestBase {
         this.datastore.forceInsert(newRev, "1-a", "2-a", "3-a", "4-a");
 
         Iterator<String> iterator = this.datastore.getConflictedDocumentIds();
-        List<String> conflictedDocId = Lists.newArrayList(iterator);
+        List<String> conflictedDocId = CollectionUtils.newArrayList(iterator);
         Assert.assertThat(conflictedDocId, hasSize(0));
     }
 
@@ -450,7 +450,7 @@ public class DatastoreImplConflictsTest extends BasicDatastoreTestBase {
     private void testWithConflictCount(int conflictCount) throws Exception {
         List<String> expectedConflicts = createConflictDocuments(conflictCount);
         Iterator<String> iterator = this.datastore.getConflictedDocumentIds();
-        List<String> actualConflicts = Lists.newArrayList(iterator);
+        List<String> actualConflicts = CollectionUtils.newArrayList(iterator);
         Assert.assertThat(actualConflicts, hasSize(expectedConflicts.size()));
         for(String id : expectedConflicts) {
             Assert.assertThat(actualConflicts, hasItem(id));

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/util/CollectionUtilsTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/util/CollectionUtilsTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.util;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CollectionUtilsTest {
+
+    static List<Integer> INTS_1_to_100 = getInts(1, 100);
+
+    @Test
+    public void arrayListFromIterator() throws Exception {
+        assertEquals("The lists should be the same", INTS_1_to_100, CollectionUtils.newArrayList
+                (INTS_1_to_100.iterator()));
+    }
+
+    @Test
+    public void equalPartitions() throws Exception {
+        List<Integer> ints1to50 = getInts(1, 50);
+        List<Integer> ints51to100 = getInts(51, 100);
+        List<List<Integer>> intParts = CollectionUtils.partition(INTS_1_to_100, 50);
+        assertEquals("There should be two partitions", 2, intParts.size());
+        List<Integer> part1 = intParts.get(0);
+        List<Integer> part2 = intParts.get(1);
+        assertEquals("Part 1 should be first 50", ints1to50, part1);
+        assertEquals("Part 2 should be second 50", ints51to100, part2);
+    }
+
+    @Test
+    public void unequalPartitions() throws Exception {
+        List<List<Integer>> intParts = CollectionUtils.partition(getInts(1,3), 2);
+        assertEquals("There should be two partitions", 2, intParts.size());
+        List<Integer> part1 = intParts.get(0);
+        List<Integer> part2 = intParts.get(1);
+        assertEquals("Part 1 should be 1,2", getInts(1,2), part1);
+        assertEquals("Part 2 should be 3", getInts(3,3), part2);
+    }
+
+    @Test
+    public void morePartitions() throws Exception {
+        List<List<Integer>> intParts = CollectionUtils.partition(INTS_1_to_100, 8);
+        assertEquals("There should be thirteen partitions", 13, intParts.size());
+        int start = 1;
+        for (List<Integer> part : intParts) {
+            int end = start + part.size() - 1;
+            assertEquals(getInts(start, end), part);
+            start = end + 1;
+        }
+    }
+
+    /**
+     * Generate a list of integers
+     *
+     * @param m start
+     * @param n end (inclusive)
+     * @return a list of the integers from m to n inclusive
+     */
+    private static List<Integer> getInts(int m, int n) {
+        List<Integer> ints = new ArrayList<Integer>((n - m) + 1);
+        for (int i = m; i <= n; i++) {
+            ints.add(i);
+        }
+        return ints;
+    }
+}


### PR DESCRIPTION
*What*

Removed usages of Guava `Lists`

*How*

Created `CollectionUtils` class that offers static methods for list partitioning and creating new `ArrayList` instances from `Iterator`s.

*Testing*

Existing tests pass.
Added new `CollectionUtilsTest` to validate `CollectionUtils` functionality.

*Issues*

Part of #308