### PR TITLE
Remove type wildcards on public API

### DIFF
--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/Database.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/Database.java
@@ -146,7 +146,7 @@ public interface Database {
      *                   descending order.
      * @return list of {@code DBObjects}, maximum length {@code limit}.
      */
-    List<? extends DocumentRevision> getAllDocuments(int offset, int limit, boolean descending);
+    List<DocumentRevision> getAllDocuments(int offset, int limit, boolean descending);
 
     /**
      * <p>Enumerates the current winning revision for all documents in the
@@ -168,7 +168,7 @@ public interface Database {
      * @throws DocumentException if there was an error retrieving the
      * documents.
      */
-    List<? extends DocumentRevision> getDocumentsWithIds(List<String> documentIds) throws DocumentException;
+    List<DocumentRevision> getDocumentsWithIds(List<String> documentIds) throws DocumentException;
 
     /**
      * <p>Retrieves the datastore's current sequence number.</p>
@@ -331,7 +331,7 @@ public interface Database {
      * @see Database#getEventBus()
      * @see Database#deleteDocumentFromRevision(DocumentRevision)
      */
-    List<? extends DocumentRevision> deleteDocument(String id) throws DocumentException;
+    List<DocumentRevision> deleteDocument(String id) throws DocumentException;
 
     /**
      * Compacts the sqlDatabase storage by removing the bodies and attachments of obsolete revisions.

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/DatabaseImpl.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/DatabaseImpl.java
@@ -359,7 +359,7 @@ public class DatabaseImpl implements Database {
     }
 
     @Override
-    public List<InternalDocumentRevision> getAllDocuments(final int offset, final int limit, final
+    public List<DocumentRevision> getAllDocuments(final int offset, final int limit, final
     boolean descending) {
         Misc.checkState(this.isOpen(), "Database is closed");
         if (offset < 0) {
@@ -389,7 +389,7 @@ public class DatabaseImpl implements Database {
     }
 
     @Override
-    public List<? extends DocumentRevision> getDocumentsWithIds(final List<String> docIds) throws
+    public List<DocumentRevision> getDocumentsWithIds(final List<String> docIds) throws
             DocumentException {
         Misc.checkState(this.isOpen(), "Database is closed");
         Misc.checkNotNull(docIds, "Input document id list");
@@ -1235,7 +1235,7 @@ public class DatabaseImpl implements Database {
 
     // delete all leaf nodes
     @Override
-    public List<InternalDocumentRevision> deleteDocument(final String id)
+    public List<DocumentRevision> deleteDocument(final String id)
             throws DocumentException {
         Misc.checkNotNull(id, "ID");
         try {

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/DeleteAllRevisionsCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/DeleteAllRevisionsCallable.java
@@ -15,6 +15,7 @@
 package com.cloudant.sync.internal.documentstore.callables;
 
 import com.cloudant.sync.documentstore.ConflictException;
+import com.cloudant.sync.documentstore.DocumentRevision;
 import com.cloudant.sync.documentstore.DocumentStoreException;
 import com.cloudant.sync.documentstore.DocumentNotFoundException;
 import com.cloudant.sync.internal.documentstore.InternalDocumentRevision;
@@ -32,7 +33,7 @@ import java.util.List;
  *
  * @api_private
  */
-public class DeleteAllRevisionsCallable implements SQLCallable<List<InternalDocumentRevision>> {
+public class DeleteAllRevisionsCallable implements SQLCallable<List<DocumentRevision>> {
 
     private String id;
 
@@ -41,10 +42,10 @@ public class DeleteAllRevisionsCallable implements SQLCallable<List<InternalDocu
     }
 
     @Override
-    public List<InternalDocumentRevision> call(SQLDatabase db) throws DocumentStoreException, ConflictException,
+    public List<DocumentRevision> call(SQLDatabase db) throws DocumentStoreException, ConflictException,
             DocumentNotFoundException {
 
-        ArrayList<InternalDocumentRevision> deleted = new ArrayList<InternalDocumentRevision>();
+        ArrayList<DocumentRevision> deleted = new ArrayList<DocumentRevision>();
         Cursor cursor = null;
         // delete all in one tx
         try {

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/GetAllDocumentsCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/GetAllDocumentsCallable.java
@@ -14,12 +14,14 @@
 
 package com.cloudant.sync.internal.documentstore.callables;
 
+import com.cloudant.sync.documentstore.DocumentRevision;
 import com.cloudant.sync.internal.documentstore.AttachmentStreamFactory;
 import com.cloudant.sync.internal.documentstore.DatabaseImpl;
 import com.cloudant.sync.internal.documentstore.InternalDocumentRevision;
 import com.cloudant.sync.internal.sqlite.SQLCallable;
 import com.cloudant.sync.internal.sqlite.SQLDatabase;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -28,7 +30,7 @@ import java.util.List;
  *
  * @api_private
  */
-public class GetAllDocumentsCallable implements SQLCallable<List<InternalDocumentRevision>> {
+public class GetAllDocumentsCallable implements SQLCallable<List<DocumentRevision>> {
 
     private int offset;
     private int limit;
@@ -47,12 +49,15 @@ public class GetAllDocumentsCallable implements SQLCallable<List<InternalDocumen
     }
 
     @Override
-    public List<InternalDocumentRevision> call(SQLDatabase db) throws Exception {
+    public List<DocumentRevision> call(SQLDatabase db) throws Exception {
         // Generate the SELECT statement, based on the options:
         String sql = String.format("SELECT " + DatabaseImpl.FULL_DOCUMENT_COLS +
                 " FROM revs, docs WHERE deleted = 0 AND current = 1 AND docs.doc_id = revs.doc_id " +
                 " ORDER BY docs.doc_id %1$s, revid DESC LIMIT %2$s OFFSET %3$s ",
                 (descending ? "DESC" : "ASC"), limit, offset);
-        return DatabaseImpl.getRevisionsFromRawQuery(db, sql, new String[]{}, attachmentsDir, attachmentStreamFactory);
+
+        return new ArrayList<DocumentRevision>(DatabaseImpl.getRevisionsFromRawQuery(db, sql,
+                new String[]{}, attachmentsDir, attachmentStreamFactory));
+
     }
 }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/CrudImplDatabaseTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/CrudImplDatabaseTest.java
@@ -519,7 +519,7 @@ public class CrudImplDatabaseTest extends BasicDatastoreTestBase {
         }
     }
 
-    private void assertIdAndRevisionAndShallowContent(DocumentRevision expected, InternalDocumentRevision actual) {
+    private void assertIdAndRevisionAndShallowContent(DocumentRevision expected, DocumentRevision actual) {
         Assert.assertEquals(expected.getId(), actual.getId());
         Assert.assertEquals(expected.getRevision(), actual.getRevision());
 
@@ -600,7 +600,7 @@ public class CrudImplDatabaseTest extends BasicDatastoreTestBase {
 
         int count;
         int offset = 0;
-        List<InternalDocumentRevision> result;
+        List<DocumentRevision> result;
 
         // Count
         count = 10;
@@ -661,13 +661,13 @@ public class CrudImplDatabaseTest extends BasicDatastoreTestBase {
         }
     }
 
-    private void getAllDocuments_compareResult(List<DocumentRevision> expectedDocumentRevisions, List<InternalDocumentRevision> result, int count, int offset) {
-        ListIterator<InternalDocumentRevision> iterator;
+    private void getAllDocuments_compareResult(List<DocumentRevision> expectedDocumentRevisions, List<DocumentRevision> result, int count, int offset) {
+        ListIterator<DocumentRevision> iterator;
         iterator = result.listIterator();
         Assert.assertEquals(count, result.size());
         while (iterator.hasNext()) {
             int index = iterator.nextIndex();
-            InternalDocumentRevision actual = iterator.next();
+            DocumentRevision actual = iterator.next();
             DocumentRevision expected = expectedDocumentRevisions.get(index + offset);
 
             assertIdAndRevisionAndShallowContent(expected, actual);


### PR DESCRIPTION
_What_: Don't expose type wildcards like `List<? extends DocumentRevision>` on public API

_Why_: Because it confuses users and looks ugly

_Testing_: All existing tests pass