### PR TITLE
284 Refactor IndexManager - "User Friendly API"

### DIFF
--- a/cloudant-sync-datastore-android-encryption/src/test/java/com/cloudant/sync/datastore/encryption/EndToEndEncryptionTest.java
+++ b/cloudant-sync-datastore-android-encryption/src/test/java/com/cloudant/sync/datastore/encryption/EndToEndEncryptionTest.java
@@ -34,6 +34,7 @@ import com.cloudant.sync.datastore.UnsavedStreamAttachment;
 import com.cloudant.sync.query.FieldSort;
 import com.cloudant.sync.query.IndexManager;
 import com.cloudant.sync.query.IndexManagerImpl;
+import com.cloudant.sync.query.QueryException;
 import com.cloudant.sync.query.QueryResult;
 import com.cloudant.sync.util.TestUtils;
 
@@ -120,7 +121,7 @@ public class EndToEndEncryptionTest {
     }
 
     @Test
-    public void jsonDataEncrypted() throws IOException {
+    public void jsonDataEncrypted() throws IOException, QueryException {
         File jsonDatabase = new File(datastoreManagerDir
                 + File.separator + "EndToEndEncryptionTest"
                 + File.separator + "db.sync");
@@ -152,7 +153,7 @@ public class EndToEndEncryptionTest {
     }
 
     @Test
-    public void indexDataEncrypted() throws IOException {
+    public void indexDataEncrypted() throws IOException, QueryException {
 
         IndexManager im = this.database.query;
         try {
@@ -244,7 +245,7 @@ public class EndToEndEncryptionTest {
      * A basic check things round trip successfully.
      */
     @Test
-    public void readAndWriteDocument() throws DocumentException, IOException {
+    public void readAndWriteDocument() throws DocumentException, IOException, QueryException {
 
         String documentId = "a-test-document";
         final String nonAsciiText = "摇;摃:xx\uD83D\uDC79⌚️\uD83D\uDC7D";

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/Index.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/Index.java
@@ -58,7 +58,7 @@ class Index {
      * @return the Index object or null if arguments passed in were invalid.
      */
     public Index (List<FieldSort> fieldNames, String indexName, IndexType indexType) {
-        this(fieldNames, indexName, indexType, TEXT_DEFAULT_TOKENIZER);
+        this(fieldNames, indexName, indexType, null);
     }
 
     /**
@@ -93,8 +93,9 @@ class Index {
                 this.tokenize = tokenize;
             }
         } else {
-            // ignore tokenize if we're not doing text indexing
-            this.tokenize = null;
+            // tokenize isn't valid if we're not doing text indexing
+            Misc.checkArgument(tokenize == null, "tokenize must not be null if indexType is JSON");
+            this.tokenize = tokenize;
         }
 
     }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/Index.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/Index.java
@@ -13,6 +13,8 @@
 package com.cloudant.sync.query;
 
 
+import com.cloudant.sync.util.Misc;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
@@ -25,11 +27,7 @@ class Index {
 
     private static final Logger logger = Logger.getLogger(Index.class.getCanonicalName());
 
-  //  private static final String TEXT_TOKENIZE = "tokenize";
-
     private static final String TEXT_DEFAULT_TOKENIZER = "simple";
-
-    //private static final List<String> validSettings = Arrays.asList(TEXT_TOKENIZE);
 
     public final List<FieldSort> fieldNames;
 
@@ -37,13 +35,7 @@ class Index {
 
     public final IndexType indexType;
 
-    // TODO remove
-//    public final Map<String, String> indexSettings;
-
-    // TODO should this be an enum
     public final String tokenize;
-
-
 
     /**
      * This method sets the index type to the default setting of "json"
@@ -84,18 +76,10 @@ class Index {
                  IndexType indexType,
                  String tokenize) {
 
-        if (tokenize == null) {
-            System.out.println("null");
-        }
-
-        if (fieldNames == null || fieldNames.isEmpty()) {
-            logger.log(Level.SEVERE, "No field names were provided.");
-            throw new IllegalArgumentException("No field names were provided.");
-        }
-
-        if(indexName != null && indexName.isEmpty()){
-            throw new IllegalArgumentException("No index name was provided.");
-        }
+        Misc.checkNotNull(fieldNames, "fieldNames");
+        Misc.checkArgument(!fieldNames.isEmpty(), "fieldNames isEmpty()");
+        // NB indexName can be null (IndexCreator will generate one if needed) but not empty
+        Misc.checkArgument((indexName == null || !indexName.isEmpty()), "indexName");
 
         this.fieldNames = new ArrayList<FieldSort>(fieldNames);
         this.indexName = indexName;
@@ -103,6 +87,7 @@ class Index {
 
         if (indexType == IndexType.TEXT) {
             if (tokenize == null) {
+                // set default tokenizer if one wasn't set
                 this.tokenize = TEXT_DEFAULT_TOKENIZER;
             } else {
                 this.tokenize = tokenize;
@@ -112,12 +97,6 @@ class Index {
             this.tokenize = null;
         }
 
-        //if (tokenize == null) {
-            // TODO
-//            this.tokenize = TEXT_DEFAULT_TOKENIZER;
-        //} else {
-            //this.tokenize = tokenize;
-        //}
     }
 
     /**
@@ -126,6 +105,7 @@ class Index {
      * @return the JSON representation of the index settings
      */
     protected String settingsAsJSON() {
+        // this is a trivial enough operation that we don't need a JSON serializer
         if (tokenize == null) {
             return "{}";
         }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/Index.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/Index.java
@@ -115,8 +115,6 @@ class Index {
     @Override
     public boolean equals(Object o) {
 
-        System.out.println(this.toString() + " equals " + o.toString());
-
         if (this == o) {
             return true;
         }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexCreator.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexCreator.java
@@ -147,7 +147,6 @@ class IndexCreator {
             if (existingIndexNames.containsKey(proposedIndex.indexName)) {
                 Index existingIndex = existingIndexNames.get(proposedIndex.indexName);
                 if (proposedIndex.equals(existingIndex)) {
-                    System.out.println("EQUALS");
                     // index name and fields match existing index, update index and return
                     IndexUpdater.updateIndex(proposedIndex.indexName,
                             fieldNamesList,

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexCreator.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexCreator.java
@@ -146,7 +146,6 @@ class IndexCreator {
             }
             if (existingIndexNames.containsKey(proposedIndex.indexName)) {
                 Index existingIndex = existingIndexNames.get(proposedIndex.indexName);
-                // TODO need to compare ignoring direction
                 if (proposedIndex.equals(existingIndex)) {
                     System.out.println("EQUALS");
                     // index name and fields match existing index, update index and return
@@ -289,7 +288,7 @@ class IndexCreator {
                                                                     InterruptedException {
         Future<List<Index>> indexes = queue.submit(new SQLCallable<List<Index>>() {
             @Override
-            public List<Index> call(SQLDatabase database) {
+            public List<Index> call(SQLDatabase database) throws SQLException {
                 return IndexManagerImpl.listIndexesInDatabase(database);
             }
         });

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexCreator.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexCreator.java
@@ -71,7 +71,6 @@ class IndexCreator {
      *  @param proposedIndex The object that defines an index.  Includes field list, name, type and options.
      *  @return name of created index
      */
-    @SuppressWarnings("unchecked")
     private String ensureIndexed(Index proposedIndex) throws QueryException {
         Misc.checkNotNull(proposedIndex, "proposedIndex");
 
@@ -264,7 +263,6 @@ class IndexCreator {
      * @param existingIndexes the list of already existing indexes
      * @return whether the index limit has been reached
      */
-    @SuppressWarnings("unchecked")
     protected static boolean indexLimitReached(Index index, List<Index> existingIndexes) {
         if (index.indexType == IndexType.TEXT) {
             for (Index existingIndex : existingIndexes) {

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexManager.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexManager.java
@@ -12,7 +12,7 @@ public interface IndexManager {
 
     Map<String, Map<String, Object>> listIndexes() throws QueryException;
 
-    String ensureIndexed(List<FieldSort> fieldNames);
+    String ensureIndexed(List<FieldSort> fieldNames) throws QueryException;
 
     String ensureIndexed(List<FieldSort> fieldNames, String indexName) throws QueryException;
 
@@ -27,7 +27,7 @@ public interface IndexManager {
 
     void deleteIndex(String indexName) throws QueryException;
 
-    void updateAllIndexes(); // not sure if this should throw or not.
+    void updateAllIndexes() throws QueryException; // not sure if this should throw or not.
 
     QueryResult find(Map<String, Object> query) throws QueryException;
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexManager.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexManager.java
@@ -10,7 +10,7 @@ import java.util.Map;
 public interface IndexManager {
 
 
-    Map<String, Map<String, Object>> listIndexes() throws QueryException;
+    List<Index> listIndexes() throws QueryException;
 
     String ensureIndexed(List<FieldSort> fieldNames) throws QueryException;
 
@@ -22,7 +22,7 @@ public interface IndexManager {
     String ensureIndexed(List<FieldSort> fieldNames,
                          String indexName,
                          IndexType indexType,
-                         Map<String, String> IndexSettings) throws QueryException;
+                         String tokenize) throws QueryException;
 
 
     void deleteIndex(String indexName) throws QueryException;

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexManagerImpl.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexManagerImpl.java
@@ -307,9 +307,13 @@ public class IndexManagerImpl implements IndexManager {
         try {
             result.get();
         } catch (ExecutionException e) {
-            throw new QueryException("Execution error during index deletion:", e);
+            String message = "Execution error during index deletion";
+            logger.log(Level.SEVERE, message, e);
+            throw new QueryException(message, e);
         } catch (InterruptedException e) {
-            throw new QueryException("Execution interrupted error during index deletion:", e);
+            String message = "Execution interrupted error during index deletion";
+            logger.log(Level.SEVERE, message, e);
+            throw new QueryException(message, e);
         }
 
     }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexManagerImpl.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexManagerImpl.java
@@ -155,7 +155,7 @@ public class IndexManagerImpl implements IndexManager {
 
     }
 
-    protected static List<Index> listIndexesInDatabase(SQLDatabase db) {
+    protected static List<Index> listIndexesInDatabase(SQLDatabase db) throws SQLException {
         // Accumulate indexes and definitions into a map
         String sqlIndexNames = String.format("SELECT DISTINCT index_name FROM %s", INDEX_METADATA_TABLE_NAME);
         Cursor cursorIndexNames = null;
@@ -194,9 +194,6 @@ public class IndexManagerImpl implements IndexManager {
 
 
             }
-        } catch (SQLException sqe) {
-            // TODO
-            System.out.println("ERROR "+sqe);
         } finally {
             DatabaseUtils.closeCursorQuietly(cursorIndexNames);
         }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexManagerImpl.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexManagerImpl.java
@@ -45,11 +45,12 @@ import com.cloudant.sync.sqlite.SQLCallable;
 import com.cloudant.sync.sqlite.SQLDatabase;
 import com.cloudant.sync.sqlite.SQLDatabaseQueue;
 import com.cloudant.sync.util.DatabaseUtils;
+import com.cloudant.sync.util.JSONUtils;
 
 import java.io.File;
+import java.nio.charset.Charset;
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -136,11 +137,11 @@ public class IndexManagerImpl implements IndexManager {
      *  @return Map of indexes in the database.
      */
     @Override
-    public Map<String, Map<String, Object>> listIndexes() {
+    public List<Index> listIndexes() {
         try {
-            return dbQueue.submit(new SQLCallable<Map<String, Map<String, Object>> >() {
+            return dbQueue.submit(new SQLCallable<List<Index>>() {
                 @Override
-                public Map<String, Map<String, Object>> call(SQLDatabase database) throws Exception {
+                public List<Index> call(SQLDatabase database) throws Exception {
                      return IndexManagerImpl.listIndexesInDatabase(database);
                 }
             }).get();
@@ -154,42 +155,50 @@ public class IndexManagerImpl implements IndexManager {
 
     }
 
-    protected static Map<String, Map<String, Object>> listIndexesInDatabase(SQLDatabase db) {
+    protected static List<Index> listIndexesInDatabase(SQLDatabase db) {
         // Accumulate indexes and definitions into a map
-        String sql;
-        sql = String.format("SELECT index_name, index_type, field_name, index_settings FROM %s",
-                             INDEX_METADATA_TABLE_NAME);
-        Map<String, Map<String, Object>> indexes = null;
-        Map<String, Object> index;
-        List<String> fields = null;
-        Cursor cursor = null;
+        String sqlIndexNames = String.format("SELECT DISTINCT index_name FROM %s", INDEX_METADATA_TABLE_NAME);
+        Cursor cursorIndexNames = null;
+        ArrayList<Index> indexes = new ArrayList<Index>();
         try {
-            cursor = db.rawQuery(sql, new String[]{});
-            indexes = new HashMap<String, Map<String, Object>>();
-            while (cursor.moveToNext()) {
-                String rowIndex = cursor.getString(0);
-                IndexType rowType = IndexType.enumValue(cursor.getString(1));
-                String rowField = cursor.getString(2);
-                String rowSettings = cursor.getString(3);
-                if (!indexes.containsKey(rowIndex)) {
-                    index = new HashMap<String, Object>();
-                    fields = new ArrayList<String>();
-                    index.put("type", rowType);
-                    index.put("name", rowIndex);
-                    index.put("fields", fields);
-                    if (rowSettings != null && !rowSettings.isEmpty()) {
-                        index.put("settings", rowSettings);
+            cursorIndexNames = db.rawQuery(sqlIndexNames, new String[]{});
+            while (cursorIndexNames.moveToNext()) {
+                String indexName = cursorIndexNames.getString(0);
+                String sqlIndexes = String.format("SELECT index_type, field_name, index_settings FROM %s "+
+                        "WHERE index_name = ?",
+                        INDEX_METADATA_TABLE_NAME);
+                Cursor cursorIndexes = null;
+                try {
+                    cursorIndexes = db.rawQuery(sqlIndexes, new String[]{indexName});
+                    int i=0;
+                    IndexType indexType = null;
+                    String settings = null;
+                    ArrayList<FieldSort> fieldNames = new ArrayList<FieldSort>();
+                    while (cursorIndexes.moveToNext()) {
+                        if (i++ == 0) {
+                            // first time round
+                            indexType = IndexType.enumValue(cursorIndexes.getString(0));
+                            settings = cursorIndexes.getString(2);
+                        }
+                        fieldNames.add(new FieldSort(cursorIndexes.getString(1)));
                     }
-                    indexes.put(rowIndex, index);
+                    Map<String, Object> settingsMap = JSONUtils.deserialize(settings.getBytes(Charset.forName("UTF-8")));
+                    if (settingsMap.containsKey("tokenize") && settingsMap.get("tokenize") instanceof String) {
+                        indexes.add(new Index(fieldNames, indexName, indexType, (String)settingsMap.get("tokenize")));
+                    } else {
+                        indexes.add(new Index(fieldNames, indexName, indexType));
+                    }
+                } finally {
+                    DatabaseUtils.closeCursorQuietly(cursorIndexes);
                 }
-                if (fields != null) {
-                    fields.add(rowField);
-                }
+
+
             }
-        } catch (SQLException e) {
-            logger.log(Level.SEVERE, "Failed to get a list of indexes in the database.", e);
+        } catch (SQLException sqe) {
+            // TODO
+            System.out.println("ERROR "+sqe);
         } finally {
-            DatabaseUtils.closeCursorQuietly(cursor);
+            DatabaseUtils.closeCursorQuietly(cursorIndexNames);
         }
 
         return indexes;
@@ -219,7 +228,7 @@ public class IndexManagerImpl implements IndexManager {
      */
     @Override
     public String ensureIndexed(List<FieldSort> fieldNames, String indexName) throws QueryException {
-        return IndexCreator.ensureIndexed(Index.getInstance(fieldNames, indexName),
+        return IndexCreator.ensureIndexed(new Index(fieldNames, indexName),
                 database,
                 dbQueue);
     }
@@ -247,7 +256,7 @@ public class IndexManagerImpl implements IndexManager {
      *  @param fieldNames List of field names in the sort format
      *  @param indexName Name of index to create or null to generate an index name.
      *  @param indexType The type of index (json or text currently supported)
-     *  @param indexSettings The optional settings to be applied to an index
+     *  @param tokenize
      *                       Only text indexes support settings - Ex. { "tokenize" : "simple" }
      *  @return name of created index
      */
@@ -255,11 +264,11 @@ public class IndexManagerImpl implements IndexManager {
     public String ensureIndexed(List<FieldSort> fieldNames,
                                 String indexName,
                                 IndexType indexType,
-                                Map<String, String> indexSettings) throws QueryException {
-        return IndexCreator.ensureIndexed(Index.getInstance(fieldNames,
+                                String tokenize) throws QueryException {
+        return IndexCreator.ensureIndexed(new Index(fieldNames,
                         indexName,
                         indexType,
-                        indexSettings),
+                        tokenize),
                 database,
                 dbQueue);
     }
@@ -311,7 +320,7 @@ public class IndexManagerImpl implements IndexManager {
      */
     @Override
     public void updateAllIndexes() throws QueryException {
-        Map<String, Map<String, Object>> indexes = listIndexes();
+        List<Index> indexes = listIndexes();
 
         IndexUpdater.updateAllIndexes(indexes, database, dbQueue);
     }
@@ -334,7 +343,7 @@ public class IndexManagerImpl implements IndexManager {
         updateAllIndexes();
 
         QueryExecutor queryExecutor = new QueryExecutor(database, dbQueue);
-        Map<String, Map<String, Object>> indexes = listIndexes();
+        List<Index> indexes = listIndexes();
 
         return queryExecutor.find(query, indexes, skip, limit, fields, sortDocument);
     }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexManagerImpl.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexManagerImpl.java
@@ -46,6 +46,7 @@ import com.cloudant.sync.sqlite.SQLDatabase;
 import com.cloudant.sync.sqlite.SQLDatabaseQueue;
 import com.cloudant.sync.util.DatabaseUtils;
 import com.cloudant.sync.util.JSONUtils;
+import com.cloudant.sync.util.Misc;
 
 import java.io.File;
 import java.nio.charset.Charset;
@@ -278,9 +279,7 @@ public class IndexManagerImpl implements IndexManager {
      */
     @Override
     public void deleteIndex(final String indexName) throws QueryException {
-        if (indexName == null || indexName.isEmpty()) {
-            throw new QueryException("TO delete an index, index name should be provided.");
-        }
+        Misc.checkNotNullOrEmpty(indexName, "indexName");
 
         Future<Void> result = dbQueue.submitTransaction(new SQLCallable<Void>() {
             @Override
@@ -338,9 +337,7 @@ public class IndexManagerImpl implements IndexManager {
                             long limit,
                             List<String> fields,
                             List<FieldSort> sortDocument) throws QueryException {
-        if (query == null) {
-            throw new QueryException("Query must not be null");
-        }
+        Misc.checkNotNull(query, "query");
 
         updateAllIndexes();
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexManagerImpl.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexManagerImpl.java
@@ -170,15 +170,16 @@ public class IndexManagerImpl implements IndexManager {
                 Cursor cursorIndexes = null;
                 try {
                     cursorIndexes = db.rawQuery(sqlIndexes, new String[]{indexName});
-                    int i=0;
                     IndexType indexType = null;
                     String settings = null;
                     ArrayList<FieldSort> fieldNames = new ArrayList<FieldSort>();
+                    boolean first = true;
                     while (cursorIndexes.moveToNext()) {
-                        if (i++ == 0) {
+                        if (first) {
                             // first time round
                             indexType = IndexType.enumValue(cursorIndexes.getString(0));
                             settings = cursorIndexes.getString(2);
+                            first = false;
                         }
                         fieldNames.add(new FieldSort(cursorIndexes.getString(1)));
                     }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexUpdater.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexUpdater.java
@@ -99,6 +99,9 @@ class IndexUpdater {
     }
 
     private void updateIndex(String indexName, List<FieldSort> fieldNames) throws QueryException {
+
+        Misc.checkNotNullOrEmpty(indexName, "indexName");
+
         Changes changes;
         long lastSequence = sequenceNumberForIndex(indexName);
 
@@ -113,7 +116,6 @@ class IndexUpdater {
                                 final List<FieldSort> fieldNames,
                                 final Changes changes,
                                 long lastSequence) throws QueryException {
-        Misc.checkNotNullOrEmpty(indexName, "indexName");
 
         Future<Void> result = queue.submitTransaction(new SQLCallable<Void>() {
             @Override

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexUpdater.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexUpdater.java
@@ -303,14 +303,13 @@ class IndexUpdater {
             } else if (argument instanceof String) {
                 contentValues.put(fieldName, (String) argument);
             } else {
-                System.out.println("**** null ***" + argument);
+                // TODO it shouldn't be possible to get here and adding null to contentValues is not
+                // the right thing to do!
                 contentValues.put(fieldName, (String) null);
             }
             argIndex = argIndex + 1;
         }
         String tableName = IndexManagerImpl.tableNameForIndex(indexName);
-
-        System.out.println("populate "+tableName+", "+contentValues);
 
         return new DBParameter(tableName, contentValues);
     }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexUpdater.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexUpdater.java
@@ -132,6 +132,7 @@ class IndexUpdater {
                                                                                  indexName,
                                                                                  fieldNames);
                         if (parameters == null) {
+                            // non-fatal error found with this rev, but we can carry on indexing
                             continue;
                         }
                         for (DBParameter parameter: parameters) {
@@ -196,11 +197,14 @@ class IndexUpdater {
             }
         }
 
-        Misc.checkState(arrayCount <= 1, String.format("Indexing %s in index %s includes > 1 " +
-                "array field; " +
-                        "Only one array field per index allowed.",
-                rev.getId(),
-                indexName));
+        if (arrayCount > 1) {
+            String msg = String.format("Indexing %s in index %s includes > 1 array field; " +
+                            "Only one array field per index allowed.",
+                    rev.getId(),
+                    indexName);
+            logger.log(Level.SEVERE, msg);
+            return null;
+        }
 
         List<DBParameter> parameters = new ArrayList<DBParameter>();
         List<Object> arrayFieldValues = null;

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexUpdater.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexUpdater.java
@@ -91,7 +91,6 @@ class IndexUpdater {
         updater.updateIndex(indexName, fieldNames);
     }
 
-    @SuppressWarnings("unchecked")
     private void updateAllIndexes(List<Index> indexes) throws QueryException {
 
         for (Index index : indexes) {
@@ -136,13 +135,11 @@ class IndexUpdater {
                             continue;
                         }
                         for (DBParameter parameter: parameters) {
-                            if (parameter != null) {
-                                long rowId = database.insert(parameter.tableName,
-                                                             parameter.contentValues);
-                                if (rowId < 0) {
-                                    String msg = String.format("Updating index %s failed.", indexName);
-                                    throw new QueryException(msg);
-                                }
+                            long rowId = database.insert(parameter.tableName,
+                                    parameter.contentValues);
+                            if (rowId < 0) {
+                                String msg = String.format("Updating index %s failed.", indexName);
+                                throw new QueryException(msg);
                             }
                         }
                     }
@@ -302,11 +299,8 @@ class IndexUpdater {
                 contentValues.put(fieldName, (Short) argument);
             } else if (argument instanceof String) {
                 contentValues.put(fieldName, (String) argument);
-            } else {
-                // TODO it shouldn't be possible to get here and adding null to contentValues is not
-                // the right thing to do!
-                contentValues.put(fieldName, (String) null);
             }
+            // NB there is no default case - if the type isn't supported, it doesn't get indexed
             argIndex = argIndex + 1;
         }
         String tableName = IndexManagerImpl.tableNameForIndex(indexName);

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexUpdater.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexUpdater.java
@@ -62,12 +62,12 @@ class IndexUpdater {
      *  @param queue The executor service queue
      *  @return index update success status (true/false)
      */
-    public static boolean updateAllIndexes(Map<String, Map<String, Object>> indexes,
+    public static void updateAllIndexes(Map<String, Map<String, Object>> indexes,
                                            Database database,
-                                           SQLDatabaseQueue queue) {
+                                           SQLDatabaseQueue queue) throws QueryException {
         IndexUpdater updater = new IndexUpdater(database, queue);
 
-        return updater.updateAllIndexes(indexes);
+        updater.updateAllIndexes(indexes);
     }
 
     /**
@@ -81,62 +81,47 @@ class IndexUpdater {
      *  @param queue The executor service queue
      *  @return index update success status (true/false)
      */
-    public static boolean updateIndex(String indexName,
+    public static void updateIndex(String indexName,
                                       List<String> fieldNames,
                                       Database database,
-                                      SQLDatabaseQueue queue) {
+                                      SQLDatabaseQueue queue) throws QueryException {
         IndexUpdater updater = new IndexUpdater(database, queue);
 
-        return updater.updateIndex(indexName, fieldNames);
+        updater.updateIndex(indexName, fieldNames);
     }
 
     @SuppressWarnings("unchecked")
-    private boolean updateAllIndexes(Map<String, Map<String, Object>> indexes) {
-        boolean success = true;
+    private void updateAllIndexes(Map<String, Map<String, Object>> indexes) throws QueryException {
 
         for (Map.Entry<String, Map<String, Object>> entry: indexes.entrySet()) {
             Map<String, Object> index = entry.getValue();
             List<String> fields = (ArrayList<String>) index.get("fields");
-            success = updateIndex(entry.getKey(), fields);
-            if (!success) {
-                break;
-            }
+            updateIndex(entry.getKey(), fields);
         }
-
-        return success;
     }
 
-    private boolean updateIndex(String indexName, List<String> fieldNames) {
-        boolean success;
+    private void updateIndex(String indexName, List<String> fieldNames) throws QueryException {
         Changes changes;
         long lastSequence = sequenceNumberForIndex(indexName);
 
         do {
             changes = database.changes(lastSequence, 10000);
-            success = updateIndex(indexName, fieldNames, changes, lastSequence);
+            updateIndex(indexName, fieldNames, changes, lastSequence);
             lastSequence = changes.getLastSequence();
-        } while (success && changes.size() > 0);
-
-        // raise error
-        if (!success) {
-            logger.log(Level.SEVERE, String.format("Problem updating index %s", indexName));
-        }
-
-        return success;
+        } while (changes.size() > 0);
     }
 
-    private boolean updateIndex(final String indexName,
+    private void updateIndex(final String indexName,
                                 final List<String> fieldNames,
                                 final Changes changes,
-                                long lastSequence) {
+                                long lastSequence) throws QueryException {
         if (indexName == null || indexName.isEmpty()) {
-            return false;
+            throw new QueryException("Index name was null or empty");
         }
 
-        Future<Boolean> result = queue.submitTransaction(new SQLCallable<Boolean>() {
+        Future<Void> result = queue.submitTransaction(new SQLCallable<Void>() {
             @Override
-            public Boolean call(SQLDatabase database) {
-                database.beginTransaction();
+            public Void call(SQLDatabase database) throws QueryException {
                 for (DocumentRevision rev: changes.getResults()) {
                     // Delete existing values
                     String tableName = IndexManagerImpl.tableNameForIndex(indexName);
@@ -158,7 +143,6 @@ class IndexUpdater {
                                                              parameter.contentValues);
                                 if (rowId < 0) {
                                     String msg = String.format("Updating index %s failed.", indexName);
-                                    logger.log(Level.SEVERE, msg);
                                     throw new QueryException(msg);
                                 }
                             }
@@ -166,27 +150,23 @@ class IndexUpdater {
                     }
                 }
 
-                return true;
+                return null;
             }
         });
 
-        boolean success;
         try {
-            success = result.get();
+            result.get();
         } catch (ExecutionException e) {
-            logger.log(Level.SEVERE, "Execution error encountered:", e);
-            success = false;
+            throw new QueryException("Execution error encountered:", e);
         } catch (InterruptedException e) {
-            logger.log(Level.SEVERE, "Execution interrupted error encountered:", e);
-            success = false;
+            throw new QueryException("Execution interrupted error encountered:",e);
         }
 
-        // if there was a problem, we rolled back, so the sequence won't be updated
-        if (success) {
-            success = updateMetadataForIndex(indexName, lastSequence);
-        }
+        // if there was a problem, we rolled back, and threw an exception, so the sequence won't be
+        // updated. otherwise if we got here we can update the sequence.
+        updateMetadataForIndex(indexName, lastSequence);
 
-        return success;
+
     }
 
     /**
@@ -337,7 +317,7 @@ class IndexUpdater {
         return new DBParameter(tableName, contentValues);
     }
 
-    private long sequenceNumberForIndex(final String indexName) {
+    private long sequenceNumberForIndex(final String indexName) throws QueryException {
         Future<Long> sequenceNumber = queue.submit( new SQLCallable<Long>() {
             @Override
             public Long call(SQLDatabase database) {
@@ -365,19 +345,18 @@ class IndexUpdater {
         try {
             lastSequenceNumber = sequenceNumber.get();
         } catch (ExecutionException e) {
-            logger.log(Level.SEVERE, "Execution error encountered:", e);
+            throw new QueryException("Execution error encountered:", e);
         } catch (InterruptedException e) {
-            logger.log(Level.SEVERE, "Execution interrupted error encountered:", e);
+            throw new QueryException("Execution interrupted error encountered:", e);
         }
 
         return lastSequenceNumber;
     }
 
-    private boolean updateMetadataForIndex(final String indexName, final long lastSequence) {
-        Future<Boolean> result = queue.submit(new SQLCallable<Boolean>() {
+    private void updateMetadataForIndex(final String indexName, final long lastSequence) throws QueryException {
+        Future<Void> result = queue.submit(new SQLCallable<Void>() {
             @Override
-            public Boolean call(SQLDatabase database) {
-                boolean updateSuccess = true;
+            public Void call(SQLDatabase database) throws QueryException {
                 ContentValues v = new ContentValues();
                 v.put("last_sequence", lastSequence);
                 int row = database.update(IndexManagerImpl.INDEX_METADATA_TABLE_NAME,
@@ -385,24 +364,19 @@ class IndexUpdater {
                                           " index_name = ? ",
                                           new String[]{ indexName });
                 if (row <= 0) {
-                    updateSuccess = false;
+                    throw new QueryException("Failed to update index metadata for index "+indexName);
                 }
-                return updateSuccess;
+                return null;
             }
         });
 
-        boolean success;
         try {
-            success = result.get();
+            result.get();
         } catch (ExecutionException e) {
-            logger.log(Level.SEVERE, "Execution error encountered:", e);
-            success = false;
+            throw new QueryException("Execution error encountered:", e);
         } catch (InterruptedException e) {
-            logger.log(Level.SEVERE, "Execution interrupted error encountered:", e);
-            success = false;
+            throw new QueryException("Execution interrupted error encountered:", e);
         }
-
-        return success;
     }
 
     private static class DBParameter {

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexUpdater.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexUpdater.java
@@ -155,7 +155,6 @@ class IndexUpdater {
         try {
             result.get();
         } catch (ExecutionException e) {
-            // TODO we should unwrarp executionexception
             String message = String.format("Execution error encountered whilst updating index %s", indexName);
             logger.log(Level.SEVERE, message, e);
             throw new QueryException(message, e);

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/QueryException.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/QueryException.java
@@ -1,19 +1,22 @@
 package com.cloudant.sync.query;
 
+import com.cloudant.sync.datastore.DatastoreException;
+
 /**
- * This unchecked exception is used to wrap another exception so
- * we can pass meaningful exception traces over the {@link QueryResult#iterator()}
- * boundary as we can't change the signature of {@link QueryResult#iterator} to
- * add a checked exception.
- *
+
  * @api_public
  */
-public class QueryException extends RuntimeException {
-    public QueryException(Exception causedBy){
+public class QueryException extends DatastoreException {
+    public QueryException(Throwable causedBy){
         super(causedBy);
     }
 
-    public QueryException(String messaage){
-        super(messaage);
+    public QueryException(String message){
+        super(message);
     }
+
+    public QueryException(String message, Throwable causedBy) {
+        super(message, causedBy);
+    }
+
 }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/QueryResult.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/QueryResult.java
@@ -62,7 +62,6 @@ public class QueryResult implements Iterable<DocumentRevision> {
      *  Returns the number of documents in this query result.
      *
      *  @return the number of documents {@code DocumentRevision} in this query result.
-     *  @throws QueryException if the document ids for this query cannot be retrieved
      */
     public int size() {
         return documentIds().size();
@@ -75,7 +74,6 @@ public class QueryResult implements Iterable<DocumentRevision> {
      *  consistent with the iterator results.
      *
      *  @return list of the document ids
-     *  @throws QueryException if the document ids for this query cannot be retrieved
      */
     public List<String> documentIds() {
         List<String> documentIds = new ArrayList<String>();
@@ -88,7 +86,6 @@ public class QueryResult implements Iterable<DocumentRevision> {
 
     /**
      * @return a newly created Iterator over the query results
-     * @throws QueryException if the document ids for this query cannot be retrieved
      */
     @Override
     public Iterator<DocumentRevision> iterator() {
@@ -193,7 +190,8 @@ public class QueryResult implements Iterable<DocumentRevision> {
                 }
                 return docList.iterator();
             } catch (DocumentException e) {
-                throw new QueryException(e);
+                // TODO - not sure what the right thing is here
+                throw new NoSuchElementException(e.toString());
             }
         }
     }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/QuerySqlTranslator.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/QuerySqlTranslator.java
@@ -399,7 +399,6 @@ class QuerySqlTranslator {
         return chooseIndexForFields(neededFields, indexes);
     }
 
-    @SuppressWarnings("unchecked")
     protected static String chooseIndexForFields(Set<String> neededFields,
                                                  List<Index> indexes) {
         String chosenIndex = null;
@@ -425,7 +424,6 @@ class QuerySqlTranslator {
         return chosenIndex;
     }
 
-    @SuppressWarnings("unchecked")
     private static String getTextIndex(List<Index> indexes) {
         String textIndex = null;
         for (Index index : indexes) {

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexCreatorTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexCreatorTest.java
@@ -43,7 +43,6 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
         assertThat(indexes.isEmpty(), is(true));
     }
 
-    // TODO check that these exceptions are correct
     @Test
     public void preconditionsToCreatingIndexes() throws QueryException {
         // doesn't create an index on null fields
@@ -85,8 +84,8 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
             fieldNames = Arrays.<FieldSort>asList(new FieldSort("age"), new FieldSort("pet"), new
                     FieldSort("age"));
             im.ensureIndexed(fieldNames, "basic");
-            Assert.fail("Expected ensureIndexed to throw a QueryException");
-        } catch (QueryException qe) {
+            Assert.fail("Expected ensureIndexed to throw a IllegalArgumentException");
+        } catch (IllegalArgumentException qe) {
             ;
         }
 
@@ -267,12 +266,11 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
 //        assertThat(indexes.keySet(), containsInAnyOrder("textIndex", "jsonIndex"));
     }
 
-    @Test
+    @Test(expected = QueryException.class)
     public void correctlyLimitsTextIndexesToOne() throws QueryException {
         String indexName = im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("age")), "basic", IndexType.TEXT);
         assertThat(indexName, is("basic"));
         indexName = im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("age")), "anotherIndex", IndexType.TEXT);
-        assertThat(indexName, is(nullValue()));
     }
 
     @Test
@@ -304,8 +302,8 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
         // rejects indexes with $ at start
         try {
             im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("$name"), new FieldSort("datatype")), "basic");
-            Assert.fail("Expected ensureIndexed to throw a QueryException");
-        } catch (QueryException qe) {
+            Assert.fail("Expected ensureIndexed to throw a IllegalArgumentException");
+        } catch (IllegalArgumentException qe) {
             ;
         }
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexCreatorTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexCreatorTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -37,32 +38,55 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void preconditionsToCreatingIndexes() {
+    public void preconditionsToCreatingIndexes() throws QueryException {
         // doesn't create an index on null fields
-        String name = im.ensureIndexed(null, "basic");
-        assertThat(name, is(nullValue()));
+        try {
+            im.ensureIndexed(null, "basic");
+            Assert.fail("Expected ensureIndexed to throw a QueryException");
+        } catch (QueryException qe) {
+            ;
+        }
 
+        List<FieldSort> fieldNames = null;
         // doesn't create an index on no fields
-        List<FieldSort> fieldNames = new ArrayList<FieldSort>();
-        name = im.ensureIndexed(fieldNames, "basic");
-        assertThat(name, is(nullValue()));
+        try {
+            fieldNames = new ArrayList<FieldSort>();
+            im.ensureIndexed(fieldNames, "basic");
+            Assert.fail("Expected ensureIndexed to throw a QueryException");
+        } catch (QueryException qe) {
+            ;
+        }
 
         // doesn't create an index without a name
-        name = im.ensureIndexed(fieldNames, "");
-        assertThat(name, is(nullValue()));
+        try {
+            im.ensureIndexed(fieldNames, "");
+            Assert.fail("Expected ensureIndexed to throw a QueryException");
+        } catch (QueryException qe) {
+            ;
+        }
 
         // doesn't create an index on null index type
-        name = im.ensureIndexed(fieldNames, "basic", null);
-        assertThat(name, is(nullValue()));
+        try {
+            im.ensureIndexed(fieldNames, "basic", null);
+            Assert.fail("Expected ensureIndexed to throw a QueryException");
+        } catch (QueryException qe) {
+            ;
+        }
 
         // doesn't create an index if duplicate fields
-        fieldNames = Arrays.<FieldSort>asList(new FieldSort("age"), new FieldSort("pet"), new FieldSort("age"));
-        name = im.ensureIndexed(fieldNames, "basic");
-        assertThat(name, is(nullValue()));
+        try {
+            fieldNames = Arrays.<FieldSort>asList(new FieldSort("age"), new FieldSort("pet"), new
+                    FieldSort("age"));
+            im.ensureIndexed(fieldNames, "basic");
+            Assert.fail("Expected ensureIndexed to throw a QueryException");
+        } catch (QueryException qe) {
+            ;
+        }
+
     }
 
     @Test
-    public void createIndexOverOneField() {
+    public void createIndexOverOneField() throws QueryException {
         String indexName = im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name")), "basic");
         assertThat(indexName, is("basic"));
 
@@ -77,7 +101,7 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void createIndexOverTwoFields() {
+    public void createIndexOverTwoFields() throws QueryException {
         String indexName = im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("age")), "basic");
         assertThat(indexName, is("basic"));
 
@@ -92,7 +116,7 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void createIndexUsingDottedNotation() {
+    public void createIndexUsingDottedNotation() throws QueryException {
         String indexName = im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name.first"), new FieldSort("age.years")),
                                             "basic");
         assertThat(indexName, is("basic"));
@@ -109,7 +133,7 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void createMultipleIndexes() {
+    public void createMultipleIndexes() throws QueryException {
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("age")), "basic");
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("age")), "another");
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("cat")), "petname");
@@ -131,7 +155,7 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void createIndexSpecifiedWithAscOrDesc() {
+    public void createIndexSpecifiedWithAscOrDesc() throws QueryException {
         String indexName = im.ensureIndexed(Arrays.<FieldSort>asList(
                 new FieldSort("name", FieldSort.Direction.ASCENDING),
                 new FieldSort("age", FieldSort.Direction.DESCENDING)), "basic");
@@ -148,7 +172,7 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void createIndexWhenIndexNameExistsIdxDefinitionSame() {
+    public void createIndexWhenIndexNameExistsIdxDefinitionSame() throws QueryException {
         String indexName = im.ensureIndexed(Arrays.<FieldSort>asList(
                 new FieldSort("name", FieldSort.Direction.ASCENDING),
                 new FieldSort("age", FieldSort.Direction.DESCENDING)), "basic");
@@ -162,21 +186,25 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void createIndexWhenIndexNameExistsIdxDefinitionDifferent() {
+    public void createIndexWhenIndexNameExistsIdxDefinitionDifferent() throws QueryException {
         String indexName = im.ensureIndexed(Arrays.<FieldSort>asList(
                 new FieldSort("name", FieldSort.Direction.ASCENDING),
                 new FieldSort("age", FieldSort.Direction.DESCENDING)), "basic");
         assertThat(indexName, is("basic"));
 
         // fails when the index definition is different
-        indexName = im.ensureIndexed(Arrays.<FieldSort>asList(
-                new FieldSort("name", FieldSort.Direction.ASCENDING),
-                new FieldSort("pet", FieldSort.Direction.DESCENDING)), "basic");
-        assertThat(indexName, is(nullValue()));
+        try {
+            indexName = im.ensureIndexed(Arrays.<FieldSort>asList(
+                    new FieldSort("name", FieldSort.Direction.ASCENDING),
+                    new FieldSort("pet", FieldSort.Direction.DESCENDING)), "basic");
+            Assert.fail("ensureIndexed should throw QueryException");
+        } catch (QueryException qe) {
+            ;
+        }
     }
 
     @Test
-    public void createIndexWithJsonType() {
+    public void createIndexWithJsonType() throws QueryException {
         // supports using the json type
         String indexName = im.ensureIndexed(Arrays.<FieldSort>asList(
                 new FieldSort("name", FieldSort.Direction.ASCENDING),
@@ -193,7 +221,7 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void createIndexWithTextType() {
+    public void createIndexWithTextType() throws QueryException {
         String indexName = im.ensureIndexed(Arrays.<FieldSort>asList(
                 new FieldSort("name", FieldSort.Direction.ASCENDING),
                 new FieldSort("age", FieldSort.Direction.DESCENDING)),
@@ -209,7 +237,7 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void createIndexWithTextTypeAndTokenizeSetting() {
+    public void createIndexWithTextTypeAndTokenizeSetting() throws QueryException {
         Map<String, String> settings = new HashMap<String, String>();
         settings.put("tokenize", "porter");
         String indexName = im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("age")),
@@ -226,7 +254,7 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void indexAndTextIndexCanCoexist() {
+    public void indexAndTextIndexCanCoexist() throws QueryException {
         Map<String, String> settings = new HashMap<String, String>();
         settings.put("tokenize", "porter");
         String indexName = im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("age")),
@@ -241,7 +269,7 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void correctlyLimitsTextIndexesToOne() {
+    public void correctlyLimitsTextIndexesToOne() throws QueryException {
         String indexName = im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("age")), "basic", IndexType.TEXT);
         assertThat(indexName, is("basic"));
         indexName = im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("age")), "anotherIndex", IndexType.TEXT);
@@ -249,7 +277,7 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void createIndexUsingNonAsciiText() {
+    public void createIndexUsingNonAsciiText() throws QueryException {
         // can create indexes successfully
         String indexName = im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("اسم"), new FieldSort("datatype"), new FieldSort("ages")),
                                             "basic");
@@ -272,13 +300,18 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void createIndexWhereFieldNameContainsDollarSign() {
+    public void createIndexWhereFieldNameContainsDollarSign() throws QueryException {
+
         // rejects indexes with $ at start
-        String indexName = im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("$name"), new FieldSort("datatype")), "basic");
-        assertThat(indexName, is(nullValue()));
+        try {
+            im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("$name"), new FieldSort("datatype")), "basic");
+            Assert.fail("Expected ensureIndexed to throw a QueryException");
+        } catch (QueryException qe) {
+            ;
+        }
 
         // creates indexes with $ not at start
-        indexName = im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("na$me"), new FieldSort("datatype$")), "basic");
+        String indexName = im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("na$me"), new FieldSort("datatype$")), "basic");
         assertThat(indexName, is("basic"));
     }
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexCreatorTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexCreatorTest.java
@@ -250,17 +250,13 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
         assertThat(indexName, is("basic"));
     }
 
-    @Test
-    public void createIndexWhereFieldNameContainsDollarSign() throws QueryException {
-
+    @Test(expected = IllegalArgumentException.class)
+    public void createIndexWhereFieldNameContainsDollarSignAtStart() throws QueryException {
         // rejects indexes with $ at start
-        try {
-            im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("$name"), new FieldSort("datatype")), "basic");
-            Assert.fail("Expected ensureIndexed to throw a IllegalArgumentException");
-        } catch (IllegalArgumentException qe) {
-            ;
-        }
-
+       im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("$name"), new FieldSort("datatype")), "basic");
+    }
+    @Test
+    public void createIndexWhereFieldNameContainsDollarSignNotAtStart() throws QueryException {
         // creates indexes with $ not at start
         String indexName = im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("na$me"), new FieldSort("datatype$")), "basic");
         assertThat(indexName, is("basic"));

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexManagerTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexManagerTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import com.cloudant.sync.datastore.DocumentBodyFactory;
 import com.cloudant.sync.datastore.DocumentRevision;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -30,60 +31,73 @@ import java.util.Map;
 public class IndexManagerTest extends AbstractIndexTestBase {
 
     @Test
-    public void enusureIndexedGeneratesIndexName() {
+    public void enusureIndexedGeneratesIndexName() throws QueryException {
         assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"))), is(notNullValue()));
     }
 
     @Test
-    public void deleteFailOnNoIndexName() {
+    public void deleteFailOnNoIndexName() throws QueryException {
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "basic");
         assertThat(im.listIndexes().keySet(), contains("basic"));
 
-        // TODO assert exception
-        im.deleteIndex(null);
+        try {
+            im.deleteIndex(null);
+            Assert.fail("Expected deleteIndex to throw a QueryException");
+        } catch (QueryException qe) {
+            ;
+        }
         assertThat(im.listIndexes().keySet(), contains("basic"));
 
-        // TODO assert exception
-        im.deleteIndex("");
+        try {
+            im.deleteIndex("");
+            Assert.fail("Expected deleteIndex to throw a QueryException");
+        } catch (QueryException qe) {
+            ;
+        }
+
         assertThat(im.listIndexes().keySet(), contains("basic"));
     }
 
     @Test
-    public void deleteFailOnInvalidIndexName() {
+    public void deleteFailOnInvalidIndexName() throws QueryException {
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "basic");
         assertThat(im.listIndexes().keySet(), contains("basic"));
 
-        // TODO assert exception
-        im.deleteIndex("invalid");
+        try {
+            im.deleteIndex("invalid");
+            Assert.fail("Expected deleteIndex to throw a QueryException");
+        } catch (QueryException qe) {
+            ;
+        }
         assertThat(im.listIndexes().keySet(), contains("basic"));
     }
 
     @Test
-    public void createIndexWithSpaceInName() {
+    public void createIndexWithSpaceInName() throws QueryException {
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "basic index");
         assertThat(im.listIndexes().keySet(), contains("basic index"));
     }
 
     @Test
-         public void createIndexWithSingleQuoteInName() {
+         public void createIndexWithSingleQuoteInName() throws QueryException {
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "basic'index");
         assertThat(im.listIndexes().keySet(), contains("basic'index"));
     }
 
     @Test
-    public void createIndexWithSemiColonQuoteInName() {
+    public void createIndexWithSemiColonQuoteInName() throws QueryException {
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "basic;index");
         assertThat(im.listIndexes().keySet(), contains("basic;index"));
     }
 
     @Test
-    public void createIndexWithBracketsInName() {
+    public void createIndexWithBracketsInName() throws QueryException {
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "basic(index)");
         assertThat(im.listIndexes().keySet(), contains("basic(index)"));
     }
 
     @Test
-    public void createIndexWithKeyWordName() {
+    public void createIndexWithKeyWordName() throws QueryException {
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "INSERT INDEX");
         assertThat(im.listIndexes().keySet(), contains("INSERT INDEX"));
     }
@@ -91,7 +105,7 @@ public class IndexManagerTest extends AbstractIndexTestBase {
 
 
     @Test
-     public void deleteEmptyIndex() {
+     public void deleteEmptyIndex() throws QueryException {
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "basic");
         assertThat(im.listIndexes().keySet(), contains("basic"));
 
@@ -100,7 +114,7 @@ public class IndexManagerTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void deleteTheCorrectEmptyIndex() {
+    public void deleteTheCorrectEmptyIndex() throws QueryException {
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "basic");
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("age")), "basic2");
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name")), "basic3");

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexManagerTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexManagerTest.java
@@ -43,16 +43,16 @@ public class IndexManagerTest extends AbstractIndexTestBase {
 
         try {
             im.deleteIndex(null);
-            Assert.fail("Expected deleteIndex to throw a QueryException");
-        } catch (QueryException qe) {
+            Assert.fail("Expected deleteIndex to throw a IllegalArgumentException");
+        } catch (IllegalArgumentException iae) {
             ;
         }
         assertThat(im.listIndexes(), contains(getIndexNameMatcher("basic")));
 
         try {
             im.deleteIndex("");
-            Assert.fail("Expected deleteIndex to throw a QueryException");
-        } catch (QueryException qe) {
+            Assert.fail("Expected deleteIndex to throw a IllegalArgumentException");
+        } catch (IllegalArgumentException iae) {
             ;
         }
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexManagerTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexManagerTest.java
@@ -30,6 +30,8 @@ import java.util.Map;
 
 public class IndexManagerTest extends AbstractIndexTestBase {
 
+    // TODO fix
+/*
     @Test
     public void enusureIndexedGeneratesIndexName() throws QueryException {
         assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"))), is(notNullValue()));
@@ -38,7 +40,7 @@ public class IndexManagerTest extends AbstractIndexTestBase {
     @Test
     public void deleteFailOnNoIndexName() throws QueryException {
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "basic");
-        assertThat(im.listIndexes().keySet(), contains("basic"));
+        assertThat(im.listIndexes(), contains(new FieldSort("basic")));
 
         try {
             im.deleteIndex(null);
@@ -46,7 +48,7 @@ public class IndexManagerTest extends AbstractIndexTestBase {
         } catch (QueryException qe) {
             ;
         }
-        assertThat(im.listIndexes().keySet(), contains("basic"));
+        assertThat(im.listIndexes(), contains(new FieldSort("basic")));
 
         try {
             im.deleteIndex("");
@@ -55,13 +57,13 @@ public class IndexManagerTest extends AbstractIndexTestBase {
             ;
         }
 
-        assertThat(im.listIndexes().keySet(), contains("basic"));
+        assertThat(im.listIndexes(), contains(new FieldSort("basic")));
     }
 
     @Test
     public void deleteFailOnInvalidIndexName() throws QueryException {
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "basic");
-        assertThat(im.listIndexes().keySet(), contains("basic"));
+        assertThat(im.listIndexes(), contains(new FieldSort("basic")));
 
         try {
             im.deleteIndex("invalid");
@@ -69,37 +71,37 @@ public class IndexManagerTest extends AbstractIndexTestBase {
         } catch (QueryException qe) {
             ;
         }
-        assertThat(im.listIndexes().keySet(), contains("basic"));
+        assertThat(im.listIndexes(), contains(new FieldSort("basic")));
     }
 
     @Test
     public void createIndexWithSpaceInName() throws QueryException {
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "basic index");
-        assertThat(im.listIndexes().keySet(), contains("basic index"));
+        assertThat(im.listIndexes(), contains(new FieldSort("basic index")));
     }
 
     @Test
          public void createIndexWithSingleQuoteInName() throws QueryException {
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "basic'index");
-        assertThat(im.listIndexes().keySet(), contains("basic'index"));
+        assertThat(im.listIndexes(), contains(new FieldSort("basic'index")));
     }
 
     @Test
     public void createIndexWithSemiColonQuoteInName() throws QueryException {
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "basic;index");
-        assertThat(im.listIndexes().keySet(), contains("basic;index"));
+        assertThat(im.listIndexes(), contains(new FieldSort("basic;index")));
     }
 
     @Test
     public void createIndexWithBracketsInName() throws QueryException {
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "basic(index)");
-        assertThat(im.listIndexes().keySet(), contains("basic(index)"));
+        assertThat(im.listIndexes(), contains(new FieldSort("basic(index)")));
     }
 
     @Test
     public void createIndexWithKeyWordName() throws QueryException {
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "INSERT INDEX");
-        assertThat(im.listIndexes().keySet(), contains("INSERT INDEX"));
+        assertThat(im.listIndexes(), contains(new FieldSort("INSERT INDEX")));
     }
 
 
@@ -107,7 +109,7 @@ public class IndexManagerTest extends AbstractIndexTestBase {
     @Test
      public void deleteEmptyIndex() throws QueryException {
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "basic");
-        assertThat(im.listIndexes().keySet(), contains("basic"));
+        assertThat(im.listIndexes(), contains(new FieldSort("basic")));
 
         im.deleteIndex("basic");
         assertThat(im.listIndexes().isEmpty(), is(true));
@@ -118,10 +120,10 @@ public class IndexManagerTest extends AbstractIndexTestBase {
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "basic");
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("age")), "basic2");
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name")), "basic3");
-        assertThat(im.listIndexes().keySet(), containsInAnyOrder("basic", "basic2", "basic3"));
+        assertThat(im.listIndexes(), containsInAnyOrder("basic", "basic2", "basic3"));
 
         im.deleteIndex("basic2");
-        assertThat(im.listIndexes().keySet(), containsInAnyOrder("basic", "basic3"));
+        assertThat(im.listIndexes(), containsInAnyOrder("basic", "basic3"));
     }
 
     @Test
@@ -140,7 +142,7 @@ public class IndexManagerTest extends AbstractIndexTestBase {
         }
 
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "basic");
-        assertThat(im.listIndexes().keySet(), contains("basic"));
+        assertThat(im.listIndexes(), contains(new FieldSort("basic")));
         im.deleteIndex("basic");
         assertThat(im.listIndexes().isEmpty(), is(true));
     }
@@ -163,10 +165,10 @@ public class IndexManagerTest extends AbstractIndexTestBase {
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "basic");
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("age")), "basic2");
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name")), "basic3");
-        assertThat(im.listIndexes().keySet(), containsInAnyOrder("basic", "basic2", "basic3"));
+        assertThat(im.listIndexes(), containsInAnyOrder("basic", "basic2", "basic3"));
 
         im.deleteIndex("basic2");
-        assertThat(im.listIndexes().keySet(), containsInAnyOrder("basic", "basic3"));
+        assertThat(im.listIndexes(), containsInAnyOrder("basic", "basic3"));
     }
 
     @Test
@@ -185,7 +187,7 @@ public class IndexManagerTest extends AbstractIndexTestBase {
         }
 
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "basic", IndexType.TEXT);
-        assertThat(im.listIndexes().keySet(), contains("basic"));
+        assertThat(im.listIndexes(), contains(new FieldSort("basic")));
 
         im.deleteIndex("basic");
         assertThat(im.listIndexes().isEmpty(), is(true));
@@ -195,5 +197,5 @@ public class IndexManagerTest extends AbstractIndexTestBase {
     public void validateTextSearchIsAvailable() throws Exception {
         assertThat(im.isTextSearchEnabled(), is(true));
     }
-
+*/
 }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexManagerTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexManagerTest.java
@@ -12,6 +12,7 @@
 
 package com.cloudant.sync.query;
 
+import static com.cloudant.sync.query.MatcherHelper.getIndexNameMatcher;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -30,8 +31,6 @@ import java.util.Map;
 
 public class IndexManagerTest extends AbstractIndexTestBase {
 
-    // TODO fix
-/*
     @Test
     public void enusureIndexedGeneratesIndexName() throws QueryException {
         assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"))), is(notNullValue()));
@@ -40,7 +39,7 @@ public class IndexManagerTest extends AbstractIndexTestBase {
     @Test
     public void deleteFailOnNoIndexName() throws QueryException {
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "basic");
-        assertThat(im.listIndexes(), contains(new FieldSort("basic")));
+        assertThat(im.listIndexes(), contains(getIndexNameMatcher("basic")));
 
         try {
             im.deleteIndex(null);
@@ -48,7 +47,7 @@ public class IndexManagerTest extends AbstractIndexTestBase {
         } catch (QueryException qe) {
             ;
         }
-        assertThat(im.listIndexes(), contains(new FieldSort("basic")));
+        assertThat(im.listIndexes(), contains(getIndexNameMatcher("basic")));
 
         try {
             im.deleteIndex("");
@@ -57,13 +56,13 @@ public class IndexManagerTest extends AbstractIndexTestBase {
             ;
         }
 
-        assertThat(im.listIndexes(), contains(new FieldSort("basic")));
+        assertThat(im.listIndexes(), contains(getIndexNameMatcher("basic")));
     }
 
     @Test
     public void deleteFailOnInvalidIndexName() throws QueryException {
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "basic");
-        assertThat(im.listIndexes(), contains(new FieldSort("basic")));
+        assertThat(im.listIndexes(), contains(getIndexNameMatcher("basic")));
 
         try {
             im.deleteIndex("invalid");
@@ -71,37 +70,37 @@ public class IndexManagerTest extends AbstractIndexTestBase {
         } catch (QueryException qe) {
             ;
         }
-        assertThat(im.listIndexes(), contains(new FieldSort("basic")));
+        assertThat(im.listIndexes(), contains(getIndexNameMatcher("basic")));
     }
 
     @Test
     public void createIndexWithSpaceInName() throws QueryException {
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "basic index");
-        assertThat(im.listIndexes(), contains(new FieldSort("basic index")));
+        assertThat(im.listIndexes(), contains(getIndexNameMatcher("basic index")));
     }
 
     @Test
          public void createIndexWithSingleQuoteInName() throws QueryException {
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "basic'index");
-        assertThat(im.listIndexes(), contains(new FieldSort("basic'index")));
+        assertThat(im.listIndexes(), contains(getIndexNameMatcher("basic'index")));
     }
 
     @Test
     public void createIndexWithSemiColonQuoteInName() throws QueryException {
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "basic;index");
-        assertThat(im.listIndexes(), contains(new FieldSort("basic;index")));
+        assertThat(im.listIndexes(), contains(getIndexNameMatcher("basic;index")));
     }
 
     @Test
     public void createIndexWithBracketsInName() throws QueryException {
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "basic(index)");
-        assertThat(im.listIndexes(), contains(new FieldSort("basic(index)")));
+        assertThat(im.listIndexes(), contains(getIndexNameMatcher("basic(index)")));
     }
 
     @Test
     public void createIndexWithKeyWordName() throws QueryException {
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "INSERT INDEX");
-        assertThat(im.listIndexes(), contains(new FieldSort("INSERT INDEX")));
+        assertThat(im.listIndexes(), contains(getIndexNameMatcher("INSERT INDEX")));
     }
 
 
@@ -109,7 +108,7 @@ public class IndexManagerTest extends AbstractIndexTestBase {
     @Test
      public void deleteEmptyIndex() throws QueryException {
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "basic");
-        assertThat(im.listIndexes(), contains(new FieldSort("basic")));
+        assertThat(im.listIndexes(), contains(getIndexNameMatcher("basic")));
 
         im.deleteIndex("basic");
         assertThat(im.listIndexes().isEmpty(), is(true));
@@ -120,10 +119,12 @@ public class IndexManagerTest extends AbstractIndexTestBase {
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "basic");
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("age")), "basic2");
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name")), "basic3");
-        assertThat(im.listIndexes(), containsInAnyOrder("basic", "basic2", "basic3"));
+        assertThat(im.listIndexes().size(), is(3));
+        assertThat(im.listIndexes(), containsInAnyOrder(getIndexNameMatcher("basic"), getIndexNameMatcher("basic2"), getIndexNameMatcher("basic3")));
 
         im.deleteIndex("basic2");
-        assertThat(im.listIndexes(), containsInAnyOrder("basic", "basic3"));
+        assertThat(im.listIndexes().size(), is(2));
+        assertThat(im.listIndexes(), containsInAnyOrder(getIndexNameMatcher("basic"), getIndexNameMatcher("basic3")));
     }
 
     @Test
@@ -142,7 +143,7 @@ public class IndexManagerTest extends AbstractIndexTestBase {
         }
 
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "basic");
-        assertThat(im.listIndexes(), contains(new FieldSort("basic")));
+        assertThat(im.listIndexes(), contains(getIndexNameMatcher("basic")));
         im.deleteIndex("basic");
         assertThat(im.listIndexes().isEmpty(), is(true));
     }
@@ -165,10 +166,12 @@ public class IndexManagerTest extends AbstractIndexTestBase {
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "basic");
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("age")), "basic2");
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name")), "basic3");
-        assertThat(im.listIndexes(), containsInAnyOrder("basic", "basic2", "basic3"));
+        assertThat(im.listIndexes().size(), is(3));
+        assertThat(im.listIndexes(), containsInAnyOrder(getIndexNameMatcher("basic"), getIndexNameMatcher("basic2"), getIndexNameMatcher("basic3")));
 
         im.deleteIndex("basic2");
-        assertThat(im.listIndexes(), containsInAnyOrder("basic", "basic3"));
+        assertThat(im.listIndexes().size(), is(2));
+        assertThat(im.listIndexes(), containsInAnyOrder(getIndexNameMatcher("basic"), getIndexNameMatcher("basic3")));
     }
 
     @Test
@@ -187,7 +190,7 @@ public class IndexManagerTest extends AbstractIndexTestBase {
         }
 
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "basic", IndexType.TEXT);
-        assertThat(im.listIndexes(), contains(new FieldSort("basic")));
+        assertThat(im.listIndexes(), contains(getIndexNameMatcher("basic")));
 
         im.deleteIndex("basic");
         assertThat(im.listIndexes().isEmpty(), is(true));
@@ -197,5 +200,5 @@ public class IndexManagerTest extends AbstractIndexTestBase {
     public void validateTextSearchIsAvailable() throws Exception {
         assertThat(im.isTextSearchEnabled(), is(true));
     }
-*/
+
 }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexManagerTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexManagerTest.java
@@ -12,7 +12,7 @@
 
 package com.cloudant.sync.query;
 
-import static com.cloudant.sync.query.MatcherHelper.getIndexNameMatcher;
+import static com.cloudant.sync.query.IndexMatcherHelpers.getIndexNameMatcher;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexMatcherHelpers.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexMatcherHelpers.java
@@ -13,8 +13,9 @@ import java.util.List;
  * Created by tomblench on 12/10/2016.
  */
 
-public class MatcherHelper {
+public class IndexMatcherHelpers {
 
+    // hamcrest matcher to map from an index to its name
     public static Matcher<Index> getIndexNameMatcher(String index) {
         return new FeatureMatcher<Index, String>(equalTo(index), "indexName", "indexName") {
             @Override
@@ -24,17 +25,10 @@ public class MatcherHelper {
         };
     }
 
-    public static Index getIndexNamed(String name, List<Index> indexes) {
-        for (Index i : indexes) {
-            if (i.indexName.equals(name)) {
-                return i;
-            }
-        }
-        return null;
-    }
-
-    public static Matcher<Index> getFields(String... index) {
-        return new FeatureMatcher<Index, List<String>>(Matchers.containsInAnyOrder(index), "fields", "fields") {
+    // hamcrest matcher to assert that an index has a given list of field names
+    public static Matcher<Index> hasFieldsInAnyOrder(String... index) {
+        return new FeatureMatcher<Index, List<String>>(Matchers.containsInAnyOrder(index),
+                "fields", "fields") {
             @Override
             protected List<String> featureValueOf(Index i) {
                 ArrayList fields = new ArrayList<String>();
@@ -46,6 +40,14 @@ public class MatcherHelper {
         };
     }
 
-
+    // helper to return an index with a given name from a list
+    public static Index getIndexNamed(String name, List<Index> indexes) {
+        for (Index i : indexes) {
+            if (i.indexName.equals(name)) {
+                return i;
+            }
+        }
+        return null;
+    }
 
 }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexTest.java
@@ -90,31 +90,34 @@ public class IndexTest {
         Index index = new Index(fieldNames, indexName, IndexType.TEXT, "porter");
         assertThat(index.tokenize, is("porter"));
     }
-    // TODO these should test that .equals() does the right thing
-/*
+
     @Test
     public void comparesIndexTypeAndReturnsInEquality() {
         Index index = new Index(fieldNames, indexName);
-        assertThat(index.compareIndexTypeTo(IndexType.TEXT, null), is(false));
+        Index index2 = new Index(fieldNames, indexName, IndexType.TEXT, null);
+        assertThat(index.equals(index2), is(false));
     }
 
     @Test
     public void comparesIndexTypeAndReturnsEquality() {
         Index index = new Index(fieldNames, indexName);
-        assertThat(index.compareIndexTypeTo(IndexType.JSON, null), is(true));
+        Index index2 = new Index(fieldNames, indexName, IndexType.JSON, null);
+        assertThat(index.equals(index2), is(true));
     }
 
     @Test
     public void comparesIndexSettingsAndReturnsInEquality() {
         Index index = new Index(fieldNames, indexName, IndexType.TEXT);
-        assertThat(index.compareIndexTypeTo(IndexType.TEXT, "{\"tokenize\":\"porter\"}"), is(false));
+        Index index2 = new Index(fieldNames, indexName, IndexType.TEXT, "porter");
+        assertThat(index.equals(index2), is(false));
     }
 
     @Test
     public void comparesIndexSettingsAndReturnsEquality() {
         Index index = new Index(fieldNames, indexName, IndexType.TEXT);
-        assertThat(index.compareIndexTypeTo(IndexType.TEXT, "{\"tokenize\":\"simple\"}"), is(true));
-    }*/
+        Index index2 = new Index(fieldNames, indexName, IndexType.TEXT, "simple");
+        assertThat(index.equals(index2), is(true));
+    }
 
     @Test
     public void returnsIndexSettingsAsAString() {

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexTest.java
@@ -40,105 +40,92 @@ public class IndexTest {
 
     @Test
     public void constructsIndexWithDefaultType() {
-        Index index = Index.getInstance(fieldNames, indexName);
+        Index index = new Index(fieldNames, indexName);
         assertThat(index.indexName, is("basic"));
         assertThat(index.fieldNames, is(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("age"))));
         assertThat(index.indexType, is(IndexType.JSON));
-        assertThat(index.indexSettings, is(nullValue()));
+        assertThat(index.tokenize, is(nullValue()));
     }
 
     @Test
     public void constructsIndexWithTextTypeDefaultSettings() {
-        Index index = Index.getInstance(fieldNames, indexName, IndexType.TEXT);
+        Index index = new Index(fieldNames, indexName, IndexType.TEXT);
         assertThat(index.indexName, is("basic"));
         assertThat(index.fieldNames, is(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("age"))));
         assertThat(index.indexType, is(IndexType.TEXT));
-        assertThat(index.indexSettings.size(), is(1));
-        assertThat(index.indexSettings.get("tokenize"), is("simple"));
+        assertThat(index.tokenize, is("simple"));
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void returnsNullWhenNoFields() {
-        Index index = Index.getInstance(null, indexName);
+        Index index = new Index(null, indexName);
         assertThat(index, is(nullValue()));
 
-        index = Index.getInstance(new ArrayList<FieldSort>(), indexName);
+        index = new Index(new ArrayList<FieldSort>(), indexName);
         assertThat(index, is(nullValue()));
     }
 
     @Test
     public void returnsValueWhenIndexNameIsNull(){
-        Index index = Index.getInstance(fieldNames, null);
+        Index index = new Index(fieldNames, null);
         assertThat(index, is(notNullValue()));
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void returnsNullWhenNoIndexName() {
-        Index index = Index.getInstance(fieldNames, "");
-        assertThat(index, is(nullValue()));
-    }
-
-    @Test
-    public void returnsNullWhenInvalidIndexSettings() {
-        Map<String, String> indexSettings = new HashMap<String, String>();
-        indexSettings.put("foo", "bar");
-        Index index = Index.getInstance(fieldNames, indexName, IndexType.TEXT, indexSettings);
+        Index index = new Index(fieldNames, "");
         assertThat(index, is(nullValue()));
     }
 
     @Test
     public void correctlyIgnoresIndexSettings() {
-        Map<String, String> indexSettings = new HashMap<String, String>();
-        indexSettings.put("tokenize", "porter");
         // json indexes do not support index settings.  Index settings will be ignored.
-        Index index = Index.getInstance(fieldNames, indexName, IndexType.JSON, indexSettings);
-        assertThat(index.indexSettings, is(nullValue()));
+        Index index = new Index(fieldNames, indexName, IndexType.JSON, "porter");
+        assertThat(index.tokenize, is(nullValue()));
     }
 
     @Test
     public void correctlySetsIndexSettings() {
-        Map<String, String> indexSettings = new HashMap<String, String>();
-        indexSettings.put("tokenize", "porter");
         // text indexes support the tokenize setting.
-        Index index = Index.getInstance(fieldNames, indexName, IndexType.TEXT, indexSettings);
-        assertThat(index.indexSettings.size(), is(1));
-        assertThat(index.indexSettings.get("tokenize"), is("porter"));
+        Index index = new Index(fieldNames, indexName, IndexType.TEXT, "porter");
+        assertThat(index.tokenize, is("porter"));
     }
-
+    // TODO these should test that .equals() does the right thing
+/*
     @Test
     public void comparesIndexTypeAndReturnsInEquality() {
-        Index index = Index.getInstance(fieldNames, indexName);
+        Index index = new Index(fieldNames, indexName);
         assertThat(index.compareIndexTypeTo(IndexType.TEXT, null), is(false));
     }
 
     @Test
     public void comparesIndexTypeAndReturnsEquality() {
-        Index index = Index.getInstance(fieldNames, indexName);
+        Index index = new Index(fieldNames, indexName);
         assertThat(index.compareIndexTypeTo(IndexType.JSON, null), is(true));
     }
 
     @Test
     public void comparesIndexSettingsAndReturnsInEquality() {
-        Index index = Index.getInstance(fieldNames, indexName, IndexType.TEXT);
+        Index index = new Index(fieldNames, indexName, IndexType.TEXT);
         assertThat(index.compareIndexTypeTo(IndexType.TEXT, "{\"tokenize\":\"porter\"}"), is(false));
     }
 
     @Test
     public void comparesIndexSettingsAndReturnsEquality() {
-        Index index = Index.getInstance(fieldNames, indexName, IndexType.TEXT);
+        Index index = new Index(fieldNames, indexName, IndexType.TEXT);
         assertThat(index.compareIndexTypeTo(IndexType.TEXT, "{\"tokenize\":\"simple\"}"), is(true));
-    }
+    }*/
 
     @Test
     public void returnsIndexSettingsAsAString() {
-        Index index = Index.getInstance(fieldNames, indexName, IndexType.TEXT);
+        Index index = new Index(fieldNames, indexName, IndexType.TEXT);
         assertThat(index.settingsAsJSON(), is("{\"tokenize\":\"simple\"}"));
     }
 
     @Test
     public void returnsNullIndexSettingsAsAString() {
-        Index index = Index.getInstance(fieldNames, indexName);
-        assertThat(index.settingsAsJSON(), is(nullValue()));
+        Index index = new Index(fieldNames, indexName);
+        assertThat(index.settingsAsJSON(), is("{}"));
     }
 
 }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexTest.java
@@ -56,7 +56,7 @@ public class IndexTest {
         assertThat(index.tokenize, is("simple"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = NullPointerException.class)
     public void returnsNullWhenNoFields() {
         Index index = new Index(null, indexName);
         assertThat(index, is(nullValue()));

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexTest.java
@@ -72,16 +72,14 @@ public class IndexTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void returnsNullWhenNoIndexName() {
+    public void throwsWhenNoIndexName() {
         Index index = new Index(fieldNames, "");
-        assertThat(index, is(nullValue()));
     }
 
-    @Test
-    public void correctlyIgnoresIndexSettings() {
-        // json indexes do not support index settings.  Index settings will be ignored.
+    @Test(expected = IllegalArgumentException.class)
+    public void throwsWhenTokenizeSetForJson() {
+        // json indexes do not support tokenize setting.
         Index index = new Index(fieldNames, indexName, IndexType.JSON, "porter");
-        assertThat(index.tokenize, is(nullValue()));
     }
 
     @Test

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexUpdaterTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexUpdaterTest.java
@@ -50,7 +50,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
 
     private String testType = null;
 
-    List<String> fields;
+    List<FieldSort> fields;
 
     @Parameterized.Parameters(name = "{0}")
     public static Iterable<Object[]> data() throws Exception {
@@ -1082,16 +1082,20 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
     private void createIndex(String indexName, List<FieldSort> fieldNames, IndexType indexType) throws QueryException{
         assertThat(im.ensureIndexed(fieldNames, indexName, indexType), is(indexName));
 
-        Map<String, Map<String, Object>> indexes = im.listIndexes();
-        assertThat(indexes, hasKey(indexName));
-
-        Map<String, Object> index = indexes.get(indexName);
-        fields = (List<String>) index.get("fields");
-        assertThat(fields.size(), is(fieldNames.size() + 2));
-        for (FieldSort fieldSort : fieldNames) {
-            assertThat(fields, Matchers.hasItem(fieldSort.field));
+        List<Index> indexes = im.listIndexes();
+        // TODO use custom/better hamcrest matcher rather than interating through
+        for(Index index : indexes) {
+            if (index.indexName.equals(indexName)) {
+                assertThat(index.fieldNames.size(), is(fieldNames.size() + 2));
+                for (FieldSort fieldSort : fieldNames) {
+                    assertThat(index.fieldNames, Matchers.hasItem(fieldSort));
+                }
+                assertThat(index.fieldNames, hasItems(new FieldSort("_id"), new FieldSort("_rev")));
+                this.fields = index.fieldNames;
+                return;
+            }
         }
-        assertThat(fields, hasItems("_id", "_rev"));
+        Assert.fail("Didn't find expected index "+indexName);
     }
 
 }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexUpdaterTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexUpdaterTest.java
@@ -717,13 +717,9 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         saved = ds.createDocumentFromRevision(goodRev);
         ds.createDocumentFromRevision(badRev);
 
-        try {
-            IndexUpdater.updateIndex("basic", fields, ds, indexManagerDatabaseQueue);
-            fail("Expected IllegalStateException to be thrown");
-        } catch (IllegalStateException ise) {
-            // Document id456 is rejected due to multiple arrays
-            ;
-        }
+        // TODO should the index updating continue once it's encountered a document with multiple arrays?
+
+        IndexUpdater.updateIndex("basic", fields, ds, indexManagerDatabaseQueue);
         assertThat(getIndexSequenceNumber("basic"), is(2l));
 
         // Document id123 is successfully indexed. 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexUpdaterTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexUpdaterTest.java
@@ -71,7 +71,12 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
     @Test
     public void updateIndexNoIndexName() throws Exception {
         createIndex("basic", Arrays.<FieldSort>asList(new FieldSort("name")));
-        assertThat(IndexUpdater.updateIndex(null, fields, ds, indexManagerDatabaseQueue), is(false));
+        try {
+            IndexUpdater.updateIndex(null, fields, ds, indexManagerDatabaseQueue);
+            Assert.fail("Expected ensureIndexed to throw a QueryException");
+        } catch (QueryException qe) {
+            ;
+        }
     }
 
     @Test
@@ -108,7 +113,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         saved = ds.createDocumentFromRevision(rev);
 
 
-        assertThat(IndexUpdater.updateIndex("basic", fields, ds, indexManagerDatabaseQueue), is(true));
+        IndexUpdater.updateIndex("basic", fields, ds, indexManagerDatabaseQueue);
         assertThat(getIndexSequenceNumber("basic"), is(1l));
 
         indexManagerDatabaseQueue.submit(new SQLCallable<Void>() {
@@ -295,7 +300,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         final DocumentRevision saved;
         saved = ds.createDocumentFromRevision(rev);
 
-        assertThat(IndexUpdater.updateIndex("basic", fields, ds, indexManagerDatabaseQueue), is(true));
+        IndexUpdater.updateIndex("basic", fields, ds, indexManagerDatabaseQueue);
         assertThat(getIndexSequenceNumber("basic"), is(1l));
 
         indexManagerDatabaseQueue.submit(new SQLCallable<Void>() {
@@ -365,7 +370,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         final DocumentRevision saved;
         saved = ds.createDocumentFromRevision(rev);
 
-        assertThat(IndexUpdater.updateIndex("basic", fields, ds, indexManagerDatabaseQueue), is(true));
+        IndexUpdater.updateIndex("basic", fields, ds, indexManagerDatabaseQueue);
         assertThat(getIndexSequenceNumber("basic"), is(1l));
 
         indexManagerDatabaseQueue.submit(new SQLCallable<Void>() {
@@ -434,7 +439,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         final DocumentRevision saved;
         saved = ds.createDocumentFromRevision(rev);
 
-        assertThat(IndexUpdater.updateIndex("basic", fields, ds, indexManagerDatabaseQueue), is(true));
+        IndexUpdater.updateIndex("basic", fields, ds, indexManagerDatabaseQueue);
         assertThat(getIndexSequenceNumber("basic"), is(1l));
 
         indexManagerDatabaseQueue.submit(new SQLCallable<Void>() {
@@ -503,7 +508,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         final DocumentRevision saved;
         saved = ds.createDocumentFromRevision(rev);
 
-        assertThat(IndexUpdater.updateIndex("basic", fields, ds, indexManagerDatabaseQueue), is(true));
+        IndexUpdater.updateIndex("basic", fields, ds, indexManagerDatabaseQueue);
         assertThat(getIndexSequenceNumber("basic"), is(1l));
 
         indexManagerDatabaseQueue.submit(new SQLCallable<Void>() {
@@ -570,7 +575,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         final DocumentRevision saved;
         saved = ds.createDocumentFromRevision(rev);
 
-        assertThat(IndexUpdater.updateIndex("basic", fields, ds, indexManagerDatabaseQueue), is(true));
+        IndexUpdater.updateIndex("basic", fields, ds, indexManagerDatabaseQueue);
         assertThat(getIndexSequenceNumber("basic"), is(1l));
 
         indexManagerDatabaseQueue.submit(new SQLCallable<Void>() {
@@ -639,7 +644,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         final DocumentRevision saved;
         saved = ds.createDocumentFromRevision(rev);
 
-        assertThat(IndexUpdater.updateIndex("basic", fields, ds, indexManagerDatabaseQueue), is(true));
+        IndexUpdater.updateIndex("basic", fields, ds, indexManagerDatabaseQueue);
         assertThat(getIndexSequenceNumber("basic"), is(1l));
 
         indexManagerDatabaseQueue.submit(new SQLCallable<Void>() {
@@ -716,7 +721,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         saved = ds.createDocumentFromRevision(goodRev);
         ds.createDocumentFromRevision(badRev);
 
-        assertThat(IndexUpdater.updateIndex("basic", fields, ds, indexManagerDatabaseQueue), is(true));
+        IndexUpdater.updateIndex("basic", fields, ds, indexManagerDatabaseQueue);
         assertThat(getIndexSequenceNumber("basic"), is(2l));
 
         // Document id123 is successfully indexed. 
@@ -787,7 +792,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         final DocumentRevision saved;
         saved = ds.createDocumentFromRevision(rev);
 
-        assertThat(IndexUpdater.updateIndex("basic", fields, ds, indexManagerDatabaseQueue), is(true));
+        IndexUpdater.updateIndex("basic", fields, ds, indexManagerDatabaseQueue);
         assertThat(getIndexSequenceNumber("basic"), is(1l));
 
         indexManagerDatabaseQueue.submit(new SQLCallable<Void>() {
@@ -855,7 +860,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         final DocumentRevision saved;
         saved = ds.createDocumentFromRevision(rev);
 
-        assertThat(IndexUpdater.updateIndex("basic", fields, ds, indexManagerDatabaseQueue), is(true));
+        IndexUpdater.updateIndex("basic", fields, ds, indexManagerDatabaseQueue);
         assertThat(getIndexSequenceNumber("basic"), is(1l));
 
         indexManagerDatabaseQueue.submit(new SQLCallable<Void>() {
@@ -1065,7 +1070,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         }).get();
     }
 
-    private void createIndex(String indexName, List<FieldSort> fieldNames) {
+    private void createIndex(String indexName, List<FieldSort> fieldNames) throws QueryException {
         if (testType.equals(TEXT_INDEX_EXECUTION)) {
             createIndex(indexName, fieldNames, IndexType.TEXT);
         } else {
@@ -1074,7 +1079,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
     }
 
     @SuppressWarnings("unchecked")
-    private void createIndex(String indexName, List<FieldSort> fieldNames, IndexType indexType) {
+    private void createIndex(String indexName, List<FieldSort> fieldNames, IndexType indexType) throws QueryException{
         assertThat(im.ensureIndexed(fieldNames, indexName, indexType), is(indexName));
 
         Map<String, Map<String, Object>> indexes = im.listIndexes();

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexUpdaterTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexUpdaterTest.java
@@ -720,8 +720,6 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         saved = ds.createDocumentFromRevision(goodRev);
         ds.createDocumentFromRevision(badRev);
 
-        // TODO should the index updating continue once it's encountered a document with multiple arrays?
-
         IndexUpdater.updateIndex("basic", fields, ds, indexManagerDatabaseQueue);
         assertThat(getIndexSequenceNumber("basic"), is(2l));
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/MatcherHelper.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/MatcherHelper.java
@@ -1,0 +1,51 @@
+package com.cloudant.sync.query;
+
+import static org.hamcrest.core.IsEqual.equalTo;
+
+import org.hamcrest.FeatureMatcher;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by tomblench on 12/10/2016.
+ */
+
+public class MatcherHelper {
+
+    public static Matcher<Index> getIndexNameMatcher(String index) {
+        return new FeatureMatcher<Index, String>(equalTo(index), "indexName", "indexName") {
+            @Override
+            protected String featureValueOf(Index i) {
+                return i.indexName;
+            }
+        };
+    }
+
+    public static Index getIndexNamed(String name, List<Index> indexes) {
+        for (Index i : indexes) {
+            if (i.indexName.equals(name)) {
+                return i;
+            }
+        }
+        return null;
+    }
+
+    public static Matcher<Index> getFields(String... index) {
+        return new FeatureMatcher<Index, List<String>>(Matchers.containsInAnyOrder(index), "fields", "fields") {
+            @Override
+            protected List<String> featureValueOf(Index i) {
+                ArrayList fields = new ArrayList<String>();
+                for (FieldSort f : i.fieldNames) {
+                    fields.add(f.field);
+                }
+                return fields;
+            }
+        };
+    }
+
+
+
+}

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/MockMatcherIndexManager.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/MockMatcherIndexManager.java
@@ -13,6 +13,7 @@
 package com.cloudant.sync.query;
 
 import com.cloudant.sync.datastore.Database;
+import com.cloudant.sync.util.Misc;
 import com.cloudant.sync.util.TestUtils;
 
 import java.util.List;
@@ -39,9 +40,7 @@ public class MockMatcherIndexManager extends IndexManagerImpl {
                             long limit,
                             List<String> fields,
                             List<FieldSort> sortDocument) throws QueryException {
-        if (query == null) {
-            throw new QueryException("Query must not be null");
-        }
+        Misc.checkNotNull(query, "query");
 
         updateAllIndexes();
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/MockMatcherIndexManager.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/MockMatcherIndexManager.java
@@ -52,7 +52,7 @@ public class MockMatcherIndexManager extends IndexManagerImpl {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-        Map<String, Map<String, Object>> indexes = listIndexes();
+        List<Index> indexes = listIndexes();
         return queryExecutor.find(query, indexes, skip, limit, fields, sortDocument);
     }
 }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/MockMatcherIndexManager.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/MockMatcherIndexManager.java
@@ -38,9 +38,9 @@ public class MockMatcherIndexManager extends IndexManagerImpl {
                             long skip,
                             long limit,
                             List<String> fields,
-                            List<FieldSort> sortDocument) {
+                            List<FieldSort> sortDocument) throws QueryException {
         if (query == null) {
-            return null;
+            throw new QueryException("Query must not be null");
         }
 
         updateAllIndexes();

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/MockMatcherQueryExecutor.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/MockMatcherQueryExecutor.java
@@ -17,6 +17,7 @@ import com.cloudant.sync.sqlite.SQLDatabase;
 import com.cloudant.sync.sqlite.SQLDatabaseQueue;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -41,7 +42,7 @@ public class MockMatcherQueryExecutor extends QueryExecutor{
     // return just a blank node (we don't execute it anyway).
     @Override
     protected ChildrenQueryNode translateQuery(Map<String, Object> query,
-                                               Map<String, Map<String, Object>> indexes,
+                                               List<Index> indexes,
                                                Boolean[] indexesCoverQuery) {
         return new AndQueryNode();
     }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/MockSQLOnlyIndexManager.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/MockSQLOnlyIndexManager.java
@@ -52,7 +52,7 @@ public class MockSQLOnlyIndexManager extends IndexManagerImpl {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-        Map<String, Map<String, Object>> indexes = listIndexes();
+        List<Index> indexes = listIndexes();
         return queryExecutor.find(query, indexes, skip, limit, fields, sortDocument);
     }
 }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/MockSQLOnlyIndexManager.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/MockSQLOnlyIndexManager.java
@@ -38,9 +38,9 @@ public class MockSQLOnlyIndexManager extends IndexManagerImpl {
                             long skip,
                             long limit,
                             List<String> fields,
-                            List<FieldSort> sortDocument) {
+                            List<FieldSort> sortDocument) throws QueryException {
         if (query == null) {
-            return null;
+            throw new QueryException("Query must not be null");
         }
 
         updateAllIndexes();

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/MockSQLOnlyIndexManager.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/MockSQLOnlyIndexManager.java
@@ -13,6 +13,7 @@
 package com.cloudant.sync.query;
 
 import com.cloudant.sync.datastore.Database;
+import com.cloudant.sync.util.Misc;
 import com.cloudant.sync.util.TestUtils;
 
 import java.util.List;
@@ -39,9 +40,7 @@ public class MockSQLOnlyIndexManager extends IndexManagerImpl {
                             long limit,
                             List<String> fields,
                             List<FieldSort> sortDocument) throws QueryException {
-        if (query == null) {
-            throw new QueryException("Query must not be null");
-        }
+        Misc.checkNotNull(query, "query");
 
         updateAllIndexes();
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryCoveringIndexesTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryCoveringIndexesTest.java
@@ -94,7 +94,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
 
     // When executing AND queries
 
-    @Test(expected = QueryException.class)
+    @Test(expected = NullPointerException.class)
     public void returnsNullForNoQuery() throws Exception {
         setUpBasicQueryData();
         im.find(null);

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryCoveringIndexesTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryCoveringIndexesTest.java
@@ -26,6 +26,7 @@ import com.cloudant.sync.datastore.DocumentRevision;
 import com.cloudant.sync.util.SQLDatabaseTestUtils;
 import com.cloudant.sync.util.TestUtils;
 
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -96,7 +97,12 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
     @Test
     public void returnsNullForNoQuery() throws Exception {
         setUpBasicQueryData();
-        assertThat(im.find(null), is(nullValue()));
+        try {
+            im.find(null);
+            Assert.fail("find should throw QueryException");
+        } catch (QueryException qe) {
+            ;
+        }
     }
 
     @Test

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryCoveringIndexesTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryCoveringIndexesTest.java
@@ -94,15 +94,10 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
 
     // When executing AND queries
 
-    @Test
+    @Test(expected = QueryException.class)
     public void returnsNullForNoQuery() throws Exception {
         setUpBasicQueryData();
-        try {
-            im.find(null);
-            Assert.fail("find should throw QueryException");
-        } catch (QueryException qe) {
-            ;
-        }
+        im.find(null);
     }
 
     @Test

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryFilterFieldsTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryFilterFieldsTest.java
@@ -54,7 +54,7 @@ public class QueryFilterFieldsTest extends AbstractQueryTestBase {
     // When filtering fields on find
 
     @Test
-    public void returnsFieldSpecifiedOnly() {
+    public void returnsFieldSpecifiedOnly() throws QueryException {
         // query - { "name" : "mike" }
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", "mike");
@@ -66,7 +66,7 @@ public class QueryFilterFieldsTest extends AbstractQueryTestBase {
     }
 
     @Test
-    public void returnsAllFieldsWhenFieldsArrayEmpty() {
+    public void returnsAllFieldsWhenFieldsArrayEmpty() throws QueryException {
         // query - { "name" : "mike" }
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", "mike");
@@ -78,7 +78,7 @@ public class QueryFilterFieldsTest extends AbstractQueryTestBase {
     }
 
     @Test
-    public void returnsAllFieldsWhenFieldsArrayNull() {
+    public void returnsAllFieldsWhenFieldsArrayNull() throws QueryException {
         // query - { "name" : "mike" }
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", "mike");
@@ -90,7 +90,7 @@ public class QueryFilterFieldsTest extends AbstractQueryTestBase {
     }
 
     @Test
-    public void returnsNullWhenUsingDottedNotation() {
+    public void returnsNullWhenUsingDottedNotation() throws QueryException {
         // query - { "name" : "mike" }
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", "mike");
@@ -103,7 +103,7 @@ public class QueryFilterFieldsTest extends AbstractQueryTestBase {
     }
 
     @Test
-    public void returnsOnlyFieldsSpecified() {
+    public void returnsOnlyFieldsSpecified() throws QueryException {
         // query - { "name" : "mike" }
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", "mike");

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryResultTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryResultTest.java
@@ -31,6 +31,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.concurrent.ExecutionException;
 
 public class QueryResultTest extends AbstractQueryTestBase {
@@ -63,9 +64,9 @@ public class QueryResultTest extends AbstractQueryTestBase {
      * Perform a simple query then drop the revs table from the database before attempting
      * to get the document ids from the QueryResult.
      */
-    @Test(expected = QueryException.class)
+    @Test(expected = NoSuchElementException.class)
     public void testQueryGetDocumentsWithIdsFails() throws InterruptedException,
-        ExecutionException {
+        ExecutionException, QueryException {
         List<FieldSort> fields = Collections.<FieldSort>singletonList(new FieldSort("pet"));
         assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
 
@@ -85,7 +86,7 @@ public class QueryResultTest extends AbstractQueryTestBase {
         }).get();
 
         // Attempt to retrieve the document ids. This should fail with an
-        // UncheckedDocumentException because the revs table has been dropped.
+        // NoSuchElementException because the revs table has been dropped.
         queryResult.documentIds();
     }
 }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QuerySortTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QuerySortTest.java
@@ -24,6 +24,7 @@ import com.cloudant.sync.util.TestUtils;
 
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -33,7 +34,7 @@ import java.util.Set;
 
 public class QuerySortTest extends AbstractQueryTestBase {
 
-    Map<String, Map<String, Object>> indexes;
+    List<Index> indexes;
     Set<String> smallDocIdSet;
     Set<String> largeDocIdSet;
 
@@ -47,17 +48,11 @@ public class QuerySortTest extends AbstractQueryTestBase {
         String[] metadataTableList = new String[] { IndexManagerImpl.INDEX_METADATA_TABLE_NAME };
         SQLDatabaseTestUtils.assertTablesExist(indexManagerDatabaseQueue, metadataTableList);
 
-        Map<String, Object> indexA = new HashMap<String, Object>();
-        indexA.put("name", "a");
-        indexA.put("type", "json");
-        indexA.put("fields", Arrays.<Object>asList("name", "age", "pet"));
-        Map<String, Object> indexB = new HashMap<String, Object>();
-        indexB.put("name", "b");
-        indexB.put("type", "json");
-        indexB.put("fields", Arrays.<Object>asList("x", "y", "z"));
-        indexes = new HashMap<String, Map<String, Object>>();
-        indexes.put("a", indexA);
-        indexes.put("b", indexB);
+        Index indexA = new Index(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("age"), new FieldSort("pet")), "a", IndexType.JSON, null);
+        Index indexB = new Index(Arrays.<FieldSort>asList(new FieldSort("x"), new FieldSort("y"), new FieldSort("z")), "b", IndexType.JSON, null);
+        indexes = new ArrayList<Index>();
+        indexes.add(indexA);
+        indexes.add(indexB);
         smallDocIdSet = new HashSet<String>(Arrays.asList("mike", "john"));
         largeDocIdSet = new HashSet<String>();
         for (int i = 0; i < 501; i++) {  // 500 max id set for placeholders
@@ -240,7 +235,7 @@ public class QuerySortTest extends AbstractQueryTestBase {
     @Test
     public void returnsNullWhenNoIndexes() {
         List<FieldSort> order = Arrays.<FieldSort>asList(new FieldSort("y", FieldSort.Direction.DESCENDING));
-        assertThat(sqlToSortIds(smallDocIdSet, order, new HashMap<String, Map<String, Object>>()),
+        assertThat(sqlToSortIds(smallDocIdSet, order, new ArrayList<Index>()),
                 is(nullValue()));
         assertThat(sqlToSortIds(smallDocIdSet, order, null), is(nullValue()));
     }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QuerySqlTranslatorTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QuerySqlTranslatorTest.java
@@ -1230,7 +1230,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void nullWhenTextSearchDoesNotFindTextIndex() {
+    public void nullWhenTextSearchDoesNotFindTextIndex() throws QueryException {
         im.deleteIndex("basic_text");
         // query - { "$text" : { "$search" : "foo bar baz" } }
         Map<String, Object> searchMap = new HashMap<String, Object>();
@@ -1246,7 +1246,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void nullWhenCompoundQueryIncludesTextSearchDoesNotFindJsonIndex() {
+    public void nullWhenCompoundQueryIncludesTextSearchDoesNotFindJsonIndex() throws QueryException {
         im.deleteIndex("basic");
         // query - { "$and" : [ { "name" : "mike" }, { "$text" : { "$search" : "foo bar baz" } } ] }
         Map<String, Object> nameMap = new HashMap<String, Object>();

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QuerySqlTranslatorTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QuerySqlTranslatorTest.java
@@ -482,155 +482,121 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
 
     @Test
     public void indexSelectionFailsWhenNoQueryKeys() {
-        Map<String, Map<String, Object>> indexes = new HashMap<String, Map<String, Object>>();
-        Map<String, Object> indexMap = new HashMap<String, Object>();
-        indexMap.put("name", null);
-        indexMap.put("age", null);
-        indexMap.put("pet", null);
-        indexes.put("named", indexMap);
-        // TODO
-        //assertThat(QuerySqlTranslator.chooseIndexForAndClause(null, indexes), is(nullValue()));
+        Index index = new Index(Arrays.<FieldSort>asList(new FieldSort("name"),
+                new FieldSort("age"),
+                new FieldSort("pet")),
+                "named");
+
+        assertThat(QuerySqlTranslator.chooseIndexForAndClause(null, Collections.<Index>singletonList(index)), is(nullValue()));
         assertThat(QuerySqlTranslator.chooseIndexForAndClause(new ArrayList<Object>(), null),
                    is(nullValue()));
     }
 
     @Test
     public void selectsIndexForSingleFieldQuery() {
-        Map<String, Map<String, Object>> indexes = new HashMap<String, Map<String, Object>>();
-        Map<String, Object> index = new HashMap<String, Object>();
-        index.put("name", "named");
-        index.put("type", IndexType.JSON);
-        index.put("fields", Arrays.<Object>asList("name"));
-        indexes.put("named", index);
+        Index index = new Index(Arrays.<FieldSort>asList(new FieldSort("name")),
+                "named",
+                IndexType.JSON);
 
         Map<String, Object> eq = new HashMap<String, Object>();
         eq.put("$eq", "mike");
         Map<String, Object> name = new HashMap<String, Object>();
         name.put("name", eq);
-        // TODO
-//        String idx = QuerySqlTranslator.chooseIndexForAndClause(Arrays.<Object>asList(name), indexes);
-//        assertThat(idx, is("named"));
+
+        String idx = QuerySqlTranslator.chooseIndexForAndClause(Arrays.<Object>asList(name), Collections.<Index>singletonList(index));
+        assertThat(idx, is("named"));
     }
 
     @Test
     public void selectsIndexForMultiFieldQuery() {
-        Map<String, Map<String, Object>> indexes = new HashMap<String, Map<String, Object>>();
-        Map<String, Object> index = new HashMap<String, Object>();
-        index.put("name", "named");
-        index.put("type", IndexType.JSON);
-        index.put("fields", Arrays.<Object>asList("name", "age", "pet"));
-        indexes.put("named", index);
+        Index index = new Index(Arrays.<FieldSort>asList(new FieldSort("name"),
+                new FieldSort("age"),
+                new FieldSort("pet")),
+                "named",
+                IndexType.JSON);
 
         Map<String, Object> name = new HashMap<String, Object>();
         name.put("name", "mike");
         Map<String, Object> pet = new HashMap<String, Object>();
         pet.put("pet", "cat");
 
-        // TODO
-//        String idx = QuerySqlTranslator.chooseIndexForAndClause(Arrays.<Object>asList(name, pet),
-//                                                                indexes);
-//        assertThat(idx, is("named"));
+        String idx = QuerySqlTranslator.chooseIndexForAndClause(Arrays.<Object>asList(name, pet),
+                                                                Collections.<Index>singletonList(index));
+        assertThat(idx, is("named"));
     }
 
     @Test
     public void selectsIndexFromMultipleIndexesForMultiFieldQuery() {
-        Map<String, Map<String, Object>> indexes = new HashMap<String, Map<String, Object>>();
+        Index index0 = new Index(Arrays.<FieldSort>asList(new FieldSort("name"),
+                new FieldSort("age"),
+                new FieldSort("pet")),
+                "named",
+                IndexType.JSON);
 
-        Map<String, Object> named = new HashMap<String, Object>();
-        named.put("name", "named");
-        named.put("type", IndexType.JSON);
-        named.put("fields", Arrays.<Object>asList("name", "age", "pet"));
+        Index index1 = new Index(Arrays.<FieldSort>asList(new FieldSort("house_number"),
+                new FieldSort("pet")),
+                "bopped",
+                IndexType.JSON);
 
-        Map<String, Object> bopped = new HashMap<String, Object>();
-        bopped.put("name", "bopped");
-        bopped.put("type", IndexType.JSON);
-        bopped.put("fields", Arrays.<Object>asList("house_number", "pet"));
-
-        Map<String, Object> unsuitable = new HashMap<String, Object>();
-        unsuitable.put("name", "unsuitable");
-        unsuitable.put("type", IndexType.JSON);
-        unsuitable.put("fields", Arrays.<Object>asList("name"));
-
-        indexes.put("named", named);
-        indexes.put("bopped", bopped);
-        indexes.put("unsuitable", unsuitable);
+        Index index2 = new Index(Arrays.<FieldSort>asList(new FieldSort("name")),
+                "unsuitable",
+                IndexType.JSON);
 
         Map<String, Object> name = new HashMap<String, Object>();
         name.put("name", "mike");
         Map<String, Object> pet = new HashMap<String, Object>();
         pet.put("pet", "cat");
 
-        // TODO
-//        String idx = QuerySqlTranslator.chooseIndexForAndClause(Arrays.<Object>asList(name, pet),
-//                                                                indexes);
-//        assertThat(idx, is("named"));
+        String idx = QuerySqlTranslator.chooseIndexForAndClause(Arrays.<Object>asList(name, pet),
+                                                                Arrays.<Index>asList(index0, index1, index2));
+        assertThat(idx, is("named"));
     }
 
     @Test
     public void selectsCorrectIndexWhenSeveralMatch() {
-        Map<String, Map<String, Object>> indexes = new HashMap<String, Map<String, Object>>();
+        Index index0 = new Index(Arrays.<FieldSort>asList(new FieldSort("name"),
+                new FieldSort("age"),
+                new FieldSort("pet")),
+                "named",
+                IndexType.JSON);
 
-        Map<String, Object> named = new HashMap<String, Object>();
-        named.put("name", "named");
-        named.put("type", IndexType.JSON);
-        named.put("fields", Arrays.<Object>asList("name", "age", "pet"));
+        Index index1 = new Index(Arrays.<FieldSort>asList(new FieldSort("name"),
+                new FieldSort("age"),
+                new FieldSort("pet")),
+                "bopped",
+                IndexType.JSON);
 
-        Map<String, Object> bopped = new HashMap<String, Object>();
-        bopped.put("name", "bopped");
-        bopped.put("type", "json");
-        bopped.put("fields", Arrays.<Object>asList("name", "age", "pet"));
-
-        Map<String, Object> manyField = new HashMap<String, Object>();
-        manyField.put("name", "manyField");
-        manyField.put("type", IndexType.JSON);
-        manyField.put("fields", Arrays.<Object>asList("name", "age", "pet"));
-
-        Map<String, Object> unsuitable = new HashMap<String, Object>();
-        unsuitable.put("name", "unsuitable");
-        unsuitable.put("type", IndexType.JSON);
-        unsuitable.put("fields", Arrays.<Object>asList("name"));
-
-        indexes.put("named", named);
-        indexes.put("bopped", bopped);
-        indexes.put("manyField", manyField);
-        indexes.put("unsuitable", unsuitable);
+        Index index2 = new Index(Arrays.<FieldSort>asList(new FieldSort("name")),
+                "unsuitable",
+                IndexType.JSON);
 
         Map<String, Object> name = new HashMap<String, Object>();
         name.put("name", "mike");
         Map<String, Object> pet = new HashMap<String, Object>();
         pet.put("pet", "cat");
 
-
-        // TODO
-        //String idx = QuerySqlTranslator.chooseIndexForAndClause(Arrays.<Object>asList(name, pet),
-//                                                                indexes);
-        //assertThat(Arrays.asList("named", "bopped").contains(idx), is(true));
+        String idx = QuerySqlTranslator.chooseIndexForAndClause(Arrays.<Object>asList(name, pet),
+                                                                Arrays.<Index>asList(index0, index1, index2));
+        assertThat(Arrays.asList("named", "bopped").contains(idx), is(true));
     }
 
     @Test
     public void nullWhenNoSuitableIndexAvailable() {
-        Map<String, Map<String, Object>> indexes = new HashMap<String, Map<String, Object>>();
+        Index index0 = new Index(Arrays.<FieldSort>asList(new FieldSort("name"),
+                new FieldSort("age")),
+                "named",
+                IndexType.JSON);
 
-        Map<String, Object> named = new HashMap<String, Object>();
-        named.put("name", "named");
-        named.put("type", IndexType.JSON);
-        named.put("fields", Arrays.<Object>asList("name", "age"));
-
-        Map<String, Object> unsuitable = new HashMap<String, Object>();
-        unsuitable.put("name", "unsuitable");
-        unsuitable.put("type", IndexType.JSON);
-        unsuitable.put("fields", Arrays.<Object>asList("name"));
-
-        indexes.put("named", named);
-        indexes.put("unsuitable", unsuitable);
+        Index index1 = new Index(Arrays.<FieldSort>asList(new FieldSort("name")),
+                "unsuitable",
+                IndexType.JSON);
 
         Map<String, Object> pet = new HashMap<String, Object>();
         pet.put("pet", "cat");
 
-        // TODO
-//        String idx = QuerySqlTranslator.chooseIndexForAndClause(Arrays.<Object>asList(pet), indexes);
+        String idx = QuerySqlTranslator.chooseIndexForAndClause(Arrays.<Object>asList(pet), Arrays.<Index>asList(index0, index1));
 
-//        assertThat(idx, is(nullValue()));
+        assertThat(idx, is(nullValue()));
     }
 
     // When generating query WHERE clauses

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QuerySqlTranslatorTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QuerySqlTranslatorTest.java
@@ -33,7 +33,7 @@ import java.util.Map;
 
 public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
 
-    Map<String, Map<String, Object>> indexes;
+    List<Index> indexes;
     Boolean[] indexesCoverQuery;
     String indexName;
     String indexTable;
@@ -488,7 +488,8 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         indexMap.put("age", null);
         indexMap.put("pet", null);
         indexes.put("named", indexMap);
-        assertThat(QuerySqlTranslator.chooseIndexForAndClause(null, indexes), is(nullValue()));
+        // TODO
+        //assertThat(QuerySqlTranslator.chooseIndexForAndClause(null, indexes), is(nullValue()));
         assertThat(QuerySqlTranslator.chooseIndexForAndClause(new ArrayList<Object>(), null),
                    is(nullValue()));
     }
@@ -506,9 +507,9 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         eq.put("$eq", "mike");
         Map<String, Object> name = new HashMap<String, Object>();
         name.put("name", eq);
-
-        String idx = QuerySqlTranslator.chooseIndexForAndClause(Arrays.<Object>asList(name), indexes);
-        assertThat(idx, is("named"));
+        // TODO
+//        String idx = QuerySqlTranslator.chooseIndexForAndClause(Arrays.<Object>asList(name), indexes);
+//        assertThat(idx, is("named"));
     }
 
     @Test
@@ -525,9 +526,10 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         Map<String, Object> pet = new HashMap<String, Object>();
         pet.put("pet", "cat");
 
-        String idx = QuerySqlTranslator.chooseIndexForAndClause(Arrays.<Object>asList(name, pet),
-                                                                indexes);
-        assertThat(idx, is("named"));
+        // TODO
+//        String idx = QuerySqlTranslator.chooseIndexForAndClause(Arrays.<Object>asList(name, pet),
+//                                                                indexes);
+//        assertThat(idx, is("named"));
     }
 
     @Test
@@ -558,9 +560,10 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         Map<String, Object> pet = new HashMap<String, Object>();
         pet.put("pet", "cat");
 
-        String idx = QuerySqlTranslator.chooseIndexForAndClause(Arrays.<Object>asList(name, pet),
-                                                                indexes);
-        assertThat(idx, is("named"));
+        // TODO
+//        String idx = QuerySqlTranslator.chooseIndexForAndClause(Arrays.<Object>asList(name, pet),
+//                                                                indexes);
+//        assertThat(idx, is("named"));
     }
 
     @Test
@@ -597,9 +600,11 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         Map<String, Object> pet = new HashMap<String, Object>();
         pet.put("pet", "cat");
 
-        String idx = QuerySqlTranslator.chooseIndexForAndClause(Arrays.<Object>asList(name, pet),
-                                                                indexes);
-        assertThat(Arrays.asList("named", "bopped").contains(idx), is(true));
+
+        // TODO
+        //String idx = QuerySqlTranslator.chooseIndexForAndClause(Arrays.<Object>asList(name, pet),
+//                                                                indexes);
+        //assertThat(Arrays.asList("named", "bopped").contains(idx), is(true));
     }
 
     @Test
@@ -622,9 +627,10 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         Map<String, Object> pet = new HashMap<String, Object>();
         pet.put("pet", "cat");
 
-        String idx = QuerySqlTranslator.chooseIndexForAndClause(Arrays.<Object>asList(pet), indexes);
+        // TODO
+//        String idx = QuerySqlTranslator.chooseIndexForAndClause(Arrays.<Object>asList(pet), indexes);
 
-        assertThat(idx, is(nullValue()));
+//        assertThat(idx, is(nullValue()));
     }
 
     // When generating query WHERE clauses

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryTextSearchTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryTextSearchTest.java
@@ -479,8 +479,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
     public void canQueryUsingPorterTokenizerStemmer() throws QueryException {
         List<FieldSort> fields = Collections.<FieldSort>singletonList(new FieldSort("comment"));
         Map<String, String> indexSettings = new HashMap<String, String>();
-        indexSettings.put("tokenize", "porter");
-        assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT, indexSettings), is("basic_text"));
+        assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT, "porter"), is("basic_text"));
 
         // query - { "$text" : { "$search" : "live" } }
         Map<String, Object> search = new HashMap<String, Object>();

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryTextSearchTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryTextSearchTest.java
@@ -106,7 +106,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
     }
 
     @Test
-    public void canMakeAQueryConsistingOfASingleTextSearch() {
+    public void canMakeAQueryConsistingOfASingleTextSearch() throws QueryException {
         assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("comment")), "basic_text", IndexType.TEXT),
                                     is("basic_text"));
 
@@ -120,7 +120,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
     }
 
     @Test
-    public void canMakeAPhraseSearch() {
+    public void canMakeAPhraseSearch() throws QueryException {
         assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("comment")), "basic_text", IndexType.TEXT),
                                     is("basic_text"));
 
@@ -134,7 +134,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
     }
 
     @Test
-    public void canMakeAQueryTextSearchContainingAnApostrophe() {
+    public void canMakeAQueryTextSearchContainingAnApostrophe() throws QueryException {
         assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("comment")), "basic_text", IndexType.TEXT),
                                     is("basic_text"));
 
@@ -148,7 +148,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
     }
 
     @Test
-    public void canMakeAQueryConsistingOfASingleTextSearchWithASort() {
+    public void canMakeAQueryConsistingOfASingleTextSearchWithASort() throws QueryException {
         assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("comment")), "basic_text", IndexType.TEXT),
                                     is("basic_text"));
 
@@ -164,7 +164,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
     }
 
     @Test
-    public void canMakeANDCompoundQueryWithATextSearch() {
+    public void canMakeANDCompoundQueryWithATextSearch() throws QueryException {
         assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name")), "basic"), is("basic"));
         assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("comment")), "basic_text", IndexType.TEXT),
                    is("basic_text"));
@@ -180,7 +180,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
     }
 
     @Test
-    public void canMakeORCompoundQueryWithATextSearch() {
+    public void canMakeORCompoundQueryWithATextSearch() throws QueryException {
         assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name")), "basic"), is("basic"));
         assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("comment")), "basic_text", IndexType.TEXT),
                    is("basic_text"));
@@ -203,7 +203,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
     }
 
     @Test
-    public void nullForTextSearchQueryWithoutATextIndex() {
+    public void nullForTextSearchQueryWithoutATextIndex() throws QueryException {
         assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name")), "basic"), is("basic"));
 
         // query - { "name" : "mike", "$text" : { "$search" : "best friend" } }
@@ -216,7 +216,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
     }
 
     @Test
-    public void nullForTextSearchQueryWhenAJsonIndexIsMissing() {
+    public void nullForTextSearchQueryWhenAJsonIndexIsMissing() throws QueryException {
         // All fields in a TEXT index only apply to the text search portion of any query.
         // So even though "name" exists in the text index, the clause that { "name" : "mike" }
         // expects a JSON index that contains the "name" field.  Since, this query includes a
@@ -238,7 +238,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
     }
 
     @Test
-    public void canMakeATextSearchUsingNonAsciiValues() {
+    public void canMakeATextSearchUsingNonAsciiValues() throws QueryException {
         List<FieldSort> fields = Collections.<FieldSort>singletonList(new FieldSort("comment"));
         assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
 
@@ -252,7 +252,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
     }
 
     @Test
-    public void returnsEmptyResultSetForUnmatchedPhraseSearch() {
+    public void returnsEmptyResultSetForUnmatchedPhraseSearch() throws QueryException {
         List<FieldSort> fields = Collections.<FieldSort>singletonList(new FieldSort("comment"));
         assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
 
@@ -266,7 +266,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
     }
 
     @Test
-    public void returnsCorrectResultSetForNonContiguousWordSearch() {
+    public void returnsCorrectResultSetForNonContiguousWordSearch() throws QueryException {
         List<FieldSort> fields = Collections.<FieldSort>singletonList(new FieldSort("comment"));
         assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
 
@@ -281,7 +281,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
     }
 
     @Test
-    public void canQueryUsingEnhancedQuerySyntaxOR() {
+    public void canQueryUsingEnhancedQuerySyntaxOR() throws QueryException {
         List<FieldSort> fields = Collections.<FieldSort>singletonList(new FieldSort("comment"));
         assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
 
@@ -338,7 +338,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
     }
 
     @Test
-    public void canQueryUsingNEAR() {
+    public void canQueryUsingNEAR() throws QueryException {
         List<FieldSort> fields = Collections.<FieldSort>singletonList(new FieldSort("comment"));
         assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
 
@@ -355,7 +355,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
     }
 
     @Test
-    public void ignoresCapitalizationUsingDefaultTokenizer() {
+    public void ignoresCapitalizationUsingDefaultTokenizer() throws QueryException {
         List<FieldSort> fields = Collections.<FieldSort>singletonList(new FieldSort("comment"));
         assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
 
@@ -370,7 +370,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
     }
 
     @Test
-    public void queriesNonStringFieldAsAString() {
+    public void queriesNonStringFieldAsAString() throws QueryException {
         // Text index on age field
         List<FieldSort> fields = Collections.<FieldSort>singletonList(new FieldSort("age"));
         assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
@@ -385,7 +385,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
     }
 
     @Test
-    public void returnsNullWhenSearchCriteriaNotAString() {
+    public void returnsNullWhenSearchCriteriaNotAString() throws QueryException {
         // Text index on age field
         List<FieldSort> fields = Collections.<FieldSort>singletonList(new FieldSort("age"));
         assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
@@ -400,7 +400,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
     }
 
     @Test
-    public void canQueryAcrossMultipleFields() {
+    public void canQueryAcrossMultipleFields() throws QueryException {
         // Text index on name and comment fields
         List<FieldSort> fields = Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("comment"));
         assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
@@ -417,7 +417,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
     }
 
     @Test
-    public void canQueryTargetingSpecificFields() {
+    public void canQueryTargetingSpecificFields() throws QueryException {
         // Text index on name and comment fields
         List<FieldSort> fields = Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("comment"));
         assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
@@ -434,7 +434,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
     }
 
     @Test
-    public void canQueryUsingPrefixSearches() {
+    public void canQueryUsingPrefixSearches() throws QueryException {
         List<FieldSort> fields = Collections.<FieldSort>singletonList(new FieldSort("comment"));
         assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
 
@@ -448,7 +448,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
     }
 
     @Test
-    public void returnsEmptyResultSetWhenPrefixSearchesMissingWildcards() {
+    public void returnsEmptyResultSetWhenPrefixSearchesMissingWildcards() throws QueryException {
         List<FieldSort> fields = Collections.<FieldSort>singletonList(new FieldSort("comment"));
         assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
 
@@ -462,7 +462,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
     }
 
     @Test
-    public void canQueryUsingID() {
+    public void canQueryUsingID() throws QueryException {
         List<FieldSort> fields = Collections.<FieldSort>singletonList(new FieldSort("comment"));
         assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
 
@@ -476,7 +476,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
     }
 
     @Test
-    public void canQueryUsingPorterTokenizerStemmer() {
+    public void canQueryUsingPorterTokenizerStemmer() throws QueryException {
         List<FieldSort> fields = Collections.<FieldSort>singletonList(new FieldSort("comment"));
         Map<String, String> indexSettings = new HashMap<String, String>();
         indexSettings.put("tokenize", "porter");
@@ -492,7 +492,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
     }
 
     @Test
-    public void returnsEmptyResultSetUsingDefaultTokenizerStemmer() {
+    public void returnsEmptyResultSetUsingDefaultTokenizerStemmer() throws QueryException {
         List<FieldSort> fields = Collections.<FieldSort>singletonList(new FieldSort("comment"));
         assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
 
@@ -506,7 +506,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
     }
 
     @Test
-    public void canQueryUsingAnApostrophe() {
+    public void canQueryUsingAnApostrophe() throws QueryException {
         List<FieldSort> fields = Collections.<FieldSort>singletonList(new FieldSort("comment"));
         assertThat(im.ensureIndexed(fields, "basic_text", IndexType.TEXT), is("basic_text"));
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryWithoutCoveringIndexesTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryWithoutCoveringIndexesTest.java
@@ -250,7 +250,7 @@ public class QueryWithoutCoveringIndexesTest extends AbstractQueryTestBase {
     public void canQueryORWithoutAnyIndexes() throws Exception {
         setUpWithoutCoveringIndexesQueryData();
         im.deleteIndex("pet");
-        assertThat(im.listIndexes().keySet(), contains("basic"));
+//        assertThat(im.listIndexes(), contains("basic"));
         // query - { "$or" : [ { "pet" : { "$eq" : "cat" } }, { "town" : { "$eq" : "bristol" } } ] }
         // indexes - { "basic" : { "name" : "basic", "type" : "json", "fields" : [ "_id",
         //                                                                         "_rev",
@@ -469,7 +469,7 @@ public class QueryWithoutCoveringIndexesTest extends AbstractQueryTestBase {
         //           document ids directly from the datastore.
         im.deleteIndex("basic");
         im.deleteIndex("pet");
-        assertThat(im.listIndexes().keySet(), is(empty()));
+        assertThat(im.listIndexes(), is(empty()));
 
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("town", "bristol");

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryWithoutCoveringIndexesTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryWithoutCoveringIndexesTest.java
@@ -12,6 +12,7 @@
 
 package com.cloudant.sync.query;
 
+import static com.cloudant.sync.query.MatcherHelper.getIndexNameMatcher;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -250,7 +251,7 @@ public class QueryWithoutCoveringIndexesTest extends AbstractQueryTestBase {
     public void canQueryORWithoutAnyIndexes() throws Exception {
         setUpWithoutCoveringIndexesQueryData();
         im.deleteIndex("pet");
-//        assertThat(im.listIndexes(), contains("basic"));
+        assertThat(im.listIndexes(), contains(getIndexNameMatcher("basic")));
         // query - { "$or" : [ { "pet" : { "$eq" : "cat" } }, { "town" : { "$eq" : "bristol" } } ] }
         // indexes - { "basic" : { "name" : "basic", "type" : "json", "fields" : [ "_id",
         //                                                                         "_rev",

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryWithoutCoveringIndexesTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryWithoutCoveringIndexesTest.java
@@ -12,7 +12,7 @@
 
 package com.cloudant.sync.query;
 
-import static com.cloudant.sync.query.MatcherHelper.getIndexNameMatcher;
+import static com.cloudant.sync.query.IndexMatcherHelpers.getIndexNameMatcher;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;


### PR DESCRIPTION
Part 3 of _n_ PRs for feature-284-refactor-datastore-indexmanager. See parent issue #284.

The overall theme for this PR is to finish API changes initiated in #371 and ensure that the `IndexManager` has a "user-friendly" API.

- Return `List<Index>` from `listIndexes` so user can interact with a more intuitive, self-documenting type of object.
- Remove over-generic `Map<String, String> IndexSettings` option from `ensureIndexed` and replace it with the an argument for the one current index setting - `tokenize`.
- Throw exceptions instead of returning `null` where possible. Re-throw any `ExecutionException`s as `QueryException`s where needed.
- (Continuing from previous point). Use `Misc.*` pre-conditions to do null checks, argument validity checks at the beginning of public API methods.
- Update test code for new API.
- Do some things in the more correct Java idiomatic way: implement `equals` and `hashCode` for `Index` and remove `compareIndexTypeTo`, remove `Index.getInstance()`, etc.