### PR TITLE
Updated cloudant-http to 2.6.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 # Unreleased
+- [UPGRADED] Upgraded to version 2.6.2 of the `cloudant-http` library.
 - [REMOVED] Removed com.google.guava:guava:15.0 dependency applications may need to update their own
   dependency tree to include guava if they are using it directly, but were relying on this library
   to include it.

--- a/cloudant-sync-datastore-core/build.gradle
+++ b/cloudant-sync-datastore-core/build.gradle
@@ -3,7 +3,7 @@
 // ************ //
 dependencies {
 
-    compile group: 'com.cloudant', name: 'cloudant-http', version:'2.5.1'
+    compile group: 'com.cloudant', name: 'cloudant-http', version:'2.6.2'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version:'2.1.1'
     compile group: 'commons-codec', name: 'commons-codec', version:'1.10'
     compile group: 'commons-io', name: 'commons-io', version:'2.4'


### PR DESCRIPTION
*What*

Upgraded cloudant-http to version 2.6.2 to consume upstream cookie handling fixes.

*Testing*

No new tests, existing tests pass.

*Issues*

Fixes #358 