### PR TITLE
308 remove guava res sets

### DIFF
--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/library/LibraryVersion.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/library/LibraryVersion.java
@@ -15,9 +15,10 @@
 package com.cloudant.library;
 
 import com.cloudant.sync.util.Misc;
-import com.google.common.io.Resources;
 
-import java.net.URL;
+import org.apache.commons.io.IOUtils;
+
+import java.io.InputStream;
 import java.util.Properties;
 
 /**
@@ -35,13 +36,17 @@ public class LibraryVersion implements com.cloudant.http.Version {
 
     private static String getUserAgentFromResource() {
         final String defaultUserAgent = "CloudantSync";
-        final URL url = LibraryVersion.class.getClassLoader().getResource("mazha.properties");
+        InputStream propertiesInputStream = null;
         final Properties properties = new Properties();
         try {
-            properties.load(Resources.newInputStreamSupplier(url).getInput());
+            propertiesInputStream = LibraryVersion.class.getClassLoader().getResourceAsStream
+                    ("mazha.properties");
+            properties.load(propertiesInputStream);
             return properties.getProperty("user.agent", defaultUserAgent);
         } catch (Exception ex) {
             return defaultUserAgent;
+        } finally {
+            IOUtils.closeQuietly(propertiesInputStream);
         }
     }
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/QueryExecutor.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/QueryExecutor.java
@@ -19,7 +19,6 @@ import com.cloudant.sync.sqlite.SQLDatabase;
 import com.cloudant.sync.sqlite.SQLDatabaseQueue;
 import com.cloudant.sync.util.DatabaseUtils;
 import com.google.common.base.Joiner;
-import com.google.common.collect.Sets;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -228,7 +227,7 @@ class QueryExecutor {
                 if (accumulator == null) {
                     accumulator = new HashSet<String>(childIds);
                 } else {
-                    accumulator = Sets.intersection(accumulator, childIds);
+                    accumulator.retainAll(childIds);
                 }
             }
 
@@ -246,7 +245,7 @@ class QueryExecutor {
                 if (accumulator == null) {
                     accumulator = new HashSet<String>(childIds);
                 } else {
-                    accumulator = Sets.union(accumulator, childIds);
+                    accumulator.addAll(childIds);
                 }
             }
 


### PR DESCRIPTION
*What*

Removed use of `Sets` and `Resources`

*How*

Replaced `Resources.newInputStreamSupplier(url).getInput()` with the `ClassLoader`'s `getResourceAsStream`.

Replaced `accumulator = Sets.intersection(accumulator, childIds)` with `accumulator.retainAll(childIds)`
Replaced `accumulator = Sets.union(accumulator, childIds)`with `accumulator.addAll(childIds)`.
As it happens the pattern of using `Sets.union` in that way in a loop was explicitly advised against in the Guava javadoc so it is probably best that we replace it anyway.

*Testing*

Existing tests continue to pass.

*Issues*

Part of #308 