### PR TITLE
308 remove guava precon

### DIFF
--- a/cloudant-sync-datastore-android-encryption/src/main/java/com/cloudant/sync/sqlite/android/AndroidSQLCipherSQLite.java
+++ b/cloudant-sync-datastore-android-encryption/src/main/java/com/cloudant/sync/sqlite/android/AndroidSQLCipherSQLite.java
@@ -29,8 +29,7 @@ import com.cloudant.sync.datastore.encryption.KeyProvider;
 import com.cloudant.sync.datastore.encryption.KeyUtils;
 import com.cloudant.sync.sqlite.Cursor;
 import com.cloudant.sync.sqlite.SQLDatabase;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
+import com.cloudant.sync.util.Misc;
 
 import net.sqlcipher.database.SQLiteConstraintException;
 import net.sqlcipher.database.SQLiteDatabase;
@@ -116,8 +115,7 @@ public class AndroidSQLCipherSQLite extends SQLDatabase {
 
     @Override
     public void execSQL(String sql)  {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(sql.trim()),
-                "Input SQL can not be empty String.");
+        Misc.checkNotNullOrEmpty(sql.trim(), "Input SQL");
         this.database.execSQL(sql);
     }
 
@@ -127,8 +125,7 @@ public class AndroidSQLCipherSQLite extends SQLDatabase {
 
     @Override
     public void execSQL(String sql, Object[] bindArgs) {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(sql.trim()),
-                "Input SQL can not be empty String.");
+        Misc.checkNotNullOrEmpty(sql.trim(), "Input SQL");
         this.database.execSQL(sql, bindArgs);
     }
 

--- a/cloudant-sync-datastore-android/src/main/java/com/cloudant/sync/sqlite/android/AndroidSQLite.java
+++ b/cloudant-sync-datastore-android/src/main/java/com/cloudant/sync/sqlite/android/AndroidSQLite.java
@@ -20,8 +20,7 @@ import android.database.sqlite.SQLiteDatabase;
 import com.cloudant.android.ContentValues;
 import com.cloudant.sync.sqlite.Cursor;
 import com.cloudant.sync.sqlite.SQLDatabase;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
+import com.cloudant.sync.util.Misc;
 
 import java.sql.SQLException;
 
@@ -83,15 +82,13 @@ public class AndroidSQLite extends SQLDatabase {
 
     @Override
     public void execSQL(String sql) throws SQLException {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(sql.trim()),
-                "Input SQL can not be empty String.");
+        Misc.checkNotNullOrEmpty(sql.trim(), "Input SQL");
         this.database.execSQL(sql);
     }
 
     @Override
     public void execSQL(String sql, Object[] bindArgs) throws SQLException {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(sql.trim()),
-                "Input SQL can not be empty String.");
+        Misc.checkNotNullOrEmpty(sql.trim(), "Input SQL");
         this.database.execSQL(sql, bindArgs);
     }
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/common/CouchUtils.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/common/CouchUtils.java
@@ -16,8 +16,7 @@
 
 package com.cloudant.common;
 
-import com.cloudant.common.CouchConstants;
-import com.google.common.base.Strings;
+import com.cloudant.sync.util.Misc;
 
 import java.util.List;
 import java.util.Map;
@@ -40,7 +39,7 @@ public class CouchUtils {
 
     public static boolean isValidDocumentId(String docId) {
         // http://wiki.apache.org/couch/HTTP_Document_API#Documents
-        if (Strings.isNullOrEmpty(docId)) {
+        if (Misc.isStringNullOrEmpty(docId)) {
             return false;
         }
 
@@ -99,7 +98,7 @@ public class CouchUtils {
     }
 
     public static boolean isValidRevisionId(String revisionId) {
-        if (Strings.isNullOrEmpty(revisionId)) {
+        if (Misc.isStringNullOrEmpty(revisionId)) {
             return false;
         }
         int dashPos = revisionId.indexOf("-");

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/common/RetriableTask.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/common/RetriableTask.java
@@ -21,7 +21,7 @@
 
 package com.cloudant.common;
 
-import com.google.common.base.Preconditions;
+import com.cloudant.sync.util.Misc;
 
 import java.util.concurrent.Callable;
 import java.util.logging.Logger;
@@ -43,7 +43,7 @@ public class RetriableTask<T> implements Callable<T> {
 
     public RetriableTask(Callable<T> task) {
         this(DEFAULT_TRIES, DEFAULT_WAIT_TIME, task);
-        Preconditions.checkNotNull(task, "Task must not be null");
+        Misc.checkNotNull(task, "Task");
     }
 
     public RetriableTask(int totalTries, long timeToWait, Callable<T> task) {

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/mazha/CouchClient.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/mazha/CouchClient.java
@@ -27,9 +27,8 @@ import com.cloudant.http.HttpConnectionResponseInterceptor;
 import com.cloudant.mazha.json.JSONHelper;
 import com.cloudant.sync.datastore.DocumentRevsList;
 import com.cloudant.sync.datastore.MultipartAttachmentWriter;
+import com.cloudant.sync.util.Misc;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
 
 import org.apache.commons.io.IOUtils;
 
@@ -309,7 +308,7 @@ public class CouchClient  {
 
     // TODO does this still work the same way we expect it to?
     public boolean contains(String id) {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(id), "id must not be empty");
+        Misc.checkNotNullOrEmpty(id, "id");
         URI doc = this.uriHelper.documentUri(id);
         try {
             HttpConnection connection = Http.HEAD(doc);
@@ -342,8 +341,8 @@ public class CouchClient  {
     }
 
     public InputStream getDocumentStream(String id, String rev) {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(id), "id must not be empty");
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(rev), "rev must not be empty");
+        Misc.checkNotNullOrEmpty(id, "id");
+        Misc.checkNotNullOrEmpty(rev, "rev");
         Map<String, Object> queries = new HashMap<String, Object>();
         queries.put("rev", rev);
         final URI doc = this.uriHelper.documentUri(id, queries);
@@ -352,8 +351,8 @@ public class CouchClient  {
     }
 
     public InputStream getAttachmentStream(String id, String rev, String attachmentName, final boolean acceptGzip) {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(id), "id must not be empty");
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(rev), "rev must not be empty");
+        Misc.checkNotNullOrEmpty(id, "id");
+        Misc.checkNotNullOrEmpty(rev, "rev");
         Map<String, Object> queries = new HashMap<String, Object>();
         queries.put("rev", rev);
         final URI doc = this.uriHelper.attachmentUri(id, queries, attachmentName);
@@ -365,8 +364,8 @@ public class CouchClient  {
     }
 
     public void putAttachmentStream(String id, String rev, String attachmentName, String contentType, byte[] attachmentData) {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(id), "id must not be empty");
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(rev), "rev must not be empty");
+        Misc.checkNotNullOrEmpty(id, "id");
+        Misc.checkNotNullOrEmpty(rev, "rev");
         Map<String, Object> queries = new HashMap<String, Object>();
         queries.put("rev", rev);
         URI doc = this.uriHelper.attachmentUri(id, queries, attachmentName);
@@ -405,8 +404,8 @@ public class CouchClient  {
     public List<OpenRevision> getDocWithOpenRevisions(String id, Collection<String> revisions,
                                                       Collection<String> attsSince,
                                                       boolean pullAttachmentsInline) {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(id), "id must not be empty");
-        Preconditions.checkArgument(revisions.size() > 0, "Need at lease one open revision");
+        Misc.checkNotNullOrEmpty(id, "id");
+        Misc.checkArgument(revisions.size() > 0, "Need at least one open revision");
 
         Map<String, Object> options = new HashMap<String, Object>();
         options.put("revs", true);
@@ -496,8 +495,8 @@ public class CouchClient  {
 
     public <T> T getDocument(final String id, final Map<String, Object> options, final
     TypeReference<T> type) {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(id), "id must not be empty");
-        Preconditions.checkNotNull(type, "type must not be null");
+        Misc.checkNotNullOrEmpty(id, "id");
+        Misc.checkNotNull(type, "Type");
 
         URI doc = uriHelper.documentUri(id, options);
         InputStream is = null;
@@ -518,9 +517,9 @@ public class CouchClient  {
     }
 
     public <T> T getDocument(String id, String rev, TypeReference<T> type) {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(id), "Id must not be empty");
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(rev), "Id must not be empty");
-        Preconditions.checkNotNull(type, "Type must not be null");
+        Misc.checkNotNullOrEmpty(id, "id");
+        Misc.checkNotNullOrEmpty(rev, "rev");
+        Misc.checkNotNull(type, "Type");
 
         InputStream is = null;
         try {
@@ -555,8 +554,8 @@ public class CouchClient  {
     }
 
     public <T> T getDocRevisions(String id, String rev, TypeReference<T> type) {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(id), "id must not be empty");
-        Preconditions.checkNotNull(rev, "document must not be null");
+        Misc.checkNotNullOrEmpty(id, "id");
+        Misc.checkNotNull(rev, "Revision ID");
         Map<String, Object> queries = new HashMap<String, Object>();
         queries.put("revs", "true");
         queries.put("rev", rev);
@@ -574,8 +573,8 @@ public class CouchClient  {
 
     // Document should be complete document include "_id" matches id
     public Response update(String id, Object document) {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(id), "id must not be empty");
-        Preconditions.checkNotNull(document, "document must not be null");
+        Misc.checkNotNullOrEmpty(id, "id");
+        Misc.checkNotNull(document, "Document");
         if (!this.contains(id)) {
             throw new NoResourceException("No document for given id: " + id);
         }
@@ -589,8 +588,8 @@ public class CouchClient  {
     }
 
     public Response delete(String id, String rev) {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(id), "id must not be empty");
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(rev), "rev must not be empty");
+        Misc.checkNotNullOrEmpty(id, "id");
+        Misc.checkNotNullOrEmpty(rev, "rev");
         Map<String, Object> queries = new HashMap<String, Object>();
         queries.put("rev", rev);
         URI doc = this.uriHelper.documentUri(id, queries);
@@ -609,7 +608,7 @@ public class CouchClient  {
     }
 
     private InputStream bulkCreateDocsInputStream(List<?> objects) {
-        Preconditions.checkNotNull(objects, "Object list must not be null.");
+        Misc.checkNotNull(objects, "Object list");
         String newEditsVal = "\"new_edits\": false, ";
         URI uri = this.uriHelper.bulkDocsUri();
         String payload = String.format("{%s%s%s}", newEditsVal, "\"docs\": ",
@@ -655,7 +654,7 @@ public class CouchClient  {
      * @return list of Response
      */
     public List<Response> bulkCreateSerializedDocs(List<String> serializedDocs) {
-        Preconditions.checkNotNull(serializedDocs, "Serialized doc list must not be null.");
+        Misc.checkNotNull(serializedDocs, "Serialized doc list");
         String payload = generateBulkSerializedDocsPayload(serializedDocs);
         URI uri = this.uriHelper.bulkDocsUri();
         InputStream is = null;
@@ -709,7 +708,7 @@ public class CouchClient  {
      * @see <a href="http://wiki.apache.org/couchdb/HttpPostRevsDiff">HttpPostRevsDiff documentation</a>
      */
     public Map<String, MissingRevisions> revsDiff(Map<String, Set<String>> revisions) {
-        Preconditions.checkNotNull(revisions, "Input revisions must not be null");
+        Misc.checkNotNull(revisions,"Input revisions");
         URI uri = this.uriHelper.revsDiffUri();
         String payload = this.jsonHelper.toJson(revisions);
         InputStream is = null;

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/mazha/GetOpenRevisionsResponse.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/mazha/GetOpenRevisionsResponse.java
@@ -18,7 +18,7 @@
 
 package com.cloudant.mazha;
 
-import com.google.common.base.Preconditions;
+import com.cloudant.sync.util.Misc;
 
 import java.util.HashMap;
 import java.util.List;
@@ -83,7 +83,7 @@ public class GetOpenRevisionsResponse {
     private final Map<String, MissingOpenRevision> missingDataMap = new HashMap<String, MissingOpenRevision>();
 
     public GetOpenRevisionsResponse(List<OpenRevision> data) {
-        Preconditions.checkNotNull(data, "Data should not be null");
+        Misc.checkNotNull(data, "Data");
 
         for(OpenRevision d : data) {
             if(d instanceof OkOpenRevision) {

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/mazha/HierarchicalUriComponents.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/mazha/HierarchicalUriComponents.java
@@ -23,7 +23,7 @@
 
 package com.cloudant.mazha;
 
-import com.google.common.base.Preconditions;
+import com.cloudant.sync.util.Misc;
 
 import java.io.ByteArrayOutputStream;
 import java.io.UnsupportedEncodingException;
@@ -48,15 +48,15 @@ public class HierarchicalUriComponents {
         if (source == null) {
             return null;
         }
-        Preconditions.checkNotNull(encoding, "Encoding must not be null");
-        Preconditions.checkArgument(!encoding.isEmpty(), "Encoding must not be empty");
+        Misc.checkNotNull(encoding, "Encoding");
+        Misc.checkArgument(!encoding.isEmpty(), "Encoding must not be empty");
         byte[] bytes = encodeBytes(source.getBytes(encoding), type);
         return new String(bytes, "US-ASCII");
     }
 
     private static byte[] encodeBytes(byte[] source, Type type) {
-        Preconditions.checkNotNull(source, "Source must not be null");
-        Preconditions.checkNotNull(type, "Type must not be null");
+        Misc.checkNotNull(source, "Source");
+        Misc.checkNotNull(type, "Type");
         ByteArrayOutputStream bos = new ByteArrayOutputStream(source.length);
         for (byte b : source) {
             if (b < 0) {

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/Changes.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/Changes.java
@@ -15,7 +15,7 @@
 package com.cloudant.sync.datastore;
 
 
-import com.google.common.base.Preconditions;
+import com.cloudant.sync.util.Misc;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -36,7 +36,7 @@ public class Changes {
     private final List<DocumentRevision> results;
 
     protected Changes(long lastSequence, List<DocumentRevision> results) {
-        Preconditions.checkNotNull(results, "Changes results must not be null.");
+        Misc.checkNotNull(results, "Changes results");
         this.lastSequence = lastSequence;
         this.results = results;
     }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/DatastoreManager.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/DatastoreManager.java
@@ -25,7 +25,7 @@ import com.cloudant.sync.notifications.DatabaseClosed;
 import com.cloudant.sync.notifications.DatabaseCreated;
 import com.cloudant.sync.notifications.DatabaseDeleted;
 import com.cloudant.sync.notifications.DatabaseOpened;
-import com.google.common.base.Preconditions;
+import com.cloudant.sync.util.Misc;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
@@ -252,7 +252,7 @@ public class DatastoreManager {
      */
     public Datastore openDatastore(String dbName, KeyProvider provider) throws
             DatastoreNotCreatedException {
-        Preconditions.checkArgument(dbName.matches(LEGAL_CHARACTERS),
+        Misc.checkArgument(dbName.matches(LEGAL_CHARACTERS),
                 "A database must be named with all lowercase letters (a-z), digits (0-9),"
                         + " or any of the _$()+-/ characters. The name has to start with a"
                         + " lowercase letter (a-z).");
@@ -291,7 +291,7 @@ public class DatastoreManager {
      * @see DatastoreManager#getEventBus() 
      */
     public void deleteDatastore(String dbName) throws IOException {
-        Preconditions.checkNotNull(dbName, "Datastore name must not be null");
+        Misc.checkNotNull(dbName, "Datastore name");
 
         synchronized (openedDatastores) {
             Datastore ds = openedDatastores.remove(dbName);

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/DocumentBodyImpl.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/DocumentBodyImpl.java
@@ -18,7 +18,7 @@
 package com.cloudant.sync.datastore;
 
 import com.cloudant.sync.util.JSONUtils;
-import com.google.common.base.Preconditions;
+import com.cloudant.sync.util.Misc;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -45,7 +45,8 @@ final class DocumentBodyImpl implements DocumentBody {
     }
 
     protected DocumentBodyImpl(Map map) {
-        Preconditions.checkArgument(map != null);
+        // Note uses checkArgument not checkNotNull to keep IllegalArgumentException not NPE
+        Misc.checkArgument(map != null, "Document body map must not be null.");
         if(JSONUtils.isValidJSON(map)) {
             this.map = map;
         } else {

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/DocumentRevisionTree.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/DocumentRevisionTree.java
@@ -15,9 +15,17 @@
 package com.cloudant.sync.datastore;
 
 import com.cloudant.sync.util.AbstractTreeNode;
-import com.google.common.base.Preconditions;
+import com.cloudant.sync.util.Misc;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
 
 /**
  * <p>Describes the document tree for a single
@@ -181,7 +189,7 @@ public class DocumentRevisionTree {
      * @return {@code DocumentRevisionTree} for method chaining
      */
     public DocumentRevisionTree add(DocumentRevision documentRevision) {
-        Preconditions.checkArgument(!sequenceMap.containsKey(documentRevision.getSequence()),
+        Misc.checkArgument(!sequenceMap.containsKey(documentRevision.getSequence()),
                 "The revision must not be added to the tree before.");
 
         if(documentNumericId == -1l && docId == null){
@@ -203,7 +211,7 @@ public class DocumentRevisionTree {
     }
 
     private void addRootDBObject(DocumentRevision documentRevision) {
-        Preconditions.checkArgument(documentRevision.getParent() <= 0,
+        Misc.checkArgument(documentRevision.getParent() <= 0,
                 "The added root DocumentRevision must be a valid root revision.");
 
         DocumentRevisionNode rootNode = new DocumentRevisionNode(documentRevision);
@@ -214,7 +222,7 @@ public class DocumentRevisionTree {
 
     private void addNode(DocumentRevision documentRevision) {
         long parentSequence = documentRevision.getParent();
-        Preconditions.checkArgument(sequenceMap.containsKey(parentSequence),
+        Misc.checkArgument(sequenceMap.containsKey(parentSequence),
             "The given revision's parent must be in the tree already.");
 
         DocumentRevisionNode parent = sequenceMap.get(parentSequence);
@@ -267,8 +275,8 @@ public class DocumentRevisionTree {
      * @return the child with a given revision ID of a {@code DocumentRevision}.
      */
     public DocumentRevision lookupChildByRevId(DocumentRevision parentNode, String childRevision) {
-        Preconditions.checkNotNull(parentNode, "Parent node must not be null.");
-        Preconditions.checkArgument(sequenceMap.containsKey(parentNode.getSequence()),
+        Misc.checkNotNull(parentNode, "Parent node");
+        Misc.checkArgument(sequenceMap.containsKey(parentNode.getSequence()),
                 "The given parent DocumentRevision must be in the tree.");
 
         DocumentRevisionNode p = sequenceMap.get(parentNode.getSequence());
@@ -414,7 +422,7 @@ public class DocumentRevisionTree {
      * to the root of the revision's tree.
      */
     public List<DocumentRevision> getPathForNode(long sequence) {
-        Preconditions.checkArgument(sequenceMap.containsKey(sequence),
+        Misc.checkArgument(sequenceMap.containsKey(sequence),
                 "DocumentRevision for that sequence must be in the tree already.");
         DocumentRevisionNode l = sequenceMap.get(sequence);
         List<DocumentRevision> r = new LinkedList<DocumentRevision>();

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/DocumentRevsList.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/DocumentRevsList.java
@@ -15,7 +15,7 @@
 package com.cloudant.sync.datastore;
 
 import com.cloudant.mazha.DocumentRevs;
-import com.google.common.base.Preconditions;
+import com.cloudant.sync.util.Misc;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -66,7 +66,7 @@ public class DocumentRevsList implements Iterable<DocumentRevs> {
     private final List<DocumentRevs> documentRevsList;
 
     public DocumentRevsList(List<DocumentRevs> list) {
-        Preconditions.checkNotNull(list, "DocumentRevs list must not be null");
+        Misc.checkNotNull(list, "DocumentRevs list");
         this.documentRevsList = new ArrayList<DocumentRevs>(list);
 
         // Order of the list decides which DocumentRevs is inserted first in bulkCreateDocs update.

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/DocumentRevsUtils.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/DocumentRevsUtils.java
@@ -16,8 +16,7 @@ package com.cloudant.sync.datastore;
 
 import com.cloudant.mazha.DocumentRevs;
 import com.cloudant.sync.util.CouchUtils;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
+import com.cloudant.sync.util.Misc;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -75,10 +74,8 @@ public class DocumentRevsUtils {
     }
 
     private static void validateDocumentRevs(DocumentRevs documentRevs) {
-        Preconditions.checkNotNull(documentRevs, "DocumentRevs must not be null.");
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(documentRevs.getId()),
-                "DocumentRevs.id must not be empty.");
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(documentRevs.getRev()),
-                "DocumentRevs.rev must not be empty.");
+        Misc.checkNotNull(documentRevs, "DocumentRevs");
+        Misc.checkNotNullOrEmpty(documentRevs.getId(), "DocumentRevs.id");
+        Misc.checkNotNullOrEmpty(documentRevs.getRev(), "DocumentRevs.rev");
     }
 }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/RevisionHistoryHelper.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/RevisionHistoryHelper.java
@@ -19,7 +19,7 @@ import com.cloudant.common.CouchConstants;
 import com.cloudant.mazha.DocumentRevs;
 import com.cloudant.sync.replication.PushAttachmentsInline;
 import com.cloudant.sync.util.CouchUtils;
-import com.google.common.base.Preconditions;
+import com.cloudant.sync.util.Misc;
 
 import org.apache.commons.io.IOUtils;
 
@@ -93,8 +93,8 @@ public class RevisionHistoryHelper {
      * @see com.cloudant.mazha.DocumentRevs
      */
     public static List<String> getRevisionPath(DocumentRevs documentRevs) {
-        Preconditions.checkNotNull(documentRevs, "History must not be null");
-        Preconditions.checkArgument(checkRevisionStart(documentRevs.getRevisions()),
+        Misc.checkNotNull(documentRevs, "History");
+        Misc.checkArgument(checkRevisionStart(documentRevs.getRevisions()),
                 "Revision start must be bigger than revision ids' length");
         List<String> path = new ArrayList<String>();
         int start = documentRevs.getRevisions().getStart();
@@ -145,9 +145,9 @@ public class RevisionHistoryHelper {
                                                             List<? extends Attachment> attachments,
                                                             boolean shouldInline,
                                                             int minRevPos) {
-        Preconditions.checkNotNull(history, "History must not be null");
-        Preconditions.checkArgument(history.size() > 0, "History must have at least one DocumentRevision.");
-        Preconditions.checkArgument(checkHistoryIsInDescendingOrder(history),
+        Misc.checkNotNull(history, "History");
+        Misc.checkArgument(history.size() > 0, "History must have at least one DocumentRevision.");
+        Misc.checkArgument(checkHistoryIsInDescendingOrder(history),
                 "History must be in descending order.");
 
         DocumentRevision currentNode = history.get(0);

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ChangesResultWrapper.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ChangesResultWrapper.java
@@ -15,7 +15,7 @@
 package com.cloudant.sync.replication;
 
 import com.cloudant.mazha.ChangesResult;
-import com.google.common.base.Preconditions;
+import com.cloudant.sync.util.Misc;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 
@@ -31,7 +31,7 @@ class ChangesResultWrapper {
     private final ChangesResult changes;
 
     public ChangesResultWrapper(ChangesResult changes) {
-        Preconditions.checkNotNull(changes, "Changes feed can not be null");
+        Misc.checkNotNull(changes, "Changes");
         this.changes = changes;
     }
 
@@ -49,9 +49,10 @@ class ChangesResultWrapper {
     }
 
     public Multimap<String, String> openRevisions(int start, int end) {
-        Preconditions.checkArgument(start >= 0, "Start position must be greater or equal to zero.");
-        Preconditions.checkArgument(end > start, "End position must be greater than start.");
-        Preconditions.checkArgument(end <= this.size(), "End position must be smaller than changes feed size.");
+        Misc.checkArgument(start >= 0, "Start position must be greater or equal to zero.");
+        Misc.checkArgument(end > start, "End position must be greater than start.");
+        Misc.checkArgument(end <= this.size(), "End position must be less than or equal to the " +
+                "changes feed size.");
 
         Multimap<String, String> openRevisions = HashMultimap.create();
         for(int i = start; i < end ; i ++) {

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/CouchClientWrapper.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/CouchClientWrapper.java
@@ -28,8 +28,7 @@ import com.cloudant.sync.datastore.DocumentRevision;
 import com.cloudant.sync.datastore.DocumentRevsList;
 import com.cloudant.sync.datastore.MultipartAttachmentWriter;
 import com.cloudant.sync.datastore.UnsavedStreamAttachment;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
+import com.cloudant.sync.util.Misc;
 
 import java.io.InputStream;
 import java.net.URI;
@@ -52,7 +51,7 @@ public class CouchClientWrapper implements CouchDB {
     final CouchClient couchClient;
 
     public CouchClientWrapper(CouchClient client) {
-        Preconditions.checkNotNull(client, "Couch client must not be null");
+        Misc.checkNotNull(client, "Couch client");
         this.couchClient = client;
     }
 
@@ -87,8 +86,7 @@ public class CouchClientWrapper implements CouchDB {
 
     @Override
     public String getCheckpoint(String checkpointId) {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(checkpointId),
-                "Checkpoint id must not be empty");
+        Misc.checkNotNullOrEmpty(checkpointId, "Checkpoint id");
         try {
             RemoteCheckpointDoc response = couchClient.getDocument(
                     getCheckpointLocalDocId(checkpointId), RemoteCheckpointDoc.class);
@@ -104,9 +102,8 @@ public class CouchClientWrapper implements CouchDB {
 
     @Override
     public void putCheckpoint(String checkpointId, String sequence) {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(checkpointId),
-                "Checkpoint id must not be empty");
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(sequence), "Sequence must not be empty");
+        Misc.checkNotNullOrEmpty(checkpointId, "Checkpoint id");
+        Misc.checkNotNullOrEmpty(sequence, "Sequence");
         String replicatorLocalDocId = getCheckpointLocalDocId(checkpointId);
         if (couchClient.contains(replicatorLocalDocId)) {
             updateCheckpoint(replicatorLocalDocId, sequence);

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/GetRevisionTaskBulk.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/GetRevisionTaskBulk.java
@@ -15,7 +15,7 @@
 package com.cloudant.sync.replication;
 
 import com.cloudant.sync.datastore.DocumentRevsList;
-import com.google.common.base.Preconditions;
+import com.cloudant.sync.util.Misc;
 
 import java.util.Iterator;
 import java.util.List;
@@ -68,11 +68,11 @@ class GetRevisionTaskBulk implements Iterable<DocumentRevsList> {
     public GetRevisionTaskBulk(CouchDB sourceDb,
                            List<BulkGetRequest> requests,
                            boolean pullAttachmentsInline) {
-        Preconditions.checkNotNull(sourceDb, "sourceDb cannot be null");
-        Preconditions.checkNotNull(requests, "requests cannot be null");
+        Misc.checkNotNull(sourceDb, "sourceDb");
+        Misc.checkNotNull(requests, "requests");
         for(BulkGetRequest request : requests) {
-            Preconditions.checkNotNull(request.id, "id cannot be null");
-            Preconditions.checkNotNull(request.revs, "revs cannot be null");
+            Misc.checkNotNull(request.id, "id");
+            Misc.checkNotNull(request.revs,"revs");
         }
         this.sourceDb = sourceDb;
         this.requests = requests;

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/GetRevisionTaskThreaded.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/GetRevisionTaskThreaded.java
@@ -15,7 +15,7 @@
 package com.cloudant.sync.replication;
 
 import com.cloudant.sync.datastore.DocumentRevsList;
-import com.google.common.base.Preconditions;
+import com.cloudant.sync.util.Misc;
 
 import java.util.Iterator;
 import java.util.List;
@@ -25,7 +25,6 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
@@ -109,11 +108,11 @@ class GetRevisionTaskThreaded implements Iterable<DocumentRevsList> {
     public GetRevisionTaskThreaded(CouchDB sourceDb,
                                    List<BulkGetRequest> requests,
                                    boolean pullAttachmentsInline) {
-        Preconditions.checkNotNull(sourceDb, "sourceDb cannot be null");
-        Preconditions.checkNotNull(requests, "requests cannot be null");
+        Misc.checkNotNull(sourceDb, "sourceDb");
+        Misc.checkNotNull(requests, "requests");
         for (BulkGetRequest request : requests) {
-            Preconditions.checkNotNull(request.id, "id cannot be null");
-            Preconditions.checkNotNull(request.revs, "revs cannot be null");
+            Misc.checkNotNull(request.id, "id");
+            Misc.checkNotNull(request.revs, "revs");
         }
 
         this.sourceDb = sourceDb;

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/PushStrategy.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/PushStrategy.java
@@ -32,7 +32,6 @@ import com.cloudant.sync.event.EventBus;
 import com.cloudant.sync.util.CollectionUtils;
 import com.cloudant.sync.util.JSONUtils;
 import com.cloudant.sync.util.Misc;
-import com.google.common.base.Strings;
 
 import org.apache.commons.codec.binary.Hex;
 
@@ -447,7 +446,7 @@ class PushStrategy implements ReplicationStrategy {
     private long getLastCheckpointSequence() throws DatastoreException {
         String lastSequence =  targetDb.getCheckpoint(this.getReplicationId());
         // As we are pretty sure the checkpoint is a number
-        return Strings.isNullOrEmpty(lastSequence) ? 0 : Long.parseLong(lastSequence);
+        return Misc.isStringNullOrEmpty(lastSequence) ? 0 : Long.parseLong(lastSequence);
     }
 
     private void putCheckpoint(String checkpoint) throws DatastoreException {

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ReplicatorImpl.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ReplicatorImpl.java
@@ -18,7 +18,7 @@ import com.cloudant.sync.event.EventBus;
 import com.cloudant.sync.event.Subscribe;
 import com.cloudant.sync.notifications.ReplicationCompleted;
 import com.cloudant.sync.notifications.ReplicationErrored;
-import com.google.common.base.Preconditions;
+import com.cloudant.sync.util.Misc;
 
 import java.util.Locale;
 
@@ -143,7 +143,7 @@ public class ReplicatorImpl implements Replicator {
      * Working thread are running when state is either STARTED or STOPPING.
      */
     private void assertRunningState() {
-        Preconditions.checkArgument(this.state == State.STARTED || this.state == State.STOPPING,
+        Misc.checkArgument(this.state == State.STARTED || this.state == State.STOPPING,
                 "Replicate state must be STARTED or STOPPING.");
     }
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/sqlite/SQLDatabaseFactory.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/sqlite/SQLDatabaseFactory.java
@@ -21,7 +21,6 @@ import com.cloudant.sync.datastore.encryption.KeyProvider;
 import com.cloudant.sync.datastore.migrations.Migration;
 import com.cloudant.sync.util.DatabaseUtils;
 import com.cloudant.sync.util.Misc;
-import com.google.common.base.Preconditions;
 
 import java.io.File;
 import java.io.IOException;
@@ -183,7 +182,7 @@ public class SQLDatabaseFactory {
      */
     public static void updateSchema(SQLDatabase database, Migration migration, int version)
             throws SQLException {
-        Preconditions.checkArgument(version > 0, "Schema version number must be positive");
+        Misc.checkArgument(version > 0, "Schema version number must be positive");
         // ensure foreign keys are enforced in the case that we are up to date and no migration happen
         database.execSQL("PRAGMA foreign_keys = ON;");
         int dbVersion = database.getVersion();

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/sqlite/sqlite4java/QueryBuilder.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/sqlite/sqlite4java/QueryBuilder.java
@@ -15,7 +15,7 @@
 package com.cloudant.sync.sqlite.sqlite4java;
 
 import com.cloudant.android.ContentValues;
-import com.google.common.base.Strings;
+import com.cloudant.sync.util.Misc;
 
 import java.util.ArrayList;
 import java.util.regex.Pattern;
@@ -45,7 +45,7 @@ public class QueryBuilder {
             i++;
         }
 
-        if (!Strings.isNullOrEmpty(whereClause)) {
+        if (!Misc.isStringNullOrEmpty(whereClause)) {
             query.append(" WHERE ");
             query.append(whereClause);
         }
@@ -83,11 +83,11 @@ public class QueryBuilder {
     public static String buildSelectQuery(String table, String[] columns, String where,
             String groupBy, String having, String orderBy, String limit) {
 
-        if (Strings.isNullOrEmpty(groupBy) && !Strings.isNullOrEmpty(having)) {
+        if (Misc.isStringNullOrEmpty(groupBy) && !Misc.isStringNullOrEmpty(having)) {
             throw new IllegalArgumentException(
                     "HAVING clauses are only permitted when using a groupBy clause");
         }
-        if (!Strings.isNullOrEmpty(limit) && !sLimitPattern.matcher(limit).matches()) {
+        if (!Misc.isStringNullOrEmpty(limit) && !sLimitPattern.matcher(limit).matches()) {
             throw new IllegalArgumentException("invalid LIMIT clauses:" + limit);
         }
 
@@ -147,7 +147,7 @@ public class QueryBuilder {
     }
 
     static void appendClause(StringBuilder s, String name, String clause) {
-        if (!Strings.isNullOrEmpty(clause)) {
+        if (!Misc.isStringNullOrEmpty(clause)) {
             s.append(name);
             s.append(clause);
         }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/util/CouchUtils.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/util/CouchUtils.java
@@ -14,8 +14,6 @@
 
 package com.cloudant.sync.util;
 
-import com.google.common.base.Strings;
-
 import java.util.List;
 import java.util.Map;
 
@@ -33,7 +31,7 @@ public class CouchUtils {
 
     public static boolean isValidDocumentId(String docId) {
         // http://wiki.apache.org/couch/HTTP_Document_API#Documents
-        if (Strings.isNullOrEmpty(docId)) {
+        if (Misc.isStringNullOrEmpty(docId)) {
             return false;
         }
 
@@ -91,7 +89,7 @@ public class CouchUtils {
     }
 
     public static boolean isValidRevisionId(String revisionId) {
-        if (Strings.isNullOrEmpty(revisionId)) {
+        if (Misc.isStringNullOrEmpty(revisionId)) {
             return false;
         }
         int dashPos = revisionId.indexOf("-");

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/util/Misc.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/util/Misc.java
@@ -81,4 +81,78 @@ public class Misc {
         }
         return builder.toString();
     }
+    /**
+     * Check that a parameter is not null and throw IllegalArgumentException with a message of
+     * errorMessagePrefix + " must not be null." if it is null, defaulting to "Parameter must not be
+     * null.".
+     *
+     * @param param              the parameter to check
+     * @param errorMessagePrefix the prefix of the error message to use for the
+     *                           IllegalArgumentException if the parameter was null
+     * @throws NullPointerException if the arg is null.
+     */
+    public static void checkNotNull(Object param, String errorMessagePrefix) throws
+            NullPointerException {
+        if (param == null) {
+            throw new NullPointerException((errorMessagePrefix != null ? errorMessagePrefix :
+                    "Parameter") + " must not be null.");
+        }
+    }
+
+    /**
+     * Check that a string parameter is not null or empty and throw IllegalArgumentException with a
+     * message of errorMessagePrefix + " must not be empty." if it is empty, defaulting to
+     * "Parameter must not be empty".
+     *
+     * @param param              the string to check
+     * @param errorMessagePrefix the prefix of the error message to use for the
+     *                           IllegalArgumentException if the parameter was null or empty
+     * @throws IllegalArgumentException if the string is null or empty
+     */
+    public static void checkNotNullOrEmpty(String param, String errorMessagePrefix) throws
+            IllegalArgumentException {
+        checkArgument(!isStringNullOrEmpty(param), (errorMessagePrefix != null ? errorMessagePrefix :
+                "Parameter") + " must not be " + param == null ? "null." : "empty.");
+    }
+
+    /**
+     * @param param the string to check
+     * @return true if the string is null or emtpy
+     */
+    public static boolean isStringNullOrEmpty(String param) {
+        if (param == null || param.isEmpty()) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Check an argument meets a condition and throw an IllegalArgumentException if it doesn't.
+     *
+     * @param argCondition the condition to check
+     * @param errorMessage the error message to use in the IllegalArgumentException
+     * @throws IllegalArgumentException if the argCondition is false
+     */
+    public static void checkArgument(boolean argCondition, String errorMessage) throws
+            IllegalArgumentException {
+        if (!argCondition) {
+            throw new IllegalArgumentException(errorMessage);
+        }
+    }
+
+    /**
+     * Check if a condition is true and throw an IllegalStateException with the given
+     * errorMessage if it is not.
+     *
+     * @param stateCheck   the state condition to check
+     * @param errorMessage the error string to add to the IllegalStateException
+     * @throws IllegalStateException if the stateCheck is false
+     */
+    public static void checkState(boolean stateCheck, String errorMessage) throws
+            IllegalStateException {
+        if (!stateCheck) {
+            throw new IllegalStateException(errorMessage);
+        }
+    }
 }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/mazha/CouchClientBasicTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/mazha/CouchClientBasicTest.java
@@ -14,11 +14,15 @@
 
 package com.cloudant.mazha;
 
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.startsWith;
+
 import com.cloudant.common.CollectionFactory;
 import com.cloudant.common.CouchConstants;
 import com.cloudant.common.RequireRunningCouchDB;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
+import com.cloudant.sync.util.Misc;
+
 import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
 import org.junit.Ignore;
@@ -32,10 +36,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.CoreMatchers.hasItems;
-import static org.hamcrest.CoreMatchers.startsWith;
 
 @Category(RequireRunningCouchDB.class)
 public class CouchClientBasicTest extends CouchClientTestBase {
@@ -97,7 +97,7 @@ public class CouchClientBasicTest extends CouchClientTestBase {
         String dbName = "mazha_test_deletedb_not_exist";
         CouchConfig config = getCouchConfig(dbName);
         CouchClient customClient = new CouchClient(config.getRootUri(), config.getRequestInterceptors(), config.getResponseInterceptors());
-        Preconditions.checkArgument(!isDbExist(dbName), "%s must not exist", dbName);
+        Misc.checkArgument(!isDbExist(dbName), String.format("%s must not exist", dbName));
         customClient.deleteDb();
     }
 
@@ -120,7 +120,7 @@ public class CouchClientBasicTest extends CouchClientTestBase {
         String dbName = "mazha_test_getdbinfo_dbnotexist";
         CouchConfig config = getCouchConfig(dbName);
         CouchClient customClient = new CouchClient(config.getRootUri(), config.getRequestInterceptors(), config.getResponseInterceptors());
-        Preconditions.checkArgument(!isDbExist(dbName), "%s must not exist", dbName);
+        Misc.checkArgument(!isDbExist(dbName), String.format("%s must not exist", dbName));
         customClient.getDbInfo();
     }
 
@@ -152,8 +152,8 @@ public class CouchClientBasicTest extends CouchClientTestBase {
         doc.put(CouchConstants._id, "SomeUniqueId");
 
         Response res = client.create(doc);
-        Assert.assertTrue(!Strings.isNullOrEmpty(res.getId()));
-        Assert.assertTrue(!Strings.isNullOrEmpty(res.getRev()));
+        Assert.assertTrue(!Misc.isStringNullOrEmpty(res.getId()));
+        Assert.assertTrue(!Misc.isStringNullOrEmpty(res.getRev()));
     }
 
     @Test(expected = DocumentConflictException.class)
@@ -163,8 +163,8 @@ public class CouchClientBasicTest extends CouchClientTestBase {
 
         {
             Response res = client.create(doc);
-            Assert.assertTrue(!Strings.isNullOrEmpty(res.getId()));
-            Assert.assertTrue(!Strings.isNullOrEmpty(res.getRev()));
+            Assert.assertTrue(!Misc.isStringNullOrEmpty(res.getId()));
+            Assert.assertTrue(!Misc.isStringNullOrEmpty(res.getRev()));
         }
 
         {

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/mazha/HttpRequestsTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/mazha/HttpRequestsTest.java
@@ -19,7 +19,7 @@ import com.cloudant.common.RequireRunningCouchDB;
 import com.cloudant.common.TestOptions;
 import com.cloudant.http.HttpConnectionInterceptorContext;
 import com.cloudant.http.HttpConnectionRequestInterceptor;
-import com.google.common.base.Strings;
+import com.cloudant.sync.util.Misc;
 
 import org.apache.commons.codec.binary.Base64;
 import org.junit.Assert;
@@ -88,7 +88,7 @@ public class HttpRequestsTest extends CouchClientTestBase {
         // in admin party mode)
         org.junit.Assume.assumeTrue("Test skipped because Basic Auth credentials are required to " +
                         "access this server",
-                TestOptions.COOKIE_AUTH && Strings.isNullOrEmpty(customCouchConfig.getRootUri().getUserInfo()));
+                TestOptions.COOKIE_AUTH && Misc.isStringNullOrEmpty(customCouchConfig.getRootUri().getUserInfo()));
 
         try {
             String authString = "foo:bar";

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/mazha/matcher/IsNotEmpty.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/mazha/matcher/IsNotEmpty.java
@@ -14,7 +14,8 @@
 
 package com.cloudant.mazha.matcher;
 
-import com.google.common.base.Strings;
+import com.cloudant.sync.util.Misc;
+
 import org.hamcrest.Description;
 import org.hamcrest.Factory;
 import org.hamcrest.Matcher;
@@ -24,7 +25,7 @@ public class IsNotEmpty extends TypeSafeMatcher<String> {
 
     @Override
     protected boolean matchesSafely(String item) {
-        return !Strings.isNullOrEmpty(item);
+        return !Misc.isStringNullOrEmpty(item);
     }
 
     @Override

--- a/cloudant-sync-datastore-javase/src/main/java/com/cloudant/sync/sqlite/sqlite4java/SQLiteWrapper.java
+++ b/cloudant-sync-datastore-javase/src/main/java/com/cloudant/sync/sqlite/sqlite4java/SQLiteWrapper.java
@@ -19,8 +19,7 @@ import com.almworks.sqlite4java.SQLiteException;
 import com.almworks.sqlite4java.SQLiteStatement;
 import com.cloudant.android.ContentValues;
 import com.cloudant.sync.sqlite.SQLDatabase;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
+import com.cloudant.sync.util.Misc;
 
 import java.io.File;
 import java.sql.SQLException;
@@ -124,7 +123,7 @@ public class SQLiteWrapper extends SQLDatabase {
 
     @Override
     public void beginTransaction() {
-        Preconditions.checkState(this.isOpen(), "db must be open");
+        Misc.checkState(this.isOpen(), "db must be open");
 
         // All transaction state variables are thread-local,
         // so we don't have to lock.
@@ -152,8 +151,8 @@ public class SQLiteWrapper extends SQLDatabase {
 
     @Override
     public void endTransaction() {
-        Preconditions.checkState(this.isOpen(), "db must be open");
-        Preconditions.checkState(this.transactionStack.size() >= 1,
+        Misc.checkState(this.isOpen(), "db must be open");
+        Misc.checkState(this.transactionStack.size() >= 1,
                 "TransactionStatus stack must not be empty");
 
         // All transaction state variables are thread-local,
@@ -187,7 +186,7 @@ public class SQLiteWrapper extends SQLDatabase {
 
     @Override
     public void setTransactionSuccessful() {
-        Preconditions.checkState(this.isOpen(), "db must be open");
+        Misc.checkState(this.isOpen(), "db must be open");
 
         // Pop the false value off and replace it with true.
         // As the stack is thread-local, this is thread-safe
@@ -209,8 +208,7 @@ public class SQLiteWrapper extends SQLDatabase {
 
     @Override
     public void execSQL(String sql) throws SQLException {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(sql.trim()),
-                "Input SQL can not be empty String.");
+        Misc.checkNotNullOrEmpty(sql.trim(), "Input SQL");
         try {
             getConnection().exec(sql);
         } catch (SQLiteException e) {
@@ -220,8 +218,7 @@ public class SQLiteWrapper extends SQLDatabase {
 
     @Override
     public void execSQL(String sql, Object[] bindArgs) throws SQLException {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(sql.trim()),
-                "Input SQL can not be empty String.");
+        Misc.checkNotNullOrEmpty(sql.trim(), "Input SQL");
         SQLiteStatement stmt = null;
         try {
             stmt = this.getConnection().prepare(sql);
@@ -268,7 +265,7 @@ public class SQLiteWrapper extends SQLDatabase {
             String sql = new StringBuilder("DELETE FROM \"")
                     .append(table)
                     .append("\"")
-                    .append(!Strings.isNullOrEmpty(whereClause) ? " WHERE " +
+                    .append(!Misc.isStringNullOrEmpty(whereClause) ? " WHERE " +
                             whereClause : "")
                     .toString();
             this.executeSQLStatement(sql, whereArgs);

--- a/cloudant-sync-datastore-javase/src/test/java/com/cloudant/sync/sqlite/sqlite4java/SQLiteWrapperTest.java
+++ b/cloudant-sync-datastore-javase/src/test/java/com/cloudant/sync/sqlite/sqlite4java/SQLiteWrapperTest.java
@@ -19,9 +19,9 @@ import com.almworks.sqlite4java.SQLiteException;
 import com.cloudant.android.ContentValues;
 import com.cloudant.sync.sqlite.Cursor;
 import com.cloudant.sync.sqlite.SQLDatabase;
+import com.cloudant.sync.util.Misc;
 import com.cloudant.sync.util.SQLDatabaseTestUtils;
 import com.cloudant.sync.util.TestUtils;
-import com.google.common.base.Strings;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -492,7 +492,7 @@ public class SQLiteWrapperTest {
         cursor.moveToNext();
         Assert.assertTrue(2 == cursor.getInt(0));
         Assert.assertTrue("haha".equals(cursor.getString(1)));
-        Assert.assertTrue(Strings.isNullOrEmpty(cursor.getString(2)));
+        Assert.assertTrue(Misc.isStringNullOrEmpty(cursor.getString(2)));
         Assert.assertEquals(-0.09999f, cursor.getFloat(3), 0.000001f);
         Assert.assertTrue(Arrays.equals("this is another blob".getBytes(), cursor.getBlob(4)));
     }

--- a/sample/todo-sync/src/com/cloudant/todo/TaskAdapter.java
+++ b/sample/todo-sync/src/com/cloudant/todo/TaskAdapter.java
@@ -16,8 +16,6 @@ package com.cloudant.todo;
 
 import java.util.List;
 
-import com.google.common.base.Preconditions;
-
 import android.content.Context;
 import android.database.DataSetObserver;
 import android.view.LayoutInflater;
@@ -35,8 +33,12 @@ public class TaskAdapter extends BaseAdapter implements ListAdapter {
     private final List<Task> tasks;
 
     public TaskAdapter(Context context, List<Task> tasks) {
-        Preconditions.checkNotNull(context);
-        Preconditions.checkNotNull(tasks);
+        if (context == null) {
+            throw new IllegalArgumentException("Context must not be null.")
+        }
+        if (tasks == null) {
+            throw new IllegalArgumentException("List of tasks must not be null.")
+        }
         this.context = context;
         this.tasks = tasks;
     }


### PR DESCRIPTION
*What*

Replaced usages of Guava's `Preconditions` and `Strings`.

*How*

* Added `Misc` methods:
    * Added checkNotNull
    * Added checkNotNullOrEmpty
    * Added checkState
    * Added isStringNullOrEmpty
    * Added checkArgument
* Replaced `Precondition.checkNotNull` with `Misc.checkNotNull`:
    * Updated messages to only take a prefix.
    * Replaced Precondition with a  null check in the sample app instead of trying to use Guava or the internal utility.
* Replaced `Preconditions.checkArgument(!Strings.isNullOrEmpty(arg))` with
`Misc.checkNotNullOrEmpty`:
    * Updated messages to only take a prefix.
* Replaced usages of `Strings.isNullOrEmpty` with `Misc.isStringNullOrEmpty`
* Replaced `Precondtion.checkState` with `Misc.checkState`
* Replaced `Precondition.checkArgument` with `Misc.checkArgument`

*Testing*

No new tests, existing tests pass.

*Issues*

Part of #308