### PR TITLE
308 remove guava multimap

### DIFF
--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/common/ValueListMap.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/common/ValueListMap.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.common;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * <p>
+ * A map implementation that stores a list of values for each key. To remain consistent
+ * with existing Map interfaces the put* methods perform replacement of keys with new
+ * lists of values, the addValue* methods should be used to add new values to the existing keys.
+ * </p>
+ * <p>
+ * Note that when using put to add a list of values for a key that later calls to addValue* will
+ * modify the original list. Consequently if the list is not modifiable then these operations will
+ * fail (typically with an UnsupportedOperationException).
+ * </p>
+ * <p>
+ * This implementation does not currently support removing some values from a key.
+ * </p>
+ *
+ * @param <K> the type of key
+ * @param <V> the type of values
+ * @api_private
+ */
+public class ValueListMap<K, V> extends ConcurrentHashMap<K, List<V>> {
+
+    /**
+     * Add a value to the map under the existing key or creating a new key if it does not
+     * yet exist.
+     *
+     * @param key   the key to associate the values with
+     * @param value the value to add to the key
+     */
+    public void addValueToKey(K key, V value) {
+        this.addValuesToKey(key, Collections.singletonList(value));
+    }
+
+    /**
+     * Add a collection of one or more values to the map under the existing key or creating a new key
+     * if it does not yet exist in the map.
+     *
+     * @param key             the key to associate the values with
+     * @param valueCollection a collection of values to add to the key
+     */
+    public void addValuesToKey(K key, Collection<V> valueCollection) {
+        if (!valueCollection.isEmpty()) {
+            // Create a new collection to store the values (will be changed to internal type by call
+            // to putIfAbsent anyway)
+            List<V> collectionToAppendValuesOn = new ArrayList<V>();
+            List<V> existing = this.putIfAbsent(key, collectionToAppendValuesOn);
+            if (existing != null) {
+                // Already had a collection, discard the new one and use existing
+                collectionToAppendValuesOn = existing;
+            }
+            collectionToAppendValuesOn.addAll(valueCollection);
+        }
+    }
+}

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ChangesResultWrapper.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ChangesResultWrapper.java
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2013 Cloudant, Inc. All rights reserved.
+ * Copyright (C) 2016 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -14,13 +15,13 @@
 
 package com.cloudant.sync.replication;
 
+import com.cloudant.common.ValueListMap;
 import com.cloudant.mazha.ChangesResult;
 import com.cloudant.sync.util.Misc;
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Multimap;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -48,13 +49,13 @@ class ChangesResultWrapper {
         return this.changes.getResults();
     }
 
-    public Multimap<String, String> openRevisions(int start, int end) {
+    public Map<String, List<String>> openRevisions(int start, int end) {
         Misc.checkArgument(start >= 0, "Start position must be greater or equal to zero.");
         Misc.checkArgument(end > start, "End position must be greater than start.");
         Misc.checkArgument(end <= this.size(), "End position must be less than or equal to the " +
                 "changes feed size.");
 
-        Multimap<String, String> openRevisions = HashMultimap.create();
+        ValueListMap<String, String> openRevisions = new ValueListMap<String, String>();
         for(int i = start; i < end ; i ++) {
             ChangesResult.Row row = this.getResults().get(i);
             List<ChangesResult.Row.Rev> revisions = row.getChanges();
@@ -62,7 +63,7 @@ class ChangesResultWrapper {
             for(ChangesResult.Row.Rev rev : revisions) {
                 openRevs.add(rev.getRev());
             }
-            openRevisions.putAll(row.getId(), openRevs);
+            openRevisions.addValuesToKey(row.getId(), openRevs);
         }
         return openRevisions;
     }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/PullStrategy.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/PullStrategy.java
@@ -14,6 +14,7 @@
 
 package com.cloudant.sync.replication;
 
+import com.cloudant.common.ValueListMap;
 import com.cloudant.http.HttpConnectionRequestInterceptor;
 import com.cloudant.http.HttpConnectionResponseInterceptor;
 import com.cloudant.mazha.ChangesResult;
@@ -31,7 +32,6 @@ import com.cloudant.sync.event.EventBus;
 import com.cloudant.sync.util.CollectionUtils;
 import com.cloudant.sync.util.JSONUtils;
 import com.cloudant.sync.util.Misc;
-import com.google.common.collect.Multimap;
 
 import org.apache.commons.codec.binary.Hex;
 
@@ -39,7 +39,6 @@ import java.io.ByteArrayInputStream;
 import java.net.URI;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -301,8 +300,8 @@ class PullStrategy implements ReplicationStrategy {
         );
         logger.info(feed);
 
-        Multimap<String, String> openRevs = changeFeeds.openRevisions(0, changeFeeds.size());
-        Map<String, Collection<String>> missingRevisions = this.targetDb.getDbCore().revsDiff
+        Map<String, List<String>> openRevs = changeFeeds.openRevisions(0, changeFeeds.size());
+        Map<String, List<String>> missingRevisions = this.targetDb.getDbCore().revsDiff
                 (openRevs);
 
         int changesProcessed = 0;
@@ -448,7 +447,7 @@ class PullStrategy implements ReplicationStrategy {
     }
 
     public Iterable<DocumentRevsList> createTask(List<String> ids,
-                                                 Map<String, Collection<String>> revisions) {
+                                                 Map<String, List<String>> revisions) {
 
         List<BulkGetRequest> requests = new ArrayList<BulkGetRequest>();
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/util/CollectionUtils.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/util/CollectionUtils.java
@@ -19,6 +19,9 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
+/**
+ * @api_private
+ */
 public class CollectionUtils {
 
     public static <E> List<List<E>> partition(List<E> list, int partitionSize) {

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/DatastoreImplRevsDiffTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/DatastoreImplRevsDiffTest.java
@@ -14,20 +14,20 @@
 
 package com.cloudant.sync.datastore;
 
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Multimap;
+import com.cloudant.common.ValueListMap;
+
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 public class DatastoreImplRevsDiffTest extends BasicDatastoreTestBase{
 
     @Test
     public void revsDiff_emptyInput_returnEmpty() {
-        Map<String, Collection<String>> revs =
-                datastore.revsDiff(HashMultimap.<String, String>create());
+        Map<String, List<String>> revs =
+                datastore.revsDiff(new ValueListMap<String, String>());
         Assert.assertTrue(revs.size() == 0);
     }
 
@@ -36,10 +36,10 @@ public class DatastoreImplRevsDiffTest extends BasicDatastoreTestBase{
         DocumentRevision revMut = new DocumentRevision();
         revMut.setBody(bodyOne);
         DocumentRevision rev = datastore.createDocumentFromRevision(revMut);
-        Multimap<String, String> revs = HashMultimap.create();
-        revs.put(rev.getId(), rev.getRevision());
-        Map<String, Collection<String>> missingRevs = datastore.revsDiff(revs);
-        Assert.assertTrue(missingRevs.size() == 0);
+        ValueListMap<String, String> revs = new ValueListMap<String, String>();
+        revs.addValueToKey(rev.getId(), rev.getRevision());
+        Map<String, List<String>> missingRevs = datastore.revsDiff(revs);
+        Assert.assertEquals(0, missingRevs.size());
     }
 
     @Test
@@ -47,10 +47,10 @@ public class DatastoreImplRevsDiffTest extends BasicDatastoreTestBase{
         DocumentRevision revMut = new DocumentRevision();
         revMut.setBody(bodyOne);
         DocumentRevision rev = datastore.createDocumentFromRevision(revMut);
-        Multimap<String, String> revs = HashMultimap.create();
-        revs.put(rev.getId(), "2-a");
-        Map<String, Collection<String>> missingRevs = datastore.revsDiff(revs);
-        Assert.assertTrue(missingRevs.size() == 1);
+        ValueListMap<String, String> revs = new ValueListMap<String, String>();
+        revs.addValueToKey(rev.getId(), "2-a");
+        Map<String, List<String>> missingRevs = datastore.revsDiff(revs);
+        Assert.assertEquals(1, missingRevs.size());
         Assert.assertTrue(missingRevs.get(rev.getId()).contains("2-a"));
     }
 
@@ -62,11 +62,11 @@ public class DatastoreImplRevsDiffTest extends BasicDatastoreTestBase{
         DocumentRevision rev2Mut = rev1;
         rev2Mut.setBody(bodyTwo);
         DocumentRevision rev2 = datastore.updateDocumentFromRevision(rev2Mut);
-        Multimap<String, String> revs = HashMultimap.create();
-        revs.put(rev1.getId(), rev1.getRevision());
-        revs.put(rev2.getId(), rev2.getRevision());
-        Map<String, Collection<String>> missingRevs = datastore.revsDiff(revs);
-        Assert.assertTrue(missingRevs.size() == 0);
+        ValueListMap<String, String> revs = new ValueListMap<String, String>();
+        revs.addValueToKey(rev1.getId(), rev1.getRevision());
+        revs.addValueToKey(rev2.getId(), rev2.getRevision());
+        Map<String, List<String>> missingRevs = datastore.revsDiff(revs);
+        Assert.assertEquals(0, missingRevs.size());
     }
 
     @Test
@@ -77,13 +77,13 @@ public class DatastoreImplRevsDiffTest extends BasicDatastoreTestBase{
         DocumentRevision revMut2 = new DocumentRevision();
         revMut2.setBody(bodyTwo);
         DocumentRevision rev2 = datastore.createDocumentFromRevision(revMut2);
-        Multimap<String, String> revs = HashMultimap.create();
-        revs.put(rev1.getId(), rev1.getRevision());
-        revs.put(rev1.getId(), "2-a");
-        revs.put(rev2.getId(), rev2.getRevision());
+        ValueListMap<String, String> revs = new ValueListMap<String, String>();
+        revs.addValueToKey(rev1.getId(), rev1.getRevision());
+        revs.addValueToKey(rev1.getId(), "2-a");
+        revs.addValueToKey(rev2.getId(), rev2.getRevision());
 
-        Map<String, Collection<String>> missingRevs = datastore.revsDiff(revs);
-        Assert.assertTrue(missingRevs.size() == 1);
+        Map<String, List<String>> missingRevs = datastore.revsDiff(revs);
+        Assert.assertEquals(1, missingRevs.size());
         Assert.assertTrue(missingRevs.get(rev1.getId()).contains("2-a"));
     }
 
@@ -96,14 +96,14 @@ public class DatastoreImplRevsDiffTest extends BasicDatastoreTestBase{
         revMut2.setBody(bodyTwo);
         DocumentRevision rev2 = datastore.createDocumentFromRevision(revMut2);
 
-        Multimap<String, String> revs = HashMultimap.create();
-        revs.put(rev1.getId(), rev1.getRevision());
-        revs.put(rev1.getId(), "2-a");
-        revs.put(rev2.getId(), rev2.getRevision());
-        revs.put(rev2.getId(), "2-a");
+        ValueListMap<String, String> revs = new ValueListMap<String, String>();
+        revs.addValueToKey(rev1.getId(), rev1.getRevision());
+        revs.addValueToKey(rev1.getId(), "2-a");
+        revs.addValueToKey(rev2.getId(), rev2.getRevision());
+        revs.addValueToKey(rev2.getId(), "2-a");
 
-        Map<String, Collection<String>> missingRevs = datastore.revsDiff(revs);
-        Assert.assertTrue(missingRevs.size() == 2);
+        Map<String, List<String>> missingRevs = datastore.revsDiff(revs);
+        Assert.assertEquals(2, missingRevs.size());
         Assert.assertTrue(missingRevs.get(rev1.getId()).contains("2-a"));
         Assert.assertTrue(missingRevs.get(rev2.getId()).contains("2-a"));
     }
@@ -117,16 +117,16 @@ public class DatastoreImplRevsDiffTest extends BasicDatastoreTestBase{
         revMut2.setBody(bodyTwo);
         DocumentRevision rev2 = datastore.createDocumentFromRevision(revMut2);
 
-        Multimap<String, String> revs = HashMultimap.create();
+        ValueListMap<String, String> revs = new ValueListMap<String, String>();
         // Add two existing revisions first, and then add many
         // revisions that do not exist yet. The two existing
         // revisions should not return in the api result.
-        revs.put(rev1.getId(), rev1.getRevision());
-        revs.put(rev2.getId(), rev2.getRevision());
+        revs.addValueToKey(rev1.getId(), rev1.getRevision());
+        revs.addValueToKey(rev2.getId(), rev2.getRevision());
         for(int i = 1 ; i < 100000 ; i ++) {
-            revs.put(rev1.getId(), i + "-a");
+            revs.addValueToKey(rev1.getId(), i + "-a");
         }
-        Map<String, Collection<String>> missing = datastore.revsDiff(revs);
+        Map<String, List<String>> missing = datastore.revsDiff(revs);
         Assert.assertEquals(1, missing.size());
         Assert.assertEquals(99999, missing.get(rev1.getId()).size());
         Assert.assertTrue(missing.get(rev1.getId()).contains("1-a"));

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/ChangesResultWrapperTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/ChangesResultWrapperTest.java
@@ -15,10 +15,9 @@
 package com.cloudant.sync.replication;
 
 import com.cloudant.mazha.ChangesResult;
-import com.cloudant.mazha.OpenRevision;
 import com.cloudant.sync.util.JSONUtils;
 import com.cloudant.sync.util.TestUtils;
-import com.google.common.collect.Multimap;
+
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 import org.junit.Before;
@@ -26,13 +25,8 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.CoreMatchers.hasItems;
 
 public class ChangesResultWrapperTest {
 
@@ -61,10 +55,10 @@ public class ChangesResultWrapperTest {
         ChangesResult data = getChangeResultFromFile(TestUtils.loadFixture("fixture/change_feed_0.json"));
         ChangesResultWrapper changes = new ChangesResultWrapper(data);
 
-        Multimap<String, String> openRevisionsList1 = changes.openRevisions(0, 1);
+        Map<String, List<String>> openRevisionsList1 = changes.openRevisions(0, 1);
         Assert.assertEquals(1, openRevisionsList1.size());
 
-        Multimap<String, String> openRevisionsList2 = changes.openRevisions(0, 2);
+        Map<String, List<String>> openRevisionsList2 = changes.openRevisions(0, 2);
         Assert.assertEquals(2, openRevisionsList2.size());
     }
 


### PR DESCRIPTION
*What*

Replaced Guava `Multimap` usages.

*How*

* Reworked the batching of `revsDiff` to first break down by doc ID then by groups of rev IDs up to the placeholder limit. Previously in cases where a rev ID clashed between documents the SQL statement could return revisions from the database that did not match the list of revisions passed in. Since the revision list is filtered by the `revsDiff` the impact was simply calling remove for entries that didn't exist so it did not cause any issues, but it seems more clear to avoid the ambiguity.
* Added `ValueListMap` to provide `Map<String, List<String>>` implementation
with functionality to add values to a key.
* Refactored methods using `Multimap` to use `Map<String, List<String>>`.
* Replaced `Multimap` creation with `ValueListMap`.

*Testing*

Existing tests continue to pass. No new tests as the usage of the map should be covered by the revs diff testing.

*Issues*
Part of #308 