### PR TITLE
Correctly perform cookie authentication

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [FIXED] Issue performing cookie authentication in version 1.1.3.
+
 # 1.1.3 (2016-11-22)
 - [FIXED] Incorrect message output from parameter `null` or empty checks.
 - [FIXED] Issue where replications would error if the server returned missing revisions.

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ReplicatorBuilder.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ReplicatorBuilder.java
@@ -70,7 +70,27 @@ public abstract class ReplicatorBuilder<S, T, E> {
         if (uri.getUserInfo() != null) {
             String[] parts = uri.getUserInfo().split(":");
             if (parts.length == 2) {
-                CookieInterceptor ci = new CookieInterceptor(parts[0], parts[1], uri.toString());
+
+                String path = uri.getRawPath();
+                int index = path.lastIndexOf("/");
+                if (index == path.length() - 1) {
+                    // we need to go back one
+                    path = path.substring(0, index);
+                    index = path.lastIndexOf("/");
+                }
+
+                path = path.substring(0, index);
+
+                URI baseURI;
+
+                try {
+                    baseURI = new URI(uriProtocol, null, uriHost, uriPort, path, null, null);
+                } catch (URISyntaxException e) {
+                    throw new RuntimeException(e);
+                }
+
+
+                CookieInterceptor ci = new CookieInterceptor(parts[0], parts[1], baseURI.toString());
                 requestInterceptors.add(ci);
                 responseInterceptors.add(ci);
             }


### PR DESCRIPTION
## What

Correctly generate the URI for the cookie interceptor so it can perform
authentication. 

## How

Remove the last whole path component of the supplied URI, which is the database name that the replication is replicating with.

## Testing

Manual testing against Cloudant.
The Jenkinsfile testing from #411 will automatically run tests that show up this kind of problem.

## Issues

Fixes #415