### PR TITLE
Avoid creating duplicate indexes with different generated names.

### DIFF
--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/FieldSort.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/FieldSort.java
@@ -18,7 +18,7 @@ package com.cloudant.sync.query;
  * Created by tomblench on 28/09/2016.
  */
 
-public class FieldSort implements Comparable<FieldSort> {
+public class FieldSort {
 
     public final String field;
     public final Direction sort;
@@ -64,17 +64,6 @@ public class FieldSort implements Comparable<FieldSort> {
                 ", sort=" + sort +
                 '}';
     }
-
-    @Override
-    public int compareTo(FieldSort other) {
-
-        int fieldCompare = field.compareTo(other.field);
-        if( fieldCompare == 0){
-            return sort.compareTo(other.sort);
-        }
-        return fieldCompare;
-    }
-
 
     public enum Direction {
         ASCENDING,

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/FieldSort.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/FieldSort.java
@@ -18,7 +18,7 @@ package com.cloudant.sync.query;
  * Created by tomblench on 28/09/2016.
  */
 
-public class FieldSort {
+public class FieldSort implements Comparable<FieldSort> {
 
     public final String field;
     public final Direction sort;
@@ -64,6 +64,16 @@ public class FieldSort {
                 ", sort=" + sort +
                 '}';
     }
+
+    @Override
+    public int compareTo(FieldSort other) {
+
+        if(field.compareTo(other.field) == 0){
+            return sort.compareTo(other.sort);
+        }
+        return field.compareTo(other.field);
+    }
+
 
     public enum Direction {
         ASCENDING,

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/FieldSort.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/FieldSort.java
@@ -68,10 +68,11 @@ public class FieldSort implements Comparable<FieldSort> {
     @Override
     public int compareTo(FieldSort other) {
 
-        if(field.compareTo(other.field) == 0){
+        int fieldCompare = field.compareTo(other.field);
+        if( fieldCompare == 0){
             return sort.compareTo(other.sort);
         }
-        return field.compareTo(other.field);
+        return fieldCompare;
     }
 
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexManagerImpl.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexManagerImpl.java
@@ -262,7 +262,9 @@ public class IndexManagerImpl implements IndexManager {
         // if an index already exists that matches the request index definition.
         if (indexName == null) {
             List<Index> indexes = this.listIndexes();
-            Collections.sort(fieldNames);
+            // Create a copy of the field names list so we know its mutable.
+            List<FieldSort> mFieldNames = new ArrayList<FieldSort>(fieldNames);
+            Collections.sort(mFieldNames);
             for (Index index : indexes) {
                 Collections.sort(index.fieldNames);
                 if (!fieldNames.equals(filterMeta(index.fieldNames))) {

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexManagerImpl.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexManagerImpl.java
@@ -207,15 +207,6 @@ public class IndexManagerImpl implements IndexManager {
      */
     @Override
     public String ensureIndexed(List<FieldSort> fieldNames) throws QueryException {
-        List<Index> indexes = this.listIndexes();
-        Collections.sort(fieldNames);
-        for(Index index: indexes){
-            Collections.sort(index.fieldNames);
-            if (fieldNames.equals(filterMeta(index.fieldNames))){
-                return index.indexName;
-            }
-        }
-
         return this.ensureIndexed(fieldNames, null);
     }
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexManagerImpl.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexManagerImpl.java
@@ -274,9 +274,21 @@ public class IndexManagerImpl implements IndexManager {
             Collections.sort(fieldNames);
             for (Index index : indexes) {
                 Collections.sort(index.fieldNames);
-                if (fieldNames.equals(filterMeta(index.fieldNames))) {
-                    return index.indexName;
+                if (!fieldNames.equals(filterMeta(index.fieldNames))) {
+                    continue;
                 }
+
+                boolean equalTokenize = tokenize == null ? index.tokenize == null : tokenize.equals(index.tokenize);
+                if(!equalTokenize){
+                    continue;
+                }
+
+
+                if (index.indexType != indexType){
+                    continue;
+                }
+
+                return index.indexName;
             }
         }
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexManagerImpl.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexManagerImpl.java
@@ -268,7 +268,7 @@ public class IndexManagerImpl implements IndexManager {
             Set<FieldSort> fieldNamesSet = new HashSet<FieldSort>(filterMeta(fieldNames));
             for (Index index : indexes) {
                 Set<FieldSort> indexFieldNamesSet = new HashSet<FieldSort>(filterMeta(index.fieldNames));
-                if (!(indexFieldNamesSet.size() == fieldNamesSet.size() && indexFieldNamesSet.containsAll(fieldNamesSet))) {
+                if (!indexFieldNamesSet.equals(fieldNamesSet)) {
                     continue;
                 }
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexManagerImpl.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexManagerImpl.java
@@ -52,13 +52,16 @@ import com.cloudant.sync.util.Misc;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.nio.charset.Charset;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.logging.Level;
@@ -262,12 +265,10 @@ public class IndexManagerImpl implements IndexManager {
         // if an index already exists that matches the request index definition.
         if (indexName == null) {
             List<Index> indexes = this.listIndexes();
-            // Create a copy of the field names list so we know its mutable.
-            List<FieldSort> mFieldNames = new ArrayList<FieldSort>(fieldNames);
-            Collections.sort(mFieldNames);
+            Set<FieldSort> fieldNamesSet = new HashSet<FieldSort>(filterMeta(fieldNames));
             for (Index index : indexes) {
-                Collections.sort(index.fieldNames);
-                if (!mFieldNames.equals(filterMeta(index.fieldNames))) {
+                Set<FieldSort> indexFieldNamesSet = new HashSet<FieldSort>(filterMeta(index.fieldNames));
+                if (!(indexFieldNamesSet.containsAll(fieldNamesSet) && indexFieldNamesSet.size() == fieldNamesSet.size())) {
                     continue;
                 }
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexManagerImpl.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexManagerImpl.java
@@ -267,7 +267,7 @@ public class IndexManagerImpl implements IndexManager {
             Collections.sort(mFieldNames);
             for (Index index : indexes) {
                 Collections.sort(index.fieldNames);
-                if (!fieldNames.equals(filterMeta(index.fieldNames))) {
+                if (!mFieldNames.equals(filterMeta(index.fieldNames))) {
                     continue;
                 }
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexManagerImpl.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexManagerImpl.java
@@ -268,7 +268,7 @@ public class IndexManagerImpl implements IndexManager {
             Set<FieldSort> fieldNamesSet = new HashSet<FieldSort>(filterMeta(fieldNames));
             for (Index index : indexes) {
                 Set<FieldSort> indexFieldNamesSet = new HashSet<FieldSort>(filterMeta(index.fieldNames));
-                if (!(indexFieldNamesSet.containsAll(fieldNamesSet) && indexFieldNamesSet.size() == fieldNamesSet.size())) {
+                if (!(indexFieldNamesSet.size() == fieldNamesSet.size() && indexFieldNamesSet.containsAll(fieldNamesSet))) {
                     continue;
                 }
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexManagerTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexManagerTest.java
@@ -73,6 +73,27 @@ public class IndexManagerTest extends AbstractIndexTestBase {
 
         assertThat("There should be 2 indexes", im.listIndexes().size(), is(2));
     }
+    @Test
+    public void ensureIndexedGeneratesTwoIndexesForDifferingType() throws QueryException {
+        String indexName = im.ensureIndexed(Arrays.asList(new FieldSort("name")), null, IndexType.JSON);
+        assertThat("index name should not be null", indexName, is(notNullValue()));
+        assertThat("the previously generated index name should not be returned",
+                im.ensureIndexed(Arrays.asList( new FieldSort("name")), null, IndexType.TEXT),
+                is(not(indexName)));
+
+        assertThat("There should be 2 indexes", im.listIndexes().size(), is(2));
+    }
+
+    @Test
+    public void ensureIndexedGeneratesTwoIndexesForDifferingTokenize() throws QueryException {
+        String indexName =  im.ensureIndexed(Arrays.asList(new FieldSort("name")), null, IndexType.JSON);
+        assertThat("index name should not be null", indexName, is(notNullValue()));
+        assertThat("the previously generated index name should not be returned",
+                im.ensureIndexed(Arrays.asList( new FieldSort("name")), null, IndexType.TEXT, "simple"),
+                is(not(indexName)));
+
+        assertThat("There should be 2 indexes", im.listIndexes().size(), is(2));
+    }
 
     @Test
     public void ensureIndexGeneratesTwoIndexSecondIndexSuperSet() throws QueryException {

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexManagerTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexManagerTest.java
@@ -53,6 +53,17 @@ public class IndexManagerTest extends AbstractIndexTestBase {
     }
 
     @Test
+    public void ensureIndexedGeneratesSingleIndexWithMeta() throws QueryException {
+        String indexName = im.ensureIndexed(Arrays.asList(new FieldSort("name"), new FieldSort("_id"), new FieldSort("_rev")));
+        assertThat("index name should not be null", indexName, is(notNullValue()));
+        assertThat("the previously generated index name should be returned",
+                im.ensureIndexed(Arrays.asList(new FieldSort("name"), new FieldSort("_id"), new FieldSort("_rev"))),
+                is(indexName));
+
+        assertThat("There should only be 1 index", im.listIndexes().size(), is(1));
+    }
+
+    @Test
     public void ensureIndexedGeneratesSingleIndexRegardlessOfFieldOrder() throws QueryException {
         String indexName = im.ensureIndexed(Arrays.asList(new FieldSort("name"), new FieldSort("otherName")));
         assertThat("index name should not be null", indexName, is(notNullValue()));

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexManagerTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/query/IndexManagerTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 
 import com.cloudant.sync.datastore.DocumentBodyFactory;
@@ -29,6 +30,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -37,6 +39,50 @@ public class IndexManagerTest extends AbstractIndexTestBase {
     @Test
     public void enusureIndexedGeneratesIndexName() throws QueryException {
         assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"))), is(notNullValue()));
+    }
+
+    @Test
+    public void ensureIndexedGeneratesSingleIndexForSameFields() throws QueryException {
+        String indexName = im.ensureIndexed(Collections.singletonList(new FieldSort("name")));
+        assertThat("index name should not be null", indexName, is(notNullValue()));
+        assertThat("the previously generated index name should be returned",
+                im.ensureIndexed(Collections.singletonList(new FieldSort("name"))),
+                is(indexName));
+
+        assertThat("There should only be 1 index", im.listIndexes().size(), is(1));
+    }
+
+    @Test
+    public void ensureIndexedGeneratesSingleIndexRegardlessOfFieldOrder() throws QueryException {
+        String indexName = im.ensureIndexed(Arrays.asList(new FieldSort("name"), new FieldSort("otherName")));
+        assertThat("index name should not be null", indexName, is(notNullValue()));
+        assertThat("the previously generated index name should be returned",
+                im.ensureIndexed(Arrays.asList(new FieldSort("otherName"), new FieldSort("name"))),
+                is(indexName));
+
+        assertThat("There should only be 1 index", im.listIndexes().size(), is(1));
+    }
+
+    @Test
+    public void ensureIndexedGeneratesTwoIndexesForDifferingFields() throws QueryException {
+        String indexName = im.ensureIndexed(Arrays.asList(new FieldSort("name"), new FieldSort("otherName")));
+        assertThat("index name should not be null", indexName, is(notNullValue()));
+        assertThat("the previously generated index name should not be returned",
+                im.ensureIndexed(Arrays.asList( new FieldSort("name"))),
+                is(not(indexName)));
+
+        assertThat("There should be 2 indexes", im.listIndexes().size(), is(2));
+    }
+
+    @Test
+    public void ensureIndexGeneratesTwoIndexSecondIndexSuperSet() throws QueryException {
+        String indexName = im.ensureIndexed(Arrays.asList(new FieldSort("name")));
+        assertThat("index name should not be null", indexName, is(notNullValue()));
+        assertThat("the previously generated index name should not be returned",
+                im.ensureIndexed(Arrays.asList( new FieldSort("name"), new FieldSort("otherName"))),
+                is(not(indexName)));
+
+        assertThat("There should be 2 indexes", im.listIndexes().size(), is(2));
     }
 
     @Test


### PR DESCRIPTION
## What
Avoid creating duplicate indexes with different generated names, when calling `ensureIndexed` without a name parameter.

## How

- Implement comparable on FieldSort
- Ensure all `ensureIndex` methods call down into the same method.
- Compare the fields for an index with `_id` and `_rev` omitted, with the remaining fields sorted.

## Tests

New Tests added to `IndexManagerTests`

## Issues

Fixes #377