### PR TITLE
Removed ForwardingMap

### DIFF
--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/common/ChangeNotifyingMap.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/common/ChangeNotifyingMap.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.common;
+
+import java.util.Map;
+
+public interface ChangeNotifyingMap<K, V> extends Map<K, V> {
+
+    boolean hasChanged();
+
+}

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/common/SimpleChangeNotifyingMap.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/common/SimpleChangeNotifyingMap.java
@@ -1,48 +1,54 @@
+/*
+ * Copyright © 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
 package com.cloudant.common;
 
-import com.google.common.collect.ForwardingMap;
-
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Created by tomblench on 10/02/16.
+ *
  * @api_private
  */
-public class SimpleChangeNotifyingMap<K, V> extends ForwardingMap<K, V> {
+public class SimpleChangeNotifyingMap {
 
-    Map<K, V> delegateMap;
-    private boolean mapChanged;
+    private static List<String> METHODS_OF_CHANGE = Arrays.asList(new String[]{"put", "putAll",
+            "remove", "clear"});
 
-    public SimpleChangeNotifyingMap(Map<K, V> delegateMap) {
-        this.delegateMap = delegateMap;
-        this.mapChanged = false;
+    @SuppressWarnings("unchecked")
+    public static <K, V> ChangeNotifyingMap<K, V> wrap(final Map<K, V> delegateMap) {
+        return (ChangeNotifyingMap<K, V>) Proxy.newProxyInstance(SimpleChangeNotifyingMap.class
+                .getClassLoader(), new Class[]{ChangeNotifyingMap.class}, new InvocationHandler() {
+
+            private final AtomicBoolean hasChanged = new AtomicBoolean();
+
+            @Override
+            public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+                if ("hasChanged".equals(method.getName())) {
+                    return hasChanged.get();
+                } else {
+                    if (METHODS_OF_CHANGE.contains(method.getName())) {
+                        hasChanged.set(true);
+                    }
+                    return method.invoke(delegateMap, args);
+                }
+            }
+        });
     }
-
-    protected Map<K, V> delegate() {
-        return delegateMap;
-    }
-
-    public boolean hasChanged() {
-        return mapChanged;
-    }
-
-
-    @Override
-    public V put(K key, V value) {
-        mapChanged = true;
-        return super.put(key, value);
-    }
-
-    @Override
-    public void putAll(Map<? extends K, ? extends V> map) {
-        mapChanged = true;
-        super.putAll(map);
-    }
-
-    @Override
-    public V remove(Object object) {
-        mapChanged = true;
-        return super.remove(object);
-    }
-
 }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/common/SimpleChangeNotifyingMap.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/common/SimpleChangeNotifyingMap.java
@@ -19,7 +19,6 @@ import java.lang.reflect.Proxy;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Created by tomblench on 10/02/16.
@@ -36,15 +35,15 @@ public class SimpleChangeNotifyingMap {
         return (ChangeNotifyingMap<K, V>) Proxy.newProxyInstance(SimpleChangeNotifyingMap.class
                 .getClassLoader(), new Class[]{ChangeNotifyingMap.class}, new InvocationHandler() {
 
-            private final AtomicBoolean hasChanged = new AtomicBoolean();
+            private volatile boolean hasChanged = false;
 
             @Override
             public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
                 if ("hasChanged".equals(method.getName())) {
-                    return hasChanged.get();
+                    return hasChanged;
                 } else {
                     if (METHODS_OF_CHANGE.contains(method.getName())) {
-                        hasChanged.set(true);
+                        hasChanged = true;
                     }
                     return method.invoke(delegateMap, args);
                 }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/DocumentRevision.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/DocumentRevision.java
@@ -17,6 +17,7 @@
 
 package com.cloudant.sync.datastore;
 
+import com.cloudant.common.ChangeNotifyingMap;
 import com.cloudant.common.SimpleChangeNotifyingMap;
 import com.cloudant.sync.util.CouchUtils;
 
@@ -61,8 +62,8 @@ public class DocumentRevision implements Comparable<DocumentRevision> {
 
     protected boolean fullRevision = true;
 
-    SimpleChangeNotifyingMap<String, Attachment> attachments =
-            new SimpleChangeNotifyingMap<String, Attachment>(new HashMap<String, Attachment>());
+    ChangeNotifyingMap<String, Attachment> attachments = SimpleChangeNotifyingMap.wrap(new
+            HashMap<String, Attachment>());
 
     private DocumentBody body;
 
@@ -145,7 +146,7 @@ public class DocumentRevision implements Comparable<DocumentRevision> {
 
     public void setAttachments(Map<String, Attachment> attachments) {
         if (attachments != null) {
-            this.attachments = new SimpleChangeNotifyingMap<String, Attachment>(attachments);
+            this.attachments = SimpleChangeNotifyingMap.wrap(attachments);
         } else {
             // user cleared the dict, we don't want our notifying map to try to forward to null
             this.attachments = null;
@@ -165,7 +166,7 @@ public class DocumentRevision implements Comparable<DocumentRevision> {
             for (Attachment att : attachments) {
                 m.put(att.name, att);
             }
-            this.attachments = new SimpleChangeNotifyingMap<String, Attachment>(m);
+            this.attachments = SimpleChangeNotifyingMap.wrap(m);
         }
     }
 


### PR DESCRIPTION
*What*

Removed usage of Guava `ForwardingMap`.

*How*

Replaced `SimpleChangeNotifyingMap` class usages with `ChangeNotifyingMap`
interface.
Created new instances of `ChangeNotifyingMap` with `SimpleChangeNotifyingMap.wrap` method that uses a reflection proxy to delegate to another `Map` and implements the `hasChanged` method and checks for map changes in an `InvocationHandler`.

*Testing*

Added `resolveConflictsForDocument_twoConflictAndNewWinner_newWinnerInsertedWithModifiedAttachments` to exercise the `hasChanged` path which was untested before.

*Issues*

Part of #308