### PR TITLE
291 refactor datastore callables part 3

### DIFF
--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/AttachmentManager.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/AttachmentManager.java
@@ -197,7 +197,7 @@ public class AttachmentManager {
      * @throws AttachmentException if there was an error preparing the attachment, e.g., reading
      *                  attachment data.
      */
-    protected static PreparedAttachment prepareAttachment(String attachmentsDir,
+    public static PreparedAttachment prepareAttachment(String attachmentsDir,
                                                           AttachmentStreamFactory attachmentStreamFactory,
                                                           Attachment attachment)
             throws AttachmentException {
@@ -232,7 +232,7 @@ public class AttachmentManager {
      * @param attachments Attachments to search.
      * @return List of attachments which already exist in the attachment store, or an empty list if none.
      */
-    protected static List<SavedAttachment> findExistingAttachments(
+    public static List<SavedAttachment> findExistingAttachments(
             Collection<? extends Attachment> attachments) {
         ArrayList<SavedAttachment> list = new ArrayList<SavedAttachment>();
         for (Attachment a : attachments) {
@@ -249,7 +249,7 @@ public class AttachmentManager {
      * @param attachments Attachments to search.
      * @return List of attachments which need adding to the attachment store, or an empty list if none.
      */
-    protected static List<Attachment> findNewAttachments(Collection<? extends Attachment> attachments) {
+    public static List<Attachment> findNewAttachments(Collection<? extends Attachment> attachments) {
         ArrayList<Attachment> list = new ArrayList<Attachment>();
         for (Attachment a : attachments) {
             if (!(a instanceof SavedAttachment)) {
@@ -263,12 +263,13 @@ public class AttachmentManager {
      * Download each attachment in {@code attachments} to a temporary location, and
      * return a list of attachments suitable for passing to {@code setAttachments}.
      *
-     * Typically {@code attachments} is found via a call to {@see findNewAttachments}.
+     * Typically {@code attachments} is found via a call to {@link #findNewAttachments}.
      *
      * @param attachments List of attachments to prepare.
      * @return Attachments prepared for inserting into attachment store.
+     * @see #findNewAttachments
      */
-    protected static List<PreparedAttachment> prepareAttachments(String attachmentsDir,
+    public static List<PreparedAttachment> prepareAttachments(String attachmentsDir,
                                                                  AttachmentStreamFactory attachmentStreamFactory,
                                                                  List<Attachment> attachments)
         throws AttachmentException {
@@ -393,7 +394,7 @@ public class AttachmentManager {
      * @param newSequence identifies sequence number of revision to copy attachment data to
      * @param filename filename of attachment to copy
      */
-    protected static void copyAttachment(SQLDatabase db, long parentSequence, long newSequence,
+    public static void copyAttachment(SQLDatabase db, long parentSequence, long newSequence,
                                          String filename) throws SQLException {
         Cursor c = null;
         try{
@@ -409,7 +410,7 @@ public class AttachmentManager {
      * Called by BasicDatastore on the execution queue, this needs have the db passed ot it
      * @param db database to purge attachments from
      */
-    protected static void purgeAttachments(SQLDatabase db, String attachmentsDir) {
+    public static void purgeAttachments(SQLDatabase db, String attachmentsDir) {
         // it's easier to deal with Strings since java doesn't know how to compare byte[]s
         Set<String> currentKeys = new HashSet<String>();
         Cursor c = null;

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/Changes.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/Changes.java
@@ -35,7 +35,22 @@ public class Changes {
 
     private final List<DocumentRevision> results;
 
-    protected Changes(long lastSequence, List<DocumentRevision> results) {
+    /**
+     * <p>
+     * Construct a list of changes
+     * </p>
+     * <p>
+     * Note that this constructor is for internal use. To get a set of changes from a given sequence
+     * number, use {@link com.cloudant.sync.datastore.Datastore#changes}
+     * </p>
+     * @param lastSequence the last sequence number of this change set
+     * @param results the list of {@code DocumentRevision}s in this change set
+     *
+     * @see com.cloudant.sync.datastore.Datastore#changes
+     *
+     * @api_private
+     */
+    public Changes(long lastSequence, List<DocumentRevision> results) {
         Misc.checkNotNull(results, "Changes results");
         this.lastSequence = lastSequence;
         this.results = results;

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/DatastoreException.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/DatastoreException.java
@@ -24,16 +24,15 @@ public class DatastoreException extends Exception {
     public DatastoreException(){
 
     }
-
     public DatastoreException(String message){
         super(message);
     }
 
-    public DatastoreException(Exception causedBy){
+    public DatastoreException(Throwable causedBy){
         super(causedBy);
     }
 
-    public DatastoreException(String message, Exception causedBy){
+    public DatastoreException(String message, Throwable causedBy){
         super(message,causedBy);
     }
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/DocumentException.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/DocumentException.java
@@ -31,11 +31,11 @@ public class DocumentException extends Exception {
         super(message);
     }
 
-    public DocumentException(Exception causedBy){
+    public DocumentException(Throwable causedBy){
         super(causedBy);
     }
 
-    public DocumentException(String message,Exception causedBy){
+    public DocumentException(String message,Throwable causedBy){
         super(message,causedBy);
     }
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/DocumentNotFoundException.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/DocumentNotFoundException.java
@@ -47,11 +47,11 @@ public class DocumentNotFoundException extends DocumentException {
         super(s);
     }
 
-    public DocumentNotFoundException(String s, Exception e) {
+    public DocumentNotFoundException(String s, Throwable e) {
         super(s, e);
     }
 
-    public DocumentNotFoundException(String docId,String revId, Exception e){
+    public DocumentNotFoundException(String docId,String revId, Throwable e){
         super(createMessage(docId, revId),e);
     }
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/DocumentRevision.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/DocumentRevision.java
@@ -312,6 +312,16 @@ public class DocumentRevision implements Comparable<DocumentRevision> {
         }
     }
 
+    /**
+     * @return Whether the body has been modified since this DocumentRevision was constructed or
+     * retrieved from the Datastore. For internal use only.
+     *
+     * @api_private
+     */
+    public boolean isBodyModified() {
+        return bodyModified;
+    }
+
     @Override
     public String toString() {
         return "{ id: " + this.id + ", rev: " + this.revision + ", seq: " + sequence + ", parent: " + parent + ", current: " + current + ", deleted " + deleted +" }";

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/ChangesCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/ChangesCallable.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.datastore.callables;
+
+import com.cloudant.sync.datastore.AttachmentStreamFactory;
+import com.cloudant.sync.datastore.Changes;
+import com.cloudant.sync.datastore.DatastoreImpl;
+import com.cloudant.sync.datastore.DocumentRevision;
+import com.cloudant.sync.sqlite.Cursor;
+import com.cloudant.sync.sqlite.SQLCallable;
+import com.cloudant.sync.sqlite.SQLDatabase;
+import com.cloudant.sync.util.DatabaseUtils;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Return the list of changes to the datastore, starting at a given `since` sequence value, limited
+ * to a maximum number of `limit` changes
+ *
+ * @api_private
+ */
+public class ChangesCallable implements SQLCallable<Changes> {
+
+    private long since;
+    private int limit;
+
+    private String attachmentsDir;
+    private AttachmentStreamFactory attachmentStreamFactory;
+
+    /**
+     * @param since Starting sequence number to retrieve changes from
+     * @param limit Maximum number of changes to retrieve
+     * @param attachmentsDir          Location of attachments
+     * @param attachmentStreamFactory Factory to manage access to attachment streams
+     */
+    public ChangesCallable(long since, int limit, String attachmentsDir, AttachmentStreamFactory
+            attachmentStreamFactory) {
+        this.since = since;
+        this.limit = limit;
+        this.attachmentsDir = attachmentsDir;
+        this.attachmentStreamFactory = attachmentStreamFactory;
+    }
+
+    @Override
+    public Changes call(SQLDatabase db) throws Exception {
+
+        String[] args = {Long.toString(since), Long.toString(since +
+                limit)};
+        Cursor cursor = null;
+        try {
+            Long lastSequence = since;
+            List<Long> ids = new ArrayList<Long>();
+            cursor = db.rawQuery(DatastoreImpl.SQL_CHANGE_IDS_SINCE_LIMIT, args);
+            while (cursor.moveToNext()) {
+                ids.add(cursor.getLong(0));
+                lastSequence = Math.max(lastSequence, cursor.getLong(1));
+            }
+            List<DocumentRevision> results = new GetDocumentsWithInternalIdsCallable(ids, attachmentsDir, attachmentStreamFactory).call(db);
+            if (results.size() != ids.size()) {
+                throw new IllegalStateException(String.format(Locale.ENGLISH,
+                        "The number of documents does not match number of ids, " +
+                                "something must be wrong here. Number of IDs: %s, " +
+                                "number of documents: %s",
+                        ids.size(),
+                        results.size()
+                ));
+            }
+
+            return new Changes(lastSequence, results);
+        } catch (SQLException e) {
+            throw new IllegalStateException("Error querying all changes since: " +
+                    since + ", limit: " + limit, e);
+        } finally {
+            DatabaseUtils.closeCursorQuietly(cursor);
+        }
+    }
+
+}

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/CompactCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/CompactCallable.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.datastore.callables;
+
+import com.cloudant.android.ContentValues;
+import com.cloudant.sync.datastore.AttachmentManager;
+import com.cloudant.sync.datastore.DatastoreImpl;
+import com.cloudant.sync.sqlite.SQLCallable;
+import com.cloudant.sync.sqlite.SQLDatabase;
+
+import java.util.logging.Logger;
+
+/**
+ * Compact datastore by deleting JSON and attachments of non-leaf revisions
+ * @api_private
+ */
+public class CompactCallable implements SQLCallable<Void> {
+
+    private static final Logger logger = Logger.getLogger(DatastoreImpl.class.getCanonicalName());
+
+    private String attachmentsDir;
+
+    public CompactCallable(String attachmentsDir) {
+        this.attachmentsDir = attachmentsDir;
+    }
+
+    @Override
+    public Void call(SQLDatabase db) throws Exception {
+        logger.finer("Deleting JSON of old revisions...");
+
+        // set json = null for non-leaf nodes
+        ContentValues args = new ContentValues();
+        args.put("json", (String) null);
+        int revsCompacted = db.update("revs", args, "sequence IN (SELECT parent FROM revs)", null);
+        logger.finer(String.format("Compacted %d revisions", revsCompacted));
+
+        logger.finer("Deleting old attachments...");
+
+        // delete attachments not referenced by leaf nodes
+        AttachmentManager.purgeAttachments(db, attachmentsDir);
+
+        // issue SQL vacuum
+        logger.finer("Vacuuming SQLite database...");
+        db.compactDatabase();
+        return null;
+
+    }
+}

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/DeleteAllRevisionsCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/DeleteAllRevisionsCallable.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.datastore.callables;
+
+import com.cloudant.sync.datastore.ConflictException;
+import com.cloudant.sync.datastore.DatastoreException;
+import com.cloudant.sync.datastore.DocumentNotFoundException;
+import com.cloudant.sync.datastore.DocumentRevision;
+import com.cloudant.sync.sqlite.Cursor;
+import com.cloudant.sync.sqlite.SQLCallable;
+import com.cloudant.sync.sqlite.SQLDatabase;
+import com.cloudant.sync.util.DatabaseUtils;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Delete all Revisions for a given Document ID
+ *
+ * @api_private
+ */
+public class DeleteAllRevisionsCallable implements SQLCallable<List<DocumentRevision>> {
+
+    private String id;
+
+    public DeleteAllRevisionsCallable(String id) {
+        this.id = id;
+    }
+
+    @Override
+    public List<DocumentRevision> call(SQLDatabase db) throws DatastoreException, ConflictException,
+            DocumentNotFoundException {
+
+        ArrayList<DocumentRevision> deleted = new ArrayList<DocumentRevision>();
+        Cursor cursor = null;
+        // delete all in one tx
+        try {
+            // get revid for each leaf
+            final String sql = "SELECT revs.revid FROM docs,revs " +
+                    "WHERE revs.doc_id = docs.doc_id " +
+                    "AND docs.docid = ? " +
+                    "AND deleted = 0 AND revs.sequence NOT IN " +
+                    "(SELECT DISTINCT parent FROM revs WHERE parent NOT NULL) ";
+
+            cursor = db.rawQuery(sql, new String[]{id});
+            while (cursor.moveToNext()) {
+                String revId = cursor.getString(0);
+                deleted.add(new DeleteDocumentCallable(id, revId).call(db));
+            }
+            return deleted;
+        } catch (SQLException sqe) {
+            throw new DatastoreException("SQLException in deleteDocument, not " +
+                    "deleting revisions", sqe);
+        } finally {
+            DatabaseUtils.closeCursorQuietly(cursor);
+        }
+    }
+}

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/DeleteLocalDocumentCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/DeleteLocalDocumentCallable.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.datastore.callables;
+
+import com.cloudant.sync.datastore.DocumentNotFoundException;
+import com.cloudant.sync.datastore.LocalDocument;
+import com.cloudant.sync.sqlite.SQLCallable;
+import com.cloudant.sync.sqlite.SQLDatabase;
+
+/**
+ * Delete a local (non-replicated) Document
+ *
+ * @api_private
+ */
+public class DeleteLocalDocumentCallable implements SQLCallable<Void> {
+
+    private String docId;
+
+    public DeleteLocalDocumentCallable(String docId) {
+        this.docId = docId;
+    }
+
+    @Override
+    public Void call(SQLDatabase db) throws DocumentNotFoundException {
+        String[] whereArgs = {docId};
+        int rowsDeleted = db.delete("localdocs", "docid=? ", whereArgs);
+        if (rowsDeleted == 0) {
+            throw new DocumentNotFoundException(docId, (String) null);
+        }
+        return null;
+    }
+}

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/DoForceInsertExistingDocumentWithHistoryCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/DoForceInsertExistingDocumentWithHistoryCallable.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.datastore.callables;
+
+import com.cloudant.sync.datastore.AttachmentException;
+import com.cloudant.sync.datastore.AttachmentStreamFactory;
+import com.cloudant.sync.datastore.DatastoreException;
+import com.cloudant.sync.datastore.DatastoreImpl;
+import com.cloudant.sync.datastore.DocumentNotFoundException;
+import com.cloudant.sync.datastore.DocumentRevision;
+import com.cloudant.sync.sqlite.SQLCallable;
+import com.cloudant.sync.sqlite.SQLDatabase;
+import com.cloudant.sync.util.Misc;
+
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+
+/**
+ * Force insert a Revision where the Document already exists in the local database (ie at least one
+ * Revision already exists)
+ *
+ * @api_private
+ */
+public class DoForceInsertExistingDocumentWithHistoryCallable implements SQLCallable<Long> {
+
+    private static final Logger logger = Logger.getLogger(DatastoreImpl.class.getCanonicalName());
+
+    private DocumentRevision newRevision;
+    private long docNumericId;
+    private List<String> revisions;
+    private Map<String, Object> attachments;
+
+    private String attachmentsDir;
+    private AttachmentStreamFactory attachmentStreamFactory;
+
+    /**
+     *
+     * @param newRevision DocumentRevision to insert
+     * @param revisions   revision history to insert, it includes all revisions (include the
+     *                    revision of the DocumentRevision
+     *                    as well) sorted in ascending order.
+     */
+    public DoForceInsertExistingDocumentWithHistoryCallable(DocumentRevision newRevision, long
+            docNumericId, List<String> revisions, Map<String, Object> attachments, String
+            attachmentsDir, AttachmentStreamFactory attachmentStreamFactory) {
+        this.newRevision = newRevision;
+        this.docNumericId = docNumericId;
+        this.revisions = revisions;
+        this.attachments = attachments;
+        this.attachmentsDir = attachmentsDir;
+        this.attachmentStreamFactory = attachmentStreamFactory;
+    }
+
+    @Override
+    public Long call(SQLDatabase db) throws AttachmentException, DocumentNotFoundException, DatastoreException {
+
+        logger.entering("BasicDatastore",
+                "doForceInsertExistingDocumentWithHistory",
+                new Object[]{newRevision, revisions, attachments});
+        Misc.checkNotNull(newRevision, "New document revision");
+        Misc.checkArgument(new GetDocumentCallable(newRevision.getId(), null, attachmentsDir, attachmentStreamFactory).call(db) !=
+                null, "DocumentRevisionTree must exist.");
+        Misc.checkNotNull(revisions, "Revision history");
+        Misc.checkArgument(revisions.size() > 0, "Revision history should have at least " +
+                "one revision.");
+
+        // do we have a common ancestor?
+        long ancestorSequence = new GetSequenceCallable(newRevision.getId(), revisions.get(0)).call(db);
+
+        long sequence;
+
+        if (ancestorSequence == -1) {
+            sequence = new InsertDocumentHistoryToNewTreeCallable(newRevision, revisions, docNumericId).call(db);
+        } else {
+            sequence = new InsertDocumentHistoryIntoExistingTreeCallable(newRevision, revisions,
+                    docNumericId, attachments).call(db);
+        }
+        return sequence;
+    }
+}

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/DoForceInsertNewDocumentWithHistoryCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/DoForceInsertNewDocumentWithHistoryCallable.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.datastore.callables;
+
+import com.cloudant.sync.datastore.AttachmentException;
+import com.cloudant.sync.datastore.DatastoreException;
+import com.cloudant.sync.datastore.DatastoreImpl;
+import com.cloudant.sync.datastore.DocumentRevision;
+import com.cloudant.sync.sqlite.SQLCallable;
+import com.cloudant.sync.sqlite.SQLDatabase;
+
+import java.util.List;
+import java.util.logging.Logger;
+
+/**
+ * Force insert a Revision where the Document does not exist in the local database (ie no Revisions
+ * exist). Since there is no Revision tree (yet), build the initial tree by creating stub Revisions
+ * as described by `revHistory` and make `rev` the leaf node of this linear "tree".
+ *
+ * @api_private
+ */
+public class DoForceInsertNewDocumentWithHistoryCallable implements SQLCallable<Long> {
+
+    private static final Logger logger = Logger.getLogger(DatastoreImpl.class.getCanonicalName());
+
+    private DocumentRevision rev;
+    private List<String> revHistory;
+
+    /**
+     * @param rev        DocumentRevision to insert
+     * @param revHistory revision history to insert, it includes all revisions (include the
+     *                   revision of the DocumentRevision
+     *                   as well) sorted in ascending order.
+     */
+    public DoForceInsertNewDocumentWithHistoryCallable(DocumentRevision rev, List<String>
+            revHistory) {
+        this.rev = rev;
+        this.revHistory = revHistory;
+    }
+
+    @Override
+    public Long call(SQLDatabase db) throws AttachmentException, DatastoreException {
+        logger.entering("DocumentRevision",
+                "doForceInsertNewDocumentWithHistory()",
+                new Object[]{rev, revHistory});
+
+        long docNumericID = new InsertDocumentIDCallable(rev.getId()).call(db);
+        long parentSequence = 0L;
+        for (int i = 0; i < revHistory.size() - 1; i++) {
+            // Insert stub node
+            parentSequence = DatastoreImpl.insertStubRevisionAdaptor(docNumericID, revHistory.get(i),
+                    parentSequence).call(db);
+        }
+        // Insert the leaf node (don't copy attachments)
+        InsertRevisionCallable callable = new InsertRevisionCallable();
+        callable.docNumericId = docNumericID;
+        callable.revId = revHistory.get(revHistory.size() - 1);
+        callable.parentSequence = parentSequence;
+        callable.deleted = rev.isDeleted();
+        callable.current = true;
+        callable.data = rev.getBody().asBytes();
+        callable.available = true;
+        long sequence = callable.call(db);
+        return sequence;
+    }
+}

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/ForceInsertCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/ForceInsertCallable.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (C) 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.datastore.callables;
+
+import com.cloudant.android.Base64InputStreamFactory;
+import com.cloudant.sync.datastore.AttachmentManager;
+import com.cloudant.sync.datastore.AttachmentStreamFactory;
+import com.cloudant.sync.datastore.DatastoreException;
+import com.cloudant.sync.datastore.DatastoreImpl;
+import com.cloudant.sync.datastore.DocumentNotFoundException;
+import com.cloudant.sync.datastore.DocumentRevision;
+import com.cloudant.sync.datastore.ForceInsertItem;
+import com.cloudant.sync.datastore.PreparedAttachment;
+import com.cloudant.sync.datastore.UnsavedStreamAttachment;
+import com.cloudant.sync.notifications.DocumentCreated;
+import com.cloudant.sync.notifications.DocumentModified;
+import com.cloudant.sync.notifications.DocumentUpdated;
+import com.cloudant.sync.sqlite.SQLCallable;
+import com.cloudant.sync.sqlite.SQLDatabase;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Force insert a list of items (Revisions) obtained by pull Replication into the local database
+ *
+ * @api_private
+ */
+public class ForceInsertCallable implements SQLCallable<List<DocumentModified>> {
+
+    private static final Logger logger = Logger.getLogger(DatastoreImpl.class.getCanonicalName());
+
+    private List<ForceInsertItem> items;
+
+    private String attachmentsDir;
+    private AttachmentStreamFactory attachmentStreamFactory;
+
+    public ForceInsertCallable(List<ForceInsertItem> items, String attachmentsDir,
+                               AttachmentStreamFactory attachmentStreamFactory) {
+        this.items = items;
+        this.attachmentsDir = attachmentsDir;
+        this.attachmentStreamFactory = attachmentStreamFactory;
+    }
+
+    @Override
+    public List<DocumentModified> call(SQLDatabase db) throws Exception {
+
+        List<DocumentModified> events = new ArrayList<DocumentModified>();
+
+        for (ForceInsertItem item : items) {
+
+            logger.finer("forceInsert(): " + item.rev.toString());
+
+            DocumentCreated documentCreated = null;
+            DocumentUpdated documentUpdated = null;
+
+            boolean ok = true;
+
+            long docNumericId = new GetNumericIdCallable(item.rev.getId()).call(db);
+            long seq = 0;
+
+            if (docNumericId != -1) {
+                seq = new DoForceInsertExistingDocumentWithHistoryCallable(item.rev,
+                        docNumericId, item.revisionHistory,
+                        item.attachments, attachmentsDir, attachmentStreamFactory).call(db);
+                item.rev.initialiseSequence(seq);
+                // TODO fetch the parent doc?
+                documentUpdated = new DocumentUpdated(null, item.rev);
+            } else {
+                seq = new DoForceInsertNewDocumentWithHistoryCallable(item.rev, item
+                        .revisionHistory).call(db);
+                item.rev.initialiseSequence(seq);
+                documentCreated = new DocumentCreated(item.rev);
+            }
+
+            // now deal with any attachments
+            if (item.pullAttachmentsInline) {
+                if (item.attachments != null) {
+                    for (String att : item.attachments.keySet()) {
+                        Map attachmentMetadata = (Map) item.attachments.get(att);
+                        Boolean stub = (Boolean) attachmentMetadata.get("stub");
+
+                        if (stub != null && stub) {
+                            // stubs get copied forward at the end of
+                            // insertDocumentHistoryIntoExistingTree - nothing to do
+                            // here
+                            continue;
+                        }
+                        String data = (String) attachmentMetadata.get("data");
+                        String type = (String) attachmentMetadata.get("content_type");
+                        InputStream is = Base64InputStreamFactory.get(new
+                                ByteArrayInputStream(data.getBytes("UTF-8")));
+                        // inline attachments are automatically decompressed,
+                        // so we don't have to worry about that
+                        UnsavedStreamAttachment usa = new UnsavedStreamAttachment(is,
+                                att, type);
+                        try {
+                            PreparedAttachment pa = AttachmentManager.prepareAttachment(
+                                    attachmentsDir, attachmentStreamFactory, usa);
+                            AttachmentManager.addAttachment(db, attachmentsDir, item
+                                    .rev, pa);
+                        } catch (Exception e) {
+                            logger.log(Level.SEVERE, "There was a problem adding the " +
+                                            "attachment "
+                                            + usa + "to the datastore for document "
+                                            + item.rev,
+                                    e);
+                            throw e;
+                        }
+                    }
+                }
+            } else {
+
+                try {
+                    if (item.preparedAttachments != null) {
+                        for (String[] key : item.preparedAttachments.keySet()) {
+                            String id = key[0];
+                            String rev = key[1];
+                            try {
+                                DocumentRevision doc = new GetDocumentCallable(id, rev, attachmentsDir, attachmentStreamFactory).call(db);
+                                if (doc != null) {
+                                    AttachmentManager.addAttachmentsToRevision(db,
+                                            attachmentsDir, doc, item
+                                                    .preparedAttachments.get(key));
+                                }
+                            } catch (DocumentNotFoundException e) {
+                                //safe to continue, previously getDocumentInQueue
+                                // could return
+                                // null and this was deemed safe and expected behaviour
+                                // DocumentNotFoundException is thrown instead of
+                                // returning
+                                // null now.
+                                continue;
+                            }
+                        }
+                    }
+                } catch (Exception e) {
+                    logger.log(Level.SEVERE, "There was a problem adding an " +
+                            "attachment to the datastore", e);
+                    throw e;
+                }
+
+
+            }
+            if (ok) {
+                logger.log(Level.FINER, "Inserted revision: %s", item.rev);
+                if (documentCreated != null) {
+                    events.add(documentCreated);
+                } else if (documentUpdated != null) {
+                    events.add(documentUpdated);
+                }
+            }
+        }
+        return events;
+    }
+}

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/GetAllDocumentsCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/GetAllDocumentsCallable.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.datastore.callables;
+
+import com.cloudant.sync.datastore.AttachmentStreamFactory;
+import com.cloudant.sync.datastore.DatastoreImpl;
+import com.cloudant.sync.datastore.DocumentRevision;
+import com.cloudant.sync.sqlite.SQLCallable;
+import com.cloudant.sync.sqlite.SQLDatabase;
+
+import java.util.List;
+
+/**
+ * Get all non-deleted winning Revisions of Documents, ordered by Document ID, starting from
+ * `offset` and with maximum `limit` results.
+ *
+ * @api_private
+ */
+public class GetAllDocumentsCallable implements SQLCallable<List<DocumentRevision>> {
+
+    private int offset;
+    private int limit;
+    private boolean descending;
+
+    private String attachmentsDir;
+    private AttachmentStreamFactory attachmentStreamFactory;
+
+    public GetAllDocumentsCallable(int offset, int limit, boolean descending, String
+            attachmentsDir, AttachmentStreamFactory attachmentStreamFactory) {
+        this.offset = offset;
+        this.limit = limit;
+        this.descending = descending;
+        this.attachmentsDir = attachmentsDir;
+        this.attachmentStreamFactory = attachmentStreamFactory;
+    }
+
+    @Override
+    public List<DocumentRevision> call(SQLDatabase db) throws Exception {
+        // Generate the SELECT statement, based on the options:
+        String sql = String.format("SELECT " + DatastoreImpl.FULL_DOCUMENT_COLS +
+                " FROM revs, docs WHERE deleted = 0 AND current = 1 AND docs.doc_id = revs.doc_id " +
+                " ORDER BY docs.doc_id %1$s, revid DESC LIMIT %2$s OFFSET %3$s ",
+                (descending ? "DESC" : "ASC"), limit, offset);
+        return DatastoreImpl.getRevisionsFromRawQuery(db, sql, new String[]{}, attachmentsDir, attachmentStreamFactory);
+    }
+}

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/GetDocumentCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/GetDocumentCallable.java
@@ -63,7 +63,7 @@ public class GetDocumentCallable implements SQLCallable<DocumentRevision> {
     private static final Logger logger = Logger.getLogger(DatastoreImpl.class.getCanonicalName());
 
 
-    public DocumentRevision call(SQLDatabase db) throws DocumentNotFoundException, AttachmentException, DatastoreException{
+    public DocumentRevision call(SQLDatabase db) throws DocumentNotFoundException, AttachmentException, DatastoreException {
 
         Cursor cursor = null;
         try {

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/GetDocumentsWithIdsCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/GetDocumentsWithIdsCallable.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.datastore.callables;
+
+import com.cloudant.sync.datastore.AttachmentStreamFactory;
+import com.cloudant.sync.datastore.DatastoreImpl;
+import com.cloudant.sync.datastore.DocumentRevision;
+import com.cloudant.sync.sqlite.SQLCallable;
+import com.cloudant.sync.sqlite.SQLDatabase;
+import com.cloudant.sync.util.DatabaseUtils;
+
+import java.util.List;
+
+/**
+ * Get a List of Document Revisions by Document ID
+ *
+ * @api_private
+ */
+public class GetDocumentsWithIdsCallable implements SQLCallable<List<DocumentRevision>> {
+
+    private List<String> docIds;
+
+    private String attachmentsDir;
+    private AttachmentStreamFactory attachmentStreamFactory;
+
+    public GetDocumentsWithIdsCallable(List<String> docIds, String attachmentsDir,
+                                       AttachmentStreamFactory attachmentStreamFactory) {
+        this.docIds = docIds;
+        this.attachmentsDir = attachmentsDir;
+        this.attachmentStreamFactory = attachmentStreamFactory;
+    }
+
+    @Override
+    public List<DocumentRevision> call(SQLDatabase db) throws Exception {
+        String sql = String.format("SELECT " + DatastoreImpl.FULL_DOCUMENT_COLS + " FROM revs, docs" +
+                " WHERE docid IN ( %1$s ) AND current = 1 AND docs.doc_id = revs.doc_id " +
+                " ORDER BY docs.doc_id ", DatabaseUtils.makePlaceholders(docIds.size
+                ()));
+        String[] args = docIds.toArray(new String[docIds.size()]);
+        List<DocumentRevision> docs = DatastoreImpl.getRevisionsFromRawQuery(db, sql, args, attachmentsDir, attachmentStreamFactory);
+        // Sort in memory since seems not able to sort them using SQL
+        return DatastoreImpl.sortDocumentsAccordingToIdList(docIds, docs);
+    }
+}

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/InsertDocumentHistoryIntoExistingTreeCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/InsertDocumentHistoryIntoExistingTreeCallable.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.datastore.callables;
+
+import com.cloudant.sync.datastore.AttachmentManager;
+import com.cloudant.sync.datastore.DatastoreException;
+import com.cloudant.sync.datastore.DatastoreImpl;
+import com.cloudant.sync.datastore.DocumentRevision;
+import com.cloudant.sync.sqlite.SQLCallable;
+import com.cloudant.sync.sqlite.SQLDatabase;
+import com.cloudant.sync.util.Misc;
+
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Insert a Revision @{code newRevision} into an existing Revision tree according to the history
+ * described by @{code revisions}. Stub Revisions described by @{code revisions} are inserted where they do not
+ * already exist
+ *
+ * @api_private
+ */
+public class InsertDocumentHistoryIntoExistingTreeCallable implements SQLCallable<Long> {
+
+    private static final Logger logger = Logger.getLogger(DatastoreImpl.class.getCanonicalName());
+
+    private DocumentRevision newRevision;
+    private List<String> revisions;
+    private Long docNumericID;
+    private Map<String, Object> attachments;
+
+    public InsertDocumentHistoryIntoExistingTreeCallable(DocumentRevision newRevision,
+                                                         List<String> revisions, Long
+                                                                 docNumericID, Map<String,
+            Object> attachments) {
+        this.newRevision = newRevision;
+        this.revisions = revisions;
+        this.docNumericID = docNumericID;
+        this.attachments = attachments;
+    }
+
+    @Override
+    public Long call(SQLDatabase db) throws DatastoreException {
+
+        // get info about previous "winning" rev
+        long previousLeafSeq = new GetSequenceCallable(newRevision.getId(), null).call(db);
+        Misc.checkArgument(previousLeafSeq > 0, "Parent revision must exist");
+
+        // Insert the new stub revisions, going down the tree
+        // at the end of the loop, parentSeq will be the parent of our doc to insert
+        long parentSeq = 0L;
+        for (int i = 0; i < revisions.size() - 1; i++) {
+            String revId = revisions.get(i);
+            long seq = new GetSequenceCallable(newRevision.getId(), revId).call(db);
+            if (seq == -1) {
+                seq = DatastoreImpl.insertStubRevisionAdaptor(docNumericID, revId, parentSeq).call(db);
+                new SetCurrentCallable(parentSeq, false).call(db);
+            }
+            parentSeq = seq;
+        }
+
+        // Insert the new leaf revision
+        String newLeafRev = revisions.get(revisions.size() - 1);
+        logger.finer("Inserting new revision, id: " + docNumericID + ", rev: " + newLeafRev);
+        new SetCurrentCallable(parentSeq, false).call(db);
+        // don't copy over attachments
+        InsertRevisionCallable callable = new InsertRevisionCallable();
+        callable.docNumericId = docNumericID;
+        callable.revId = newLeafRev;
+        callable.parentSequence = parentSeq;
+        callable.deleted = newRevision.isDeleted();
+        callable.current = false; // we'll call pickWinnerOfConflicts to set this if it needs it
+        callable.data = newRevision.asBytes();
+        callable.available = true;
+        long newLeafSeq = callable.call(db);
+
+        new PickWinningRevisionCallable(docNumericID).call(db);
+
+        // copy stubbed attachments forward from last real revision to this revision
+        if (attachments != null) {
+            for (Map.Entry<String, Object> att : attachments.entrySet()) {
+                Boolean stub = ((Map<String, Boolean>) att.getValue()).get("stub");
+                if (stub != null && stub.booleanValue()) {
+                    try {
+                        AttachmentManager.copyAttachment(db, previousLeafSeq, newLeafSeq, att
+                                .getKey());
+                    } catch (SQLException sqe) {
+                        logger.log(Level.SEVERE, "Error copying stubbed attachments", sqe);
+                        throw new DatastoreException("Error copying stubbed attachments", sqe);
+                    }
+                }
+            }
+        }
+
+        return newLeafSeq;
+    }
+}

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/InsertDocumentHistoryToNewTreeCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/InsertDocumentHistoryToNewTreeCallable.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.datastore.callables;
+
+import com.cloudant.sync.datastore.DatastoreException;
+import com.cloudant.sync.datastore.DatastoreImpl;
+import com.cloudant.sync.datastore.DocumentRevision;
+import com.cloudant.sync.sqlite.SQLCallable;
+import com.cloudant.sync.sqlite.SQLDatabase;
+import com.cloudant.sync.util.Misc;
+
+import java.util.List;
+import java.util.logging.Logger;
+
+/**
+ * Insert a Document Revision @{code newRevision} into a new Revision tree. Since there is no Revision
+ * tree rooted at the oldest Revision in `revisions`, build the initial tree by creating stub
+ * Revisions as described by @{code revisions} and make `newRevision` the leaf node of this linear "tree"
+ *
+ * Note that this is a similar case to @{link DoForceInsertNewDocumentWithHistoryCallable} except
+ * there is already a Revision tree for this Document ID (the only material difference between these
+ * callables is an extra insert into the `docs` table). Because there is no common ancestor, the
+ * result is a "forest" of trees.
+ *
+ * @api_private
+ */
+public class InsertDocumentHistoryToNewTreeCallable implements SQLCallable<Long> {
+
+    private static final Logger logger = Logger.getLogger(DatastoreImpl.class.getCanonicalName());
+
+    private DocumentRevision newRevision;
+    private List<String> revisions;
+    private Long docNumericID;
+
+    public InsertDocumentHistoryToNewTreeCallable(DocumentRevision newRevision, List<String>
+            revisions, Long docNumericID) {
+        this.newRevision = newRevision;
+        this.revisions = revisions;
+        this.docNumericID = docNumericID;
+    }
+
+    @Override
+    public Long call(SQLDatabase db) throws DatastoreException {
+        Misc.checkArgument(DatastoreImpl.checkCurrentRevisionIsInRevisionHistory(newRevision, revisions),
+                "Current revision must exist in revision history.");
+
+        // Adding a brand new tree
+        logger.finer("Inserting a brand new tree for an existing document.");
+        long parentSequence = 0L;
+        for (int i = 0; i < revisions.size() - 1; i++) {
+            //we copy attachments here so allow the exception to propagate
+            parentSequence = DatastoreImpl.insertStubRevisionAdaptor(docNumericID, revisions.get(i), parentSequence).call(db);
+        }
+        // don't copy attachments
+        String newLeafRev = newRevision.getRevision();
+        InsertRevisionCallable callable = new InsertRevisionCallable();
+        callable.docNumericId = docNumericID;
+        callable.revId = newLeafRev;
+        callable.parentSequence = parentSequence;
+        callable.deleted = newRevision.isDeleted();
+        callable.current = false; // we'll call pickWinnerOfConflicts to set this if it needs it
+        callable.data = newRevision.asBytes();
+        callable.available = !newRevision.isDeleted();
+        long newLeafSeq = callable.call(db);
+
+        new PickWinningRevisionCallable(docNumericID).call(db);
+        return newLeafSeq;
+    }
+}

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/InsertDocumentIDCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/InsertDocumentIDCallable.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.datastore.callables;
+
+import com.cloudant.android.ContentValues;
+import com.cloudant.sync.datastore.DatastoreException;
+import com.cloudant.sync.sqlite.SQLCallable;
+import com.cloudant.sync.sqlite.SQLDatabase;
+
+/**
+ * Insert a new Document ID into the @{docs} table. Required when inserting the first Revision.
+ *
+ * @api_private
+ */
+public class InsertDocumentIDCallable implements SQLCallable<Long> {
+
+    private String docId;
+
+    public InsertDocumentIDCallable(String docId) {
+        this.docId = docId;
+    }
+
+    @Override
+    public Long call(SQLDatabase db) throws DatastoreException {
+        ContentValues args = new ContentValues();
+        args.put("docid", docId);
+        long result = db.insert("docs", args);
+        if (result == -1) {
+            throw new DatastoreException("Failed to insert docid "+docId+" into docs table, check log for details");
+        }
+        return result;
+    }
+}

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/InsertLocalDocumentCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/InsertLocalDocumentCallable.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.datastore.callables;
+
+import com.cloudant.android.ContentValues;
+import com.cloudant.sync.datastore.DatastoreException;
+import com.cloudant.sync.datastore.DatastoreImpl;
+import com.cloudant.sync.datastore.DocumentBody;
+import com.cloudant.sync.datastore.DocumentException;
+import com.cloudant.sync.datastore.LocalDocument;
+import com.cloudant.sync.sqlite.SQLCallable;
+import com.cloudant.sync.sqlite.SQLDatabase;
+
+import java.util.logging.Logger;
+
+/**
+ * Insert a local (non-replicated) Document
+ *
+ * @api_private
+ */
+public class InsertLocalDocumentCallable implements SQLCallable<LocalDocument> {
+
+    private static final Logger logger = Logger.getLogger(DatastoreImpl.class.getCanonicalName());
+
+    private String docId;
+    private DocumentBody body;
+
+    public InsertLocalDocumentCallable(String docId, DocumentBody body) {
+        this.docId = docId;
+        this.body = body;
+    }
+
+    @Override
+    public LocalDocument call(SQLDatabase db) throws DocumentException, DatastoreException {
+        ContentValues values = new ContentValues();
+        values.put("docid", docId);
+        values.put("json", body.asBytes());
+
+        long rowId = db.insertWithOnConflict("localdocs", values, SQLDatabase
+                .CONFLICT_REPLACE);
+        if (rowId < 0) {
+            throw new DocumentException("Failed to insert local document");
+        } else {
+            logger.finer(String.format("Local doc inserted: %d , %s", rowId, docId));
+        }
+
+        // TODO - just reconstruct LocalDocument rather than refetching, we already know the docId as it was passed in
+        return new GetLocalDocumentCallable(docId).call(db);
+    }
+}

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/ResolveConflictsForDocumentCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/ResolveConflictsForDocumentCallable.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.datastore.callables;
+
+import com.cloudant.sync.datastore.DocumentRevision;
+import com.cloudant.sync.datastore.DocumentRevisionTree;
+import com.cloudant.sync.sqlite.SQLCallable;
+import com.cloudant.sync.sqlite.SQLDatabase;
+
+/**
+ * Delete and mark non-current all Document Revisions except the one with the Revision ID
+ * {@code revIdKeep}
+ *
+ * @api_private
+ */
+public class ResolveConflictsForDocumentCallable implements SQLCallable<Void> {
+
+    private DocumentRevisionTree docTree;
+    private String revIdKeep;
+
+
+    public ResolveConflictsForDocumentCallable(DocumentRevisionTree docTree, String revIdKeep) {
+        this.docTree = docTree;
+        this.revIdKeep = revIdKeep;
+    }
+
+    @Override
+    public Void call(SQLDatabase db) throws Exception {
+
+        for (DocumentRevision revision : docTree.leafRevisions()) {
+            if (revision.getRevision().equals(revIdKeep)) {
+                // this is the one we want to keep, set it to current
+                new SetCurrentCallable(revision.getSequence(), true).call(db);
+            } else {
+                if (revision.isDeleted()) {
+                    // if it is deleted, just make it non-current
+                    new SetCurrentCallable(revision.getSequence(), false).call(db);
+                } else {
+                    // if it's not deleted, deleted and make it non-current
+                    DocumentRevision deleted = new DeleteDocumentCallable(
+                            revision.getId(), revision.getRevision()).call(db);
+                    new SetCurrentCallable(deleted.getSequence(), false).call(db);
+                }
+            }
+        }
+
+        return null;
+
+    }
+}

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/RevsDiffBatchCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/RevsDiffBatchCallable.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.datastore.callables;
+
+import com.cloudant.sync.datastore.DatastoreException;
+import com.cloudant.sync.sqlite.Cursor;
+import com.cloudant.sync.sqlite.SQLCallable;
+import com.cloudant.sync.sqlite.SQLDatabase;
+import com.cloudant.sync.util.DatabaseUtils;
+
+import java.sql.SQLException;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Checks the supplied collection of revisions for the given document ID and returns a
+ * collection containing only those entries that are missing from the database.
+ *
+ * @api_private
+ */
+
+public class RevsDiffBatchCallable implements SQLCallable<Collection<String>> {
+
+    private String docId;
+    private Set<String> missingRevs;
+
+    /**
+     * @param docId the doc ID to check
+     * @param revs  the rev IDs to check
+     */
+    public RevsDiffBatchCallable(String docId, Collection<String> revs) {
+        this.docId = docId;
+        // Consider all missing to start
+        this.missingRevs = new HashSet<String>(revs);
+    }
+
+    /**
+     * @return collection of rev IDs not present in the database
+     */
+    @Override
+    public Collection<String> call(SQLDatabase db) throws Exception {
+
+        final String sql = String.format(
+                "SELECT revs.revid FROM docs, revs " +
+                        "WHERE docs.doc_id = revs.doc_id AND docs.docid = ? AND revs.revid IN " +
+                        "(%s) ", DatabaseUtils.makePlaceholders(missingRevs.size()));
+
+        String[] args = new String[1 + missingRevs.size()];
+        args[0] = docId;
+        // Copy the revisions into the end of the args array
+        System.arraycopy(missingRevs.toArray(new String[missingRevs.size()]), 0, args, 1,
+                missingRevs.size());
+
+        Cursor cursor = null;
+        try {
+            cursor = db.rawQuery(sql, args);
+            while (cursor.moveToNext()) {
+                String revId = cursor.getString(cursor.getColumnIndex("revid"));
+                missingRevs.remove(revId);
+            }
+        } catch (SQLException e) {
+            throw new DatastoreException(e);
+        } finally {
+            DatabaseUtils.closeCursorQuietly(cursor);
+        }
+        return missingRevs;
+    }
+}

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/SetCurrentCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/SetCurrentCallable.java
@@ -41,7 +41,7 @@ public class SetCurrentCallable implements SQLCallable<Void> {
      * @param sequence       Sequence number of revision
      * @param valueOfCurrent New value of {@code current} (true/false)
      *
-     * @see com.cloudant.sync.datastore.DatastoreImpl#pickWinnerOfConflicts(long)
+     * @see PickWinningRevisionCallable
      */
     public SetCurrentCallable(long sequence, boolean valueOfCurrent) {
         this.sequence = sequence;

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/UpdateDocumentBodyCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/UpdateDocumentBodyCallable.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.datastore.callables;
+
+import com.cloudant.sync.datastore.AttachmentStreamFactory;
+import com.cloudant.sync.datastore.ConflictException;
+import com.cloudant.sync.datastore.DatastoreImpl;
+import com.cloudant.sync.datastore.DocumentBody;
+import com.cloudant.sync.datastore.DocumentRevision;
+import com.cloudant.sync.sqlite.SQLCallable;
+import com.cloudant.sync.sqlite.SQLDatabase;
+import com.cloudant.sync.util.CouchUtils;
+import com.cloudant.sync.util.Misc;
+
+/**
+ * Update body of Document Revision by inserting a new child Revision with the JSON contents
+ * {@code body}
+ *
+ * @api_private
+ */
+public class UpdateDocumentBodyCallable implements SQLCallable<DocumentRevision> {
+
+    private String docId;
+    private String prevRevId;
+    private DocumentBody body;
+
+    private String attachmentsDir;
+    private AttachmentStreamFactory attachmentStreamFactory;
+
+    public UpdateDocumentBodyCallable(String docId, String prevRevId, DocumentBody body, String
+            attachmentsDir, AttachmentStreamFactory attachmentStreamFactory) {
+        this.docId = docId;
+        this.prevRevId = prevRevId;
+        this.body = body;
+        this.attachmentsDir = attachmentsDir;
+        this.attachmentStreamFactory = attachmentStreamFactory;
+    }
+
+    @Override
+    public DocumentRevision call(SQLDatabase db) throws Exception {
+        Misc.checkNotNullOrEmpty(docId, "Input document id");
+        Misc.checkNotNullOrEmpty(prevRevId, "Input previous revision id cannot be empty");
+        Misc.checkNotNull(body, "Input document body");
+
+        DatastoreImpl.validateDBBody(body);
+        CouchUtils.validateRevisionId(prevRevId);
+
+        // TODO quicker way of finding if current than fetching whole revision
+        DocumentRevision preRevision = new GetDocumentCallable(docId, prevRevId, this.attachmentsDir, this.attachmentStreamFactory).call(db);
+
+        if (!preRevision.isCurrent()) {
+            throw new ConflictException("Revision to be updated is not current revision.");
+        }
+
+        new SetCurrentCallable(preRevision.getSequence(), false).call(db);
+        InsertRevisionCallable insertRevisionCallable = DatastoreImpl.insertNewWinnerRevisionAdaptor(body, preRevision);
+        String newRevisionId = insertRevisionCallable.revId;
+        insertRevisionCallable.call(db);
+        // TODO build the new DocumentRevision instead of retrieving the whole document again
+        return new GetDocumentCallable(docId, newRevisionId, this.attachmentsDir, this.attachmentStreamFactory).call(db);
+    }
+}

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/UpdateDocumentFromRevisionCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/callables/UpdateDocumentFromRevisionCallable.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.datastore.callables;
+
+import com.cloudant.sync.datastore.AttachmentManager;
+import com.cloudant.sync.datastore.AttachmentStreamFactory;
+import com.cloudant.sync.datastore.DocumentRevision;
+import com.cloudant.sync.datastore.PreparedAttachment;
+import com.cloudant.sync.datastore.SavedAttachment;
+import com.cloudant.sync.sqlite.SQLCallable;
+import com.cloudant.sync.sqlite.SQLDatabase;
+import com.cloudant.sync.util.Misc;
+
+import java.util.List;
+
+/**
+ * Update body and attachments of Document Revision by inserting a new child Revision with the JSON contents
+ * {@code rev.body} and the new and existing attachments {@code preparedNewAttachments} and {@code existingAttachments}
+ *
+ * @api_private
+ */
+public class UpdateDocumentFromRevisionCallable implements SQLCallable<DocumentRevision> {
+
+
+
+    private DocumentRevision rev;
+    private List<PreparedAttachment> preparedNewAttachments;
+    private List<SavedAttachment> existingAttachments;
+
+    private String attachmentsDir;
+    private AttachmentStreamFactory attachmentStreamFactory;
+
+    public UpdateDocumentFromRevisionCallable(DocumentRevision rev, List<PreparedAttachment>
+            preparedNewAttachments, List<SavedAttachment> existingAttachments, String
+            attachmentsDir, AttachmentStreamFactory attachmentStreamFactory) {
+        this.rev = rev;
+        this.preparedNewAttachments = preparedNewAttachments;
+        this.existingAttachments = existingAttachments;
+        this.attachmentsDir = attachmentsDir;
+        this.attachmentStreamFactory = attachmentStreamFactory;
+    }
+
+    @Override
+    public DocumentRevision call(SQLDatabase db) throws Exception {
+        Misc.checkNotNull(rev, "DocumentRevision");
+
+        DocumentRevision updated = new UpdateDocumentBodyCallable(rev.getId(), rev.getRevision(), rev
+                .getBody(), attachmentsDir, attachmentStreamFactory).call(db);
+        AttachmentManager.addAttachmentsToRevision(db, attachmentsDir, updated,
+                preparedNewAttachments);
+
+        AttachmentManager.copyAttachmentsToRevision(db, existingAttachments, updated);
+
+        // now re-fetch the revision with updated attachments
+        DocumentRevision updatedWithAttachments = new GetDocumentCallable(updated.getId(),
+                updated.getRevision(), this.attachmentsDir, this.attachmentStreamFactory).call(db);
+        return updatedWithAttachments;
+    }
+
+}


### PR DESCRIPTION
Everything except AttachmentManager into callables

**TODO**
* ~~Check exception correctness~~ `DatastoreImpl` signatures haven't changed so they still throw the same exceptions. See https://github.com/cloudant/sync-android/issues/354 and https://github.com/cloudant/sync-android/issues/280 - these are the correct follow on PRs to use to address the other exception issues
* ~~Fix up `catch(InterruptedException e)`/ `catch (ExecutionException e)` pattern in `DatastoreImpl`~~
* ~~javadoc comments~~
* ~~Copyright headers~~
* ~~Run some proper replication tests~~ - pull and pull replication looks good with the Airfi dataset