### PR TITLE
Updated tests to throw on replication errors

### DIFF
--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/AttachmentsPullTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/AttachmentsPullTest.java
@@ -315,8 +315,7 @@ public class AttachmentsPullTest extends ReplicationTestBase {
                 (pullAttachmentsInline).build();
         pull.strategy.getEventBus().register(listener);
         pull.strategy.run();
-        Assert.assertTrue(listener.finishCalled);
-        Assert.assertFalse(listener.errorCalled);
+        listener.assertReplicationCompletedOrThrow();
         return new PullResult((PullStrategy) pull.strategy, listener);
     }
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/BasicPushStrategyTest2.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/BasicPushStrategyTest2.java
@@ -204,8 +204,7 @@ public class BasicPushStrategyTest2 extends ReplicationTestBase {
         Thread t = new Thread(push);
         t.start();
         t.join();
-        Assert.assertTrue(listener.finishCalled);
-        Assert.assertFalse(listener.errorCalled);
+        listener.assertReplicationCompletedOrThrow();
         push.eventBus.unregister(listener);
     }
 
@@ -215,8 +214,7 @@ public class BasicPushStrategyTest2 extends ReplicationTestBase {
         Thread t = new Thread(pull);
         t.start();
         t.join();
-        Assert.assertTrue(listener.finishCalled);
-        Assert.assertFalse(listener.errorCalled);
+        listener.assertReplicationCompletedOrThrow();
         pull.getEventBus().unregister(listener);
     }
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/PullStrategyTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/PullStrategyTest.java
@@ -70,8 +70,7 @@ public class PullStrategyTest extends ReplicationTestBase {
         TestStrategyListener listener = new TestStrategyListener();
         replicator.getEventBus().register(listener);
         replicator.run();
-        Assert.assertTrue(listener.finishCalled);
-        Assert.assertFalse(listener.errorCalled);
+        listener.assertReplicationCompletedOrThrow();
         Assert.assertEquals(expectedDocs, listener.documentsReplicated);
     }
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/PushStrategyTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/PushStrategyTest.java
@@ -40,8 +40,7 @@ public class PushStrategyTest extends ReplicationTestBase {
         TestStrategyListener listener = new TestStrategyListener();
         replicator.eventBus.register(listener);
         replicator.run();
-        Assert.assertTrue(listener.finishCalled);
-        Assert.assertFalse(listener.errorCalled);
+        listener.assertReplicationCompletedOrThrow();
         Assert.assertEquals(expectedDocs, listener.documentsReplicated);
     }
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/ReplicationTestBase.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/ReplicationTestBase.java
@@ -148,8 +148,7 @@ public abstract class ReplicationTestBase extends CouchTestBase {
         PushStrategy replicator = this.getPushStrategy();
         replicator.getEventBus().register(listener);
         replicator.run();
-        Assert.assertTrue(listener.finishCalled);
-        Assert.assertFalse(listener.errorCalled);
+        listener.assertReplicationCompletedOrThrow();
         return new PushResult(replicator, listener);
     }
 
@@ -158,8 +157,7 @@ public abstract class ReplicationTestBase extends CouchTestBase {
         PullStrategy replicator = this.getPullStrategy();
         replicator.getEventBus().register(listener);
         replicator.run();
-        Assert.assertTrue(listener.finishCalled);
-        Assert.assertFalse(listener.errorCalled);
+        listener.assertReplicationCompletedOrThrow();
         return new PullResult(replicator, listener);
     }
 
@@ -168,8 +166,7 @@ public abstract class ReplicationTestBase extends CouchTestBase {
         PullStrategy replicator = this.getPullStrategy(filter);
         replicator.getEventBus().register(listener);
         replicator.run();
-        Assert.assertTrue(listener.finishCalled);
-        Assert.assertFalse(listener.errorCalled);
+        listener.assertReplicationCompletedOrThrow();
         return new PullResult(replicator, listener);
     }
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/TestStrategyListener.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/TestStrategyListener.java
@@ -16,6 +16,8 @@ package com.cloudant.sync.replication;
 
 import com.cloudant.sync.event.Subscribe;
 
+import org.junit.Assert;
+
 /**
  * Simple implementation of <code>StrategyListener</code>. It can be checked if the complete() or
  * error() has been called or not.
@@ -23,6 +25,7 @@ import com.cloudant.sync.event.Subscribe;
 
 public class TestStrategyListener {
 
+    public ErrorInfo errorInfo = null;
     public boolean errorCalled = false;
     public boolean finishCalled = false;
     public int documentsReplicated = 0;
@@ -38,5 +41,14 @@ public class TestStrategyListener {
     @Subscribe
     public void error(ReplicationStrategyErrored re) {
         errorCalled = true;
+        errorInfo = re.errorInfo;
+    }
+
+    public void assertReplicationCompletedOrThrow() throws Exception {
+        if (errorCalled) {
+            throw new Exception("Replication errored", errorInfo.getException());
+        } else {
+            Assert.assertTrue("The replication should finish.", finishCalled);
+        }
     }
 }


### PR DESCRIPTION
*What*

Updated replication tests to throw on replication errors.

*Why*

Many tests currently do:
```java
Assert.assertTrue(listener.finishCalled);
Assert.assertFalse(listener.errorCalled);
```

This doesn't help use see what the error was in test cases where the replication did not complete as expected. By changing to use `listener.assertReplicationCompletedOrThrow();` we can get the exception thrown up from the tests and still assert that finish was called.

*How*

Added `assertReplicationCompletedOrThrow` to `TestStrategyListener` and called from appropriate tests.

*Testing*

Updated tests to use new assertion:
`AttachmentsPullTest`
`ReplicationTestBase`
`BasicPushStrategyTest2`
`PullStrategyTest`
`PushStrategyTest`

*Issues*

Adds debug for #381 