### PR TITLE
Move com.cloudant.library.LibraryVersion

### DIFF
--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/library/LibraryVersion.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/library/LibraryVersion.java
@@ -12,7 +12,7 @@
  *  and limitations under the License.
  */
 
-package com.cloudant.library;
+package com.cloudant.sync.library;
 
 import com.cloudant.sync.util.Misc;
 


### PR DESCRIPTION
Move this class to sit under the `sync` package at
`com.cloudant.sync.library.LibraryVersion`

This allows users to use sync-android and java-cloudant in the same
application.