### PR TITLE
381 more debug

### DIFF
--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/AttachmentsPullTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/AttachmentsPullTest.java
@@ -63,11 +63,7 @@ public class AttachmentsPullTest extends ReplicationTestBase {
     @Test
     public void pullRevisionsWithAttachments() throws Exception {
         createRevisionAndAttachment();
-        try {
-            pull();
-        } catch (Exception e) {
-            Assert.fail("Pull error " + e);
-        }
+        pull();
         Attachment a = datastore.getAttachment(id, rev, attachmentName);
         Assert.assertNotNull("Attachment is null", a);
         Assert.assertEquals(attachmentName, a.name);
@@ -80,11 +76,7 @@ public class AttachmentsPullTest extends ReplicationTestBase {
         // update revision and attachment on remote (same id) - this tests the other code path of
         // updating the sequence on the rev
         updateRevisionAndAttachment();
-        try {
-            pull();
-        } catch (Exception e) {
-            Assert.fail("Pull error " + e);
-        }
+        pull();
         Attachment a2 = datastore.getAttachment(id, rev, attachmentName);
         Assert.assertNotNull("Attachment is null", a2);
         Assert.assertEquals(attachmentName, a2.name);
@@ -98,12 +90,8 @@ public class AttachmentsPullTest extends ReplicationTestBase {
 
     @Test
     public void pullRevisionsWithBigAttachments() throws Exception {
-        try {
-            createRevisionAndBigAttachment();
-            pull();
-        } catch (Exception e) {
-            Assert.fail("Create/pull error " + e);
-        }
+        createRevisionAndBigAttachment();
+        pull();
         Attachment a = datastore.getAttachment(id, rev, bigAttachmentName);
         Assert.assertNotNull("Attachment is null", a);
         Assert.assertEquals(bigAttachmentName, a.name);
@@ -117,12 +105,8 @@ public class AttachmentsPullTest extends ReplicationTestBase {
 
     @Test
     public void pullRevisionsWithBigTextAttachments() throws Exception {
-        try {
-            createRevisionAndBigTextAttachment();
-            pull();
-        } catch (Exception e) {
-            Assert.fail("Create/pull error " + e);
-        }
+        createRevisionAndBigTextAttachment();
+        pull();
         Attachment a = datastore.getAttachment(id, rev, bigTextAttachmentName);
         Assert.assertNotNull("Attachment is null", a);
         Assert.assertEquals(bigTextAttachmentName, a.name);
@@ -162,41 +146,30 @@ public class AttachmentsPullTest extends ReplicationTestBase {
     }
 
     @Test
-    public void dontPullAttachmentNoLongerExists() {
-        try {
-            // create a rev with an attachment, then update it without attachment
-            // ensure updated version no longer has attachment associated with it locally
-            createRevisionAndBigTextAttachment();
-            pull();
-            Attachment a1 = datastore.getAttachment(id, rev, bigTextAttachmentName);
-            updateRevision();
-            pull();
-            Attachment a2 = datastore.getAttachment(id, rev, bigTextAttachmentName);
-            Assert.assertNull(a2);
-
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail("Create/pull error " + e);
-        }
+    public void dontPullAttachmentNoLongerExists() throws Exception {
+        // create a rev with an attachment, then update it without attachment
+        // ensure updated version no longer has attachment associated with it locally
+        createRevisionAndBigTextAttachment();
+        pull();
+        Attachment a1 = datastore.getAttachment(id, rev, bigTextAttachmentName);
+        updateRevision();
+        pull();
+        Attachment a2 = datastore.getAttachment(id, rev, bigTextAttachmentName);
+        Assert.assertNull(a2);
     }
 
     @Test
-    public void dontPullAttachmentAlreadyPulled() {
-        try {
-            // create a rev with an attachment, then update it keeping attachment
-            // TODO we need to somehow check the attachment wasn't re-downloaded
-            createRevisionAndBigTextAttachment();
-            pull();
-            Attachment a1 = datastore.getAttachment(id, rev, bigTextAttachmentName);
-            updateRevisionAndKeepAttachment();
-            updateRevisionAndKeepAttachment();
-            pull();
-            Attachment a2 = datastore.getAttachment(id, rev, bigTextAttachmentName);
-            Assert.assertNotNull(a2);
-
-        } catch (Exception e) {
-            Assert.fail("Create/pull error " + e);
-        }
+    public void dontPullAttachmentAlreadyPulled() throws Exception {
+        // create a rev with an attachment, then update it keeping attachment
+        // TODO we need to somehow check the attachment wasn't re-downloaded
+        createRevisionAndBigTextAttachment();
+        pull();
+        Attachment a1 = datastore.getAttachment(id, rev, bigTextAttachmentName);
+        updateRevisionAndKeepAttachment();
+        updateRevisionAndKeepAttachment();
+        pull();
+        Attachment a2 = datastore.getAttachment(id, rev, bigTextAttachmentName);
+        Assert.assertNotNull(a2);
     }
 
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/PullReplicationTerminationTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/PullReplicationTerminationTest.java
@@ -31,6 +31,9 @@ import java.util.concurrent.TimeUnit;
 @Category(RequireRunningCouchDB.class)
 public class PullReplicationTerminationTest extends ReplicationTestBase {
 
+    // Test exception to use in error tests
+    private static final RuntimeException TEST_EXCEPTION = new RuntimeException("Test Exception");
+
     // Test configuration fields
     private int docBatches = 3;
     private int docsPerBatch = 700;
@@ -116,14 +119,12 @@ public class PullReplicationTerminationTest extends ReplicationTestBase {
         // Now run the replicator to completion
         waitForReplicatorToReachState(Replicator.State.COMPLETE, 5, TimeUnit.MINUTES);
 
+        // Assert that the listener was called
+        listener.assertReplicationCompletedOrThrow();
+
         // Validate that the local datastore contains all the documents
         Assert.assertEquals("The local datastore should contain all the documents", expectedDocs,
                 datastore.getDocumentCount());
-
-        // Assert that the listener was called
-        Assert.assertTrue("The listener should have been called when the replication " +
-                        "completed.",
-                listener.finishCalled);
     }
 
     /**
@@ -138,7 +139,7 @@ public class PullReplicationTerminationTest extends ReplicationTestBase {
         public HttpConnectionInterceptorContext interceptRequest
                 (HttpConnectionInterceptorContext context) {
             if (shouldThrow == true) {
-                throw new RuntimeException("Test exception");
+                throw TEST_EXCEPTION;
             } else {
                 return context;
             }
@@ -163,10 +164,10 @@ public class PullReplicationTerminationTest extends ReplicationTestBase {
         // Wait until the replicator is stopped
         waitForReplicatorToReachState(Replicator.State.STOPPED);
 
-        Assert.assertTrue("The listener should have been called when the replication stopped.",
-                listener.finishCalled);
+        listener.assertReplicationCompletedOrThrow();
+
         // Record the number of docs written before stopping
-        int docs = listener.docs;
+        int docs = listener.documentsReplicated;
 
         // Assert that the listener data matches the local datastore
         Assert.assertEquals("The local datastore should contain the expected number of " +
@@ -186,15 +187,17 @@ public class PullReplicationTerminationTest extends ReplicationTestBase {
         stopRunningReplication();
 
         // Record the number of docs written at the time of the stop
-        int docs = listener.docs;
+        int docs = listener.documentsReplicated;
 
         // Assert that the existing replicator is invalid
         replicator.start();
         // This should complete instantly
         waitForReplicatorToReachState(Replicator.State.COMPLETE, 10, TimeUnit.SECONDS);
         // Validate that the listener recorded 0 batches and docs
-        Assert.assertEquals("The listener should have recorded 0 batches", 0, listener.batches);
-        Assert.assertEquals("The listener should have recorded 0 docs", 0, listener.docs);
+        Assert.assertEquals("The listener should have recorded 0 batches", 0, listener
+                .batchesReplicated);
+        Assert.assertEquals("The listener should have recorded 0 docs", 0, listener
+                .documentsReplicated);
 
         // Validate that no additional documents were added to the local datastore
         Assert.assertEquals("The local datastore should contain all the documents", docs,
@@ -222,6 +225,18 @@ public class PullReplicationTerminationTest extends ReplicationTestBase {
 
         Assert.assertTrue("The listener should have been called when the replication errored.",
                 listener.errorCalled);
+
+        Assert.assertNotNull("There should be errorInfo set on the listener", listener.errorInfo);
+        Throwable cause = listener.errorInfo.getException();
+        Assert.assertNotNull("There should be an exception set on the listener", cause);
+
+        // Get all the causes and assert that the test exception was one of them.
+        List<Throwable> causes = new ArrayList<Throwable>();
+        do {
+            causes.add(cause);
+        } while ((cause = cause.getCause()) != null);
+        Assert.assertTrue("The test exception should be a cause of the listener exception",
+                causes.contains(TEST_EXCEPTION));
     }
 
     @Test
@@ -230,8 +245,10 @@ public class PullReplicationTerminationTest extends ReplicationTestBase {
         // Execute the same steps as the HttpException case
         replicatorHttpException();
 
-        // Turn off the exception
+        // Turn off the exception and reset the listener's error state
         throwingInterceptor.shouldThrow = false;
+        listener.errorCalled = false;
+        listener.errorInfo = null;
 
         // Now start it again
         startReplication();

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/PullReplicatorTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/PullReplicatorTest.java
@@ -54,7 +54,7 @@ public class PullReplicatorTest extends ReplicationTestBase {
     }
 
     @Test
-    public void start_StartedThenComplete() throws InterruptedException {
+    public void start_StartedThenComplete() throws Exception {
         Replicator replicator = super.getPullBuilder().build();
 
         TestReplicationListener listener = new TestReplicationListener();
@@ -70,8 +70,7 @@ public class PullReplicatorTest extends ReplicationTestBase {
         Assert.assertEquals(Replicator.State.COMPLETE, replicator.getState());
         Assert.assertEquals(2, datastore.getDocumentCount());
 
-        Assert.assertTrue(listener.finishCalled);
-        Assert.assertFalse(listener.errorCalled);
+        listener.assertReplicationCompletedOrThrow();
     }
 
     @Test
@@ -173,8 +172,7 @@ public class PullReplicatorTest extends ReplicationTestBase {
         }
 
         Assert.assertEquals(Replicator.State.COMPLETE, replicator.getState());
-        Assert.assertFalse(listener.errorCalled);
-        Assert.assertTrue(listener.finishCalled);
+        listener.assertReplicationCompletedOrThrow();
 
         //check that the response and request interceptors have been called.
         Assert.assertTrue(interceptorCallCounter.interceptorResponseTimesCalled >= 1);

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/ReplicationTestBase.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/ReplicationTestBase.java
@@ -102,8 +102,7 @@ public abstract class ReplicationTestBase extends CouchTestBase {
         }
 
         Assert.assertEquals(Replicator.State.COMPLETE, replicator.getState());
-        Assert.assertFalse(listener.errorCalled);
-        Assert.assertTrue(listener.finishCalled);
+        listener.assertReplicationCompletedOrThrow();
     }
 
     protected ReplicatorBuilder.Push getPushBuilder() {

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/ReplicationTestBase.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/ReplicationTestBase.java
@@ -45,12 +45,12 @@ public abstract class ReplicationTestBase extends CouchTestBase {
 
     protected CouchConfig couchConfig = null;
 
-    private long dbSuffix;
+    private String dbSuffix;
 
     @Before
     public void setUp() throws Exception {
         // Use a unique suffix for each test
-        dbSuffix = System.currentTimeMillis();
+        dbSuffix = System.currentTimeMillis() + "" + System.nanoTime();
         this.createDatastore();
         this.createRemoteDB();
     }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/TestReplicationListener.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/TestReplicationListener.java
@@ -17,25 +17,20 @@ package com.cloudant.sync.replication;
 import com.cloudant.sync.event.Subscribe;
 import com.cloudant.sync.notifications.ReplicationCompleted;
 import com.cloudant.sync.notifications.ReplicationErrored;
+import com.cloudant.sync.util.TestEventListener;
 
-public class TestReplicationListener {
-
-    public boolean errorCalled = false;
-    public boolean finishCalled = false;
-    public Throwable exception = null;
-    public int batches = 0;
-    public int docs = 0;
+public class TestReplicationListener extends TestEventListener {
 
     @Subscribe
     public void complete(ReplicationCompleted rc) {
         finishCalled = true;
-        batches = rc.batchesReplicated;
-        docs = rc.documentsReplicated;
+        batchesReplicated = rc.batchesReplicated;
+        documentsReplicated = rc.documentsReplicated;
     }
 
     @Subscribe
     public void error(ReplicationErrored re) {
         errorCalled = true;
-        exception = re.errorInfo.getException();
+        errorInfo = re.errorInfo;
     }
 }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/TestStrategyListener.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/TestStrategyListener.java
@@ -15,21 +15,14 @@
 package com.cloudant.sync.replication;
 
 import com.cloudant.sync.event.Subscribe;
-
-import org.junit.Assert;
+import com.cloudant.sync.util.TestEventListener;
 
 /**
  * Simple implementation of <code>StrategyListener</code>. It can be checked if the complete() or
  * error() has been called or not.
  */
 
-public class TestStrategyListener {
-
-    public ErrorInfo errorInfo = null;
-    public boolean errorCalled = false;
-    public boolean finishCalled = false;
-    public int documentsReplicated = 0;
-    public int batchesReplicated = 0;
+public class TestStrategyListener extends TestEventListener {
 
     @Subscribe
     public void complete(ReplicationStrategyCompleted rc) {
@@ -42,13 +35,5 @@ public class TestStrategyListener {
     public void error(ReplicationStrategyErrored re) {
         errorCalled = true;
         errorInfo = re.errorInfo;
-    }
-
-    public void assertReplicationCompletedOrThrow() throws Exception {
-        if (errorCalled) {
-            throw new Exception("Replication errored", errorInfo.getException());
-        } else {
-            Assert.assertTrue("The replication should finish.", finishCalled);
-        }
     }
 }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/util/TestEventListener.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/util/TestEventListener.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.util;
+
+import com.cloudant.sync.replication.ErrorInfo;
+
+import org.junit.Assert;
+
+public class TestEventListener {
+
+    public ErrorInfo errorInfo = null;
+    public boolean errorCalled = false;
+    public boolean finishCalled = false;
+    public int documentsReplicated = 0;
+    public int batchesReplicated = 0;
+
+    public void assertReplicationCompletedOrThrow() throws Exception {
+        if (errorCalled) {
+            throw new Exception("Replication errored", errorInfo.getException());
+        } else {
+            Assert.assertTrue("The replication should finish.", finishCalled);
+        }
+    }
+}


### PR DESCRIPTION
*What*

Allowed replication error causes to show through replication tests

*How*

* Added a common superclass `TestEventListener` for the `TestReplicationListener` and the `TestStrategyListener`.
* Moved fields and `assertReplicationCompletedOrThrow()` method to superclass and updated field names/references to be common.
* Changed tests to use `assertReplicationCompletedOrThrow` where appropriate.
* Removed try/catch from AttachmentsPullTest to allow replication errors to fail the tests with a cause/stack.
* Improved exception assertions in `resumeErroredReplication` test
* Added additional uniqueness to remote db name after yet another 412 for an existing database was seen.

*Testing*

Test changes, no new tests added. Travis showed a failure with this demonstrating the underlying replication issue being visible in the test report.

*Issues*

Obtain more debug info for #381 