### PR TITLE
Replaced Guava Joiner with Misc static method

### DIFF
--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/mazha/CouchURIHelper.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/mazha/CouchURIHelper.java
@@ -20,12 +20,11 @@ package com.cloudant.mazha;
 
 import com.cloudant.common.CouchConstants;
 import com.cloudant.mazha.json.JSONHelper;
-import com.google.common.base.Joiner;
+import com.cloudant.sync.util.Misc;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Map;
 
@@ -35,8 +34,6 @@ import java.util.Map;
  * @api_private
  */
 public class CouchURIHelper {
-
-    private final static Joiner queryJoiner = Joiner.on('&').skipNulls();
 
     // CouchDB/Cloudant server instance URL. Does not end in /
     private final URI rootUri;
@@ -174,7 +171,7 @@ public class CouchURIHelper {
             String term = String.format("%s=%s", key, value);
             queryParts.add(term);
         }
-        return queryJoiner.join(queryParts);
+        return Misc.join("&", queryParts);
     }
 
     private URI uriFor(String uri) {

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexCreator.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexCreator.java
@@ -17,7 +17,7 @@ import com.cloudant.sync.datastore.Datastore;
 import com.cloudant.sync.sqlite.SQLCallable;
 import com.cloudant.sync.sqlite.SQLDatabase;
 import com.cloudant.sync.sqlite.SQLDatabaseQueue;
-import com.google.common.base.Joiner;
+import com.cloudant.sync.util.Misc;
 
 import org.apache.commons.codec.binary.Hex;
 
@@ -336,8 +336,7 @@ class IndexCreator {
 
     private String createIndexTableStatementForIndex(String indexName, List<String> columns) {
         String tableName = String.format(Locale.ENGLISH, "\"%s\"", IndexManager.tableNameForIndex(indexName));
-        Joiner joiner = Joiner.on(" NONE,").skipNulls();
-        String cols = joiner.join(columns);
+        String cols = Misc.join(" NONE, ", columns);
 
         return String.format("CREATE TABLE %s ( %s NONE )", tableName, cols);
     }
@@ -345,8 +344,7 @@ class IndexCreator {
     private String createIndexIndexStatementForIndex(String indexName, List<String> columns) {
         String tableName = IndexManager.tableNameForIndex(indexName);
         String sqlIndexName = tableName.concat("_index");
-        Joiner joiner = Joiner.on(",").skipNulls();
-        String cols = joiner.join(columns);
+        String cols = Misc.join(",", columns);
 
         return String.format(Locale.ENGLISH, "CREATE INDEX \"%s\" ON \"%s\" ( %s )", sqlIndexName, tableName, cols);
     }
@@ -367,9 +365,8 @@ class IndexCreator {
                                                        List<String> indexSettings) {
         String tableName = String.format(Locale.ENGLISH, "\"%s\"", IndexManager
                 .tableNameForIndex(indexName));
-        Joiner joiner = Joiner.on(",").skipNulls();
-        String cols = joiner.join(columns);
-        String settings = joiner.join(indexSettings);
+        String cols = Misc.join(",", columns);
+        String settings = Misc.join(",", indexSettings);
 
         return String.format("CREATE VIRTUAL TABLE %s USING FTS4 ( %s, %s )", tableName,
                                                                               cols,

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/QueryExecutor.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/QueryExecutor.java
@@ -18,7 +18,7 @@ import com.cloudant.sync.sqlite.SQLCallable;
 import com.cloudant.sync.sqlite.SQLDatabase;
 import com.cloudant.sync.sqlite.SQLDatabaseQueue;
 import com.cloudant.sync.util.DatabaseUtils;
-import com.google.common.base.Joiner;
+import com.cloudant.sync.util.Misc;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -378,7 +378,6 @@ class QueryExecutor {
         List<String> parameterList = new ArrayList<String>();
 
         String whereClause = "";
-        Joiner joiner = Joiner.on(", ").skipNulls();
         if (docIdSet.size() < SMALL_RESULT_SET_SIZE_THRESHOLD) {
             List<String> placeholders = new ArrayList<String>();
             for (String docId : docIdSet) {
@@ -386,10 +385,10 @@ class QueryExecutor {
                 parameterList.add(docId);
             }
 
-            whereClause = String.format("WHERE _id IN (%s)", joiner.join(placeholders));
+            whereClause = String.format("WHERE _id IN (%s)", Misc.join(", ", placeholders));
         }
 
-        String orderBy = joiner.join(orderClauses);
+        String orderBy = Misc.join(", ", orderClauses);
         String sql = String.format("SELECT DISTINCT _id FROM %s %s ORDER BY %s", indexTable,
                                                                                  whereClause,
                                                                                  orderBy);

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/QuerySqlTranslator.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/QuerySqlTranslator.java
@@ -12,9 +12,22 @@
 
 package com.cloudant.sync.query;
 
-import static com.cloudant.sync.query.QueryConstants.*;
+import static com.cloudant.sync.query.QueryConstants.AND;
+import static com.cloudant.sync.query.QueryConstants.EQ;
+import static com.cloudant.sync.query.QueryConstants.EXISTS;
+import static com.cloudant.sync.query.QueryConstants.GT;
+import static com.cloudant.sync.query.QueryConstants.GTE;
+import static com.cloudant.sync.query.QueryConstants.IN;
+import static com.cloudant.sync.query.QueryConstants.LT;
+import static com.cloudant.sync.query.QueryConstants.LTE;
+import static com.cloudant.sync.query.QueryConstants.MOD;
+import static com.cloudant.sync.query.QueryConstants.NOT;
+import static com.cloudant.sync.query.QueryConstants.OR;
+import static com.cloudant.sync.query.QueryConstants.SEARCH;
+import static com.cloudant.sync.query.QueryConstants.SIZE;
+import static com.cloudant.sync.query.QueryConstants.TEXT;
 
-import com.google.common.base.Joiner;
+import com.cloudant.sync.util.Misc;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -621,8 +634,7 @@ class QuerySqlTranslator {
                 }
             }
         }
-        Joiner joiner = Joiner.on(" AND ").skipNulls();
-        String where = joiner.join(whereClauses);
+        String where = Misc.join(" AND ", whereClauses);
         String[] parameterArray = new String[sqlParameters.size()];
         int idx = 0;
         for (Object parameter: sqlParameters) {
@@ -640,8 +652,7 @@ class QuerySqlTranslator {
             sqlParameters.add(String.valueOf(value));
         }
 
-        Joiner opJoiner = Joiner.on(", ").skipNulls();
-        return String.format("( %s )", opJoiner.join(inOperands));
+        return String.format("( %s )", Misc.join(", ", inOperands));
     }
 
     /**

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/PullFilter.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/PullFilter.java
@@ -14,7 +14,7 @@
 
 package com.cloudant.sync.replication;
 
-import com.google.common.base.Joiner;
+import com.cloudant.sync.util.Misc;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -136,7 +136,7 @@ public class PullFilter {
 
             queries.add(0, String.format("filter=%s", this.name));
 
-            return Joiner.on('&').skipNulls().join(queries);
+            return Misc.join("&", queries);
         }
     }
 }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/util/Misc.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/util/Misc.java
@@ -16,6 +16,8 @@ package com.cloudant.sync.util;
 
 import java.io.InputStream;
 import java.security.MessageDigest;
+import java.util.Collection;
+import java.util.Iterator;
 import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -49,10 +51,34 @@ public class Misc {
                 sha1.update(buf, 0, bytesRead);
             }
         } catch (Exception e) {
-            logger.log(Level.WARNING,"Problem calacualting SHA1 for stream",e);
+            logger.log(Level.WARNING,"Problem calculating SHA1 for stream",e);
             return null;
         }
         return sha1.digest();
     }
 
+    /**
+     * Utility to join strings with a separator. Skips null strings and does not append a trailing
+     * separator.
+     *
+     * @param separator     the string to use to separate the entries
+     * @param stringsToJoin the strings to join together
+     * @return the joined string
+     */
+    public static String join(String separator, Collection<String> stringsToJoin) {
+        Iterator<String> iterator = stringsToJoin.iterator();
+        StringBuilder builder = new StringBuilder();
+        // Check if there is at least 1 element then use do/while to avoid trailing separator
+        int index = stringsToJoin.size();
+        for (String str : stringsToJoin) {
+            index--;
+            if (str != null) {
+                builder.append(str);
+                if (index > 0) {
+                    builder.append(separator);
+                }
+            }
+        }
+        return builder.toString();
+    }
 }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/util/MiscTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/util/MiscTest.java
@@ -17,6 +17,8 @@ package com.cloudant.sync.util;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Arrays;
+
 public class MiscTest {
 
     @Test
@@ -45,5 +47,31 @@ public class MiscTest {
         } finally {
             System.setProperty("java.runtime.name", p);
         }
+    }
+
+    @Test
+    public void joinSkipsNulls() throws Exception {
+        String joined =
+                Misc.join("##", Arrays.asList(new String[]{"alpha", null, "beta", null, "gamma"}));
+        Assert.assertEquals("The joined string should not have null elements",
+                "alpha##beta##gamma", joined);
+    }
+
+    @Test
+    public void joinDoesNotAppendTrailingSeparator() throws Exception {
+        String joined = Misc.join("##", Arrays.asList(new String[]{"alpha"}));
+        Assert.assertFalse("The joined string should not end with the separator", joined.endsWith
+                ("##"));
+
+        joined = Misc.join("##", Arrays.asList(new String[]{"alpha", "beta"}));
+        Assert.assertFalse("The joined string should not end with the separator", joined.endsWith
+                ("##"));
+    }
+
+    @Test
+    public void basicJoin() throws Exception {
+        String joined = Misc.join(", ", Arrays.asList(new String[]{"alpha", "beta", "gamma"}));
+        Assert.assertEquals("Should get the correct joined string",
+                "alpha, beta, gamma", joined);
     }
 }


### PR DESCRIPTION
*What*

Replaced Guava `Joiner` with `Misc` static method

*How*

Added `Misc.join` method to join a collection of strings together with a
separator, skipping `null`s and not appending a final terminator.
Replaced usages of `Joiner` with `Misc.join`.

*Testing*

Existing tests pass.
Added new tests for `join` method.

*Issues*

Part of #308 