### PR TITLE
Refactor Datastore and IndexManager - New IndexManager API

### DIFF
--- a/cloudant-sync-datastore-android-encryption/src/test/java/com/cloudant/sync/datastore/encryption/EndToEndEncryptionTest.java
+++ b/cloudant-sync-datastore-android-encryption/src/test/java/com/cloudant/sync/datastore/encryption/EndToEndEncryptionTest.java
@@ -31,6 +31,7 @@ import com.cloudant.sync.datastore.DocumentException;
 import com.cloudant.sync.datastore.DocumentRevision;
 import com.cloudant.sync.datastore.UnsavedFileAttachment;
 import com.cloudant.sync.datastore.UnsavedStreamAttachment;
+import com.cloudant.sync.query.FieldSort;
 import com.cloudant.sync.query.IndexManagerImpl;
 import com.cloudant.sync.query.QueryResult;
 import com.cloudant.sync.util.TestUtils;
@@ -129,7 +130,7 @@ public class EndToEndEncryptionTest {
 
         IndexManager im = this.database.query;
         try {
-            im.ensureIndexed(Arrays.<Object>asList("name", "age"));
+            im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("age")));
         } finally {
             im.close();
         }
@@ -154,7 +155,7 @@ public class EndToEndEncryptionTest {
 
         IndexManager im = this.database.query;
         try {
-            im.ensureIndexed(Arrays.<Object>asList("name", "age"));
+            im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("age")));
         } finally {
             im.close();
         }
@@ -301,7 +302,7 @@ public class EndToEndEncryptionTest {
         // perform a query to ensure we can use special chars
         IndexManager indexManager = database.query;
         try {
-            assertNotNull(indexManager.ensureIndexed(Arrays.<Object>asList("name", "pet"), "my index"));
+            assertNotNull(indexManager.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("pet")), "my index"));
 
             // query for the name fred and check that docs are returned.
             Map<String, Object> selector = new HashMap<String, Object>();

--- a/cloudant-sync-datastore-android-encryption/src/test/java/com/cloudant/sync/datastore/encryption/EndToEndEncryptionTest.java
+++ b/cloudant-sync-datastore-android-encryption/src/test/java/com/cloudant/sync/datastore/encryption/EndToEndEncryptionTest.java
@@ -32,6 +32,7 @@ import com.cloudant.sync.datastore.DocumentRevision;
 import com.cloudant.sync.datastore.UnsavedFileAttachment;
 import com.cloudant.sync.datastore.UnsavedStreamAttachment;
 import com.cloudant.sync.query.FieldSort;
+import com.cloudant.sync.query.IndexManager;
 import com.cloudant.sync.query.IndexManagerImpl;
 import com.cloudant.sync.query.QueryResult;
 import com.cloudant.sync.util.TestUtils;

--- a/cloudant-sync-datastore-android-encryption/src/test/java/com/cloudant/sync/datastore/encryption/EndToEndEncryptionTest.java
+++ b/cloudant-sync-datastore-android-encryption/src/test/java/com/cloudant/sync/datastore/encryption/EndToEndEncryptionTest.java
@@ -31,7 +31,7 @@ import com.cloudant.sync.datastore.DocumentException;
 import com.cloudant.sync.datastore.DocumentRevision;
 import com.cloudant.sync.datastore.UnsavedFileAttachment;
 import com.cloudant.sync.datastore.UnsavedStreamAttachment;
-import com.cloudant.sync.query.IndexManager;
+import com.cloudant.sync.query.IndexManagerImpl;
 import com.cloudant.sync.query.QueryResult;
 import com.cloudant.sync.util.TestUtils;
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/CloudantSync.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/CloudantSync.java
@@ -2,7 +2,6 @@ package com.cloudant.sync.datastore;
 
 import com.cloudant.sync.datastore.encryption.KeyProvider;
 import com.cloudant.sync.query.IndexManager;
-import com.cloudant.sync.query.IndexManagerImpl;
 
 import java.io.IOException;
 import java.sql.SQLException;

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/CloudantSync.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/CloudantSync.java
@@ -2,6 +2,7 @@ package com.cloudant.sync.datastore;
 
 import com.cloudant.sync.datastore.encryption.KeyProvider;
 import com.cloudant.sync.query.IndexManager;
+import com.cloudant.sync.query.IndexManagerImpl;
 
 import java.io.IOException;
 import java.sql.SQLException;

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/DatabaseImpl.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/datastore/DatabaseImpl.java
@@ -1098,7 +1098,7 @@ public class DatabaseImpl implements Database {
 
     @Override
     public EventBus getEventBus() {
-        Misc.checkState(this.isOpen(), "Database is closed");
+//        Misc.checkState(this.isOpen(), "Database is closed");
         return eventBus;
     }
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/FieldSort.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/FieldSort.java
@@ -19,11 +19,42 @@ public class FieldSort {
         this.sort = sort;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        FieldSort fieldSort = (FieldSort) o;
+
+        if (!field.equals(fieldSort.field)) {
+            return false;
+        }
+        return sort == fieldSort.sort;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = field.hashCode();
+        result = 31 * result + sort.hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "FieldSort{" +
+                "field='" + field + '\'' +
+                ", sort=" + sort +
+                '}';
+    }
 
     public enum Direction {
         ASCENDING,
         DESCENDING
     };
-
 
 }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/FieldSort.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/FieldSort.java
@@ -1,0 +1,29 @@
+package com.cloudant.sync.query;
+
+/**
+ * Created by tomblench on 28/09/2016.
+ */
+
+public class FieldSort {
+
+    public final String field;
+    public final Direction sort;
+
+    public FieldSort(String field) {
+        this.field = field;
+        this.sort = Direction.ASCENDING;
+    }
+
+    public FieldSort(String field, Direction sort) {
+        this.field = field;
+        this.sort = sort;
+    }
+
+
+    public enum Direction {
+        ASCENDING,
+        DESCENDING
+    };
+
+
+}

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/FieldSort.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/FieldSort.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright (C) 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
 package com.cloudant.sync.query;
 
 /**
@@ -10,8 +24,7 @@ public class FieldSort {
     public final Direction sort;
 
     public FieldSort(String field) {
-        this.field = field;
-        this.sort = Direction.ASCENDING;
+        this(field, Direction.ASCENDING);
     }
 
     public FieldSort(String field, Direction sort) {

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/Index.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/Index.java
@@ -37,7 +37,7 @@ class Index {
 
     private static final List<String> validSettings = Arrays.asList(TEXT_TOKENIZE);
 
-    protected final List<Object> fieldNames;
+    protected final List<FieldSort> fieldNames;
 
     protected final String indexName;
 
@@ -47,7 +47,7 @@ class Index {
 
     private ObjectMapper objectMapper;
 
-    private Index(List<Object> fieldNames,
+    private Index(List<FieldSort> fieldNames,
                   String indexName,
                   IndexType indexType,
                   Map<String, String> indexSettings) {
@@ -64,11 +64,11 @@ class Index {
      * @param indexName the index name or null
      * @return the Index object or null if arguments passed in were invalid.
      */
-    public static Index getInstance(List<Object> fieldNames, String indexName) {
+    public static Index getInstance(List<FieldSort> fieldNames, String indexName) {
         return getInstance(fieldNames, indexName, IndexType.JSON);
     }
 
-    public static Index getInstance(List<Object> fieldNames, String indexName, IndexType indexType) {
+    public static Index getInstance(List<FieldSort> fieldNames, String indexName, IndexType indexType) {
         return getInstance(fieldNames, indexName, indexType, null);
     }
 
@@ -83,7 +83,7 @@ class Index {
      *                      Only supported parameter is 'tokenize' for text indexes only.
      * @return the Index object or null if arguments passed in were invalid.
      */
-    public static Index getInstance(List<Object> fieldNames,
+    public static Index getInstance(List<FieldSort> fieldNames,
                               String indexName,
                               IndexType indexType,
                               Map<String, String> indexSettings) {

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexCreator.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexCreator.java
@@ -114,7 +114,7 @@ class IndexCreator {
         // else fail.
         try {
 
-            Map<String, Object> existingIndexes = listIndexesInDatabaseQueue();
+            Map<String, Map<String, Object>> existingIndexes = listIndexesInDatabaseQueue();
 
             if(proposedIndex.indexName == null){
                 // generate a name for the index.
@@ -272,21 +272,11 @@ class IndexCreator {
      *  We don't support directions on field names, but they are an optimisation so
      *  we can discard them safely.
      */
-    protected static List<String> removeDirectionsFromFields(List<Object> fieldNames) {
+    protected static List<String> removeDirectionsFromFields(List<FieldSort> fieldNames) {
         List<String> result = new ArrayList<String>();
 
-        for (Object field: fieldNames) {
-            if (field instanceof Map) {
-                Map specifier = (Map) field;
-                if (specifier.size() == 1) {
-                    for (Object key: specifier.keySet()) {
-                        // This will iterate only once
-                        result.add((String) key);
-                    }
-                }
-            } else if (field instanceof String) {
-                result.add((String) field);
-            }
+        for (FieldSort field: fieldNames) {
+            result.add(field.field);
         }
 
         return result;
@@ -302,9 +292,9 @@ class IndexCreator {
      * @return whether the index limit has been reached
      */
     @SuppressWarnings("unchecked")
-    protected static boolean indexLimitReached(Index index, Map<String, Object> existingIndexes) {
+    protected static boolean indexLimitReached(Index index, Map<String, Map<String, Object>> existingIndexes) {
         if (index.indexType == IndexType.TEXT) {
-            for (Map.Entry<String, Object> entry : existingIndexes.entrySet()) {
+            for (Map.Entry<String, Map<String, Object>> entry : existingIndexes.entrySet()) {
                 String name = entry.getKey();
                 Map<String, Object> existingIndex = (Map<String, Object>) entry.getValue();
                 IndexType type = (IndexType) existingIndex.get("type");
@@ -322,11 +312,11 @@ class IndexCreator {
         return false;
     }
 
-    private Map<String, Object> listIndexesInDatabaseQueue() throws ExecutionException,
+    private Map<String, Map<String, Object>> listIndexesInDatabaseQueue() throws ExecutionException,
                                                                     InterruptedException {
-        Future<Map<String, Object>> indexes = queue.submit(new SQLCallable<Map<String,Object>>() {
+        Future<Map<String, Map<String, Object>>> indexes = queue.submit(new SQLCallable<Map<String,Map<String, Object>>>() {
             @Override
-            public Map<String, Object> call(SQLDatabase database) {
+            public Map<String, Map<String, Object>> call(SQLDatabase database) {
                 return IndexManagerImpl.listIndexesInDatabase(database);
             }
         });

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexManager.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexManager.java
@@ -4,39 +4,43 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Created by tomblench on 03/10/2016.
+ * Created by tomblench on 28/09/2016.
  */
 
 public interface IndexManager {
 
-    Map<String, Object> listIndexes();
 
-    String ensureIndexed(List<Object> fieldNames);
+    Map<String, Map<String, Object>> listIndexes() throws QueryException;
 
-    String ensureIndexed(List<Object> fieldNames, String indexName);
+    String ensureIndexed(List<FieldSort> fieldNames);
 
-    String ensureIndexed(List<Object> fieldNames, String indexName, IndexType indexType);
+    String ensureIndexed(List<FieldSort> fieldNames, String indexName) throws QueryException;
 
-    String ensureIndexed(List<Object> fieldNames,
+    String ensureIndexed(List<FieldSort> fieldNames, String indexName, IndexType indexType)
+            throws QueryException;
+
+    String ensureIndexed(List<FieldSort> fieldNames,
                          String indexName,
                          IndexType indexType,
-                         Map<String, String> indexSettings);
+                         Map<String, String> IndexSettings) throws QueryException;
 
-    boolean deleteIndexNamed(final String indexName);
 
-    boolean updateAllIndexes();
+    void deleteIndex(String indexName) throws QueryException;
+
+    void updateAllIndexes(); // not sure if this should throw or not.
+
+    QueryResult find(Map<String, Object> query) throws QueryException;
+
+    QueryResult find(Map<String, Object> query,
+                     long skip,
+                     long limit,
+                     List<String> fields,
+                     List<FieldSort> sortDocument)
+            throws QueryException;
 
     boolean isTextSearchEnabled();
 
     // TODO we may not want to expose this publicly
     void close();
-
-    QueryResult find(Map<String, Object> query);
-
-    QueryResult find(Map<String, Object> query,
-                            long skip,
-                            long limit,
-                            List<String> fields,
-                            List<Map<String, String>> sortDocument);
 
 }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexManagerImpl.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexManagerImpl.java
@@ -270,7 +270,6 @@ public class IndexManagerImpl implements IndexManager {
      *  Delete an index.
      *
      *  @param indexName Name of index to delete
-     *  @return deletion status as true/false
      */
     @Override
     public void deleteIndex(final String indexName) {
@@ -325,7 +324,6 @@ public class IndexManagerImpl implements IndexManager {
     /**
      *  Update all indexes.
      *
-     *  @return update status as true/false
      */
     @Override
     public void updateAllIndexes() {

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexManagerImpl.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexManagerImpl.java
@@ -40,8 +40,6 @@ import com.cloudant.sync.datastore.Database;
 import com.cloudant.sync.datastore.DatabaseImpl;
 import com.cloudant.sync.datastore.encryption.KeyProvider;
 import com.cloudant.sync.datastore.migrations.SchemaOnlyMigration;
-import com.cloudant.sync.event.Subscribe;
-import com.cloudant.sync.notifications.DocumentPurged;
 import com.cloudant.sync.sqlite.Cursor;
 import com.cloudant.sync.sqlite.SQLCallable;
 import com.cloudant.sync.sqlite.SQLDatabase;
@@ -420,11 +418,6 @@ public class IndexManagerImpl implements IndexManager {
                     "the full text search compile options enabled.");
         }
         return textSearchEnabled;
-    }
-
-    @Subscribe
-    public void onPurge(DocumentPurged documentPurged) {
-        // TODO remove from index
     }
 
 }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexUpdater.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexUpdater.java
@@ -62,7 +62,7 @@ class IndexUpdater {
      *  @param queue The executor service queue
      *  @return index update success status (true/false)
      */
-    public static boolean updateAllIndexes(Map<String, Object> indexes,
+    public static boolean updateAllIndexes(Map<String, Map<String, Object>> indexes,
                                            Database database,
                                            SQLDatabaseQueue queue) {
         IndexUpdater updater = new IndexUpdater(database, queue);
@@ -91,11 +91,11 @@ class IndexUpdater {
     }
 
     @SuppressWarnings("unchecked")
-    private boolean updateAllIndexes(Map<String, Object> indexes) {
+    private boolean updateAllIndexes(Map<String, Map<String, Object>> indexes) {
         boolean success = true;
 
-        for (Map.Entry<String, Object> entry: indexes.entrySet()) {
-            Map<String, Object> index = (Map<String, Object>) entry.getValue();
+        for (Map.Entry<String, Map<String, Object>> entry: indexes.entrySet()) {
+            Map<String, Object> index = entry.getValue();
             List<String> fields = (ArrayList<String>) index.get("fields");
             success = updateIndex(entry.getKey(), fields);
             if (!success) {

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/QuerySqlTranslator.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/QuerySqlTranslator.java
@@ -114,7 +114,7 @@ class QuerySqlTranslator {
     private static final Logger logger = Logger.getLogger(QuerySqlTranslator.class.getName());
 
     public static QueryNode translateQuery(Map<String, Object> query,
-                                           Map<String, Object> indexes,
+                                           Map<String, Map<String, Object>> indexes,
                                            Boolean[] indexesCoverQuery) {
         TranslatorState state = new TranslatorState();
         QueryNode node = translateQuery(query, indexes, state);
@@ -159,7 +159,7 @@ class QuerySqlTranslator {
 
     @SuppressWarnings("unchecked")
     private static QueryNode translateQuery(Map<String, Object> query,
-                                           Map<String, Object> indexes,
+                                           Map<String, Map<String, Object>> indexes,
                                            TranslatorState state) {
         // At this point we will have a root compound predicate, AND or OR, and
         // the query will be reduced to a single entry:
@@ -371,7 +371,7 @@ class QuerySqlTranslator {
     }
 
     protected static String chooseIndexForAndClause(List<Object> clause,
-                                                    Map<String, Object> indexes) {
+                                                    Map<String, Map<String, Object>> indexes) {
         if (clause == null || clause.isEmpty()) {
             return null;
         }
@@ -401,10 +401,10 @@ class QuerySqlTranslator {
 
     @SuppressWarnings("unchecked")
     protected static String chooseIndexForFields(Set<String> neededFields,
-                                                 Map<String, Object> indexes) {
+                                                 Map<String, Map<String, Object>> indexes) {
         String chosenIndex = null;
-        for (Map.Entry<String, Object> entry: indexes.entrySet()) {
-            Map<String, Object> indexDefinition = (Map<String, Object>) entry.getValue();
+        for (Map.Entry<String, Map<String, Object>> entry: indexes.entrySet()) {
+            Map<String, Object> indexDefinition = entry.getValue();
 
             // Don't choose a text index for a non-text query clause
             IndexType indexType = (IndexType) indexDefinition.get("type");
@@ -424,10 +424,10 @@ class QuerySqlTranslator {
     }
 
     @SuppressWarnings("unchecked")
-    private static String getTextIndex(Map<String, Object> indexes) {
+    private static String getTextIndex(Map<String, Map<String, Object>> indexes) {
         String textIndex = null;
-        for (Map.Entry<String, Object> entry: indexes.entrySet()) {
-            Map<String, Object> indexDefinition = (Map<String, Object>) entry.getValue();
+        for (Map.Entry<String, Map<String, Object>> entry: indexes.entrySet()) {
+            Map<String, Object> indexDefinition = entry.getValue();
             IndexType indexType = (IndexType) indexDefinition.get("type");
             if (indexType == IndexType.TEXT) {
                 textIndex = entry.getKey();

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/AbstractQueryTestBase.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/AbstractQueryTestBase.java
@@ -278,7 +278,7 @@ public abstract class AbstractQueryTestBase {
         Map<String, Object> bodyMap = new HashMap<String, Object>();
         bodyMap.put("name", "mike");
         bodyMap.put("age", 12);
-        bodyMap.put("pet", Arrays.<FieldSort>asList(new FieldSort("cat"), new FieldSort("dog")));
+        bodyMap.put("pet", Arrays.<String>asList("cat", "dog"));
         rev.setBody(DocumentBodyFactory.create(bodyMap));
         ds.createDocumentFromRevision(rev);
 
@@ -294,7 +294,7 @@ public abstract class AbstractQueryTestBase {
         bodyMap.clear();
         bodyMap.put("name", "mike");
         bodyMap.put("age", 34);
-        bodyMap.put("pet", Arrays.<FieldSort>asList(new FieldSort("cat"), new FieldSort("dog"), new FieldSort("fish")));
+        bodyMap.put("pet", Arrays.<String>asList("cat", "dog", "fish"));
         rev.setBody(DocumentBodyFactory.create(bodyMap));
         ds.createDocumentFromRevision(rev);
 
@@ -309,7 +309,7 @@ public abstract class AbstractQueryTestBase {
         bodyMap.clear();
         bodyMap.put("name", "john");
         bodyMap.put("age", 44);
-        bodyMap.put("pet", Arrays.<FieldSort>asList(new FieldSort("hamster"), new FieldSort("snake")));
+        bodyMap.put("pet", Arrays.<String>asList("hamster", "snake"));
         rev.setBody(DocumentBodyFactory.create(bodyMap));
         ds.createDocumentFromRevision(rev);
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/AbstractQueryTestBase.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/AbstractQueryTestBase.java
@@ -125,8 +125,8 @@ public abstract class AbstractQueryTestBase {
         ds.createDocumentFromRevision(rev);
 
 
-        assertThat(im.ensureIndexed(Arrays.<Object>asList("name", "age"), "basic"), is("basic"));
-        assertThat(im.ensureIndexed(Arrays.<Object>asList("name", "pet"), "pet"), is("pet"));
+        assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("age")), "basic"), is("basic"));
+        assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("pet")), "pet"), is("pet"));
     }
 
     // Used to setup document data testing:
@@ -134,9 +134,9 @@ public abstract class AbstractQueryTestBase {
     public void setUpDottedQueryData() throws Exception {
         setUpSharedDocs();
 
-        assertThat(im.ensureIndexed(Arrays.<Object>asList("age", "pet.name", "pet.species"), "pet"),
+        assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("age"), new FieldSort("pet.name"), new FieldSort("pet.species")), "pet"),
                 is("pet"));
-        assertThat(im.ensureIndexed(Arrays.<Object>asList("name", "pet.name.first"), "firstname"),
+        assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("pet.name.first")), "firstname"),
                 is("firstname"));
     }
 
@@ -208,11 +208,11 @@ public abstract class AbstractQueryTestBase {
     public void setUpOrQueryData() throws Exception {
         setUpSharedDocs();
 
-        assertThat(im.ensureIndexed(Arrays.<Object>asList("age", "pet", "name"), "basic"),
+        assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("age"), new FieldSort("pet"), new FieldSort("name")), "basic"),
                 is("basic"));
-        assertThat(im.ensureIndexed(Arrays.<Object>asList("age", "pet.name", "pet.species"), "pet"),
+        assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("age"), new FieldSort("pet.name"), new FieldSort("pet.species")), "pet"),
                 is("pet"));
-        assertThat(im.ensureIndexed(Arrays.<Object>asList("age", "pet.name.first"), "firstname"),
+        assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("age"), new FieldSort("pet.name.first")), "firstname"),
                 is("firstname"));
     }
 
@@ -266,7 +266,7 @@ public abstract class AbstractQueryTestBase {
         rev.setBody(DocumentBodyFactory.create(bodyMap));
         ds.createDocumentFromRevision(rev);
 
-        assertThat(im.ensureIndexed(Arrays.<Object>asList("age", "pet", "name"), "basic"),
+        assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("age"), new FieldSort("pet"), new FieldSort("name")), "basic"),
                 is("basic"));
     }
 
@@ -278,7 +278,7 @@ public abstract class AbstractQueryTestBase {
         Map<String, Object> bodyMap = new HashMap<String, Object>();
         bodyMap.put("name", "mike");
         bodyMap.put("age", 12);
-        bodyMap.put("pet", Arrays.<Object>asList("cat", "dog"));
+        bodyMap.put("pet", Arrays.<FieldSort>asList(new FieldSort("cat"), new FieldSort("dog")));
         rev.setBody(DocumentBodyFactory.create(bodyMap));
         ds.createDocumentFromRevision(rev);
 
@@ -294,7 +294,7 @@ public abstract class AbstractQueryTestBase {
         bodyMap.clear();
         bodyMap.put("name", "mike");
         bodyMap.put("age", 34);
-        bodyMap.put("pet", Arrays.<Object>asList("cat", "dog", "fish"));
+        bodyMap.put("pet", Arrays.<FieldSort>asList(new FieldSort("cat"), new FieldSort("dog"), new FieldSort("fish")));
         rev.setBody(DocumentBodyFactory.create(bodyMap));
         ds.createDocumentFromRevision(rev);
 
@@ -309,7 +309,7 @@ public abstract class AbstractQueryTestBase {
         bodyMap.clear();
         bodyMap.put("name", "john");
         bodyMap.put("age", 44);
-        bodyMap.put("pet", Arrays.<Object>asList("hamster", "snake"));
+        bodyMap.put("pet", Arrays.<FieldSort>asList(new FieldSort("hamster"), new FieldSort("snake")));
         rev.setBody(DocumentBodyFactory.create(bodyMap));
         ds.createDocumentFromRevision(rev);
 
@@ -321,7 +321,7 @@ public abstract class AbstractQueryTestBase {
         rev.setBody(DocumentBodyFactory.create(bodyMap));
         ds.createDocumentFromRevision(rev);
 
-        assertThat(im.ensureIndexed(Arrays.<Object>asList("name", "pet", "age"), "pet"),
+        assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("pet"), new FieldSort("age")), "pet"),
                 is("pet"));
     }
 
@@ -398,7 +398,7 @@ public abstract class AbstractQueryTestBase {
         rev.setBody(DocumentBodyFactory.create(bodyMap));
         ds.createDocumentFromRevision(rev);
 
-        assertThat(im.ensureIndexed(Arrays.<Object>asList("name", "score"), "name_score"),
+        assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("score")), "name_score"),
                                     is("name_score"));
     }
 
@@ -413,7 +413,7 @@ public abstract class AbstractQueryTestBase {
             rev.setBody(DocumentBodyFactory.create(bodyMap));
             ds.createDocumentFromRevision(rev);
         }
-        assertThat(im.ensureIndexed(Arrays.<Object>asList("large_field", "idx"), "large"),
+        assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("large_field"), new FieldSort("idx")), "large"),
                 is("large"));
     }
 
@@ -462,8 +462,8 @@ public abstract class AbstractQueryTestBase {
         rev.setBody(DocumentBodyFactory.create(bodyMap));
         ds.createDocumentFromRevision(rev);
 
-        assertThat(im.ensureIndexed(Arrays.<Object>asList("name", "age"), "basic"), is("basic"));
-        assertThat(im.ensureIndexed(Arrays.<Object>asList("name", "pet"), "pet"), is("pet"));
+        assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("age")), "basic"), is("basic"));
+        assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("pet")), "pet"), is("pet"));
     }
 
     // Used to setup document data testing for queries containing a $size operator:
@@ -532,7 +532,7 @@ public abstract class AbstractQueryTestBase {
         rev.setBody(DocumentBodyFactory.create(bodyMap));
         ds.createDocumentFromRevision(rev);
 
-        assertThat(im.ensureIndexed(Arrays.<Object>asList("name", "pet", "age"), "basic"), is("basic"));
+        assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("pet"), new FieldSort("age")), "basic"), is("basic"));
     }
 
     // Used to setup document data testing for sorting:
@@ -542,7 +542,7 @@ public abstract class AbstractQueryTestBase {
         Map<String, Object> bodyMap = new HashMap<String, Object>();
         bodyMap.put("name", "mike");
         bodyMap.put("age", 12);
-        bodyMap.put("age", Arrays.<Object>asList("cat", "dog"));
+        bodyMap.put("age", Arrays.<FieldSort>asList(new FieldSort("cat"), new FieldSort("dog")));
         bodyMap.put("same", "all");
         rev.setBody(DocumentBodyFactory.create(bodyMap));
         ds.createDocumentFromRevision(rev);
@@ -565,7 +565,7 @@ public abstract class AbstractQueryTestBase {
         rev.setBody(DocumentBodyFactory.create(bodyMap));
         ds.createDocumentFromRevision(rev);
 
-        assertThat(im.ensureIndexed(Arrays.<Object>asList("name", "pet", "age", "same"), "pet"),
+        assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("pet"), new FieldSort("age"), new FieldSort("same")), "pet"),
                 is("pet"));
     }
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexCreatorTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexCreatorTest.java
@@ -26,13 +26,12 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 public class IndexCreatorTest extends AbstractIndexTestBase {
 
     @Test
     public void emptyIndexList() {
-        Map<String, Object> indexes = im.listIndexes();
+        Map<String, Map<String, Object>> indexes = im.listIndexes();
         assertThat(indexes, is(notNullValue()));
         assertThat(indexes.isEmpty(), is(true));
     }
@@ -252,7 +251,7 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
     @Test
     public void createIndexUsingNonAsciiText() {
         // can create indexes successfully
-        String indexName = im.ensureIndexed(Arrays.<Object>asList("اسم", "datatype", "ages"),
+        String indexName = im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("اسم"), new FieldSort("datatype"), new FieldSort("ages")),
                                             "basic");
         assertThat(indexName, is("basic"));
     }
@@ -266,9 +265,9 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
 
         // removes directions from the field specifiers
         List<String> fields;
-        fields = IndexCreator.removeDirectionsFromFields(Arrays.<Object>asList(nameField,
-                                                                               petField,
-                                                                               "age"));
+        fields = IndexCreator.removeDirectionsFromFields(Arrays.<FieldSort>asList(new FieldSort("name", FieldSort.Direction.ASCENDING),
+                                                                               new FieldSort("pet", FieldSort.Direction.DESCENDING),
+                                                                               new FieldSort("age")));
         assertThat(fields, containsInAnyOrder("name", "pet", "age"));
     }
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexCreatorTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexCreatorTest.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 public class IndexCreatorTest extends AbstractIndexTestBase {
 
@@ -43,7 +44,7 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
         assertThat(name, is(nullValue()));
 
         // doesn't create an index on no fields
-        List<Object> fieldNames = new ArrayList<Object>();
+        List<FieldSort> fieldNames = new ArrayList<FieldSort>();
         name = im.ensureIndexed(fieldNames, "basic");
         assertThat(name, is(nullValue()));
 
@@ -56,21 +57,21 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
         assertThat(name, is(nullValue()));
 
         // doesn't create an index if duplicate fields
-        fieldNames = Arrays.<Object>asList("age", "pet", "age");
+        fieldNames = Arrays.<FieldSort>asList(new FieldSort("age"), new FieldSort("pet"), new FieldSort("age"));
         name = im.ensureIndexed(fieldNames, "basic");
         assertThat(name, is(nullValue()));
     }
 
     @Test
     public void createIndexOverOneField() {
-        String indexName = im.ensureIndexed(Arrays.<Object>asList("name"), "basic");
+        String indexName = im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name")), "basic");
         assertThat(indexName, is("basic"));
 
-        Map<String, Object> indexes = im.listIndexes();
+        Map<String, Map<String, Object>> indexes = im.listIndexes();
         assertThat(indexes, hasKey("basic"));
 
         @SuppressWarnings("unchecked")
-        Map<String, Object> index = (Map<String, Object>) indexes.get("basic");
+        Map<String, Object> index = indexes.get("basic");
         @SuppressWarnings("unchecked")
         List<String> fields = (List<String>) index.get("fields");
         assertThat(fields, containsInAnyOrder("_id", "_rev", "name"));
@@ -78,14 +79,14 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
 
     @Test
     public void createIndexOverTwoFields() {
-        String indexName = im.ensureIndexed(Arrays.<Object>asList("name", "age"), "basic");
+        String indexName = im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("age")), "basic");
         assertThat(indexName, is("basic"));
 
-        Map<String, Object> indexes = im.listIndexes();
+        Map<String, Map<String, Object>> indexes = im.listIndexes();
         assertThat(indexes, hasKey("basic"));
 
         @SuppressWarnings("unchecked")
-        Map<String, Object> index = (Map<String, Object>) indexes.get("basic");
+        Map<String, Object> index = indexes.get("basic");
         @SuppressWarnings("unchecked")
         List<String> fields = (List<String>) index.get("fields");
         assertThat(fields, containsInAnyOrder("_id", "_rev", "name", "age"));
@@ -93,15 +94,15 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
 
     @Test
     public void createIndexUsingDottedNotation() {
-        String indexName = im.ensureIndexed(Arrays.<Object>asList("name.first", "age.years"),
+        String indexName = im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name.first"), new FieldSort("age.years")),
                                             "basic");
         assertThat(indexName, is("basic"));
 
-        Map<String, Object> indexes = im.listIndexes();
+        Map<String, Map<String, Object>> indexes = im.listIndexes();
         assertThat(indexes, hasKey("basic"));
 
         @SuppressWarnings("unchecked")
-        Map<String, Object> index = (Map<String, Object>) indexes.get("basic");
+        Map<String, Object> index = indexes.get("basic");
         @SuppressWarnings("unchecked")
         List<String> fields = (List<String>) index.get("fields");
         assertThat(fields, containsInAnyOrder("_id", "_rev", "name.first", "age.years"));
@@ -110,14 +111,14 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
     @Test
     @SuppressWarnings("unchecked")
     public void createMultipleIndexes() {
-        im.ensureIndexed(Arrays.<Object>asList("name", "age"), "basic");
-        im.ensureIndexed(Arrays.<Object>asList("name", "age"), "another");
-        im.ensureIndexed(Arrays.<Object>asList("cat"), "petname");
+        im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("age")), "basic");
+        im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("age")), "another");
+        im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("cat")), "petname");
 
-        Map<String, Object> indexes = im.listIndexes();
+        Map<String, Map<String, Object>> indexes = im.listIndexes();
         assertThat(indexes.keySet(), containsInAnyOrder("basic", "another", "petname"));
 
-        Map<String, Object> index = (Map<String, Object>) indexes.get("basic");
+        Map<String, Object> index = indexes.get("basic");
         List<String> fields = (List<String>) index.get("fields");
         assertThat(fields, containsInAnyOrder("_id", "_rev", "name", "age"));
 
@@ -132,18 +133,16 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
 
     @Test
     public void createIndexSpecifiedWithAscOrDesc() {
-        HashMap<String, String> nameField = new HashMap<String, String>();
-        nameField.put("name", "asc");
-        HashMap<String, String> ageField = new HashMap<String, String>();
-        ageField.put("age", "desc");
-        String indexName = im.ensureIndexed(Arrays.<Object>asList(nameField, ageField), "basic");
+        String indexName = im.ensureIndexed(Arrays.<FieldSort>asList(
+                new FieldSort("name", FieldSort.Direction.ASCENDING),
+                new FieldSort("age", FieldSort.Direction.DESCENDING)), "basic");
         assertThat(indexName, is("basic"));
 
-        Map<String, Object> indexes = im.listIndexes();
+        Map<String, Map<String, Object>> indexes = im.listIndexes();
         assertThat(indexes, hasKey("basic"));
 
         @SuppressWarnings("unchecked")
-        Map<String, Object> index = (Map<String, Object>) indexes.get("basic");
+        Map<String, Object> index = indexes.get("basic");
         @SuppressWarnings("unchecked")
         List<String> fields = (List<String>) index.get("fields");
         assertThat(fields, containsInAnyOrder("_id", "_rev", "name", "age"));
@@ -151,69 +150,61 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
 
     @Test
     public void createIndexWhenIndexNameExistsIdxDefinitionSame() {
-        HashMap<String, String> nameField = new HashMap<String, String>();
-        nameField.put("name", "asc");
-        HashMap<String, String> ageField = new HashMap<String, String>();
-        ageField.put("age", "desc");
-        String indexName = im.ensureIndexed(Arrays.<Object>asList(nameField, ageField), "basic");
+        String indexName = im.ensureIndexed(Arrays.<FieldSort>asList(
+                new FieldSort("name", FieldSort.Direction.ASCENDING),
+                new FieldSort("age", FieldSort.Direction.DESCENDING)), "basic");
         assertThat(indexName, is("basic"));
 
         // succeeds when the index definition is the same
-        indexName = im.ensureIndexed(Arrays.<Object>asList(nameField, ageField), "basic");
+        indexName = im.ensureIndexed(Arrays.<FieldSort>asList(
+                new FieldSort("name", FieldSort.Direction.ASCENDING),
+                new FieldSort("age", FieldSort.Direction.DESCENDING)), "basic");
         assertThat(indexName, is("basic"));
     }
 
     @Test
     public void createIndexWhenIndexNameExistsIdxDefinitionDifferent() {
-        HashMap<String, String> nameField = new HashMap<String, String>();
-        nameField.put("name", "asc");
-        HashMap<String, String> ageField = new HashMap<String, String>();
-        ageField.put("age", "desc");
-        String indexName = im.ensureIndexed(Arrays.<Object>asList(nameField, ageField), "basic");
+        String indexName = im.ensureIndexed(Arrays.<FieldSort>asList(
+                new FieldSort("name", FieldSort.Direction.ASCENDING),
+                new FieldSort("age", FieldSort.Direction.DESCENDING)), "basic");
         assertThat(indexName, is("basic"));
 
         // fails when the index definition is different
-        HashMap<String, String> petField = new HashMap<String, String>();
-        petField.put("pet", "desc");
-        indexName = im.ensureIndexed(Arrays.<Object>asList(nameField, petField), "basic");
+        indexName = im.ensureIndexed(Arrays.<FieldSort>asList(
+                new FieldSort("name", FieldSort.Direction.ASCENDING),
+                new FieldSort("pet", FieldSort.Direction.DESCENDING)), "basic");
         assertThat(indexName, is(nullValue()));
     }
 
     @Test
     public void createIndexWithJsonType() {
-        HashMap<String, String> nameField = new HashMap<String, String>();
-        nameField.put("name", "asc");
-        HashMap<String, String> ageField = new HashMap<String, String>();
-        ageField.put("age", "desc");
-
         // supports using the json type
-        String indexName = im.ensureIndexed(Arrays.<Object>asList(nameField, ageField),
+        String indexName = im.ensureIndexed(Arrays.<FieldSort>asList(
+                new FieldSort("name", FieldSort.Direction.ASCENDING),
+                new FieldSort("age", FieldSort.Direction.DESCENDING)),
                                             "basic",
                                             IndexType.JSON);
         assertThat(indexName, is("basic"));
-        Map<String, Object> indexes = im.listIndexes();
+        Map<String, Map<String, Object>> indexes = im.listIndexes();
         assertThat(indexes.size(), is(1));
         @SuppressWarnings("unchecked")
-        Map<String, Object> index = (Map<String, Object>) indexes.get("basic");
+        Map<String, Object> index = indexes.get("basic");
         assertThat((IndexType) index.get("type"), is(IndexType.JSON));
         assertThat(index.get("settings"), is(nullValue()));
     }
 
     @Test
     public void createIndexWithTextType() {
-        HashMap<String, String> nameField = new HashMap<String, String>();
-        nameField.put("name", "asc");
-        HashMap<String, String> ageField = new HashMap<String, String>();
-        ageField.put("age", "desc");
-
-        String indexName = im.ensureIndexed(Arrays.<Object>asList(nameField, ageField),
+        String indexName = im.ensureIndexed(Arrays.<FieldSort>asList(
+                new FieldSort("name", FieldSort.Direction.ASCENDING),
+                new FieldSort("age", FieldSort.Direction.DESCENDING)),
                                             "basic",
                                             IndexType.TEXT);
         assertThat(indexName, is("basic"));
-        Map<String, Object> indexes = im.listIndexes();
+        Map<String, Map<String, Object>> indexes = im.listIndexes();
         assertThat(indexes.size(), is(1));
         @SuppressWarnings("unchecked")
-        Map<String, Object> index = (Map<String, Object>) indexes.get("basic");
+        Map<String, Object> index = indexes.get("basic");
         assertThat((IndexType) index.get("type"), is(IndexType.TEXT));
         assertThat((String) index.get("settings"), is("{\"tokenize\":\"simple\"}"));
     }
@@ -222,15 +213,15 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
     public void createIndexWithTextTypeAndTokenizeSetting() {
         Map<String, String> settings = new HashMap<String, String>();
         settings.put("tokenize", "porter");
-        String indexName = im.ensureIndexed(Arrays.<Object>asList("name", "age"),
+        String indexName = im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("age")),
                 "basic",
                 IndexType.TEXT,
                 settings);
         assertThat(indexName, is("basic"));
-        Map<String, Object> indexes = im.listIndexes();
+        Map<String, Map<String, Object>> indexes = im.listIndexes();
         assertThat(indexes.size(), is(1));
         @SuppressWarnings("unchecked")
-        Map<String, Object> index = (Map<String, Object>) indexes.get("basic");
+        Map<String, Object> index = indexes.get("basic");
         assertThat((IndexType) index.get("type"), is(IndexType.TEXT));
         assertThat((String) index.get("settings"), is("{\"tokenize\":\"porter\"}"));
     }
@@ -239,22 +230,22 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
     public void indexAndTextIndexCanCoexist() {
         Map<String, String> settings = new HashMap<String, String>();
         settings.put("tokenize", "porter");
-        String indexName = im.ensureIndexed(Arrays.<Object>asList("name", "age"),
+        String indexName = im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("age")),
                                             "textIndex",
                                             IndexType.TEXT,
                                             settings);
         assertThat(indexName, is("textIndex"));
-        indexName = im.ensureIndexed(Arrays.<Object>asList("name", "age"), "jsonIndex");
+        indexName = im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("age")), "jsonIndex");
         assertThat(indexName, is("jsonIndex"));
-        Map<String, Object> indexes = im.listIndexes();
+        Map<String, Map<String, Object>> indexes = im.listIndexes();
         assertThat(indexes.keySet(), containsInAnyOrder("textIndex", "jsonIndex"));
     }
 
     @Test
     public void correctlyLimitsTextIndexesToOne() {
-        String indexName = im.ensureIndexed(Arrays.<Object>asList("name", "age"), "basic", IndexType.TEXT);
+        String indexName = im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("age")), "basic", IndexType.TEXT);
         assertThat(indexName, is("basic"));
-        indexName = im.ensureIndexed(Arrays.<Object>asList("name", "age"), "anotherIndex", IndexType.TEXT);
+        indexName = im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("age")), "anotherIndex", IndexType.TEXT);
         assertThat(indexName, is(nullValue()));
     }
 
@@ -284,11 +275,11 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
     @Test
     public void createIndexWhereFieldNameContainsDollarSign() {
         // rejects indexes with $ at start
-        String indexName = im.ensureIndexed(Arrays.<Object>asList("$name", "datatype"), "basic");
+        String indexName = im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("$name"), new FieldSort("datatype")), "basic");
         assertThat(indexName, is(nullValue()));
 
         // creates indexes with $ not at start
-        indexName = im.ensureIndexed(Arrays.<Object>asList("na$me", "datatype$"), "basic");
+        indexName = im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("na$me"), new FieldSort("datatype$")), "basic");
         assertThat(indexName, is("basic"));
     }
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexManagerTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexManagerTest.java
@@ -36,7 +36,7 @@ public class IndexManagerTest extends AbstractIndexTestBase {
 
     @Test
     public void deleteFailOnNoIndexName() {
-        im.ensureIndexed(Arrays.<Object>asList("name", "address"), "basic");
+        im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "basic");
         assertThat(im.listIndexes().keySet(), contains("basic"));
 
         assertThat(im.deleteIndexNamed(null), is(false));
@@ -48,7 +48,7 @@ public class IndexManagerTest extends AbstractIndexTestBase {
 
     @Test
     public void deleteFailOnInvalidIndexName() {
-        im.ensureIndexed(Arrays.<Object>asList("name", "address"), "basic");
+        im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "basic");
         assertThat(im.listIndexes().keySet(), contains("basic"));
 
         assertThat(im.deleteIndexNamed("invalid"), is(false));
@@ -57,31 +57,31 @@ public class IndexManagerTest extends AbstractIndexTestBase {
 
     @Test
     public void createIndexWithSpaceInName() {
-        im.ensureIndexed(Arrays.<Object>asList("name", "address"), "basic index");
+        im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "basic index");
         assertThat(im.listIndexes().keySet(), contains("basic index"));
     }
 
     @Test
          public void createIndexWithSingleQuoteInName() {
-        im.ensureIndexed(Arrays.<Object>asList("name", "address"), "basic'index");
+        im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "basic'index");
         assertThat(im.listIndexes().keySet(), contains("basic'index"));
     }
 
     @Test
     public void createIndexWithSemiColonQuoteInName() {
-        im.ensureIndexed(Arrays.<Object>asList("name", "address"), "basic;index");
+        im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "basic;index");
         assertThat(im.listIndexes().keySet(), contains("basic;index"));
     }
 
     @Test
     public void createIndexWithBracketsInName() {
-        im.ensureIndexed(Arrays.<Object>asList("name", "address"), "basic(index)");
+        im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "basic(index)");
         assertThat(im.listIndexes().keySet(), contains("basic(index)"));
     }
 
     @Test
     public void createIndexWithKeyWordName() {
-        im.ensureIndexed(Arrays.<Object>asList("name", "address"), "INSERT INDEX");
+        im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "INSERT INDEX");
         assertThat(im.listIndexes().keySet(), contains("INSERT INDEX"));
     }
 
@@ -89,7 +89,7 @@ public class IndexManagerTest extends AbstractIndexTestBase {
 
     @Test
      public void deleteEmptyIndex() {
-        im.ensureIndexed(Arrays.<Object>asList("name", "address"), "basic");
+        im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "basic");
         assertThat(im.listIndexes().keySet(), contains("basic"));
 
         assertThat(im.deleteIndexNamed("basic"), is(true));
@@ -98,8 +98,8 @@ public class IndexManagerTest extends AbstractIndexTestBase {
 
     @Test
     public void deleteTheCorrectEmptyIndex() {
-        im.ensureIndexed(Arrays.<Object>asList("name", "address"), "basic");
-        im.ensureIndexed(Arrays.<Object>asList("name", "age"), "basic2");
+        im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "basic");
+        im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("age")), "basic2");
         im.ensureIndexed(Arrays.<Object>asList("name"), "basic3");
         assertThat(im.listIndexes().keySet(), containsInAnyOrder("basic", "basic2", "basic3"));
 
@@ -122,7 +122,7 @@ public class IndexManagerTest extends AbstractIndexTestBase {
             ds.createDocumentFromRevision(rev);
         }
 
-        im.ensureIndexed(Arrays.<Object>asList("name", "address"), "basic");
+        im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "basic");
         assertThat(im.listIndexes().keySet(), contains("basic"));
         im.deleteIndexNamed("basic");
         assertThat(im.listIndexes().isEmpty(), is(true));
@@ -143,8 +143,8 @@ public class IndexManagerTest extends AbstractIndexTestBase {
             ds.createDocumentFromRevision(rev);
         }
 
-        im.ensureIndexed(Arrays.<Object>asList("name", "address"), "basic");
-        im.ensureIndexed(Arrays.<Object>asList("name", "age"), "basic2");
+        im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "basic");
+        im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("age")), "basic2");
         im.ensureIndexed(Arrays.<Object>asList("name"), "basic3");
         assertThat(im.listIndexes().keySet(), containsInAnyOrder("basic", "basic2", "basic3"));
 
@@ -167,7 +167,7 @@ public class IndexManagerTest extends AbstractIndexTestBase {
             ds.createDocumentFromRevision(rev);
         }
 
-        im.ensureIndexed(Arrays.<Object>asList("name", "address"), "basic", IndexType.TEXT);
+        im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "basic", IndexType.TEXT);
         assertThat(im.listIndexes().keySet(), contains("basic"));
 
         assertThat(im.deleteIndexNamed("basic"), is(true));

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexManagerTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexManagerTest.java
@@ -31,7 +31,7 @@ public class IndexManagerTest extends AbstractIndexTestBase {
 
     @Test
     public void enusureIndexedGeneratesIndexName() {
-        assertThat(im.ensureIndexed(Arrays.<Object>asList("name")), is(notNullValue()));
+        assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"))), is(notNullValue()));
     }
 
     @Test
@@ -39,10 +39,12 @@ public class IndexManagerTest extends AbstractIndexTestBase {
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "basic");
         assertThat(im.listIndexes().keySet(), contains("basic"));
 
-        assertThat(im.deleteIndexNamed(null), is(false));
+        // TODO assert exception
+        im.deleteIndex(null);
         assertThat(im.listIndexes().keySet(), contains("basic"));
 
-        assertThat(im.deleteIndexNamed(""), is(false));
+        // TODO assert exception
+        im.deleteIndex("");
         assertThat(im.listIndexes().keySet(), contains("basic"));
     }
 
@@ -51,7 +53,8 @@ public class IndexManagerTest extends AbstractIndexTestBase {
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "basic");
         assertThat(im.listIndexes().keySet(), contains("basic"));
 
-        assertThat(im.deleteIndexNamed("invalid"), is(false));
+        // TODO assert exception
+        im.deleteIndex("invalid");
         assertThat(im.listIndexes().keySet(), contains("basic"));
     }
 
@@ -92,7 +95,7 @@ public class IndexManagerTest extends AbstractIndexTestBase {
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "basic");
         assertThat(im.listIndexes().keySet(), contains("basic"));
 
-        assertThat(im.deleteIndexNamed("basic"), is(true));
+        im.deleteIndex("basic");
         assertThat(im.listIndexes().isEmpty(), is(true));
     }
 
@@ -100,10 +103,10 @@ public class IndexManagerTest extends AbstractIndexTestBase {
     public void deleteTheCorrectEmptyIndex() {
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "basic");
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("age")), "basic2");
-        im.ensureIndexed(Arrays.<Object>asList("name"), "basic3");
+        im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name")), "basic3");
         assertThat(im.listIndexes().keySet(), containsInAnyOrder("basic", "basic2", "basic3"));
 
-        assertThat(im.deleteIndexNamed("basic2"), is(true));
+        im.deleteIndex("basic2");
         assertThat(im.listIndexes().keySet(), containsInAnyOrder("basic", "basic3"));
     }
 
@@ -124,7 +127,7 @@ public class IndexManagerTest extends AbstractIndexTestBase {
 
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "basic");
         assertThat(im.listIndexes().keySet(), contains("basic"));
-        im.deleteIndexNamed("basic");
+        im.deleteIndex("basic");
         assertThat(im.listIndexes().isEmpty(), is(true));
     }
 
@@ -145,10 +148,10 @@ public class IndexManagerTest extends AbstractIndexTestBase {
 
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "basic");
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("age")), "basic2");
-        im.ensureIndexed(Arrays.<Object>asList("name"), "basic3");
+        im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name")), "basic3");
         assertThat(im.listIndexes().keySet(), containsInAnyOrder("basic", "basic2", "basic3"));
 
-        assertThat(im.deleteIndexNamed("basic2"), is(true));
+        im.deleteIndex("basic2");
         assertThat(im.listIndexes().keySet(), containsInAnyOrder("basic", "basic3"));
     }
 
@@ -170,7 +173,7 @@ public class IndexManagerTest extends AbstractIndexTestBase {
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "basic", IndexType.TEXT);
         assertThat(im.listIndexes().keySet(), contains("basic"));
 
-        assertThat(im.deleteIndexNamed("basic"), is(true));
+        im.deleteIndex("basic");
         assertThat(im.listIndexes().isEmpty(), is(true));
     }
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexTest.java
@@ -28,12 +28,12 @@ import java.util.Map;
 
 public class IndexTest {
 
-    private List<Object> fieldNames;
+    private List<FieldSort> fieldNames;
     private String indexName;
 
     @Before
     public void setUp() {
-        fieldNames = Arrays.<Object>asList("name", "age");
+        fieldNames = Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("age"));
         indexName = "basic";
 
     }
@@ -42,7 +42,7 @@ public class IndexTest {
     public void constructsIndexWithDefaultType() {
         Index index = Index.getInstance(fieldNames, indexName);
         assertThat(index.indexName, is("basic"));
-        assertThat(index.fieldNames, is(Arrays.<Object>asList("name", "age")));
+        assertThat(index.fieldNames, is(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("age"))));
         assertThat(index.indexType, is(IndexType.JSON));
         assertThat(index.indexSettings, is(nullValue()));
     }
@@ -51,7 +51,7 @@ public class IndexTest {
     public void constructsIndexWithTextTypeDefaultSettings() {
         Index index = Index.getInstance(fieldNames, indexName, IndexType.TEXT);
         assertThat(index.indexName, is("basic"));
-        assertThat(index.fieldNames, is(Arrays.<Object>asList("name", "age")));
+        assertThat(index.fieldNames, is(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("age"))));
         assertThat(index.indexType, is(IndexType.TEXT));
         assertThat(index.indexSettings.size(), is(1));
         assertThat(index.indexSettings.get("tokenize"), is("simple"));
@@ -62,7 +62,7 @@ public class IndexTest {
         Index index = Index.getInstance(null, indexName);
         assertThat(index, is(nullValue()));
 
-        index = Index.getInstance(new ArrayList<Object>(), indexName);
+        index = Index.getInstance(new ArrayList<FieldSort>(), indexName);
         assertThat(index, is(nullValue()));
     }
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexUpdaterTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexUpdaterTest.java
@@ -13,6 +13,7 @@
 package com.cloudant.sync.query;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasKey;
@@ -28,6 +29,7 @@ import com.cloudant.sync.sqlite.SQLDatabase;
 import com.cloudant.sync.sqlite.SQLCallable;
 import com.cloudant.sync.util.DatabaseUtils;
 
+import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -1081,9 +1083,9 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         Map<String, Object> index = indexes.get(indexName);
         fields = (List<String>) index.get("fields");
         assertThat(fields.size(), is(fieldNames.size() + 2));
-        assertThat(fields, hasItems(Arrays.copyOf(fieldNames.toArray(),
-                fieldNames.size(),
-                String[].class)));
+        for (FieldSort fieldSort : fieldNames) {
+            assertThat(fields, Matchers.hasItem(fieldSort.field));
+        }
         assertThat(fields, hasItems("_id", "_rev"));
     }
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexUpdaterTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexUpdaterTest.java
@@ -68,13 +68,13 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
 
     @Test
     public void updateIndexNoIndexName() throws Exception {
-        createIndex("basic", Arrays.<Object>asList("name"));
+        createIndex("basic", Arrays.<FieldSort>asList(new FieldSort("name")));
         assertThat(IndexUpdater.updateIndex(null, fields, ds, indexManagerDatabaseQueue), is(false));
     }
 
     @Test
     public void updateOneFieldIndex() throws Exception {
-        createIndex("basic", Arrays.<Object>asList("name"));
+        createIndex("basic", Arrays.<FieldSort>asList(new FieldSort("name")));
 
         assertThat(getIndexSequenceNumber("basic"), is(0l));
 
@@ -137,7 +137,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
 
     @Test
     public void updateOneFieldIndexMultithreaded() throws Exception {
-        createIndex("basic", Arrays.<Object>asList("name"));
+        createIndex("basic", Arrays.<FieldSort>asList(new FieldSort("name")));
 
         assertThat(getIndexSequenceNumber("basic"), is(0l));
 
@@ -263,7 +263,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
 
     @Test
     public void updateTwoFieldIndex() throws Exception {
-        createIndex("basic", Arrays.<Object>asList("name", "age"));
+        createIndex("basic", Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("age")));
 
         assertThat(getIndexSequenceNumber("basic"), is(0l));
 
@@ -325,7 +325,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
 
     @Test
     public void updateMultiFieldIndex() throws Exception {
-        createIndex("basic", Arrays.<Object>asList("name", "age", "pet", "car"));
+        createIndex("basic", Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("age"), new FieldSort("pet"), new FieldSort("car")));
 
         assertThat(getIndexSequenceNumber("basic"), is(0l));
 
@@ -399,7 +399,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
 
     @Test
     public void updateMultiFieldIndexMissingFields() throws Exception {
-        createIndex("basic", Arrays.<Object>asList("name", "age", "pet", "car"));
+        createIndex("basic", Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("age"), new FieldSort("pet"), new FieldSort("car")));
 
         assertThat(getIndexSequenceNumber("basic"), is(0l));
 
@@ -468,7 +468,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
 
     @Test
     public void updateMultiFieldIndexWithBlankRow() throws Exception {
-        createIndex("basic", Arrays.<Object>asList("car", "van"));
+        createIndex("basic", Arrays.<FieldSort>asList(new FieldSort("car"), new FieldSort("van")));
 
         assertThat(getIndexSequenceNumber("basic"), is(0l));
 
@@ -533,7 +533,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
 
     @Test
     public void indexSingleArrayFieldWhenIndexingArrays() throws Exception {
-        createIndex("basic", Arrays.<Object>asList("name", "pet"));
+        createIndex("basic", Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("pet")));
 
         assertThat(getIndexSequenceNumber("basic"), is(0l));
 
@@ -603,7 +603,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
 
     @Test
     public void indexSingleArrayFieldWhenIndexingArraysInSubDoc() throws Exception {
-        createIndex("basic", Arrays.<Object>asList("name", "pet.species"));
+        createIndex("basic", Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("pet.species")));
 
         assertThat(getIndexSequenceNumber("basic"), is(0l));
 
@@ -672,7 +672,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
 
     @Test
     public void rejectsDocsWithMultipleArrays() throws Exception {
-        createIndex("basic", Arrays.<Object>asList("name", "pet", "pet2"));
+        createIndex("basic", Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("pet"), new FieldSort("pet2")));
 
         assertThat(getIndexSequenceNumber("basic"), is(0l));
 
@@ -753,7 +753,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
 
     @Test
     public void indexSingleArrayFieldWithEmptyValue() throws Exception {
-        createIndex("basic", Arrays.<Object>asList("name", "car", "pet"));
+        createIndex("basic", Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("car"), new FieldSort("pet")));
 
         assertThat(getIndexSequenceNumber("basic"), is(0l));
 
@@ -821,7 +821,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
 
     @Test
     public void indexSingleArrayFieldInSubDocWithEmptyValue() throws Exception {
-        createIndex("basic", Arrays.<Object>asList("name", "car", "pet.species"));
+        createIndex("basic", Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("car"), new FieldSort("pet.species")));
 
         assertThat(getIndexSequenceNumber("basic"), is(0l));
 
@@ -942,11 +942,11 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         // Test index updates for multiple json indexes as well as
         // index updates for co-existing json and text indexes.
         if (testType.equals(TEXT_INDEX_EXECUTION)) {
-            createIndex("basic", Arrays.<Object>asList("age", "pet", "name"), IndexType.TEXT);
+            createIndex("basic", Arrays.<FieldSort>asList(new FieldSort("age"), new FieldSort("pet"), new FieldSort("name")), IndexType.TEXT);
         } else {
-            createIndex("basic", Arrays.<Object>asList("age", "pet", "name"), IndexType.JSON);
+            createIndex("basic", Arrays.<FieldSort>asList(new FieldSort("age"), new FieldSort("pet"), new FieldSort("name")), IndexType.JSON);
         }
-        createIndex("basicName", Arrays.<Object>asList("name"), IndexType.JSON);
+        createIndex("basicName", Arrays.<FieldSort>asList(new FieldSort("name")), IndexType.JSON);
 
         im.updateAllIndexes();
 
@@ -1063,7 +1063,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         }).get();
     }
 
-    private void createIndex(String indexName, List<Object> fieldNames) {
+    private void createIndex(String indexName, List<FieldSort> fieldNames) {
         if (testType.equals(TEXT_INDEX_EXECUTION)) {
             createIndex(indexName, fieldNames, IndexType.TEXT);
         } else {
@@ -1072,13 +1072,13 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
     }
 
     @SuppressWarnings("unchecked")
-    private void createIndex(String indexName, List<Object> fieldNames, IndexType indexType) {
+    private void createIndex(String indexName, List<FieldSort> fieldNames, IndexType indexType) {
         assertThat(im.ensureIndexed(fieldNames, indexName, indexType), is(indexName));
 
-        Map<String, Object> indexes = im.listIndexes();
+        Map<String, Map<String, Object>> indexes = im.listIndexes();
         assertThat(indexes, hasKey(indexName));
 
-        Map<String, Object> index = (Map<String, Object>) indexes.get(indexName);
+        Map<String, Object> index = indexes.get(indexName);
         fields = (List<String>) index.get("fields");
         assertThat(fields.size(), is(fieldNames.size() + 2));
         assertThat(fields, hasItems(Arrays.copyOf(fieldNames.toArray(),

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/MockMatcherIndexManager.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/MockMatcherIndexManager.java
@@ -43,9 +43,7 @@ public class MockMatcherIndexManager extends IndexManagerImpl {
             return null;
         }
 
-        if (!updateAllIndexes()) {
-            return null;
-        }
+        updateAllIndexes();
 
         MockMatcherQueryExecutor queryExecutor = null;
         try {
@@ -54,7 +52,7 @@ public class MockMatcherIndexManager extends IndexManagerImpl {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-        Map<String, Object> indexes = listIndexes();
+        Map<String, Map<String, Object>> indexes = listIndexes();
         return queryExecutor.find(query, indexes, skip, limit, fields, sortDocument);
     }
 }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/MockMatcherIndexManager.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/MockMatcherIndexManager.java
@@ -38,7 +38,7 @@ public class MockMatcherIndexManager extends IndexManagerImpl {
                             long skip,
                             long limit,
                             List<String> fields,
-                            List<Map<String, String>> sortDocument) {
+                            List<FieldSort> sortDocument) {
         if (query == null) {
             return null;
         }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/MockMatcherQueryExecutor.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/MockMatcherQueryExecutor.java
@@ -18,6 +18,7 @@ import com.cloudant.sync.sqlite.SQLDatabaseQueue;
 
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -41,7 +42,7 @@ public class MockMatcherQueryExecutor extends QueryExecutor{
     // return just a blank node (we don't execute it anyway).
     @Override
     protected ChildrenQueryNode translateQuery(Map<String, Object> query,
-                                               Map<String, Object> indexes,
+                                               Map<String, Map<String, Object>> indexes,
                                                Boolean[] indexesCoverQuery) {
         return new AndQueryNode();
     }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/MockMatcherQueryExecutor.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/MockMatcherQueryExecutor.java
@@ -18,7 +18,6 @@ import com.cloudant.sync.sqlite.SQLDatabaseQueue;
 
 import java.util.HashSet;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 
 /**

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/MockSQLOnlyIndexManager.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/MockSQLOnlyIndexManager.java
@@ -43,9 +43,7 @@ public class MockSQLOnlyIndexManager extends IndexManagerImpl {
             return null;
         }
 
-        if (!updateAllIndexes()) {
-            return null;
-        }
+        updateAllIndexes();
 
         MockSQLOnlyQueryExecutor queryExecutor = null;
         try {
@@ -54,7 +52,7 @@ public class MockSQLOnlyIndexManager extends IndexManagerImpl {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-        Map<String, Object> indexes = listIndexes();
+        Map<String, Map<String, Object>> indexes = listIndexes();
         return queryExecutor.find(query, indexes, skip, limit, fields, sortDocument);
     }
 }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/MockSQLOnlyIndexManager.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/MockSQLOnlyIndexManager.java
@@ -38,7 +38,7 @@ public class MockSQLOnlyIndexManager extends IndexManagerImpl {
                             long skip,
                             long limit,
                             List<String> fields,
-                            List<Map<String, String>> sortDocument) {
+                            List<FieldSort> sortDocument) {
         if (query == null) {
             return null;
         }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryCoveringIndexesTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryCoveringIndexesTest.java
@@ -1471,7 +1471,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         setUpArrayIndexingData();
         // query - { "pet" : { "$in" : [ "fish", "hamster" ] } }
         Map<String, Object> op = new HashMap<String, Object>();
-        op.put("$in", Arrays.<FieldSort>asList(new FieldSort("fish"), new FieldSort("hamster")));
+        op.put("$in", Arrays.<String>asList("fish", "hamster"));
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("pet", op);
         QueryResult queryResult = im.find(query);
@@ -1483,7 +1483,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         setUpArrayIndexingData();
         // query - { "pet" : { "$in" : [ "parrot", "turtle" ] } }
         Map<String, Object> op = new HashMap<String, Object>();
-        op.put("$in", Arrays.<FieldSort>asList(new FieldSort("parrot"), new FieldSort("turtle")));
+        op.put("$in", Arrays.<String>asList("parrot", "turtle"));
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("pet", op);
         QueryResult queryResult = im.find(query);
@@ -1495,7 +1495,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         setUpArrayIndexingData();
         // query - { "pet" : { "$in" : [ "cat", "dog" ] } }
         Map<String, Object> op = new HashMap<String, Object>();
-        op.put("$in", Arrays.<FieldSort>asList(new FieldSort("cat"), new FieldSort("dog")));
+        op.put("$in", Arrays.<String>asList("cat", "dog"));
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("pet", op);
         QueryResult queryResult = im.find(query);
@@ -1507,7 +1507,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         setUpArrayIndexingData();
         // query - { "pet" : { "$in" : [ "turtle", "pig" ] } }
         Map<String, Object> op = new HashMap<String, Object>();
-        //op.put("$in", Arrays.<FieldSort>asList(new FieldSort("turtle"), new FieldSort("pig")));
+        op.put("$in", Arrays.<String>asList("turtle", "pig"));
         op.put("$eq", "turtle");
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("pet", op);
@@ -1520,7 +1520,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         setUpArrayIndexingData();
         // query - { "pet" : { "$not" : { "$in" : [ "cat", "dog" ] } } }
         Map<String, Object> op = new HashMap<String, Object>();
-        op.put("$in", Arrays.<FieldSort>asList(new FieldSort("cat"), new FieldSort("dog")));
+        op.put("$in", Arrays.<String>asList("cat", "dog"));
         Map<String, Object> notOp = new HashMap<String, Object>();
         notOp.put("$not", op);
         Map<String, Object> query = new HashMap<String, Object>();

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryCoveringIndexesTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryCoveringIndexesTest.java
@@ -125,7 +125,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         bodyMap.put("married", true);
         rev.setBody(DocumentBodyFactory.create(bodyMap));
         ds.createDocumentFromRevision(rev);
-        assertThat(im.ensureIndexed(Arrays.<Object>asList("name", "age", "married"), "married"), is("married"));
+        assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("age"), new FieldSort("married")), "married"), is("married"));
         // query - { "married" : { "eq" : true } }
         Map<String, Object> marriedOperator = new HashMap<String, Object>();
         marriedOperator.put("$eq", true);
@@ -145,7 +145,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         bodyMap.put("pet", "cat");
         rev.setBody(DocumentBodyFactory.create(bodyMap));
         ds.createDocumentFromRevision(rev);
-        assertThat(im.ensureIndexed(Arrays.<Object>asList("name", "age"), "basic index"), is
+        assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("age")), "basic index"), is
                 ("basic index"));
 
         // query - { "name" : "mike" }
@@ -655,7 +655,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
     @Test
     public void canQueryForNonAsciiValues() throws Exception {
         setUpNonAsciiQueryData();
-        assertThat(im.ensureIndexed(Arrays.<Object>asList("name"), "nonascii"), is("nonascii"));
+        assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name")), "nonascii"), is("nonascii"));
         // query - { "name" : { "$eq" : "اسم" } }
         Map<String, Object> op = new HashMap<String, Object>();
         op.put("$eq", "اسم");
@@ -668,7 +668,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
     @Test
     public void canQueryUsingFieldsWithOddNames() throws Exception {
         setUpNonAsciiQueryData();
-        assertThat(im.ensureIndexed(Arrays.<Object>asList("اسم", "datatype", "age"), "nonascii"),
+        assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("اسم"), new FieldSort("datatype"), new FieldSort("age")), "nonascii"),
                 is("nonascii"));
         // query - { "اسم" : { "$eq" : "fred" }, "age" : { "$eq" : 12 } }
         Map<String, Object> op1 = new HashMap<String, Object>();
@@ -1471,7 +1471,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         setUpArrayIndexingData();
         // query - { "pet" : { "$in" : [ "fish", "hamster" ] } }
         Map<String, Object> op = new HashMap<String, Object>();
-        op.put("$in", Arrays.<Object>asList("fish", "hamster"));
+        op.put("$in", Arrays.<FieldSort>asList(new FieldSort("fish"), new FieldSort("hamster")));
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("pet", op);
         QueryResult queryResult = im.find(query);
@@ -1483,7 +1483,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         setUpArrayIndexingData();
         // query - { "pet" : { "$in" : [ "parrot", "turtle" ] } }
         Map<String, Object> op = new HashMap<String, Object>();
-        op.put("$in", Arrays.<Object>asList("parrot", "turtle"));
+        op.put("$in", Arrays.<FieldSort>asList(new FieldSort("parrot"), new FieldSort("turtle")));
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("pet", op);
         QueryResult queryResult = im.find(query);
@@ -1495,7 +1495,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         setUpArrayIndexingData();
         // query - { "pet" : { "$in" : [ "cat", "dog" ] } }
         Map<String, Object> op = new HashMap<String, Object>();
-        op.put("$in", Arrays.<Object>asList("cat", "dog"));
+        op.put("$in", Arrays.<FieldSort>asList(new FieldSort("cat"), new FieldSort("dog")));
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("pet", op);
         QueryResult queryResult = im.find(query);
@@ -1507,7 +1507,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         setUpArrayIndexingData();
         // query - { "pet" : { "$in" : [ "turtle", "pig" ] } }
         Map<String, Object> op = new HashMap<String, Object>();
-        //op.put("$in", Arrays.<Object>asList("turtle", "pig"));
+        //op.put("$in", Arrays.<FieldSort>asList(new FieldSort("turtle"), new FieldSort("pig")));
         op.put("$eq", "turtle");
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("pet", op);
@@ -1520,7 +1520,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         setUpArrayIndexingData();
         // query - { "pet" : { "$not" : { "$in" : [ "cat", "dog" ] } } }
         Map<String, Object> op = new HashMap<String, Object>();
-        op.put("$in", Arrays.<Object>asList("cat", "dog"));
+        op.put("$in", Arrays.<FieldSort>asList(new FieldSort("cat"), new FieldSort("dog")));
         Map<String, Object> notOp = new HashMap<String, Object>();
         notOp.put("$not", op);
         Map<String, Object> query = new HashMap<String, Object>();
@@ -1545,11 +1545,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         setUpLargeResultSetQueryData();
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("large_field", "cat");
-        Map<String, String> sort = new HashMap<String, String>();
-        sort.put("idx", "asc");
-        List<Map<String, String>> sortDoc = new ArrayList<Map<String, String>>();
-        sortDoc.add(sort);
-        QueryResult queryResult = im.find(query, 90, 20, null, sortDoc);
+        QueryResult queryResult = im.find(query, 90, 20, null, Arrays.<FieldSort>asList(new FieldSort("idx", FieldSort.Direction.ASCENDING)));
         List<String> expected = new ArrayList<String>();
         for (int i = 90; i < 110; i++) {
             expected.add(String.format("d%d", i));

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryResultTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryResultTest.java
@@ -66,7 +66,7 @@ public class QueryResultTest extends AbstractQueryTestBase {
     @Test(expected = QueryException.class)
     public void testQueryGetDocumentsWithIdsFails() throws InterruptedException,
         ExecutionException {
-        List<Object> fields = Collections.<Object>singletonList("pet");
+        List<FieldSort> fields = Collections.<FieldSort>singletonList(new FieldSort("pet"));
         assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
 
         // query - { "$text" : { "$search" : "cat" } }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QuerySortTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QuerySortTest.java
@@ -24,7 +24,6 @@ import com.cloudant.sync.util.TestUtils;
 
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -34,7 +33,7 @@ import java.util.Set;
 
 public class QuerySortTest extends AbstractQueryTestBase {
 
-    Map<String, Object> indexes;
+    Map<String, Map<String, Object>> indexes;
     Set<String> smallDocIdSet;
     Set<String> largeDocIdSet;
 
@@ -56,7 +55,7 @@ public class QuerySortTest extends AbstractQueryTestBase {
         indexB.put("name", "b");
         indexB.put("type", "json");
         indexB.put("fields", Arrays.<Object>asList("x", "y", "z"));
-        indexes = new HashMap<String, Object>();
+        indexes = new HashMap<String, Map<String, Object>>();
         indexes.put("a", indexA);
         indexes.put("b", indexB);
         smallDocIdSet = new HashSet<String>(Arrays.asList("mike", "john"));
@@ -73,10 +72,7 @@ public class QuerySortTest extends AbstractQueryTestBase {
         setUpSortingQueryData();
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("same", "all");
-        Map<String, String> sortName = new HashMap<String, String>();
-        sortName.put("name", "asc");
-        List<Map<String, String>> order = new ArrayList<Map<String, String>>();
-        order.add(sortName);
+        List<FieldSort> order = Arrays.<FieldSort>asList(new FieldSort("name", FieldSort.Direction.ASCENDING));
         QueryResult queryResult = im.find(query, 0, Long.MAX_VALUE, null, order);
         assertThat(queryResult.documentIds(), contains("fred11", "fred34", "mike12"));
     }
@@ -86,13 +82,7 @@ public class QuerySortTest extends AbstractQueryTestBase {
         setUpSortingQueryData();
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("same", "all");
-        Map<String, String> sortName = new HashMap<String, String>();
-        sortName.put("name", "asc");
-        Map<String, String> sortAge = new HashMap<String, String>();
-        sortAge.put("age", "desc");
-        List<Map<String, String>> order = new ArrayList<Map<String, String>>();
-        order.add(sortName);
-        order.add(sortAge);
+        List<FieldSort> order = Arrays.<FieldSort>asList(new FieldSort("name", FieldSort.Direction.ASCENDING), new FieldSort("age", FieldSort.Direction.DESCENDING));
         QueryResult queryResult = im.find(query, 0, Long.MAX_VALUE, null, order);
         assertThat(queryResult.documentIds(), contains("fred34", "fred11", "mike12"));
     }
@@ -102,28 +92,9 @@ public class QuerySortTest extends AbstractQueryTestBase {
         setUpSortingQueryData();
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("same", "all");
-        Map<String, String> sortPet = new HashMap<String, String>();
-        sortPet.put("pet", "asc");
-        List<Map<String, String>> order = new ArrayList<Map<String, String>>();
-        order.add(sortPet);
+        List<FieldSort> order = Arrays.<FieldSort>asList(new FieldSort("pet", FieldSort.Direction.ASCENDING));
         QueryResult queryResult = im.find(query, 0, Long.MAX_VALUE, null, order);
         assertThat(queryResult.documentIds(), contains("mike12", "fred11", "fred34"));
-    }
-
-    @Test
-    public void returnsNullWhenNotUsingAscOrDesc() throws Exception {
-        setUpSortingQueryData();
-        Map<String, Object> query = new HashMap<String, Object>();
-        query.put("same", "all");
-        Map<String, String> sortName = new HashMap<String, String>();
-        sortName.put("name", "blah");
-        Map<String, String> sortAge = new HashMap<String, String>();
-        sortAge.put("age", "desc");
-        List<Map<String, String>> order = new ArrayList<Map<String, String>>();
-        order.add(sortName);
-        order.add(sortAge);
-        QueryResult queryResult = im.find(query, 0, Long.MAX_VALUE, null, order);
-        assertThat(queryResult, is(nullValue()));
     }
 
     @Test
@@ -131,11 +102,7 @@ public class QuerySortTest extends AbstractQueryTestBase {
         setUpSortingQueryData();
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("same", "all");
-        Map<String, String> sort = new HashMap<String, String>();
-        sort.put("name", "asc");
-        sort.put("age", "desc");
-        List<Map<String, String>> order = new ArrayList<Map<String, String>>();
-        order.add(sort);
+        List<FieldSort> order = Arrays.<FieldSort>asList(new FieldSort("name", FieldSort.Direction.ASCENDING), new FieldSort("age", FieldSort.Direction.DESCENDING));
         QueryResult queryResult = im.find(query, 0, Long.MAX_VALUE, null, order);
         assertThat(queryResult, is(nullValue()));
     }
@@ -144,10 +111,7 @@ public class QuerySortTest extends AbstractQueryTestBase {
 
     @Test
     public void smallDocSetForSingleFieldUsingAsc() {
-        Map<String, String> sortName = new HashMap<String, String>();
-        sortName.put("name", "asc");
-        List<Map<String, String>> order = new ArrayList<Map<String, String>>();
-        order.add(sortName);
+        List<FieldSort> order = Arrays.<FieldSort>asList(new FieldSort("name", FieldSort.Direction.ASCENDING));
         SqlParts parts = sqlToSortIds(smallDocIdSet, order, indexes);
         String select = "SELECT DISTINCT _id FROM _t_cloudant_sync_query_index_a";
         String where = "WHERE _id IN (?, ?) ORDER BY \"name\" ASC";
@@ -159,10 +123,7 @@ public class QuerySortTest extends AbstractQueryTestBase {
 
     @Test
     public void smallDocSetForSingleFieldUsingDesc() {
-        Map<String, String> sortY = new HashMap<String, String>();
-        sortY.put("y", "desc");
-        List<Map<String, String>> order = new ArrayList<Map<String, String>>();
-        order.add(sortY);
+        List<FieldSort> order = Arrays.<FieldSort>asList(new FieldSort("y", FieldSort.Direction.DESCENDING));
         SqlParts parts = sqlToSortIds(smallDocIdSet, order, indexes);
         String select = "SELECT DISTINCT _id FROM _t_cloudant_sync_query_index_b";
         String where = "WHERE _id IN (?, ?) ORDER BY \"y\" DESC";
@@ -174,13 +135,7 @@ public class QuerySortTest extends AbstractQueryTestBase {
 
     @Test
     public void smallDocSetForMultipleFieldUsingAsc() {
-        Map<String, String> sortY = new HashMap<String, String>();
-        sortY.put("y", "asc");
-        Map<String, String> sortX = new HashMap<String, String>();
-        sortX.put("x", "asc");
-        List<Map<String, String>> order = new ArrayList<Map<String, String>>();
-        order.add(sortY);
-        order.add(sortX);
+        List<FieldSort> order = Arrays.<FieldSort>asList(new FieldSort("y", FieldSort.Direction.ASCENDING), new FieldSort("x", FieldSort.Direction.ASCENDING));
         SqlParts parts = sqlToSortIds(smallDocIdSet, order, indexes);
         String select = "SELECT DISTINCT _id FROM _t_cloudant_sync_query_index_b";
         String where = "WHERE _id IN (?, ?) ORDER BY \"y\" ASC, \"x\" ASC";
@@ -192,13 +147,7 @@ public class QuerySortTest extends AbstractQueryTestBase {
 
     @Test
     public void smallDocSetForMultipleFieldUsingDesc() {
-        Map<String, String> sortY = new HashMap<String, String>();
-        sortY.put("y", "desc");
-        Map<String, String> sortX = new HashMap<String, String>();
-        sortX.put("x", "desc");
-        List<Map<String, String>> order = new ArrayList<Map<String, String>>();
-        order.add(sortY);
-        order.add(sortX);
+        List<FieldSort> order = Arrays.<FieldSort>asList(new FieldSort("y", FieldSort.Direction.DESCENDING), new FieldSort("x", FieldSort.Direction.DESCENDING));
         SqlParts parts = sqlToSortIds(smallDocIdSet, order, indexes);
         String select = "SELECT DISTINCT _id FROM _t_cloudant_sync_query_index_b";
         String where = "WHERE _id IN (?, ?) ORDER BY \"y\" DESC, \"x\" DESC";
@@ -210,13 +159,7 @@ public class QuerySortTest extends AbstractQueryTestBase {
 
     @Test
     public void smallDocSetForMultipleFieldUsingMixed() {
-        Map<String, String> sortY = new HashMap<String, String>();
-        sortY.put("y", "desc");
-        Map<String, String> sortX = new HashMap<String, String>();
-        sortX.put("x", "asc");
-        List<Map<String, String>> order = new ArrayList<Map<String, String>>();
-        order.add(sortY);
-        order.add(sortX);
+        List<FieldSort> order = Arrays.<FieldSort>asList(new FieldSort("y", FieldSort.Direction.DESCENDING), new FieldSort("x", FieldSort.Direction.ASCENDING));
         SqlParts parts = sqlToSortIds(smallDocIdSet, order, indexes);
         String select = "SELECT DISTINCT _id FROM _t_cloudant_sync_query_index_b";
         String where = "WHERE _id IN (?, ?) ORDER BY \"y\" DESC, \"x\" ASC";
@@ -228,10 +171,7 @@ public class QuerySortTest extends AbstractQueryTestBase {
 
     @Test
     public void largeDocSetForSingleFieldUsingAsc() {
-        Map<String, String> sortName = new HashMap<String, String>();
-        sortName.put("name", "asc");
-        List<Map<String, String>> order = new ArrayList<Map<String, String>>();
-        order.add(sortName);
+        List<FieldSort> order = Arrays.<FieldSort>asList(new FieldSort("name", FieldSort.Direction.ASCENDING));
         SqlParts parts = sqlToSortIds(largeDocIdSet, order, indexes);
         String select = "SELECT DISTINCT _id FROM _t_cloudant_sync_query_index_a";
         String orderBy = "ORDER BY \"name\" ASC";
@@ -242,10 +182,7 @@ public class QuerySortTest extends AbstractQueryTestBase {
 
     @Test
     public void largeDocSetForSingleFieldUsingDesc() {
-        Map<String, String> sortY = new HashMap<String, String>();
-        sortY.put("y", "desc");
-        List<Map<String, String>> order = new ArrayList<Map<String, String>>();
-        order.add(sortY);
+        List<FieldSort> order = Arrays.<FieldSort>asList(new FieldSort("y", FieldSort.Direction.DESCENDING));
         SqlParts parts = sqlToSortIds(largeDocIdSet, order, indexes);
         String select = "SELECT DISTINCT _id FROM _t_cloudant_sync_query_index_b";
         String orderBy = "ORDER BY \"y\" DESC";
@@ -256,13 +193,7 @@ public class QuerySortTest extends AbstractQueryTestBase {
 
     @Test
     public void largeDocSetForMultipleFieldUsingAsc() {
-        Map<String, String> sortY = new HashMap<String, String>();
-        sortY.put("y", "asc");
-        Map<String, String> sortX = new HashMap<String, String>();
-        sortX.put("x", "asc");
-        List<Map<String, String>> order = new ArrayList<Map<String, String>>();
-        order.add(sortY);
-        order.add(sortX);
+        List<FieldSort> order = Arrays.<FieldSort>asList(new FieldSort("y", FieldSort.Direction.ASCENDING), new FieldSort("x", FieldSort.Direction.ASCENDING));
         SqlParts parts = sqlToSortIds(largeDocIdSet, order, indexes);
         String select = "SELECT DISTINCT _id FROM _t_cloudant_sync_query_index_b";
         String orderBy = "ORDER BY \"y\" ASC, \"x\" ASC";
@@ -273,13 +204,7 @@ public class QuerySortTest extends AbstractQueryTestBase {
 
     @Test
     public void largeDocSetForMultipleFieldUsingDesc() {
-        Map<String, String> sortY = new HashMap<String, String>();
-        sortY.put("y", "desc");
-        Map<String, String> sortX = new HashMap<String, String>();
-        sortX.put("x", "desc");
-        List<Map<String, String>> order = new ArrayList<Map<String, String>>();
-        order.add(sortY);
-        order.add(sortX);
+        List<FieldSort> order = Arrays.<FieldSort>asList(new FieldSort("y", FieldSort.Direction.DESCENDING), new FieldSort("x", FieldSort.Direction.DESCENDING));
         SqlParts parts = sqlToSortIds(largeDocIdSet, order, indexes);
         String select = "SELECT DISTINCT _id FROM _t_cloudant_sync_query_index_b";
         String orderBy = "ORDER BY \"y\" DESC, \"x\" DESC";
@@ -290,13 +215,7 @@ public class QuerySortTest extends AbstractQueryTestBase {
 
     @Test
     public void largeDocSetForMultipleFieldUsingMixed() {
-        Map<String, String> sortY = new HashMap<String, String>();
-        sortY.put("y", "desc");
-        Map<String, String> sortX = new HashMap<String, String>();
-        sortX.put("x", "asc");
-        List<Map<String, String>> order = new ArrayList<Map<String, String>>();
-        order.add(sortY);
-        order.add(sortX);
+        List<FieldSort> order = Arrays.<FieldSort>asList(new FieldSort("y", FieldSort.Direction.DESCENDING), new FieldSort("x", FieldSort.Direction.ASCENDING));
         SqlParts parts = sqlToSortIds(largeDocIdSet, order, indexes);
         String select = "SELECT DISTINCT _id FROM _t_cloudant_sync_query_index_b";
         String orderBy = "ORDER BY \"y\" DESC, \"x\" ASC";
@@ -307,32 +226,20 @@ public class QuerySortTest extends AbstractQueryTestBase {
 
     @Test
     public void failsWhenUsingUnindexedField() {
-        Map<String, String> sortApples = new HashMap<String, String>();
-        sortApples.put("apples", "asc");
-        List<Map<String, String>> order = new ArrayList<Map<String, String>>();
-        order.add(sortApples);
+        List<FieldSort> order = Arrays.<FieldSort>asList(new FieldSort("apples", FieldSort.Direction.ASCENDING));
         assertThat(sqlToSortIds(smallDocIdSet, order, indexes), is(nullValue()));
     }
 
     @Test
     public void failsWhenFieldsNotInSingleIndex() {
-        Map<String, String> sortX = new HashMap<String, String>();
-        sortX.put("x", "asc");
-        Map<String, String> sortAge = new HashMap<String, String>();
-        sortAge.put("age", "asc");
-        List<Map<String, String>> order = new ArrayList<Map<String, String>>();
-        order.add(sortX);
-        order.add(sortAge);
+        List<FieldSort> order = Arrays.<FieldSort>asList(new FieldSort("x", FieldSort.Direction.ASCENDING), new FieldSort("age", FieldSort.Direction.ASCENDING));
         assertThat(sqlToSortIds(smallDocIdSet, order, indexes), is(nullValue()));
     }
 
     @Test
     public void returnsNullWhenNoIndexes() {
-        Map<String, String> sortY = new HashMap<String, String>();
-        sortY.put("y", "desc");
-        List<Map<String, String>> order = new ArrayList<Map<String, String>>();
-        order.add(sortY);
-        assertThat(sqlToSortIds(smallDocIdSet, order, new HashMap<String, Object>()),
+        List<FieldSort> order = Arrays.<FieldSort>asList(new FieldSort("y", FieldSort.Direction.DESCENDING));
+        assertThat(sqlToSortIds(smallDocIdSet, order, new HashMap<String, Map<String, Object>>()),
                 is(nullValue()));
         assertThat(sqlToSortIds(smallDocIdSet, order, null), is(nullValue()));
     }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QuerySortTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QuerySortTest.java
@@ -97,7 +97,8 @@ public class QuerySortTest extends AbstractQueryTestBase {
         assertThat(queryResult.documentIds(), contains("mike12", "fred11", "fred34"));
     }
 
-    @Test
+    // TODO check test can be deleted - i think it relates to the way the sort document is built up which is no longer relevant
+//    @Test
     public void returnsNullWhenTooManyClauses() throws Exception{
         setUpSortingQueryData();
         Map<String, Object> query = new HashMap<String, Object>();

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QuerySqlTranslatorTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QuerySqlTranslatorTest.java
@@ -30,8 +30,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.StringJoiner;
 
 public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryTextSearchTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryTextSearchTest.java
@@ -107,7 +107,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
 
     @Test
     public void canMakeAQueryConsistingOfASingleTextSearch() {
-        assertThat(im.ensureIndexed(Arrays.<Object>asList("comment"), "basic_text", IndexType.TEXT),
+        assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("comment")), "basic_text", IndexType.TEXT),
                                     is("basic_text"));
 
         // query - { "$text" : { "$search" : "lives in Bristol" } }
@@ -121,7 +121,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
 
     @Test
     public void canMakeAPhraseSearch() {
-        assertThat(im.ensureIndexed(Arrays.<Object>asList("comment"), "basic_text", IndexType.TEXT),
+        assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("comment")), "basic_text", IndexType.TEXT),
                                     is("basic_text"));
 
         // query - { "$text" : { "$search" : "\"lives in Bristol\"" } }
@@ -135,7 +135,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
 
     @Test
     public void canMakeAQueryTextSearchContainingAnApostrophe() {
-        assertThat(im.ensureIndexed(Arrays.<Object>asList("comment"), "basic_text", IndexType.TEXT),
+        assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("comment")), "basic_text", IndexType.TEXT),
                                     is("basic_text"));
 
         // query - { "$text" : { "$search" : "He's retired" } }
@@ -149,7 +149,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
 
     @Test
     public void canMakeAQueryConsistingOfASingleTextSearchWithASort() {
-        assertThat(im.ensureIndexed(Arrays.<Object>asList("name", "comment"), "basic_text", IndexType.TEXT),
+        assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("comment")), "basic_text", IndexType.TEXT),
                                     is("basic_text"));
 
         // query - { "$text" : { "$search" : "best friend" } }
@@ -169,8 +169,8 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
 
     @Test
     public void canMakeANDCompoundQueryWithATextSearch() {
-        assertThat(im.ensureIndexed(Arrays.<Object>asList("name"), "basic"), is("basic"));
-        assertThat(im.ensureIndexed(Arrays.<Object>asList("name", "comment"), "basic_text", IndexType.TEXT),
+        assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name")), "basic"), is("basic"));
+        assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("comment")), "basic_text", IndexType.TEXT),
                    is("basic_text"));
 
         // query - { "name" : "mike", "$text" : { "$search" : "best friend" } }
@@ -185,8 +185,8 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
 
     @Test
     public void canMakeORCompoundQueryWithATextSearch() {
-        assertThat(im.ensureIndexed(Arrays.<Object>asList("name"), "basic"), is("basic"));
-        assertThat(im.ensureIndexed(Arrays.<Object>asList("comment"), "basic_text", IndexType.TEXT),
+        assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name")), "basic"), is("basic"));
+        assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("comment")), "basic_text", IndexType.TEXT),
                    is("basic_text"));
 
         // query - { "$or" : [ { "name" : "mike" }, { "$text" : { "$search" : "best friend" } } ] }
@@ -208,7 +208,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
 
     @Test
     public void nullForTextSearchQueryWithoutATextIndex() {
-        assertThat(im.ensureIndexed(Arrays.<Object>asList("name"), "basic"), is("basic"));
+        assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name")), "basic"), is("basic"));
 
         // query - { "name" : "mike", "$text" : { "$search" : "best friend" } }
         Map<String, Object> search = new HashMap<String, Object>();
@@ -225,7 +225,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
         // So even though "name" exists in the text index, the clause that { "name" : "mike" }
         // expects a JSON index that contains the "name" field.  Since, this query includes a
         // text search clause then all clauses of the query must be satisfied by existing indexes.
-        assertThat(im.ensureIndexed(Arrays.<Object>asList("name", "comment"), "basic_text", IndexType.TEXT),
+        assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("comment")), "basic_text", IndexType.TEXT),
                    is("basic_text"));
 
         // query - { "$or" : [ { "name" : "mike" }, { "$text" : { "$search" : "best friend" } } ] }
@@ -243,7 +243,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
 
     @Test
     public void canMakeATextSearchUsingNonAsciiValues() {
-        List<Object> fields = Collections.<Object>singletonList("comment");
+        List<FieldSort> fields = Collections.<FieldSort>singletonList(new FieldSort("comment"));
         assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
 
         // query - { "$text" : { "$search" : "\"صديق له هو\"" } }
@@ -257,7 +257,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
 
     @Test
     public void returnsEmptyResultSetForUnmatchedPhraseSearch() {
-        List<Object> fields = Collections.<Object>singletonList("comment");
+        List<FieldSort> fields = Collections.<FieldSort>singletonList(new FieldSort("comment"));
         assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
 
         // query - { "$text" : { "$search" : "\"Remus Romulus\"" } }
@@ -271,7 +271,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
 
     @Test
     public void returnsCorrectResultSetForNonContiguousWordSearch() {
-        List<Object> fields = Collections.<Object>singletonList("comment");
+        List<FieldSort> fields = Collections.<FieldSort>singletonList(new FieldSort("comment"));
         assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
 
         // query - { "$text" : { "$search" : "Remus Romulus" } }
@@ -286,7 +286,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
 
     @Test
     public void canQueryUsingEnhancedQuerySyntaxOR() {
-        List<Object> fields = Collections.<Object>singletonList("comment");
+        List<FieldSort> fields = Collections.<FieldSort>singletonList(new FieldSort("comment"));
         assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
 
         // query - { "$text" : { "$search" : "Remus OR Romulus" } }
@@ -305,7 +305,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
         // Only execute this test if SQLite enhanced query syntax is enabled
         Set<String> compileOptions = SQLDatabaseTestUtils.getCompileOptions(indexManagerDatabaseQueue);
         if (compileOptions.containsAll(Arrays.asList("ENABLE_FTS3", "ENABLE_FTS3_PARENTHESIS"))) {
-            List<Object> fields = Collections.<Object>singletonList("comment");
+            List<FieldSort> fields = Collections.<FieldSort>singletonList(new FieldSort("comment"));
             assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
 
             // query - { "$text" : { "$search" : "Remus NOT Romulus" } }
@@ -326,7 +326,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
         // Only execute this test if SQLite enhanced query syntax is enabled
         Set<String> compileOptions = SQLDatabaseTestUtils.getCompileOptions(indexManagerDatabaseQueue);
         if (compileOptions.containsAll(Arrays.asList("ENABLE_FTS3", "ENABLE_FTS3_PARENTHESIS"))) {
-            List<Object> fields = Collections.<Object>singletonList("comment");
+            List<FieldSort> fields = Collections.<FieldSort>singletonList(new FieldSort("comment"));
             assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
 
             // query - { "$text" : { "$search" : "(Remus OR Romulus) AND \"lives next door\"" } }
@@ -343,7 +343,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
 
     @Test
     public void canQueryUsingNEAR() {
-        List<Object> fields = Collections.<Object>singletonList("comment");
+        List<FieldSort> fields = Collections.<FieldSort>singletonList(new FieldSort("comment"));
         assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
 
         // query - { "$text" : { "$search" : "\"he lives\" NEAR/2 Bristol" } }
@@ -360,7 +360,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
 
     @Test
     public void ignoresCapitalizationUsingDefaultTokenizer() {
-        List<Object> fields = Collections.<Object>singletonList("comment");
+        List<FieldSort> fields = Collections.<FieldSort>singletonList(new FieldSort("comment"));
         assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
 
         // query - { "$text" : { "$search" : "rEmUs RoMuLuS" } }
@@ -376,7 +376,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
     @Test
     public void queriesNonStringFieldAsAString() {
         // Text index on age field
-        List<Object> fields = Collections.<Object>singletonList("age");
+        List<FieldSort> fields = Collections.<FieldSort>singletonList(new FieldSort("age"));
         assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
 
         // query - { "$text" : { "$search" : "12" } }
@@ -391,7 +391,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
     @Test
     public void returnsNullWhenSearchCriteriaNotAString() {
         // Text index on age field
-        List<Object> fields = Collections.<Object>singletonList("age");
+        List<FieldSort> fields = Collections.<FieldSort>singletonList(new FieldSort("age"));
         assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
 
         // query - { "$text" : { "$search" : 12 } }
@@ -406,7 +406,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
     @Test
     public void canQueryAcrossMultipleFields() {
         // Text index on name and comment fields
-        List<Object> fields = Arrays.<Object>asList("name", "comment");
+        List<FieldSort> fields = Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("comment"));
         assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
 
         // query - { "$text" : { "$search" : "Fred" } }
@@ -423,7 +423,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
     @Test
     public void canQueryTargetingSpecificFields() {
         // Text index on name and comment fields
-        List<Object> fields = Arrays.<Object>asList("name", "comment");
+        List<FieldSort> fields = Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("comment"));
         assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
 
         // query - { "$text" : { "$search" : "name:fred comment:lives in Bristol" } }
@@ -439,7 +439,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
 
     @Test
     public void canQueryUsingPrefixSearches() {
-        List<Object> fields = Collections.<Object>singletonList("comment");
+        List<FieldSort> fields = Collections.<FieldSort>singletonList(new FieldSort("comment"));
         assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
 
         // query - { "$text" : { "$search" : "liv* riv*" } }
@@ -453,7 +453,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
 
     @Test
     public void returnsEmptyResultSetWhenPrefixSearchesMissingWildcards() {
-        List<Object> fields = Collections.<Object>singletonList("comment");
+        List<FieldSort> fields = Collections.<FieldSort>singletonList(new FieldSort("comment"));
         assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
 
         // query - { "$text" : { "$search" : "liv riv" } }
@@ -467,7 +467,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
 
     @Test
     public void canQueryUsingID() {
-        List<Object> fields = Collections.<Object>singletonList("comment");
+        List<FieldSort> fields = Collections.<FieldSort>singletonList(new FieldSort("comment"));
         assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
 
         // query - { "$text" : { "$search" : "_id:mike*" } }
@@ -481,7 +481,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
 
     @Test
     public void canQueryUsingPorterTokenizerStemmer() {
-        List<Object> fields = Collections.<Object>singletonList("comment");
+        List<FieldSort> fields = Collections.<FieldSort>singletonList(new FieldSort("comment"));
         Map<String, String> indexSettings = new HashMap<String, String>();
         indexSettings.put("tokenize", "porter");
         assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT, indexSettings), is("basic_text"));
@@ -497,7 +497,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
 
     @Test
     public void returnsEmptyResultSetUsingDefaultTokenizerStemmer() {
-        List<Object> fields = Collections.<Object>singletonList("comment");
+        List<FieldSort> fields = Collections.<FieldSort>singletonList(new FieldSort("comment"));
         assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
 
         // query - { "$text" : { "$search" : "live" } }
@@ -511,7 +511,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
 
     @Test
     public void canQueryUsingAnApostrophe() {
-        List<Object> fields = Collections.<Object>singletonList("comment");
+        List<FieldSort> fields = Collections.<FieldSort>singletonList(new FieldSort("comment"));
         assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
 
         // query - { "$text" : { "$search" : "He's retired" } }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryTextSearchTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryTextSearchTest.java
@@ -157,11 +157,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
         search.put("$search", "best friend");
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("$text", search);
-        List<Map<String, String>> sortDocument = new ArrayList<Map<String, String>>();
-        Map<String, String> sortByName = new HashMap<String, String>();
-        sortByName.put("name", "asc");
-        sortDocument.add(sortByName);
-        QueryResult queryResult = im.find(query, 0, 0, null, sortDocument);
+        QueryResult queryResult = im.find(query, 0, 0, null, Arrays.asList(new FieldSort("name", FieldSort.Direction.ASCENDING)));
         assertThat(queryResult.documentIds(), containsInAnyOrder("mike12", "fred12"));
         assertThat(queryResult.documentIds().get(0), is("fred12"));
         assertThat(queryResult.documentIds().get(1), is("mike12"));

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryWithoutCoveringIndexesTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryWithoutCoveringIndexesTest.java
@@ -249,7 +249,7 @@ public class QueryWithoutCoveringIndexesTest extends AbstractQueryTestBase {
     @Test
     public void canQueryORWithoutAnyIndexes() throws Exception {
         setUpWithoutCoveringIndexesQueryData();
-        im.deleteIndexNamed("pet");
+        im.deleteIndex("pet");
         assertThat(im.listIndexes().keySet(), contains("basic"));
         // query - { "$or" : [ { "pet" : { "$eq" : "cat" } }, { "town" : { "$eq" : "bristol" } } ] }
         // indexes - { "basic" : { "name" : "basic", "type" : "json", "fields" : [ "_id",
@@ -467,8 +467,8 @@ public class QueryWithoutCoveringIndexesTest extends AbstractQueryTestBase {
         // query - { "town" : "bristol" }
         // indexes - No user defined indexes found.  Retrieves
         //           document ids directly from the datastore.
-        assertThat(im.deleteIndexNamed("basic"), is(true));
-        assertThat(im.deleteIndexNamed("pet"), is(true));
+        im.deleteIndex("basic");
+        im.deleteIndex("pet");
         assertThat(im.listIndexes().keySet(), is(empty()));
 
         Map<String, Object> query = new HashMap<String, Object>();

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/PullStrategyTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/PullStrategyTest.java
@@ -27,6 +27,7 @@ import com.cloudant.mazha.Response;
 import com.cloudant.sync.datastore.DatabaseImpl;
 import com.cloudant.sync.datastore.DocumentRevision;
 import com.cloudant.sync.datastore.DocumentRevisionTree;
+import com.cloudant.sync.query.FieldSort;
 import com.cloudant.sync.query.IndexManagerImpl;
 import com.cloudant.sync.query.QueryResult;
 
@@ -388,7 +389,7 @@ public class PullStrategyTest extends ReplicationTestBase {
 
         IndexManagerImpl im = new IndexManagerImpl(datastore);
         try {
-            im.ensureIndexed(Arrays.<Object>asList("diet"), "diet");
+            im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("diet")), "diet");
 
             AnimalDb.populateWithoutFilter(remoteDb.couchClient);
             this.pull(replicator, 10);


### PR DESCRIPTION
Part 2 of _n_ PRs for feature-284-refactor-datastore-indexmanager. See parent issue #284.

The overall theme for this PR is to fix any shortcomings in the public `IndexManager` API. Mostly inspired by @rhyshort - see https://gist.github.com/rhyshort/237fb3d2c00b0c6f3437957635b076c8

- Add `FieldSort` class and use this class instead of a map to request result sorting
- Change `QueryException` to a checked exception and add `throws` clauses for it to IndexManager methods.
- Change Index definition type to be the more specific `Map<String,Map<String,Object>>` and remove casts which this change obviates.
- Update a huge amount of test code which the above breaks

Not done:
- Actual throwing of Exceptions marked on interface methods (instead of currently returning `null` to indicate failure). For a later PR.
- Some extra changes suggested in https://github.com/cloudant/sync-android/issues/305 - should we do them here?