### PR TITLE
Moved FTS check to SQLDatabaseFactory

### DIFF
--- a/cloudant-sync-datastore-android/src/main/java/com/cloudant/sync/sqlite/android/AndroidSQLite.java
+++ b/cloudant-sync-datastore-android/src/main/java/com/cloudant/sync/sqlite/android/AndroidSQLite.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013 Cloudant, Inc. All rights reserved.
+ * Copyright © 2013, 2016 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -33,7 +33,12 @@ public class AndroidSQLite extends SQLDatabase {
 
 
     public static AndroidSQLite createAndroidSQLite(String path) {
-        SQLiteDatabase db = SQLiteDatabase.openDatabase(path, null, SQLiteDatabase.CREATE_IF_NECESSARY);
+        SQLiteDatabase db;
+        if (path != null) {
+            db = SQLiteDatabase.openDatabase(path, null, SQLiteDatabase.CREATE_IF_NECESSARY);
+        } else {
+            db = SQLiteDatabase.create(null);
+        }
         return new AndroidSQLite(db);
     }
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexCreator.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexCreator.java
@@ -1,14 +1,16 @@
-//  Copyright (c) 2014 Cloudant. All rights reserved.
-//
-//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
-//  except in compliance with the License. You may obtain a copy of the License at
-//
-//    http://www.apache.org/licenses/LICENSE-2.0
-//
-//  Unless required by applicable law or agreed to in writing, software distributed under the
-//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
-//  either express or implied. See the License for the specific language governing permissions
-//  and limitations under the License.
+/*
+ * Copyright © 2014, 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
 
 package com.cloudant.sync.query;
 
@@ -16,6 +18,7 @@ import com.cloudant.android.ContentValues;
 import com.cloudant.sync.datastore.Database;
 import com.cloudant.sync.sqlite.SQLCallable;
 import com.cloudant.sync.sqlite.SQLDatabase;
+import com.cloudant.sync.sqlite.SQLDatabaseFactory;
 import com.cloudant.sync.sqlite.SQLDatabaseQueue;
 import com.cloudant.sync.util.Misc;
 
@@ -29,7 +32,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
@@ -75,7 +77,7 @@ class IndexCreator {
         Misc.checkNotNull(proposedIndex, "proposedIndex");
 
         if (proposedIndex.indexType == IndexType.TEXT) {
-            if (!IndexManagerImpl.ftsAvailable(queue)) {
+            if (!SQLDatabaseFactory.FTS_AVAILABLE) {
                 String message = "Text search not supported.  To add support for text " +
                         "search, enable FTS compile options in SQLite.";
                 logger.log(Level.SEVERE, message);

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexManager.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexManager.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright © 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
 package com.cloudant.sync.query;
 
 import java.util.List;
@@ -37,8 +50,6 @@ public interface IndexManager {
                      List<String> fields,
                      List<FieldSort> sortDocument)
             throws QueryException;
-
-    boolean isTextSearchEnabled();
 
     // TODO we may not want to expose this publicly
     void close();

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/AbstractIndexTestBase.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/AbstractIndexTestBase.java
@@ -16,6 +16,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
+import com.cloudant.sync.datastore.CloudantSync;
 import com.cloudant.sync.datastore.DatabaseImpl;
 import com.cloudant.sync.datastore.DatastoreManager;
 import com.cloudant.sync.sqlite.SQLDatabaseQueue;
@@ -39,9 +40,10 @@ public abstract class AbstractIndexTestBase {
         assertThat(factoryPath, is(notNullValue()));
         factory = DatastoreManager.getInstance(factoryPath);
         assertThat(factory, is(notNullValue()));
-        ds = (DatabaseImpl) factory.openDatastore(AbstractIndexTestBase.class.getSimpleName()).database;
+        CloudantSync sync = factory.openDatastore(AbstractIndexTestBase.class.getSimpleName());
+        ds = (DatabaseImpl) sync.database;
         assertThat(ds, is(notNullValue()));
-        im = new IndexManagerImpl(ds);
+        im = (IndexManagerImpl) sync.query;
         assertThat(im, is(notNullValue()));
         indexManagerDatabaseQueue = TestUtils.getDBQueue(im);
         assertThat(indexManagerDatabaseQueue, is(notNullValue()));

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/AbstractQueryTestBase.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/AbstractQueryTestBase.java
@@ -16,6 +16,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
+import com.cloudant.sync.datastore.CloudantSync;
 import com.cloudant.sync.datastore.DatabaseImpl;
 import com.cloudant.sync.datastore.DatastoreManager;
 import com.cloudant.sync.datastore.DocumentBodyFactory;
@@ -45,6 +46,7 @@ public abstract class AbstractQueryTestBase {
 
     String factoryPath = null;
     DatastoreManager factory = null;
+    CloudantSync cloudantSync = null;
     DatabaseImpl ds = null;
     IndexManagerImpl im = null;
     SQLDatabaseQueue indexManagerDatabaseQueue;
@@ -56,7 +58,9 @@ public abstract class AbstractQueryTestBase {
         factory = DatastoreManager.getInstance(factoryPath);
         assertThat(factory, is(notNullValue()));
         String datastoreName = AbstractQueryTestBase.class.getSimpleName();
-        ds = (DatabaseImpl) factory.openDatastore(datastoreName).database;
+        cloudantSync = factory.openDatastore(datastoreName);
+        ds = (DatabaseImpl) cloudantSync.database;
+        im = (IndexManagerImpl) cloudantSync.query;
         assertThat(ds, is(notNullValue()));
     }
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/DelegatingMockIndexManager.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/DelegatingMockIndexManager.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.query;
+
+import java.util.List;
+import java.util.Map;
+
+public abstract class DelegatingMockIndexManager implements IndexManager {
+
+    protected final IndexManagerImpl delegate;
+
+    DelegatingMockIndexManager(IndexManagerImpl delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public List<Index> listIndexes() throws QueryException {
+        return delegate.listIndexes();
+    }
+
+    @Override
+    public String ensureIndexed(List<FieldSort> fieldNames) throws QueryException {
+        return delegate.ensureIndexed(fieldNames);
+    }
+
+    @Override
+    public String ensureIndexed(List<FieldSort> fieldNames, String indexName) throws QueryException {
+        return delegate.ensureIndexed(fieldNames, indexName);
+    }
+
+    @Override
+    public String ensureIndexed(List<FieldSort> fieldNames, String indexName, IndexType indexType) throws QueryException {
+        return delegate.ensureIndexed(fieldNames, indexName, indexType);
+    }
+
+    @Override
+    public String ensureIndexed(List<FieldSort> fieldNames, String indexName, IndexType indexType, String tokenize) throws QueryException {
+        return delegate.ensureIndexed(fieldNames,indexName, indexType, tokenize);
+    }
+
+    @Override
+    public void deleteIndex(String indexName) throws QueryException {
+        delegate.deleteIndex(indexName);
+    }
+
+    @Override
+    public void updateAllIndexes() throws QueryException {
+        delegate.updateAllIndexes();
+    }
+
+    @Override
+    public QueryResult find(Map<String, Object> query) throws QueryException {
+        return delegate.find(query);
+    }
+
+    @Override
+    public QueryResult find(Map<String, Object> query, long skip, long limit, List<String> fields, List<FieldSort> sortDocument) throws QueryException {
+        return delegate.find(query, skip, limit, fields, sortDocument);
+    }
+
+    @Override
+    public void close() {
+        delegate.close();
+    }
+}

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexManagerTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexManagerTest.java
@@ -1,14 +1,16 @@
-//  Copyright (c) 2014 Cloudant. All rights reserved.
-//
-//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
-//  except in compliance with the License. You may obtain a copy of the License at
-//
-//    http://www.apache.org/licenses/LICENSE-2.0
-//
-//  Unless required by applicable law or agreed to in writing, software distributed under the
-//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
-//  either express or implied. See the License for the specific language governing permissions
-//  and limitations under the License.
+/*
+ * Copyright © 2014, 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
 
 package com.cloudant.sync.query;
 
@@ -21,6 +23,7 @@ import static org.hamcrest.Matchers.notNullValue;
 
 import com.cloudant.sync.datastore.DocumentBodyFactory;
 import com.cloudant.sync.datastore.DocumentRevision;
+import com.cloudant.sync.sqlite.SQLDatabaseFactory;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -198,7 +201,7 @@ public class IndexManagerTest extends AbstractIndexTestBase {
 
     @Test
     public void validateTextSearchIsAvailable() throws Exception {
-        assertThat(im.isTextSearchEnabled(), is(true));
+        assertThat(SQLDatabaseFactory.FTS_AVAILABLE, is(true));
     }
 
 }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/MockMatcherIndexManager.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/MockMatcherIndexManager.java
@@ -12,7 +12,6 @@
 
 package com.cloudant.sync.query;
 
-import com.cloudant.sync.datastore.Database;
 import com.cloudant.sync.util.Misc;
 import com.cloudant.sync.util.TestUtils;
 
@@ -28,12 +27,15 @@ import java.util.Map;
  * @see IndexManagerImpl
  * @see com.cloudant.sync.query.MockMatcherQueryExecutor
  */
-public class MockMatcherIndexManager extends IndexManagerImpl {
+public class MockMatcherIndexManager extends DelegatingMockIndexManager {
 
-    public MockMatcherIndexManager(Database database) {
-        super(database);
+    public MockMatcherIndexManager(IndexManagerImpl im) {
+        super(im);
     }
 
+    /*
+     * Override this one variant of find to use the MockMatcherQueryExecutor.
+     */
     @Override
     public QueryResult find(Map<String, Object> query,
                             long skip,
@@ -46,8 +48,8 @@ public class MockMatcherIndexManager extends IndexManagerImpl {
 
         MockMatcherQueryExecutor queryExecutor = null;
         try {
-            queryExecutor = new MockMatcherQueryExecutor(getDatabase(),
-                    TestUtils.getDBQueue(this));
+            queryExecutor = new MockMatcherQueryExecutor(delegate.getDatabase(),
+                    TestUtils.getDBQueue(delegate));
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/MockSQLOnlyIndexManager.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/MockSQLOnlyIndexManager.java
@@ -12,7 +12,6 @@
 
 package com.cloudant.sync.query;
 
-import com.cloudant.sync.datastore.Database;
 import com.cloudant.sync.util.Misc;
 import com.cloudant.sync.util.TestUtils;
 
@@ -28,12 +27,15 @@ import java.util.Map;
  * @see IndexManagerImpl
  * @see com.cloudant.sync.query.MockSQLOnlyQueryExecutor
  */
-public class MockSQLOnlyIndexManager extends IndexManagerImpl {
+public class MockSQLOnlyIndexManager extends DelegatingMockIndexManager {
 
-    public MockSQLOnlyIndexManager(Database database) {
-        super(database);
+    public MockSQLOnlyIndexManager(IndexManagerImpl im) {
+        super(im);
     }
 
+    /*
+     * Override this variant of find to use a MockSQLOnlyQueryExecutor.
+     */
     @Override
     public QueryResult find(Map<String, Object> query,
                             long skip,
@@ -46,8 +48,8 @@ public class MockSQLOnlyIndexManager extends IndexManagerImpl {
 
         MockSQLOnlyQueryExecutor queryExecutor = null;
         try {
-            queryExecutor = new MockSQLOnlyQueryExecutor(getDatabase(),
-                    TestUtils.getDBQueue(this));
+            queryExecutor = new MockSQLOnlyQueryExecutor(delegate.getDatabase(),
+                    TestUtils.getDBQueue(delegate));
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryCoveringIndexesTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryCoveringIndexesTest.java
@@ -26,7 +26,6 @@ import com.cloudant.sync.datastore.DocumentRevision;
 import com.cloudant.sync.util.SQLDatabaseTestUtils;
 import com.cloudant.sync.util.TestUtils;
 
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -64,6 +63,8 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
 
     private String testType = null;
 
+    private IndexManager idxMgr = null;
+
     @Parameters(name = "{0}")
     public static Iterable<Object[]> data() throws Exception {
         return Arrays.asList(new Object[][]{ { SQL_ONLY_EXECUTION },
@@ -79,11 +80,11 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
     public void setUp() throws Exception{
         super.setUp();
         if (testType.equals(SQL_ONLY_EXECUTION)) {
-            im = new MockSQLOnlyIndexManager(ds);
+            idxMgr = new MockSQLOnlyIndexManager(im);
         } else if (testType.equals(MATCHER_EXECUTION)) {
-            im = new MockMatcherIndexManager(ds);
+            idxMgr = new MockMatcherIndexManager(im);
         } else if (testType.equals(STANDARD_EXECUTION)) {
-            im = new IndexManagerImpl(ds);
+            idxMgr = cloudantSync.query;
         }
         indexManagerDatabaseQueue = TestUtils.getDBQueue(im);
         assertThat(im, is(notNullValue()));
@@ -97,7 +98,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
     @Test(expected = NullPointerException.class)
     public void returnsNullForNoQuery() throws Exception {
         setUpBasicQueryData();
-        im.find(null);
+        idxMgr.find(null);
     }
 
     @Test
@@ -112,7 +113,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         Map<String, Object> ageOperator = new HashMap<String, Object>();
         ageOperator.put("$eq", 12.0f);
         query.put("age", ageOperator);
-        assertThat(im.find(query), is(nullValue()));
+        assertThat(idxMgr.find(query), is(nullValue()));
     }
 
     @Test
@@ -126,13 +127,13 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         bodyMap.put("married", true);
         rev.setBody(DocumentBodyFactory.create(bodyMap));
         ds.createDocumentFromRevision(rev);
-        assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("age"), new FieldSort("married")), "married"), is("married"));
+        assertThat(idxMgr.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("age"), new FieldSort("married")), "married"), is("married"));
         // query - { "married" : { "eq" : true } }
         Map<String, Object> marriedOperator = new HashMap<String, Object>();
         marriedOperator.put("$eq", true);
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("married", marriedOperator);
-        QueryResult result = im.find(query);
+        QueryResult result = idxMgr.find(query);
         assertThat(result, is(notNullValue()));
         assertThat(result.documentIds().size(), is(1));
     }
@@ -146,13 +147,13 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         bodyMap.put("pet", "cat");
         rev.setBody(DocumentBodyFactory.create(bodyMap));
         ds.createDocumentFromRevision(rev);
-        assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("age")), "basic index"), is
+        assertThat(idxMgr.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("age")), "basic index"), is
                 ("basic index"));
 
         // query - { "name" : "mike" }
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", "mike");
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         List<String> docCheckList = new ArrayList<String>();
         for (DocumentRevision revision: queryResult) {
             assertThat(revision.getId(), is(notNullValue()));
@@ -169,7 +170,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         // query - { "name" : "mike" }
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", "mike");
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         List<String> docCheckList = new ArrayList<String>();
         for (DocumentRevision rev: queryResult) {
             assertThat(rev.getId(), is(notNullValue()));
@@ -184,7 +185,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
     public void returnsAllDocsForEmptyQuery() throws Exception {
         setUpBasicQueryData();
         Map<String, Object> query = new HashMap<String, Object>();
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), containsInAnyOrder("mike12",
                                                                  "mike34",
                                                                  "mike72",
@@ -198,7 +199,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         // query - { "name" : "mike" }
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", "mike");
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), containsInAnyOrder("mike12", "mike34", "mike72"));
     }
 
@@ -210,7 +211,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         operator.put("$eq", "mike");
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", operator);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), containsInAnyOrder("mike12", "mike34", "mike72"));
     }
 
@@ -220,7 +221,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         // query - { "age" : 12 }
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("age", 12);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), containsInAnyOrder("mike12", "fred12"));
     }
 
@@ -232,7 +233,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         operator.put("$eq", 12);
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("age", operator);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), containsInAnyOrder("mike12", "fred12"));
     }
 
@@ -243,7 +244,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", "mike");
         query.put("pet", "cat");
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), containsInAnyOrder("mike12", "mike72"));
     }
 
@@ -258,7 +259,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         Map<String, Object> petOperator = new HashMap<String, Object>();
         petOperator.put("$eq", "cat");
         query.put("pet", petOperator);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), containsInAnyOrder("mike12", "mike72"));
     }
 
@@ -269,7 +270,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", "mike");
         query.put("age", 12);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), contains("mike12"));
     }
 
@@ -284,7 +285,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         Map<String, Object> ageOperator = new HashMap<String, Object>();
         ageOperator.put("$eq", 12);
         query.put("age", ageOperator);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), contains("mike12"));
     }
 
@@ -294,7 +295,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         // query - { "name" : "bill" }
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", "bill");
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.size(), is(0));
     }
 
@@ -305,7 +306,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", "bill");
         query.put("age", 12);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.size(), is(0));
     }
 
@@ -316,7 +317,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", "bill");
         query.put("age", 17);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.size(), is(0));
     }
 
@@ -328,7 +329,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         operator.put("$blah", 12);
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("age", operator);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult, is(nullValue()));
     }
 
@@ -340,7 +341,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         operator.put("$gt", 12);
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("age", operator);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), containsInAnyOrder("mike34", "mike72", "fred34"));
     }
 
@@ -355,7 +356,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", eqOp);
         query.put("age", gtOp);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), containsInAnyOrder("mike34", "mike72"));
     }
 
@@ -367,7 +368,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         op.put("$gt", "fred");
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", op);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), containsInAnyOrder("mike12", "mike34", "mike72"));
     }
 
@@ -380,7 +381,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", op);
         query.put("age", 34);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), contains("mike34"));
     }
 
@@ -392,7 +393,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         operator.put("$gte", 12);
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("age", operator);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), containsInAnyOrder("mike12",
                                                                  "mike34",
                                                                  "mike72",
@@ -411,7 +412,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", eqOp);
         query.put("age", gteOp);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), containsInAnyOrder("mike12", "mike34", "mike72"));
     }
 
@@ -423,7 +424,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         operator.put("$lt", 12);
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("age", operator);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.size(), is(0));
     }
 
@@ -438,7 +439,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", eqOp);
         query.put("age", ltOp);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.size(), is(0));
     }
 
@@ -450,7 +451,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         op.put("$lt", "mike");
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", op);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), containsInAnyOrder("fred12", "fred34"));
     }
 
@@ -463,7 +464,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", op);
         query.put("age", 34);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), contains("fred34"));
     }
 
@@ -475,7 +476,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         operator.put("$lte", 12);
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("age", operator);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), containsInAnyOrder("mike12", "fred12"));
     }
 
@@ -490,7 +491,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", eqOp);
         query.put("age", lteOp);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), contains("mike12"));
     }
 
@@ -504,7 +505,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         operator.put("$eq", "mike");
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", operator);
-        QueryResult queryResult = im.find(query, 0, 0, null, null);
+        QueryResult queryResult = idxMgr.find(query, 0, 0, null, null);
         assertThat(queryResult.documentIds(), containsInAnyOrder("mike12", "mike34", "mike72"));
     }
 
@@ -516,7 +517,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         operator.put("$eq", "mike");
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", operator);
-        QueryResult queryResult = im.find(query, 0, 1, null, null);
+        QueryResult queryResult = idxMgr.find(query, 0, 1, null, null);
         assertThat(queryResult.size(), is(1));
     }
 
@@ -528,8 +529,8 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         operator.put("$eq", "mike");
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", operator);
-        QueryResult offsetResults = im.find(query, 1, 1, null, null);
-        QueryResult results = im.find(query, 0, 2, null, null);
+        QueryResult offsetResults = idxMgr.find(query, 1, 1, null, null);
+        QueryResult results = idxMgr.find(query, 0, 2, null, null);
         assertThat(results.size(), is(2));
         assertThat(results.documentIds().get(1), is(offsetResults.documentIds().get(0)));
     }
@@ -542,7 +543,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         operator.put("$eq", "mike");
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", operator);
-        QueryResult queryResult = im.find(query, 1, 0, null, null);
+        QueryResult queryResult = idxMgr.find(query, 1, 0, null, null);
         assertThat(queryResult.size(), is(2));
     }
 
@@ -554,7 +555,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         operator.put("$eq", "mike");
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", operator);
-        QueryResult queryResult = im.find(query, 0, 4, null, null);
+        QueryResult queryResult = idxMgr.find(query, 0, 4, null, null);
         assertThat(queryResult.size(), is(3));
     }
 
@@ -566,7 +567,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         operator.put("$eq", "mike");
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", operator);
-        QueryResult queryResult = im.find(query, 0, 1000, null, null);
+        QueryResult queryResult = idxMgr.find(query, 0, 1000, null, null);
         assertThat(queryResult.size(), is(3));
     }
 
@@ -578,7 +579,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         operator.put("$eq", "mike");
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", operator);
-        QueryResult queryResult = im.find(query, 4, 4, null, null);
+        QueryResult queryResult = idxMgr.find(query, 4, 4, null, null);
         assertThat(queryResult.size(), is(0));
     }
 
@@ -590,7 +591,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         operator.put("$eq", "mike");
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", operator);
-        QueryResult queryResult = im.find(query, 1000, 1000, null, null);
+        QueryResult queryResult = idxMgr.find(query, 1000, 1000, null, null);
         assertThat(queryResult.size(), is(0));
     }
 
@@ -607,7 +608,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("pet.name", op1);
         query.put("age", op2);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult, is(notNullValue()));
         assertThat(queryResult.documentIds(), is(empty()));
     }
@@ -623,7 +624,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("pet.name", op1);
         query.put("age", op2);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), contains("mike12"));
     }
 
@@ -635,7 +636,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         op.put("$eq", "cat");
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("pet.species", op);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), containsInAnyOrder("mike12", "mike23", "mike34"));
     }
 
@@ -647,7 +648,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         op.put("$eq", "mike");
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("pet.name.first", op);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), contains("mike23"));
     }
 
@@ -656,20 +657,20 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
     @Test
     public void canQueryForNonAsciiValues() throws Exception {
         setUpNonAsciiQueryData();
-        assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name")), "nonascii"), is("nonascii"));
+        assertThat(idxMgr.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name")), "nonascii"), is("nonascii"));
         // query - { "name" : { "$eq" : "اسم" } }
         Map<String, Object> op = new HashMap<String, Object>();
         op.put("$eq", "اسم");
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", op);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), contains("اسم34"));
     }
 
     @Test
     public void canQueryUsingFieldsWithOddNames() throws Exception {
         setUpNonAsciiQueryData();
-        assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("اسم"), new FieldSort("datatype"), new FieldSort("age")), "nonascii"),
+        assertThat(idxMgr.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("اسم"), new FieldSort("datatype"), new FieldSort("age")), "nonascii"),
                 is("nonascii"));
         // query - { "اسم" : { "$eq" : "fred" }, "age" : { "$eq" : 12 } }
         Map<String, Object> op1 = new HashMap<String, Object>();
@@ -679,14 +680,14 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("اسم", op1);
         query.put("age", op2);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), contains("fredarabic"));
 
         // query - { "datatype" : { "$eq" : "fred" }, "age" : { "$eq" : 12 } }
         query.clear();
         query.put("datatype", op1);
         query.put("age", op2);
-        queryResult = im.find(query);
+        queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), contains("freddatatype"));
     }
 
@@ -702,7 +703,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         op2.put("pet", "cat");
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("$or", Arrays.<Object>asList(op1, op2));
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), containsInAnyOrder("mike12",
                                                                  "mike23",
                                                                  "mike34",
@@ -722,7 +723,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         op2.put("age", gtAge);    // 1
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("$or", Arrays.<Object>asList(op1, op2));
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), containsInAnyOrder("mike12",
                                                                  "mike23",
                                                                  "mike34",
@@ -750,7 +751,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         op2.put("$or", Arrays.<Object>asList(eqAge, eqPet));
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("$or", Arrays.<Object>asList(op1, op2));
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), containsInAnyOrder("fred12",
                                                                  "fred34",
                                                                  "mike12",
@@ -765,7 +766,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         op.put("name", "mike");
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("$or", Arrays.<Object>asList(op));
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), containsInAnyOrder("mike12",
                                                                  "mike23",
                                                                  "mike34",
@@ -797,7 +798,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         opLvl2.put("$and", Arrays.<Object>asList(nameMapLvl2, petMapLvl2));
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("$or", Arrays.<Object>asList(nameMapLvl1, ageMapLvl1, opLvl2));
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), containsInAnyOrder("mike12",
                                                                  "mike23",
                                                                  "mike34",
@@ -828,7 +829,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         opLvl2.put("$or", Arrays.<Object>asList(nameMapLvl2, petMapLvl2));
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("$or", Arrays.<Object>asList(nameMapLvl1, ageMapLvl1, opLvl2));
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), containsInAnyOrder("mike12",
                                                                  "mike23",
                                                                  "mike34",
@@ -862,7 +863,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         opLvl2.put("$and", Arrays.<Object>asList(nameMapLvl2, petMapLvl2));
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("$and", Arrays.<Object>asList(nameMapLvl1, ageMapLvl1, opLvl2));
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), is(empty()));
     }
 
@@ -891,7 +892,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         opLvl2.put("$and", Arrays.<Object>asList(nameMapLvl2, petMapLvl2));
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("$or", Arrays.<Object>asList(nameMapLvl1, ageMapLvl1, opLvl2));
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), containsInAnyOrder("mike12",
                                                                  "mike23",
                                                                  "mike34",
@@ -923,7 +924,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         opLvl2.put("$or", Arrays.<Object>asList(nameMapLvl2, petMapLvl2));
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("$and", Arrays.<Object>asList(nameMapLvl1, ageMapLvl1, opLvl2));
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), contains("mike34"));
     }
 
@@ -963,7 +964,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         opLvl2.put("$and", Arrays.<Object>asList(opLvl3));
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("$and", Arrays.<Object>asList(nameMapLvl1, ageMapGtLvl1, ageMapLtLvl1, opLvl2));
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), contains("mike12"));
     }
 
@@ -1003,7 +1004,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         opLvl2.put("$and", Arrays.<Object>asList(opLvl3));
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("$and", Arrays.<Object>asList(nameMapLvl1, ageMapGtLvl1, ageMapLtLvl1, opLvl2));
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), is(empty()));
     }
 
@@ -1040,7 +1041,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         andOpLvl2.put("$and", Arrays.<Object>asList(nameMapAndLvl2, petMapAndLvl2));
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("$or", Arrays.<Object>asList(nameMapLvl1, petMapLvl1, orOpLvl2, andOpLvl2));
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), containsInAnyOrder("mike12",
                                                                  "mike23",
                                                                  "mike34",
@@ -1055,7 +1056,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         // query - { "_id" : "mike12" }
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("_id", "mike12");
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), contains("mike12"));
     }
 
@@ -1066,7 +1067,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("_id", "mike12");
         query.put("name", "mike");
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), contains("mike12"));
     }
 
@@ -1079,7 +1080,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         // query - { "_rev" : <docRev> }
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("_rev", docRev);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), contains("mike12"));
     }
 
@@ -1091,7 +1092,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("_rev", docRev);
         query.put("name", "mike");
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), contains("mike12"));
     }
 
@@ -1107,7 +1108,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         notOp.put("$not", eqOp);
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", notOp);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), containsInAnyOrder("fred12", "fred34"));
     }
 
@@ -1121,7 +1122,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         notOp.put("$not", gtOp);
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("age", notOp);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), containsInAnyOrder("fred12",
                                                                  "fred34",
                                                                  "mike12",
@@ -1138,7 +1139,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         notOp.put("$not", eqOp);
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("pet", notOp);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), containsInAnyOrder("fred12", "mike34"));
     }
 
@@ -1163,7 +1164,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         petMap2.put("pet", notOp2);
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("$and", Arrays.<Object>asList(petMap1, petMap2));
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), containsInAnyOrder("fred12"));
     }
 
@@ -1186,7 +1187,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         petMap2.put("pet", eqOp2);
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("$and", Arrays.<Object>asList(petMap1, petMap2));
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), is(empty()));
     }
 
@@ -1211,7 +1212,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         petMap2.put("pet", notOp2);
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("$or", Arrays.<Object>asList(petMap1, petMap2));
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), containsInAnyOrder("mike12",
                                                                  "mike34",
                                                                  "mike72",
@@ -1229,7 +1230,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         operator.put("$eq", "dog");
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("pet", operator);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), containsInAnyOrder("mike12", "mike34"));
     }
 
@@ -1241,7 +1242,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         operator.put("$eq", "parrot");
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("pet", operator);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), containsInAnyOrder("fred34"));
     }
 
@@ -1253,7 +1254,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         operator.put("$eq", "cat");
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("pet", operator);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), containsInAnyOrder("mike12", "mike34", "john22"));
     }
 
@@ -1268,7 +1269,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("pet", notNeCat);
         System.out.println("QUERY:" + query);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         System.out.println("DOCUMENTS: " + queryResult.documentIds());
         // Should be same as $eq
         assertThat(queryResult.documentIds(), containsInAnyOrder("mike12", "mike34", "john22"));
@@ -1288,7 +1289,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         notOp.put("$not", eqOp);
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("pet", notOp);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), containsInAnyOrder("fred34",
                                                                  "john44",
                                                                  "john22",
@@ -1303,7 +1304,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         neOp.put("$ne", "dog");
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("pet", neOp);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), containsInAnyOrder("fred34",
                                                                  "john44",
                                                                  "john22",
@@ -1325,7 +1326,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         gtOp.put("$gt", "dog");
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("pet", gtOp);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
 
         // mike34 appears in the results because of the "fish" entry in his
         // list of pets { "pet" : [ "cat", "dog", "fish"] }
@@ -1340,7 +1341,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         lteOp.put("$lte", "dog");
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("pet", lteOp);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
 
         // mike34 appears in the results because of the "cat" entry in his
         // list of pets { "pet" : [ "cat", "dog", "fish"] }
@@ -1357,7 +1358,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         notOp.put("$not", gtOp);
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("pet", notOp);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
 
         // mike34 does NOT appear in the results here because this result set is strictly
         // a set of documents that are NOT in the set of documents that satisfy the
@@ -1385,7 +1386,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         petNotDog.put("pet", notDog);
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("$and", Arrays.<Object>asList(petNotCat, petNotDog));
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), containsInAnyOrder("fred34", "fred12", "john44"));
     }
 
@@ -1399,7 +1400,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         notDog.put("$not", eqDog);
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("pet", notDog);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult, is(nullValue()));
     }
 
@@ -1414,7 +1415,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("pet", operator);
         System.out.println(query);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), contains("fred12"));
     }
 
@@ -1427,7 +1428,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("pet", operator);
         System.out.println(query);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), containsInAnyOrder("mike12",
                                                                  "mike34",
                                                                  "mike72",
@@ -1444,7 +1445,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         notOp.put("$not", existsOp);
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("pet", notOp);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), containsInAnyOrder("mike12",
                                                                  "mike34",
                                                                  "mike72",
@@ -1461,7 +1462,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         notOp.put("$not", existsOp);
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("pet", notOp);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), contains("fred12"));
     }
 
@@ -1475,7 +1476,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         op.put("$in", Arrays.<String>asList("fish", "hamster"));
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("pet", op);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), containsInAnyOrder("mike34", "john44"));
     }
 
@@ -1487,7 +1488,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         op.put("$in", Arrays.<String>asList("parrot", "turtle"));
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("pet", op);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), contains("fred34"));
     }
 
@@ -1499,7 +1500,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         op.put("$in", Arrays.<String>asList("cat", "dog"));
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("pet", op);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), containsInAnyOrder("mike12", "mike34", "john22"));
     }
 
@@ -1512,7 +1513,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         op.put("$eq", "turtle");
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("pet", op);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.size(), is(0));
     }
 
@@ -1526,7 +1527,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         notOp.put("$not", op);
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("pet", notOp);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), containsInAnyOrder("fred12", "fred34", "john44"));
     }
 
@@ -1537,7 +1538,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         setUpLargeResultSetQueryData();
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("large_field", "cat");
-        QueryResult queryResult = im.find(query, 0, 60, null, null);
+        QueryResult queryResult = idxMgr.find(query, 0, 60, null, null);
         assertThat(queryResult.documentIds().size(), is(60));
     }
 
@@ -1546,7 +1547,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         setUpLargeResultSetQueryData();
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("large_field", "cat");
-        QueryResult queryResult = im.find(query, 90, 20, null, Arrays.<FieldSort>asList(new FieldSort("idx", FieldSort.Direction.ASCENDING)));
+        QueryResult queryResult = idxMgr.find(query, 90, 20, null, Arrays.<FieldSort>asList(new FieldSort("idx", FieldSort.Direction.ASCENDING)));
         List<String> expected = new ArrayList<String>();
         for (int i = 90; i < 110; i++) {
             expected.add(String.format("d%d", i));
@@ -1564,7 +1565,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         op.put("$mod", Arrays.<Object>asList(10, 1));
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("score", op);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), containsInAnyOrder("mike31", "fred11"));
     }
 
@@ -1579,7 +1580,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         op.put("$mod", Arrays.<Object>asList(-10, 1));
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("score", op);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), containsInAnyOrder("mike31", "fred11"));
     }
 
@@ -1592,7 +1593,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", "mike");
         query.put("score", op);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), containsInAnyOrder("mike31"));
     }
 
@@ -1604,7 +1605,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         op.put("$mod", Arrays.<Object>asList(10, 1));
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", op);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), is(empty()));
     }
 
@@ -1619,7 +1620,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         op.put("$mod", Arrays.<Object>asList(5, 0));
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("score", op);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), containsInAnyOrder("john15",
                                                                  "john-15",
                                                                  "john15.2",
@@ -1643,7 +1644,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         op.put("$mod", Arrays.<Object>asList(10, -5));
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("score", op);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), contains("john-15"));
     }
 
@@ -1658,7 +1659,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         op.put("$mod", Arrays.<Object>asList(-10, -5));
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("score", op);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), contains("john-15"));
     }
 
@@ -1674,7 +1675,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         op.put("$mod", Arrays.<Object>asList(10, 1.6));
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("score", op);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), containsInAnyOrder("mike31", "fred11"));
     }
 
@@ -1689,7 +1690,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         op.put("$mod", Arrays.<Object>asList(5.4, 0));
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("score", op);
-        QueryResult queryResult = im.find(query);
+        QueryResult queryResult = idxMgr.find(query);
         assertThat(queryResult.documentIds(), containsInAnyOrder("john15",
                                                                  "john-15",
                                                                  "john15.2",

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryFilterFieldsTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryFilterFieldsTest.java
@@ -41,7 +41,7 @@ public class QueryFilterFieldsTest extends AbstractQueryTestBase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        im = new IndexManagerImpl(ds);
+        im = (IndexManagerImpl) cloudantSync.query;
         indexManagerDatabaseQueue = TestUtils.getDBQueue(im);
         assertThat(im, is(notNullValue()));
         assertThat(indexManagerDatabaseQueue, is(notNullValue()));

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryResultTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryResultTest.java
@@ -41,7 +41,7 @@ public class QueryResultTest extends AbstractQueryTestBase {
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        im = new IndexManagerImpl(ds);
+        im = (IndexManagerImpl) cloudantSync.query;
         indexManagerDatabaseQueue = TestUtils.getDBQueue(im);
         assertThat(im, is(notNullValue()));
         assertThat(indexManagerDatabaseQueue, is(notNullValue()));

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QuerySortTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QuerySortTest.java
@@ -41,7 +41,7 @@ public class QuerySortTest extends AbstractQueryTestBase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        im = new IndexManagerImpl(ds);
+        im = (IndexManagerImpl) cloudantSync.query;
         indexManagerDatabaseQueue = TestUtils.getDBQueue(im);
         assertThat(im, is(notNullValue()));
         assertThat(TestUtils.getDBQueue(im), is(notNullValue()));

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryTextSearchTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/QueryTextSearchTest.java
@@ -28,7 +28,6 @@ import com.cloudant.sync.util.TestUtils;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -42,7 +41,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        im = new IndexManagerImpl(ds);
+        im = (IndexManagerImpl) cloudantSync.query;
         indexManagerDatabaseQueue = TestUtils.getDBQueue(im);
         assertThat(im, is(notNullValue()));
         assertThat(indexManagerDatabaseQueue, is(notNullValue()));

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/PullStrategyTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/PullStrategyTest.java
@@ -387,7 +387,7 @@ public class PullStrategyTest extends ReplicationTestBase {
 
         Assert.assertEquals(0, datastore.getDocumentCount());
 
-        IndexManagerImpl im = new IndexManagerImpl(datastore);
+        IndexManagerImpl im = (IndexManagerImpl) cloudantSync.query;
         try {
             im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("diet")), "diet");
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/ReplicationTestBase.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/ReplicationTestBase.java
@@ -19,6 +19,7 @@ import com.cloudant.http.HttpConnectionRequestInterceptor;
 import com.cloudant.http.interceptors.CookieInterceptor;
 import com.cloudant.mazha.CouchClient;
 import com.cloudant.mazha.CouchConfig;
+import com.cloudant.sync.datastore.CloudantSync;
 import com.cloudant.sync.datastore.DatabaseImpl;
 import com.cloudant.sync.datastore.DatastoreManager;
 import com.cloudant.sync.sqlite.SQLDatabase;
@@ -36,6 +37,7 @@ public abstract class ReplicationTestBase extends CouchTestBase {
     public String datastoreManagerPath = null;
 
     protected DatastoreManager datastoreManager = null;
+    protected CloudantSync cloudantSync = null;
     protected DatabaseImpl datastore = null;
     protected SQLDatabase database = null;
     protected DatastoreWrapper datastoreWrapper = null;
@@ -64,7 +66,8 @@ public abstract class ReplicationTestBase extends CouchTestBase {
     protected void createDatastore() throws Exception {
         datastoreManagerPath = TestUtils.createTempTestingDir(this.getClass().getName());
         datastoreManager = DatastoreManager.getInstance(this.datastoreManagerPath);
-        datastore = (DatabaseImpl) datastoreManager.openDatastore(getClass().getSimpleName()).database;
+        cloudantSync = datastoreManager.openDatastore(getClass().getSimpleName());
+        datastore = (DatabaseImpl) cloudantSync.database;
         datastoreWrapper = new DatastoreWrapper(datastore);
     }
 

--- a/cloudant-sync-datastore-javase/build.gradle
+++ b/cloudant-sync-datastore-javase/build.gradle
@@ -1,12 +1,12 @@
 dependencies {
     compile project(':cloudant-sync-datastore-core')
 
-    compile group: 'com.almworks.sqlite4java', name: 'sqlite4java', version:'1.0.392'
+    compile group: 'com.almworks.sqlite4java', name: 'sqlite4java', version: '1.0.392'
 
     // there are a couple of unit tests in this project
-    testCompile group: 'org.hamcrest', name: 'hamcrest-all', version:'1.3'
-    testCompile group: 'junit', name: 'junit', version:'4.11'
-    testCompile group: 'org.mockito', name: 'mockito-all', version:'1.9.5'
+    testCompile group: 'org.hamcrest', name: 'hamcrest-all', version: '1.3'
+    testCompile group: 'junit', name: 'junit', version: '4.11'
+    testCompile group: 'org.mockito', name: 'mockito-all', version: '1.9.5'
     // and we depend on some test utilities over in core
     testCompile project(':cloudant-sync-datastore-core').sourceSets.test.output
 

--- a/cloudant-sync-datastore-javase/src/main/java/com/cloudant/sync/sqlite/sqlite4java/SQLiteWrapper.java
+++ b/cloudant-sync-datastore-javase/src/main/java/com/cloudant/sync/sqlite/sqlite4java/SQLiteWrapper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013 Cloudant, Inc. All rights reserved.
+ * Copyright © 2013, 2016 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -84,7 +84,12 @@ public class SQLiteWrapper extends SQLDatabase {
 
     SQLiteConnection createNewConnection() {
         try {
-            SQLiteConnection conn = new SQLiteConnection(new File(this.databaseFilePath));
+            SQLiteConnection conn;
+            if (this.databaseFilePath != null) {
+                conn = new SQLiteConnection(new File(this.databaseFilePath));
+            } else {
+                conn = new SQLiteConnection();
+            }
             conn.open();
             conn.setBusyTimeout(30*1000);
             return conn;


### PR DESCRIPTION
*What*

Moved FTS check to `SQLDatabaseFactory`, removing nested transaction

*How*

* Moved FTS check to `SQLDatabaseFactory`.
* Changed to perform FTS check only once in static initializer.
* Removed nested transaction from FTS check.
* Simplified FTS check to always rollback the table creation instead of
also dropping the table.
* Used an in-memory database for FTS check table creation.
* Updated subclasses of `SQLDatabase` to allow null paths for creation of
in-memory databases.
* Added internal create method to `SQLDatabaseFactory` to allow creation
of in-memory database.
* Updated copyright statements.

*Testing*

* Updated `com.cloudant.sync.query.IndexManagerTest#validateTextSearchIsAvailable`
to assert the new field.
* Refactored query tests for the feature branch to use the `IndexManager` supplied by the `CloudantSync` object instead of constructing duplicates. Using duplicates was leading to errors during the migration phase of the `IndexManager` init that were swallowed by tests by severely impacting the test speed.

*Issues*

Fixes #378 