### PR TITLE
373 index update tx

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# Unreleased
+- [FIXED] Issue that was preventing index updates from being persisted that was impacting query
+  performance.
+
 # 1.1.1 (2016-10-05)
 
 - [UPGRADED] Upgraded to version 2.6.2 of the `cloudant-http` library.

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexUpdater.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexUpdater.java
@@ -136,7 +136,6 @@ class IndexUpdater {
         Future<Boolean> result = queue.submitTransaction(new SQLCallable<Boolean>() {
             @Override
             public Boolean call(SQLDatabase database) {
-                database.beginTransaction();
                 for (DocumentRevision rev: changes.getResults()) {
                     // Delete existing values
                     String tableName = IndexManager.tableNameForIndex(indexName);

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexUpdaterTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexUpdaterTest.java
@@ -1061,9 +1061,11 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         } finally {
             im.close();
         }
-        // Now get a new IndexManager and queue and update the test fields accordingly
+
+        // Get a new IndexManager instance and extract its queue
         im = new IndexManager(ds);
         indexManagerDatabaseQueue = TestUtils.getDBQueue(im);
+
         // Check that the updates are still there
         try {
             // Assert that the index made is still there
@@ -1104,7 +1106,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
             im.close();
         }
 
-        // Now get a new IndexManager and queue and update the test fields accordingly
+        // Get a new IndexManager instance and extract its queue
         im = new IndexManager(ds);
         indexManagerDatabaseQueue = TestUtils.getDBQueue(im);
 
@@ -1127,7 +1129,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
             im.close();
         }
 
-        // Now get a new IndexManager and queue and update the test fields accordingly
+        // Get a new IndexManager instance and extract its queue
         im = new IndexManager(ds);
         indexManagerDatabaseQueue = TestUtils.getDBQueue(im);
         // Check that the updates are still there

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexUpdaterTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexUpdaterTest.java
@@ -24,8 +24,8 @@ import com.cloudant.sync.datastore.DocumentBodyFactory;
 import com.cloudant.sync.datastore.DocumentException;
 import com.cloudant.sync.datastore.DocumentRevision;
 import com.cloudant.sync.sqlite.Cursor;
-import com.cloudant.sync.sqlite.SQLDatabase;
 import com.cloudant.sync.sqlite.SQLCallable;
+import com.cloudant.sync.sqlite.SQLDatabase;
 import com.cloudant.sync.util.DatabaseUtils;
 import com.cloudant.sync.util.TestUtils;
 
@@ -34,14 +34,14 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
 
 @RunWith(Parameterized.class)
 public class IndexUpdaterTest extends AbstractIndexTestBase {
@@ -1039,6 +1039,114 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
             }
         }).get();
 
+    }
+
+    @Test
+    public void indexUpdatesPersistFromCreation() throws Exception {
+        long exepctedSequence = 0l;
+        try {
+            DocumentRevision rev = new DocumentRevision("mike12");
+            // body content: { "name" : "mike",  "age" : 12, "pet" : "cat" }
+            Map<String, Object> bodyMap = new HashMap<String, Object>();
+            bodyMap.put("name", "mike");
+            bodyMap.put("age", 12);
+            bodyMap.put("pet", "cat");
+            rev.setBody(DocumentBodyFactory.create(bodyMap));
+            ds.createDocumentFromRevision(rev);
+
+            createIndex("testIndex", Collections.singletonList((Object) "name"));
+            exepctedSequence = getIndexSequenceNumber("testIndex");
+            Assert.assertEquals("The expected sequence should be 1 for 1 document created.", 1,
+                    exepctedSequence);
+        } finally {
+            im.close();
+        }
+        // Now get a new IndexManager and queue and update the test fields accordingly
+        im = new IndexManager(ds);
+        indexManagerDatabaseQueue = TestUtils.getDBQueue(im);
+        // Check that the updates are still there
+        try {
+            // Assert that the index made is still there
+            Set<Map.Entry<String, Object>> entries = im.listIndexes().entrySet();
+            Assert.assertEquals("There should be 1 index.", 1, entries.size());
+            Map.Entry<String, Object> actualIndex = entries.iterator().next();
+            Assert.assertEquals("There should be the named index.", "testIndex", actualIndex
+                    .getKey());
+            Map<String, Object> actualIndexMetadata = (Map<String, Object>) actualIndex.getValue();
+            Assert.assertEquals("The name property of the index should be correct.", "testIndex",
+                    actualIndexMetadata.get("name"));
+            long actualSequence = getIndexSequenceNumber("testIndex");
+            Assert.assertEquals("The sequence should still be 1 for 1 document created.", 1,
+                    actualSequence);
+        } finally {
+            im.close();
+        }
+    }
+
+    @Test
+    public void indexUpdatesPersistExistingIndex() throws Exception {
+        long exepctedSequence = 0l;
+        try {
+            DocumentRevision rev = new DocumentRevision("mike12");
+            // body content: { "name" : "mike",  "age" : 12, "pet" : "cat" }
+            Map<String, Object> bodyMap = new HashMap<String, Object>();
+            bodyMap.put("name", "mike");
+            bodyMap.put("age", 12);
+            bodyMap.put("pet", "cat");
+            rev.setBody(DocumentBodyFactory.create(bodyMap));
+            ds.createDocumentFromRevision(rev);
+
+            createIndex("testIndex", Collections.singletonList((Object) "name"));
+            exepctedSequence = getIndexSequenceNumber("testIndex");
+            Assert.assertEquals("The expected sequence should be 1 for 1 document created.", 1,
+                    exepctedSequence);
+        } finally {
+            im.close();
+        }
+
+        // Now get a new IndexManager and queue and update the test fields accordingly
+        im = new IndexManager(ds);
+        indexManagerDatabaseQueue = TestUtils.getDBQueue(im);
+
+        try {
+            // Create another document to update the DB
+            DocumentRevision rev = new DocumentRevision("mike23");
+            // body content: { "name" : "mike",  "age" : 23, "pet" : "parrot" }
+            Map<String, Object> bodyMap = new HashMap<String, Object>();
+            bodyMap.put("name", "mike");
+            bodyMap.put("age", 23);
+            bodyMap.put("pet", "cat");
+            rev.setBody(DocumentBodyFactory.create(bodyMap));
+            ds.createDocumentFromRevision(rev);
+
+            im.updateAllIndexes();
+            exepctedSequence = getIndexSequenceNumber("testIndex");
+            Assert.assertEquals("The expected sequence should be 2 for 2 documents created.", 2,
+                    exepctedSequence);
+        } finally {
+            im.close();
+        }
+
+        // Now get a new IndexManager and queue and update the test fields accordingly
+        im = new IndexManager(ds);
+        indexManagerDatabaseQueue = TestUtils.getDBQueue(im);
+        // Check that the updates are still there
+        try {
+            // Assert that the index made is still there
+            Set<Map.Entry<String, Object>> entries = im.listIndexes().entrySet();
+            Assert.assertEquals("There should be 1 index.", 1, entries.size());
+            Map.Entry<String, Object> actualIndex = entries.iterator().next();
+            Assert.assertEquals("There should be the named index.", "testIndex", actualIndex
+                    .getKey());
+            Map<String, Object> actualIndexMetadata = (Map<String, Object>) actualIndex.getValue();
+            Assert.assertEquals("The name property of the index should be correct.", "testIndex",
+                    actualIndexMetadata.get("name"));
+            long actualSequence = getIndexSequenceNumber("testIndex");
+            Assert.assertEquals("The sequence should still be 2 for 2 documents created.", 2,
+                    actualSequence);
+        } finally {
+            im.close();
+        }
     }
 
     private long getIndexSequenceNumber(String indexName) throws Exception {


### PR DESCRIPTION
*What*

Fixed issue persisting index updates.

*How*

When the `IndexUpdater` was refactored to use the a `SQLDatabaseQueue` it was changed to use `submitTransaction` instead of starting and ending the transaction itself, but the `beginTransaction()` call was never removed. This started a nested transaction that was never completed.

* Removed obsolete `beginTransaction()` call.
* Updated `CHANGES.md`.

*Testing*

Added two new tests:

* `indexUpdatesPersistFromCreation()`
* `indexUpdatesPersistExistingIndex()`

*Issues*

Fixes #373 