### PR TITLE
ReplicatorBuilder takes DocumentStore

### DIFF
--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ReplicatorBuilder.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ReplicatorBuilder.java
@@ -18,6 +18,7 @@ import com.cloudant.http.interceptors.CookieInterceptor;
 import com.cloudant.http.HttpConnectionRequestInterceptor;
 import com.cloudant.http.HttpConnectionResponseInterceptor;
 import com.cloudant.sync.documentstore.Database;
+import com.cloudant.sync.documentstore.DocumentStore;
 import com.cloudant.sync.internal.replication.PullStrategy;
 import com.cloudant.sync.internal.replication.PushStrategy;
 import com.cloudant.sync.internal.replication.ReplicatorImpl;
@@ -87,7 +88,7 @@ public abstract class ReplicatorBuilder<S, T, E> {
     /**
      * A Push Replication Builder
      */
-    public static class Push extends ReplicatorBuilder<Database, URI, Push> {
+    public static class Push extends ReplicatorBuilder<DocumentStore, URI, Push> {
 
         private int changeLimitPerBatch = 500;
 
@@ -109,7 +110,7 @@ public abstract class ReplicatorBuilder<S, T, E> {
             // add cookie interceptor and remove creds from URI if required
             super.target = super.addCookieInterceptorIfRequired(super.target);
 
-            PushStrategy pushStrategy = new PushStrategy(super.source,
+            PushStrategy pushStrategy = new PushStrategy(super.source.database,
                     super.target,
                     super.requestInterceptors,
                     super.responseInterceptors);
@@ -181,7 +182,7 @@ public abstract class ReplicatorBuilder<S, T, E> {
     /**
      * A Pull Replication Builder
      */
-    public static class Pull extends ReplicatorBuilder<URI, Database, Pull> {
+    public static class Pull extends ReplicatorBuilder<URI, DocumentStore, Pull> {
 
         private PullFilter pullPullFilter = null;
 
@@ -204,7 +205,7 @@ public abstract class ReplicatorBuilder<S, T, E> {
             super.source = super.addCookieInterceptorIfRequired(super.source);
 
             PullStrategy pullStrategy = new PullStrategy(super.source,
-                    super.target,
+                    super.target.database,
                     pullPullFilter,
                     super.requestInterceptors,
                     super.responseInterceptors);

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/AttachmentsPushTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/AttachmentsPushTest.java
@@ -55,7 +55,7 @@ public class AttachmentsPushTest extends ReplicationTestBase {
     @Override
     protected ReplicatorBuilder.Push getPushBuilder() {
         return ReplicatorBuilder.push().
-                from(this.datastore).
+                from(this.documentStore).
                 to(this.couchConfig.getRootUri()).
                 pushAttachmentsInline(pushAttachmentsInline).
                 addRequestInterceptors(couchConfig.getRequestInterceptors()).

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/PullReplicatorTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/PullReplicatorTest.java
@@ -104,7 +104,7 @@ public class PullReplicatorTest extends ReplicationTestBase {
 
         Replicator replicator = ReplicatorBuilder.pull()
                 .from(this.source)
-                .to(this.datastore)
+                .to(this.documentStore)
                 .build();
 
         Assert.assertNotNull(replicator);
@@ -115,7 +115,7 @@ public class PullReplicatorTest extends ReplicationTestBase {
 
         Replicator replicator = ReplicatorBuilder.pull()
                 .from(this.source)
-                .to(this.datastore)
+                .to(this.documentStore)
                 .filter(new PullFilter("a_filter"))
                 .build();
 
@@ -129,7 +129,7 @@ public class PullReplicatorTest extends ReplicationTestBase {
         params.put("a","parameter");
         Replicator replicator = ReplicatorBuilder.pull()
                 .from(this.source)
-                .to(this.datastore)
+                .to(this.documentStore)
                 .filter(new PullFilter("a_filter",params))
                 .build();
 
@@ -142,7 +142,7 @@ public class PullReplicatorTest extends ReplicationTestBase {
         Map<String,String> params = new HashMap<String,String>();
         Replicator replicator = ReplicatorBuilder.pull()
                 .from(this.source)
-                .to(this.datastore)
+                .to(this.documentStore)
                 .filter(new PullFilter("a_filter",params))
                 .build();
 
@@ -156,7 +156,7 @@ public class PullReplicatorTest extends ReplicationTestBase {
 
         TestReplicationListener listener = new TestReplicationListener();
         ReplicatorBuilder replicatorBuilder = ReplicatorBuilder.pull()
-                .to(this.datastore)
+                .to(this.documentStore)
                 .from(this.remoteDb.couchClient.getRootUri())
                 .addRequestInterceptors(interceptorCallCounter)
                 .addResponseInterceptors(interceptorCallCounter);
@@ -212,7 +212,7 @@ public class PullReplicatorTest extends ReplicationTestBase {
     public void replicatorBuilderAddsCookieInterceptorCustomPort() throws Exception {
         ReplicatorBuilder.Pull p = ReplicatorBuilder.pull().
                 from(new URI("http://🍶:🍶@some-host:123/path%2Fsome-path-日本")).
-                to(datastore);
+                to(documentStore);
         ReplicatorImpl r = (ReplicatorImpl)p.build();
         // check that user/pass has been removed
         Assert.assertEquals("http://some-host:123/path%2Fsome-path-日本",
@@ -228,7 +228,7 @@ public class PullReplicatorTest extends ReplicationTestBase {
     public void replicatorBuilderAddsCookieInterceptorDefaultPort() throws Exception {
         ReplicatorBuilder.Pull p = ReplicatorBuilder.pull().
                 from(new URI("http://🍶:🍶@some-host/path%2Fsome-path-日本")).
-                to(datastore);
+                to(documentStore);
         ReplicatorImpl r = (ReplicatorImpl)p.build();
         // check that user/pass has been removed
         Assert.assertEquals("http://some-host:80/path%2Fsome-path-日本",

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/PushReplicatorTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/PushReplicatorTest.java
@@ -160,7 +160,7 @@ public class PushReplicatorTest extends ReplicationTestBase {
     @Test
     public void replicatorBuilderAddsCookieInterceptorCustomPort() throws Exception {
         ReplicatorBuilder.Push p = ReplicatorBuilder.push().
-                from(datastore).
+                from(documentStore).
                 to(new URI("http://🍶:🍶@some-host:123/path%2Fsome-path-日本"));
         ReplicatorImpl r = (ReplicatorImpl) p.build();
         // check that user/pass has been removed
@@ -176,7 +176,7 @@ public class PushReplicatorTest extends ReplicationTestBase {
     @Test
     public void replicatorBuilderAddsCookieInterceptorDefaultPort() throws Exception {
         ReplicatorBuilder.Push p = ReplicatorBuilder.push().
-                from(datastore).
+                from(documentStore).
                 to(new URI("http://🍶:🍶@some-host/path%2Fsome-path-日本"));
         ReplicatorImpl r = (ReplicatorImpl) p.build();
         // check that user/pass has been removed

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/ReplicationTestBase.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/ReplicationTestBase.java
@@ -110,7 +110,7 @@ public abstract class ReplicationTestBase extends CouchTestBase {
 
     protected ReplicatorBuilder.Push getPushBuilder() {
         return ReplicatorBuilder.push().
-                from(this.datastore).
+                from(this.documentStore).
                 to(this.couchConfig.getRootUri()).
                 addRequestInterceptors(couchConfig.getRequestInterceptors()).
                 addResponseInterceptors(couchConfig.getResponseInterceptors());
@@ -118,7 +118,7 @@ public abstract class ReplicationTestBase extends CouchTestBase {
 
     protected ReplicatorBuilder.Pull getPullBuilder() {
         return ReplicatorBuilder.pull().
-                to(this.datastore).
+                to(this.documentStore).
                 from(this.couchConfig.getRootUri()).
                 addRequestInterceptors(couchConfig.getRequestInterceptors()).
                 addResponseInterceptors(couchConfig.getResponseInterceptors());
@@ -126,7 +126,7 @@ public abstract class ReplicationTestBase extends CouchTestBase {
 
     protected ReplicatorBuilder.Pull getPullBuilder(PullFilter filter) {
         return ReplicatorBuilder.pull().
-                to(this.datastore).
+                to(this.documentStore).
                 from(this.couchConfig.getRootUri()).
                 addRequestInterceptors(couchConfig.getRequestInterceptors()).
                 addResponseInterceptors(couchConfig.getResponseInterceptors()).

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/ReplicatorIdTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/ReplicatorIdTest.java
@@ -14,16 +14,18 @@
 
 package com.cloudant.sync.internal.replication;
 
-import static org.mockito.Mockito.mock;
-
 import com.cloudant.common.CollectionFactory;
-import com.cloudant.sync.internal.documentstore.DatabaseImpl;
+import com.cloudant.sync.documentstore.DocumentStore;
 import com.cloudant.sync.replication.PullFilter;
 import com.cloudant.sync.replication.ReplicatorBuilder;
+import com.cloudant.sync.util.TestUtils;
 
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
+import java.io.File;
 import java.net.URI;
 
 /**
@@ -31,16 +33,31 @@ import java.net.URI;
  */
 public class ReplicatorIdTest {
 
+    String testDir;
+    DocumentStore documentStore;
+
+    @Before
+    public void before() throws Exception {
+        testDir = TestUtils.createTempTestingDir(this.getClass().getName());
+        documentStore = DocumentStore.getInstance(new File(testDir));
+    }
+
+    @After
+    public void after() throws Exception {
+        documentStore.close();
+        TestUtils.deleteTempTestingDir(testDir);
+    }
+
     // source/target switched, so ids should be different
     @Test
     public void pullNotEqualToPush() throws Exception {
         PullStrategy pull = (PullStrategy) ((ReplicatorImpl) ReplicatorBuilder.pull()
                 .from(new URI
-                ("http://default-host/default-database")).to(mock(DatabaseImpl.class)).build
+                ("http://default-host/default-database")).to(documentStore).build
                         ()).strategy;
         PushStrategy push = (PushStrategy) ((ReplicatorImpl) ReplicatorBuilder.push()
                 .to(new URI
-                ("http://default-host/default-database")).from(mock(DatabaseImpl.class))
+                ("http://default-host/default-database")).from(documentStore)
                 .build()).strategy;
 
         Assert.assertNotEquals(pull.getReplicationId(),
@@ -52,11 +69,11 @@ public class ReplicatorIdTest {
     public void pullsEqual() throws Exception {
         PullStrategy pull1 = (PullStrategy) ((ReplicatorImpl) ReplicatorBuilder.pull()
                 .from(new URI
-                ("http://default-host/default-database")).to(mock(DatabaseImpl.class)).build
+                ("http://default-host/default-database")).to(documentStore).build
                         ()).strategy;
         PullStrategy pull2 = (PullStrategy) ((ReplicatorImpl) ReplicatorBuilder.pull()
                 .from(new URI
-                ("http://default-host/default-database")).to(mock(DatabaseImpl.class)).build
+                ("http://default-host/default-database")).to(documentStore).build
                         ()).strategy;
 
         Assert.assertEquals(pull1.getReplicationId(),
@@ -68,11 +85,11 @@ public class ReplicatorIdTest {
     public void pushesEqual() throws Exception {
         PushStrategy push1 = (PushStrategy) ((ReplicatorImpl) ReplicatorBuilder.push()
                 .to(new URI
-                ("http://default-host/default-database")).from(mock(DatabaseImpl.class))
+                ("http://default-host/default-database")).from(documentStore)
                 .build()).strategy;
         PushStrategy push2 = (PushStrategy) ((ReplicatorImpl) ReplicatorBuilder.push()
                 .to(new URI
-                ("http://default-host/default-database")).from(mock(DatabaseImpl.class))
+                ("http://default-host/default-database")).from(documentStore)
                 .build()).strategy;
         Assert.assertEquals(push1.getReplicationId(),
                 push2.getReplicationId());
@@ -83,11 +100,11 @@ public class ReplicatorIdTest {
     public void pushesDifferingTargetNotEqual() throws Exception {
         PushStrategy push1 = (PushStrategy) ((ReplicatorImpl) ReplicatorBuilder.push()
                 .to(new URI
-                ("http://a-host/a-database")).from(mock(DatabaseImpl.class)).build())
+                ("http://a-host/a-database")).from(documentStore).build())
                 .strategy;
         PushStrategy push2 = (PushStrategy) ((ReplicatorImpl) ReplicatorBuilder.push()
                 .to(new URI
-                ("http://another-host/another-database")).from(mock(DatabaseImpl.class))
+                ("http://another-host/another-database")).from(documentStore)
                 .build()).strategy;
 
         Assert.assertNotEquals(push1.getReplicationId(),
@@ -99,11 +116,11 @@ public class ReplicatorIdTest {
     public void pullsDifferingSourceNotEqual() throws Exception {
         PullStrategy pull1 = (PullStrategy) ((ReplicatorImpl) ReplicatorBuilder.pull()
                 .from(new URI
-                ("http://a-host/a-database")).to(mock(DatabaseImpl.class)).build())
+                ("http://a-host/a-database")).to(documentStore).build())
                 .strategy;
         PullStrategy pull2 = (PullStrategy) ((ReplicatorImpl) ReplicatorBuilder.pull()
                 .from(new URI
-                ("http://another-host/another-database")).to(mock(DatabaseImpl.class)).build
+                ("http://another-host/another-database")).to(documentStore).build
                         ()).strategy;
 
         Assert.assertNotEquals(pull1.getReplicationId(),
@@ -115,11 +132,11 @@ public class ReplicatorIdTest {
     public void pullWithFilterNotEqual() throws Exception {
         PullStrategy pull1 = (PullStrategy) ((ReplicatorImpl) ReplicatorBuilder.pull()
                 .from(new URI
-                ("http://default-host/default-database")).to(mock(DatabaseImpl.class)).build
+                ("http://default-host/default-database")).to(documentStore).build
                         ()).strategy;
         PullStrategy pull2 = (PullStrategy) ((ReplicatorImpl) ReplicatorBuilder.pull()
                 .from(new URI
-                ("http://default-host/default-database")).to(mock(DatabaseImpl.class))
+                ("http://default-host/default-database")).to(documentStore)
                 .filter(new PullFilter("animal/by_class",
                 CollectionFactory.MAP.of("class", "mammal"))).build()).strategy;
 
@@ -132,12 +149,12 @@ public class ReplicatorIdTest {
     public void pullWithDifferentFiltersNotEqual() throws Exception {
         PullStrategy pull1 = (PullStrategy) ((ReplicatorImpl) ReplicatorBuilder.pull()
                 .from(new URI
-                ("http://default-host/default-database")).to(mock(DatabaseImpl.class))
+                ("http://default-host/default-database")).to(documentStore)
                 .filter(new PullFilter("animal/by_class",
                 CollectionFactory.MAP.of("class", "mammal"))).build()).strategy;
         PullStrategy pull2 = (PullStrategy) ((ReplicatorImpl) ReplicatorBuilder.pull()
                 .from(new URI
-                ("http://default-host/default-database")).to(mock(DatabaseImpl.class))
+                ("http://default-host/default-database")).to(documentStore)
                 .filter(new PullFilter("animal/by_class",
                 CollectionFactory.MAP.of("class", "bird"))).build()).strategy;
 


### PR DESCRIPTION
Fixes #395 

_What_: Make `ReplicatorBuilder` API more useable by taking `DocumentStore` object instead of `Database`.
_Testing_: All tests pass