### PR TITLE
Ensured unique remote db name for replication tests

### DIFF
--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/ReplicationTestBase.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/ReplicationTestBase.java
@@ -45,10 +45,12 @@ public abstract class ReplicationTestBase extends CouchTestBase {
 
     protected CouchConfig couchConfig = null;
 
-    private long dbSuffix = System.currentTimeMillis();
+    private long dbSuffix;
 
     @Before
     public void setUp() throws Exception {
+        // Use a unique suffix for each test
+        dbSuffix = System.currentTimeMillis();
         this.createDatastore();
         this.createRemoteDB();
     }
@@ -57,7 +59,7 @@ public abstract class ReplicationTestBase extends CouchTestBase {
     public void tearDown() throws Exception {
         datastore.close();
         TestUtils.deleteDatabaseQuietly(database);
-        cleanUpTempFiles();
+        cleanUpTempFilesAndDeleteRemote();
     }
 
 
@@ -78,7 +80,7 @@ public abstract class ReplicationTestBase extends CouchTestBase {
         couchClient = remoteDb.getCouchClient();
     }
 
-    protected void cleanUpTempFiles() {
+    protected void cleanUpTempFilesAndDeleteRemote() {
         TestUtils.deleteTempTestingDir(datastoreManagerPath);
         CouchClientWrapperDbUtils.deleteDbQuietly(remoteDb);
     }


### PR DESCRIPTION
*What*

Attempt to resolve intermittent issues in `com.cloudant.sync.replication.AttachmentsPullTest`

*How*

Ensured that the same remote database name wasn't being used for each test because that is prone to it being potentially deleted during a subsequent test or not being created because it already exists or other undefined issues.

* Used a unique suffix for each test instead of repeatedly using the same remote name.
* cleanUpTempFiles -> cleanUpTempFilesAndDeleteRemote to make it clear
that this method also deletes the remote database

*Testing*

Tests pass on local and travis runs.

*Issues*

Fixes #360 