### PR TITLE
Handle missing revisions correctly.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 # Unreleased
 - [FIXED] Incorrect message output from parameter `null` or empty checks.
+- [FIXED] Issue where replications would error if the server returned missing revisions.
 - [UPGRADED] Upgraded to version 2.7.0 of the `cloudant-http` library.
 
 # 1.1.2 (2016-10-20)

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/mazha/CouchClient.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/mazha/CouchClient.java
@@ -3,6 +3,8 @@
  *
  * Copyright (C) 2011 Ahmed Yehia (ahmed.yehia.m@gmail.com)
  *
+ * Copyright © 2016 IBM Corp. All rights reserved.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -409,6 +411,9 @@ public class CouchClient  {
 
         Map<String, Object> options = new HashMap<String, Object>();
         options.put("revs", true);
+        // by adding latest we should never receive a "missing" response from the server. A descendant
+        // of the revision requested will be returned even if it has been deleted.
+        options.put("latest", true);
         // only pull attachments inline if we're configured to
         if (pullAttachmentsInline) {
             options.put("attachments", true);

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/CouchClientWrapper.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/CouchClientWrapper.java
@@ -1,6 +1,8 @@
 /**
  * Copyright (c) 2013 Cloudant, Inc. All rights reserved.
  *
+ * Copyright © 2016 IBM Corp. All rights reserved.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
  *
@@ -48,7 +50,7 @@ public class CouchClientWrapper implements CouchDB {
     private final static String LOG_TAG = "CouchClientWrapper";
     private static final Logger logger = Logger.getLogger(CouchClientWrapper.class.getCanonicalName());
 
-    final CouchClient couchClient;
+    CouchClient couchClient;
 
     public CouchClientWrapper(CouchClient client) {
         Misc.checkNotNull(client, "Couch client");

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/MissingRevsReplicationTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/MissingRevsReplicationTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.replication;
+
+
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyMapOf;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
+
+import com.cloudant.mazha.ChangesResult;
+import com.cloudant.mazha.CouchClient;
+import com.cloudant.sync.datastore.DocumentRevision;
+import com.cloudant.sync.datastore.DocumentRevisionTree;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Matchers;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+
+public class MissingRevsReplicationTest extends ReplicationTestBase {
+
+    private CouchClient clientMock;
+
+    @Before
+    public void setupMocks() throws Exception {
+        // Partially mock the remote and replace it for our test
+        clientMock = spy(remoteDb.couchClient);
+        remoteDb.couchClient = clientMock;
+        couchClient = clientMock;
+    }
+
+    @Override
+    protected PullStrategy getPullStrategy() {
+        PullStrategy s = super.getPullStrategy();
+        s.sourceDb = remoteDb;
+        return s;
+    }
+
+    @Test
+    public void testReplicationWithMissingRevision() throws Exception {
+        // Create doc
+        Bar a = BarUtils.createBar(remoteDb, "testdoc", "alpha", 1);
+        // Update doc
+        final Bar b = BarUtils.updateBar(remoteDb, "testdoc", "beta", 2);
+
+        Bar c = BarUtils.updateBar(remoteDb, "testdoc", "gamma", 3);
+        // We have 3 remote revisions
+
+        doAnswer(new Answer<ChangesResult>() {
+
+            @Override
+            public ChangesResult answer(InvocationOnMock invocation) throws Throwable {
+                @SuppressWarnings("unchecked")
+                ChangesResult changesResult = (ChangesResult) invocation.callRealMethod();
+
+                // modify the changes feed so that it returns a revision that isn't a leaf revision.
+                changesResult.getResults().get(0).getChanges().get(0).setRev(b.getRevision());
+                return changesResult;
+
+            }
+        }).when(clientMock).changes(anyString(), anyMapOf(String.class, String.class), Matchers.anyObject(), anyInt());
+
+        // Do the pull replication
+        pull();
+        // Validate the document was created at the correct rev
+        DocumentRevision rev = datastore.getDocument("testdoc");
+        Assert.assertNotNull("The document should be present", rev);
+        Assert.assertEquals("The local revision should be the third generation",
+                c.getRevision(),
+                rev.getRevision());
+        // Validate that there are 3 revisions.
+        DocumentRevisionTree tree = datastore.getAllRevisionsOfDocument("testdoc");
+        Assert.assertEquals("The 3rd generation current revision should have depth 2", 2, tree.depth
+                (tree.getCurrentRevision().getSequence()));
+    }
+}


### PR DESCRIPTION
## ~What~

~Stop the replicator crashing when missing revisions are encountered.~

## ~Why~
~Missing revisions can occur for various reasons, one of them is that
revs limit has been reached on the server and the server is actively discarding
old revisions.~

## ~How~

~Insert stub revisions when missing revisions are encountered to keep the tree as expected.~


## ~Testing~

~One new test added, which mocks the changes feed with a revision that doesn't exist.~