### PR TITLE
Database APIs throw DocumentStoreException

### DIFF
--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/DocumentRevision.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/DocumentRevision.java
@@ -160,7 +160,7 @@ public class DocumentRevision {
      * @throws DocumentNotFoundException Thrown if the full document cannot be loaded from the
      * datastore.
      */
-    public DocumentRevision toFullRevision() throws DocumentNotFoundException {
+    public DocumentRevision toFullRevision() throws DocumentNotFoundException, DocumentStoreException {
         return this;
     }
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/DatabaseImpl.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/DatabaseImpl.java
@@ -248,7 +248,7 @@ public class DatabaseImpl implements Database {
         } catch (ExecutionException e) {
             String message = "Failed to get document count";
             logger.log(Level.SEVERE, message, e);
-            throw new DocumentStoreException(e.getCause());
+            throw new DocumentStoreException(message, e.getCause());
         }
     }
 
@@ -390,8 +390,9 @@ public class DatabaseImpl implements Database {
         try {
             return get (queue.submit(new GetDocumentsWithIdsCallable(docIds, attachmentsDir, attachmentStreamFactory)));
         } catch (ExecutionException e) {
-            logger.log(Level.SEVERE, "Failed to get documents with ids", e);
-            throw new DocumentStoreException("Failed to get documents with ids", e);
+            String message = "Failed to get documents with ids";
+            logger.log(Level.SEVERE, message, e);
+            throw new DocumentStoreException(message, e);
         }
     }
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/DatabaseImpl.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/DatabaseImpl.java
@@ -20,7 +20,6 @@
 package com.cloudant.sync.internal.documentstore;
 
 import com.cloudant.sync.documentstore.DocumentRevision;
-import com.cloudant.sync.internal.common.ChangeNotifyingMap;
 import com.cloudant.sync.internal.common.CouchUtils;
 import com.cloudant.sync.internal.common.ValueListMap;
 import com.cloudant.sync.documentstore.Attachment;
@@ -88,6 +87,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -227,77 +227,74 @@ public class DatabaseImpl implements Database {
     }
 
     @Override
-    public long getLastSequence() {
+    public long getLastSequence() throws DocumentStoreException {
         Misc.checkState(this.isOpen(), "Database is closed");
 
         try {
-            return queue.submit(new GetLastSequenceCallable()).get();
-        } catch (InterruptedException e) {
-            logger.log(Level.SEVERE, "Failed to get last Sequence", e);
-            throw new RuntimeException(e);
+            return get(queue.submit(new GetLastSequenceCallable()));
         } catch (ExecutionException e) {
-            logger.log(Level.SEVERE, "Failed to get last Sequence", e);
-            Throwable cause = e.getCause();
-            if (cause != null) {
-                if (cause instanceof IllegalStateException) {
-                    throw (IllegalStateException)cause;
-                }
-            }
+            throwCauseAs(e, IllegalStateException.class);
+            String message = "Failed to get last Sequence";
+            logger.log(Level.SEVERE, message, e);
+            throw new DocumentStoreException(message, e.getCause());
         }
-        return 0;
-
     }
 
     @Override
-    public int getDocumentCount() {
+    public int getDocumentCount() throws DocumentStoreException {
         Misc.checkState(this.isOpen(), "Database is closed");
         try {
             return get(queue.submit(new GetDocumentCountCallable()));
         } catch (ExecutionException e) {
-            logger.log(Level.SEVERE, "Failed to get document count", e);
+            String message = "Failed to get document count";
+            logger.log(Level.SEVERE, message, e);
+            throw new DocumentStoreException(e.getCause());
         }
-        return 0;
-
     }
 
     @Override
-    public boolean containsDocument(String docId, String revId) {
+    public boolean containsDocument(String docId, String revId) throws DocumentStoreException {
         Misc.checkState(this.isOpen(), "Database is closed");
         try {
             // TODO this can be made quicker than getting the whole document
-            return getDocument(docId, revId) != null;
+            getDocument(docId, revId);
+            return true;
         } catch (DocumentNotFoundException e) {
             return false;
         }
     }
 
     @Override
-    public boolean containsDocument(String docId) {
+    public boolean containsDocument(String docId) throws DocumentStoreException {
         Misc.checkState(this.isOpen(), "Database is closed");
         try {
             // TODO this can be made quicker than getting the whole document
-            return getDocument(docId) != null;
+            getDocument(docId);
+            return true;
         } catch (DocumentNotFoundException e) {
             return false;
         }
     }
 
     @Override
-    public InternalDocumentRevision getDocument(String id) throws DocumentNotFoundException {
+    public InternalDocumentRevision getDocument(String id) throws DocumentNotFoundException, DocumentStoreException {
         Misc.checkState(this.isOpen(), "Database is closed");
         return getDocument(id, null);
     }
 
     @Override
     public InternalDocumentRevision getDocument(final String id, final String rev) throws
-            DocumentNotFoundException {
+            DocumentNotFoundException, DocumentStoreException {
         Misc.checkState(this.isOpen(), "Database is closed");
         Misc.checkNotNullOrEmpty(id, "Document id");
 
         try {
             return get(queue.submit(new GetDocumentCallable(id, rev, this.attachmentsDir, this.attachmentStreamFactory)));
         } catch (ExecutionException e) {
-            throw new DocumentNotFoundException(id, rev, e.getCause());
+            throwCauseAs(e, DocumentNotFoundException.class);
+            String message = String.format(Locale.ENGLISH, "Failed to get document id %s at revision %s", id, rev);
+            logger.log(Level.SEVERE, message, e);
+            throw new DocumentStoreException(message, e.getCause());
         }
     }
 
@@ -321,7 +318,7 @@ public class DatabaseImpl implements Database {
     }
 
     @Override
-    public Changes changes(long since, final int limit) {
+    public Changes changes(long since, final int limit) throws DocumentStoreException {
         Misc.checkState(this.isOpen(), "Database is closed");
         Misc.checkArgument(limit > 0, "Limit must be positive number");
         final long verifiedSince = since >= 0 ? since : 0;
@@ -329,15 +326,10 @@ public class DatabaseImpl implements Database {
         try {
             return get(queue.submit(new ChangesCallable(verifiedSince, limit, attachmentsDir, attachmentStreamFactory)));
         } catch (ExecutionException e) {
-            logger.log(Level.SEVERE, "Failed to get changes", e);
-            if (e.getCause() instanceof IllegalStateException) {
-                throw new IllegalStateException("Failed to get changes, SQLite version: " + queue
-                        .getSQLiteVersion(), e);
-            }
+            String message = "Failed to get changes";
+            logger.log(Level.SEVERE, message, e);
+            throw new DocumentStoreException(message, e.getCause());
         }
-
-        return null;
-
     }
 
     /**
@@ -361,7 +353,7 @@ public class DatabaseImpl implements Database {
 
     @Override
     public List<DocumentRevision> getAllDocuments(final int offset, final int limit, final
-    boolean descending) {
+    boolean descending) throws DocumentStoreException {
         Misc.checkState(this.isOpen(), "Database is closed");
         if (offset < 0) {
             throw new IllegalArgumentException("offset must be >= 0");
@@ -372,33 +364,34 @@ public class DatabaseImpl implements Database {
         try {
             return get(queue.submit(new GetAllDocumentsCallable(offset, limit, descending, this.attachmentsDir, this.attachmentStreamFactory)));
         } catch (ExecutionException e) {
-            logger.log(Level.SEVERE, "Failed to get all documents", e);
+            String message = "Failed to get all documents";
+            logger.log(Level.SEVERE, message, e);
+            throw new DocumentStoreException(message, e.getCause());
         }
-        return null;
-
     }
 
     @Override
-    public List<String> getAllDocumentIds() {
+    public List<String> getAllDocumentIds() throws DocumentStoreException {
         Misc.checkState(this.isOpen(), "Database is closed");
         try {
             return get(queue.submit(new GetAllDocumentIdsCallable()));
         } catch (ExecutionException e) {
-            logger.log(Level.SEVERE, "Failed to get all document ids", e);
+            String message = "Failed to get all document ids";
+            logger.log(Level.SEVERE, message, e);
+            throw new DocumentStoreException(message, e.getCause());
         }
-        return null;
     }
 
     @Override
     public List<DocumentRevision> getDocumentsWithIds(final List<String> docIds) throws
-            DocumentException {
+            DocumentStoreException {
         Misc.checkState(this.isOpen(), "Database is closed");
         Misc.checkNotNull(docIds, "Input document id list");
         try {
             return get (queue.submit(new GetDocumentsWithIdsCallable(docIds, attachmentsDir, attachmentStreamFactory)));
         } catch (ExecutionException e) {
             logger.log(Level.SEVERE, "Failed to get documents with ids", e);
-            throw new DocumentException("Failed to get documents with ids", e);
+            throw new DocumentStoreException("Failed to get documents with ids", e);
         }
     }
 
@@ -780,13 +773,14 @@ public class DatabaseImpl implements Database {
 
     // TODO can this run async? if so no need to call get()
     @Override
-    public void compact() {
+    public void compact() throws DocumentStoreException {
         try {
             get(queue.submit(new CompactCallable(this.attachmentsDir)));
         } catch (ExecutionException e) {
-            logger.log(Level.SEVERE, "Failed to compact database", e);
+            String message = "Failed to compact database";
+            logger.log(Level.SEVERE, message, e);
+            throw new DocumentStoreException(message, e.getCause());
         }
-
     }
 
     public void close() {
@@ -836,15 +830,14 @@ public class DatabaseImpl implements Database {
     }
 
     @Override
-    public Iterator<String> getConflictedDocumentIds() {
-
+    public Iterator<String> getConflictedDocumentIds() throws DocumentStoreException {
         try {
             return get(queue.submit(new GetConflictedDocumentIdsCallable())).iterator();
         } catch (ExecutionException e) {
-            logger.log(Level.SEVERE, "Failed to get conflicted document Ids", e);
+            String message = "Failed to get conflicted document ids";
+            logger.log(Level.SEVERE, message, e);
+            throw new DocumentStoreException(message, e.getCause());
         }
-        return null;
-
     }
 
     @Override
@@ -1075,7 +1068,7 @@ public class DatabaseImpl implements Database {
 
     @Override
     public DocumentRevision createDocumentFromRevision(final DocumentRevision rev)
-            throws DocumentException {
+            throws AttachmentException, InvalidDocumentException, ConflictException, DocumentStoreException {
         Misc.checkNotNull(rev, "DocumentRevision");
         Misc.checkState(isOpen(), "Datastore is closed");
         Misc.checkArgument(rev.getRevision() == null, "Revision ID must be null for new " +
@@ -1123,8 +1116,13 @@ public class DatabaseImpl implements Database {
             }));
             return created;
         } catch (ExecutionException e) {
-            logger.log(Level.SEVERE, "Failed to create document", e);
-            throw new DocumentException(e);
+            // invalid if eg there are keys starting with _
+            throwCauseAs(e, InvalidDocumentException.class);
+            // conflictexception if doc id already exists
+            throwCauseAs(e, ConflictException.class);
+            String message = "Failed to create document";
+            logger.log(Level.SEVERE, message, e);
+            throw new DocumentStoreException(message, e.getCause());
         } finally {
             if (created != null) {
                 eventBus.post(new DocumentCreated(created));
@@ -1134,7 +1132,7 @@ public class DatabaseImpl implements Database {
 
     @Override
     public DocumentRevision updateDocumentFromRevision(final DocumentRevision rev)
-            throws DocumentException {
+            throws AttachmentException, DocumentStoreException, ConflictException {
 
         Misc.checkNotNull(rev, "DocumentRevision");
         Misc.checkState(isOpen(), "Datastore is closed");
@@ -1158,54 +1156,63 @@ public class DatabaseImpl implements Database {
                             rev, preparedNewAttachments, existingAttachments, this.attachmentsDir, this.attachmentStreamFactory)));
 
             if (revision != null) {
-                eventBus.post(new DocumentUpdated(getDocument(rev.getId(), rev.getRevision()),
-                        revision));
+                try {
+                    eventBus.post(new DocumentUpdated(getDocument(rev.getId(), rev.getRevision()),
+                            revision));
+                } catch (DocumentStoreException de) {
+                    ; // TODO couldn't re-fetch document to post event
+                } catch (DocumentException de) {
+                    ; // TODO couldn't re-fetch document to post event
+                }
             }
 
             return revision;
         } catch (ExecutionException e) {
-            logger.log(Level.SEVERE, "Failed to updated document", e);
-            throw new DocumentException(e);
+            // invalid if eg there are keys starting with _
+            throwCauseAs(e, InvalidDocumentException.class);
+            // conflictexception if rev id is not winning rev
+            throwCauseAs(e, ConflictException.class);
+            String message = "Failed to update document";
+            logger.log(Level.SEVERE, message, e);
+            throw new DocumentStoreException(message, e.getCause());
         }
 
     }
 
     @Override
     public DocumentRevision deleteDocumentFromRevision(final DocumentRevision rev) throws
-            ConflictException {
+            ConflictException, DocumentNotFoundException, DocumentStoreException {
         Misc.checkNotNull(rev, "DocumentRevision");
         Misc.checkState(isOpen(), "Datastore is closed");
 
         try {
             InternalDocumentRevision deletedRevision = get(queue.submit(new DeleteDocumentCallable(rev.getId(), rev.getRevision())));
-
             if (deletedRevision != null) {
                 eventBus.post(new DocumentDeleted(rev, deletedRevision));
             }
-
             return deletedRevision;
         } catch (ExecutionException e) {
-            logger.log(Level.SEVERE, "Failed to delete document", e);
-            Throwable cause = e.getCause();
-            if (cause != null) {
-                if (cause instanceof ConflictException) {
-                    throw (ConflictException) cause;
-                }
-            }
+            // conflictexception if source revision isn't current rev
+            throwCauseAs(e, ConflictException.class);
+            // documentnotfoundexception if it's already deleted
+            throwCauseAs(e, DocumentNotFoundException.class);
+            String message = "Failed to delete document";
+            logger.log(Level.SEVERE, message, e);
+            throw new DocumentStoreException(message, e.getCause());
         }
-
-        return null;
     }
 
     // delete all leaf nodes
     @Override
     public List<DocumentRevision> deleteDocument(final String id)
-            throws DocumentException {
+            throws DocumentStoreException {
         Misc.checkNotNull(id, "ID");
         try {
             return get(queue.submitTransaction(new DeleteAllRevisionsCallable(id)));
         } catch (ExecutionException e) {
-            throw new DocumentException("Failed to delete document", e);
+            String message = "Failed to delete document";
+            logger.log(Level.SEVERE, message, e);
+            throw new DocumentStoreException(message, e.getCause());
         }
     }
 
@@ -1272,4 +1279,11 @@ public class DatabaseImpl implements Database {
             return missingRevs;
         }
     }
+
+    private <T extends Throwable> void throwCauseAs(Throwable t, Class<T> type) throws T {
+        if (t.getCause().getClass().equals(type)) {
+            throw (T)t.getCause();
+        }
+    }
+
 }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/ProjectedDocumentRevision.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/ProjectedDocumentRevision.java
@@ -18,8 +18,10 @@ package com.cloudant.sync.internal.documentstore;
 import com.cloudant.sync.documentstore.Attachment;
 import com.cloudant.sync.documentstore.Database;
 import com.cloudant.sync.documentstore.DocumentBody;
+import com.cloudant.sync.documentstore.DocumentException;
 import com.cloudant.sync.documentstore.DocumentNotFoundException;
 import com.cloudant.sync.documentstore.DocumentRevision;
+import com.cloudant.sync.documentstore.DocumentStoreException;
 
 import java.util.List;
 import java.util.logging.Logger;
@@ -58,7 +60,7 @@ public class ProjectedDocumentRevision extends InternalDocumentRevision {
     }
 
     @Override
-    public DocumentRevision toFullRevision() throws DocumentNotFoundException {
+    public DocumentRevision toFullRevision() throws DocumentNotFoundException, DocumentStoreException {
         return this.database.getDocument(this.id,this.revision);
     }
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/CompactCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/CompactCallable.java
@@ -44,6 +44,9 @@ public class CompactCallable implements SQLCallable<Void> {
         ContentValues args = new ContentValues();
         args.put("json", (String) null);
         int revsCompacted = db.update("revs", args, "sequence IN (SELECT parent FROM revs)", null);
+        if (revsCompacted < 0) {
+            throw new IllegalStateException("Error running compact SQL update");
+        }
         logger.finer(String.format("Compacted %d revisions", revsCompacted));
 
         logger.finer("Deleting old attachments...");

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/GetLastSequenceCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/GetLastSequenceCallable.java
@@ -43,6 +43,7 @@ public class GetLastSequenceCallable implements SQLCallable<Long> {
         try {
             cursor = db.rawQuery(sql, null);
             if (cursor.moveToFirst()) {
+                // TODO this will always be an integer or null and we can't be expected to handle other cases
                 if (cursor.columnType(0) == Cursor.FIELD_TYPE_INTEGER) {
                     result = cursor.getLong(0);
                 } else if (cursor.columnType(0) == Cursor.FIELD_TYPE_NULL) {

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/IndexUpdater.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/IndexUpdater.java
@@ -119,7 +119,7 @@ class IndexUpdater {
         } catch (DocumentStoreException e) {
             String message = String.format(Locale.ENGLISH, "Failed to get changes feed from %d", lastSequence);
             logger.log(Level.SEVERE, message, e);
-            throw new QueryException(e.getCause());
+            throw new QueryException(message, e.getCause());
         }
     }
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/QueryExecutor.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/QueryExecutor.java
@@ -15,6 +15,8 @@
 package com.cloudant.sync.internal.query;
 
 import com.cloudant.sync.documentstore.Database;
+import com.cloudant.sync.documentstore.DocumentException;
+import com.cloudant.sync.documentstore.DocumentStoreException;
 import com.cloudant.sync.query.FieldSort;
 import com.cloudant.sync.query.Index;
 import com.cloudant.sync.query.QueryResult;
@@ -204,7 +206,7 @@ class QueryExecutor {
         return fields;
     }
 
-    protected Set<String> executeQueryTree(QueryNode node, SQLDatabase db) {
+    protected Set<String> executeQueryTree(QueryNode node, SQLDatabase db) throws DocumentStoreException {
         if (node instanceof AndQueryNode) {
             Set<String> accumulator = null;
 
@@ -242,7 +244,7 @@ class QueryExecutor {
             return accumulator;
         } else if (node instanceof SqlQueryNode) {
             SqlQueryNode sqlNode = (SqlQueryNode) node;
-            List<String> docIds;
+            List<String> docIds = null;
             if (sqlNode.sql != null) {
                 docIds = new ArrayList<String>();
                 SqlParts sqlParts = sqlNode.sql;

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/QueryResult.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/QueryResult.java
@@ -19,7 +19,7 @@ import com.cloudant.sync.documentstore.Database;
 import com.cloudant.sync.documentstore.DocumentBodyFactory;
 import com.cloudant.sync.documentstore.DocumentException;
 import com.cloudant.sync.documentstore.DocumentRevision;
-import com.cloudant.sync.internal.documentstore.InternalDocumentRevision;
+import com.cloudant.sync.documentstore.DocumentStoreException;
 import com.cloudant.sync.internal.documentstore.DocumentRevisionBuilder;
 import com.cloudant.sync.internal.query.QueryImpl;
 import com.cloudant.sync.internal.query.UnindexedMatcher;
@@ -194,9 +194,9 @@ public class QueryResult implements Iterable<DocumentRevision> {
                     }
                 }
                 return docList.iterator();
-            } catch (DocumentException e) {
+            } catch (DocumentStoreException dse) {
                 // TODO - not sure what the right thing is here
-                throw new NoSuchElementException(e.toString());
+                throw new NoSuchElementException(dse.toString());
             }
         }
     }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/BasicDBCoreObservableTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/BasicDBCoreObservableTest.java
@@ -108,7 +108,7 @@ public class BasicDBCoreObservableTest {
         }
         
         @Subscribe
-        public void onDocumentModified(DocumentModified dm) {
+        public void onDocumentModified(DocumentModified dm) throws Exception {
             this.sequence = core.getLastSequence();            
         }
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatabaseImplChangesTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatabaseImplChangesTest.java
@@ -25,7 +25,7 @@ import com.cloudant.sync.documentstore.DocumentRevision;
 public class DatabaseImplChangesTest extends BasicDatastoreTestBase {
 
     @Test
-    public void changes_noChanges_nothing() {
+    public void changes_noChanges_nothing() throws Exception {
         Changes changes = datastore.changes(0, 100);
         Assert.assertEquals(0, changes.size());
         Assert.assertEquals(0, changes.getResults().size());

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatabaseImplExceptionsTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatabaseImplExceptionsTest.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright © 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
 package com.cloudant.sync.internal.documentstore;
 
 import com.cloudant.sync.documentstore.DocumentBodyFactory;

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatabaseImplExceptionsTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatabaseImplExceptionsTest.java
@@ -1,0 +1,196 @@
+package com.cloudant.sync.internal.documentstore;
+
+import com.cloudant.sync.documentstore.DocumentBodyFactory;
+import com.cloudant.sync.documentstore.DocumentException;
+import com.cloudant.sync.documentstore.DocumentNotFoundException;
+import com.cloudant.sync.documentstore.DocumentRevision;
+import com.cloudant.sync.documentstore.DocumentStoreException;
+import com.cloudant.sync.internal.sqlite.SQLCallable;
+import com.cloudant.sync.internal.sqlite.SQLDatabase;
+import com.cloudant.sync.util.TestUtils;
+
+import org.junit.Test;
+
+import java.sql.SQLException;
+
+/**
+ * Created by tomblench on 23/11/2016.
+ */
+
+
+// tests to check that the correct exceptions get thrown for each public API call eg when the
+// underlying DB has had critical tables dropped
+
+public class DatabaseImplExceptionsTest extends BasicDatastoreTestBase {
+
+    private void dropRevs() {
+        this.datastore.runOnDbQueue(new SQLCallable<Void>() {
+            public Void call(SQLDatabase db) {
+                try {
+                    db.execSQL("DROP TABLE revs;");
+                } catch (SQLException sqe) {
+                    ;
+                }
+                return null;
+            }
+        });
+    }
+
+    // getDocument on non-existent document should throw DocumentNotFoundException
+    @Test(expected = DocumentNotFoundException.class)
+    public void getDocumentShouldThrowDocumentNotFoundException() throws Exception {
+        this.datastore.getDocument("nosuchdocument");
+    }
+
+    // getDocument after we remove the underlying SQL database should throw DocumentStoreException
+    @Test(expected = DocumentStoreException.class)
+    public void getDocumentShouldThrowDocumentStoreException() throws Exception {
+        // remove the underlying database, triggering a SQL Exception
+        dropRevs();
+        this.datastore.getDocument("nosuchdocument");
+    }
+
+    // getDocument on non-existent revid should throw DocumentNotFoundException
+    @Test(expected = DocumentNotFoundException.class)
+    public void getDocumentWithRevisionShouldThrowDocumentNotFoundException() throws Exception {
+        DocumentRevision dr = new DocumentRevision("doc1");
+        dr.setBody(DocumentBodyFactory.create("{\"hello\":\"world\"}".getBytes()));
+        this.datastore.createDocumentFromRevision(dr);
+        this.datastore.getDocument("nosuchdocument", "nosuchrevid");
+    }
+
+    // getDocument after we remove the underlying SQL database should throw DocumentStoreException
+    @Test(expected = DocumentStoreException.class)
+    public void getDocumentWithRevisionShouldThrowDocumentStoreException() throws Exception {
+        // remove the underlying database, triggering a SQL Exception
+        dropRevs();
+        this.datastore.getDocument("nosuchdocument", "nosuchrevid");
+    }
+
+    // containsDocument after we remove the underlying SQL database should throw
+    // DocumentStoreException
+    @Test(expected = DocumentStoreException.class)
+    public void containsDocumentShouldThrowDocumentStoreException() throws Exception {
+        // remove the underlying database, triggering a SQL Exception
+        dropRevs();
+        this.datastore.containsDocument("nosuchdocument");
+    }
+
+    // containsDocument after we remove the underlying SQL database should throw
+    // DocumentStoreException
+    @Test(expected = DocumentStoreException.class)
+    public void containsDocumentWithRevisionShouldThrowDocumentStoreException() throws Exception {
+        // remove the underlying database, triggering a SQL Exception
+        dropRevs();
+        this.datastore.containsDocument("nosuchdocument", "nosuchrevid");
+    }
+
+    // getAllDocuments after we remove the underlying SQL database should throw
+    // DocumentStoreException
+    @Test(expected = DocumentStoreException.class)
+    public void getAllDocumentsShouldThrowDocumentStoreException() throws Exception {
+        // remove the underlying database, triggering a SQL Exception
+        dropRevs();
+        this.datastore.getAllDocuments(0, 100, true);
+    }
+
+    // getAllDocumentIds after we remove the underlying SQL database should throw
+    // DocumentStoreException
+    @Test(expected = DocumentStoreException.class)
+    public void getAllDocumentIdsShouldThrowDocumentStoreException() throws Exception {
+        // remove the underlying database, triggering a SQL Exception
+        dropRevs();
+        this.datastore.getAllDocumentIds();
+    }
+
+    // getLastSequence after we remove the underlying SQL database should throw
+    // DocumentStoreException
+    @Test(expected = DocumentStoreException.class)
+    public void getLastSequenceShouldThrowDocumentStoreException() throws Exception {
+        // remove the underlying database, triggering a SQL Exception
+        dropRevs();
+        this.datastore.getLastSequence();
+    }
+
+    // getDocumentCount after we remove the underlying SQL database should throw
+    // DocumentStoreException
+    @Test(expected = DocumentStoreException.class)
+    public void getDocumentCountShouldThrowDocumentStoreException() throws Exception {
+        // remove the underlying database, triggering a SQL Exception
+        dropRevs();
+        this.datastore.getDocumentCount();
+    }
+
+    // getConflictedDocumentIds after we remove the underlying SQL database should throw
+    // DocumentStoreException
+    @Test(expected = DocumentStoreException.class)
+    public void getConflictedDocumentIdsShouldThrowDocumentStoreException() throws Exception {
+        // remove the underlying database, triggering a SQL Exception
+        dropRevs();
+        this.datastore.getConflictedDocumentIds();
+    }
+
+    // createDocumentFromRevision after we remove the underlying SQL database should throw
+    // DocumentStoreException
+    @Test(expected = DocumentStoreException.class)
+    public void createDocumentFromRevisionShouldThrowDocumentStoreException() throws Exception {
+        // remove the underlying database, triggering a SQL Exception
+        dropRevs();
+        DocumentRevision dr = new DocumentRevision("doc1");
+        dr.setBody(DocumentBodyFactory.create("{\"hello\":\"world\"}".getBytes()));
+        this.datastore.createDocumentFromRevision(dr);
+    }
+
+    // updateDocumentFromRevision after we remove the underlying SQL database should throw
+    // DocumentStoreException
+    @Test(expected = DocumentStoreException.class)
+    public void updateDocumentFromRevisionShouldThrowDocumentStoreException() throws Exception {
+        DocumentRevision dr = new DocumentRevision("doc1");
+        dr.setBody(DocumentBodyFactory.create("{\"hello\":\"world\"}".getBytes()));
+        dr = this.datastore.createDocumentFromRevision(dr);
+        // remove the underlying database, triggering a SQL Exception
+        dropRevs();
+        dr.setBody(DocumentBodyFactory.create("{\"hello\":\"updated\"}".getBytes()));
+        this.datastore.updateDocumentFromRevision(dr);
+    }
+
+    // updateDocumentFromRevision after we remove the underlying SQL database should throw
+    // DocumentStoreException
+    @Test(expected = DocumentStoreException.class)
+    public void deleteDocumentFromRevisionShouldThrowDocumentStoreException() throws Exception {
+        DocumentRevision dr = new DocumentRevision("doc1");
+        dr.setBody(DocumentBodyFactory.create("{\"hello\":\"world\"}".getBytes()));
+        dr = this.datastore.createDocumentFromRevision(dr);
+        // remove the underlying database, triggering a SQL Exception
+        dropRevs();
+        this.datastore.deleteDocumentFromRevision(dr);
+    }
+
+    // updateDocumentFromRevision after we remove the underlying SQL database should throw
+    // DocumentStoreException
+    @Test(expected = DocumentStoreException.class)
+    public void deleteDocumentShouldThrowDocumentStoreException() throws Exception {
+        DocumentRevision dr = new DocumentRevision("doc1");
+        dr.setBody(DocumentBodyFactory.create("{\"hello\":\"world\"}".getBytes()));
+        dr = this.datastore.createDocumentFromRevision(dr);
+        // remove the underlying database, triggering a SQL Exception
+        dropRevs();
+        this.datastore.deleteDocument(dr.getId());
+    }
+
+    @Test(expected = DocumentStoreException.class)
+    public void changesShouldThrowDocumentStoreException() throws Exception {
+        // remove the underlying database, triggering a SQL Exception
+        dropRevs();
+        this.datastore.changes(0, 1000);
+    }
+
+    @Test(expected = DocumentStoreException.class)
+    public void compactShouldThrowDocumentStoreException() throws Exception {
+        // remove the underlying database, triggering a SQL Exception
+        dropRevs();
+        this.datastore.compact();
+    }
+
+
+}

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatabaseImplExceptionsTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatabaseImplExceptionsTest.java
@@ -56,7 +56,7 @@ public class DatabaseImplExceptionsTest extends BasicDatastoreTestBase {
         DocumentRevision dr = new DocumentRevision("doc1");
         dr.setBody(DocumentBodyFactory.create("{\"hello\":\"world\"}".getBytes()));
         this.datastore.createDocumentFromRevision(dr);
-        this.datastore.getDocument("nosuchdocument", "nosuchrevid");
+        this.datastore.getDocument(dr.getId(), "nosuchrevid");
     }
 
     // getDocument after we remove the underlying SQL database should throw DocumentStoreException
@@ -154,7 +154,7 @@ public class DatabaseImplExceptionsTest extends BasicDatastoreTestBase {
         this.datastore.updateDocumentFromRevision(dr);
     }
 
-    // updateDocumentFromRevision after we remove the underlying SQL database should throw
+    // deleteDocumentFromRevision after we remove the underlying SQL database should throw
     // DocumentStoreException
     @Test(expected = DocumentStoreException.class)
     public void deleteDocumentFromRevisionShouldThrowDocumentStoreException() throws Exception {
@@ -166,7 +166,7 @@ public class DatabaseImplExceptionsTest extends BasicDatastoreTestBase {
         this.datastore.deleteDocumentFromRevision(dr);
     }
 
-    // updateDocumentFromRevision after we remove the underlying SQL database should throw
+    // deleteDocumentFromRevision after we remove the underlying SQL database should throw
     // DocumentStoreException
     @Test(expected = DocumentStoreException.class)
     public void deleteDocumentShouldThrowDocumentStoreException() throws Exception {

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatabaseImplExceptionsTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatabaseImplExceptionsTest.java
@@ -180,7 +180,7 @@ public class DatabaseImplExceptionsTest extends BasicDatastoreTestBase {
         this.datastore.deleteDocumentFromRevision(dr);
     }
 
-    // deleteDocumentFromRevision after we remove the underlying SQL database should throw
+    // deleteDocument after we remove the underlying SQL database should throw
     // DocumentStoreException
     @Test(expected = DocumentStoreException.class)
     public void deleteDocumentShouldThrowDocumentStoreException() throws Exception {

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatastoreSchemaTests.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatastoreSchemaTests.java
@@ -18,6 +18,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import com.cloudant.sync.documentstore.DocumentException;
 import com.cloudant.sync.internal.android.ContentValues;
 import com.cloudant.sync.documentstore.Attachment;
 import com.cloudant.sync.documentstore.Database;
@@ -604,7 +605,7 @@ public class DatastoreSchemaTests {
     }
 
     private void assertAttachmentCount(Database database, String docId,
-                                       int expectedAttachmentCount) {
+                                       int expectedAttachmentCount) throws DocumentNotFoundException, DocumentStoreException {
         int actualAttachmentCount = 0;
         Set<String> revIds = ((DatabaseImpl) database).getAllRevisionsOfDocument(docId).
                 leafRevisionIds();
@@ -621,7 +622,7 @@ public class DatastoreSchemaTests {
                 actualAttachmentCount);
     }
 
-    private void assertWinner(Database database, String docId, String expectedRevId) {
+    private void assertWinner(Database database, String docId, String expectedRevId) throws DocumentNotFoundException, DocumentStoreException {
         try {
             String actualRevId = database.getDocument(docId).getRevision();
             Assert.assertEquals("Should get the expected winning revision ID", expectedRevId,

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/MutableDocumentDeleteTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/MutableDocumentDeleteTest.java
@@ -44,7 +44,7 @@ public class MutableDocumentDeleteTest extends BasicDatastoreTestBase {
 
     // Delete a MutableCopy
     @Test
-    public void deleteFromRevision() throws ConflictException {
+    public void deleteFromRevision() throws Exception {
         DocumentRevision deleted = datastore.deleteDocumentFromRevision(saved);
         Assert.assertNotNull("Deleted DocumentRevision is null", deleted);
         Assert.assertTrue("Deleted DocumentRevision is not flagged as deleted", deleted.isDeleted());
@@ -52,7 +52,7 @@ public class MutableDocumentDeleteTest extends BasicDatastoreTestBase {
 
     // Delete null
     @Test
-    public void deleteNullRevision() throws ConflictException {
+    public void deleteNullRevision() throws Exception {
         try {
             DocumentRevision deleted = datastore.deleteDocumentFromRevision(null);
             Assert.fail("NullPointerException expected");

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/MutableDocumentNoInitialAttachmentsTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/MutableDocumentNoInitialAttachmentsTest.java
@@ -18,6 +18,7 @@ import com.cloudant.sync.documentstore.Attachment;
 import com.cloudant.sync.documentstore.AttachmentException;
 import com.cloudant.sync.documentstore.DocumentException;
 import com.cloudant.sync.documentstore.DocumentRevision;
+import com.cloudant.sync.documentstore.DocumentStoreException;
 import com.cloudant.sync.documentstore.UnsavedFileAttachment;
 import com.cloudant.sync.util.TestUtils;
 
@@ -53,12 +54,12 @@ public class MutableDocumentNoInitialAttachmentsTest extends BasicDatastoreTestB
     }
 
     // Update revision with updated body set to null
-    @Test(expected = DocumentException.class)
+    // TODO this probably should become become InvalidDocumentException
+    @Test(expected = DocumentStoreException.class)
     public void updateBodyNull() throws Exception {
         DocumentRevision update = saved;
         update.setBody(null);
         DocumentRevision updated = datastore.updateDocumentFromRevision(update);
-        Assert.fail("Expected NullPointerException");
     }
 
     // Update revision with updated body and new attachment

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/IndexUpdaterTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/IndexUpdaterTest.java
@@ -205,8 +205,8 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
                     rev.setBody(DocumentBodyFactory.create(bodyMap));
                     try {
                         ds.createDocumentFromRevision(rev);
-                    } catch (Exception de) {
-                        fail("Exception thrown when creating revision " + de);
+                    } catch (Exception e) {
+                        fail("Exception thrown when creating revision " + e);
                     }
                     // batch up index updates
                     if (i % nUpdates == nUpdates-1) {

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/IndexUpdaterTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/IndexUpdaterTest.java
@@ -205,7 +205,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
                     rev.setBody(DocumentBodyFactory.create(bodyMap));
                     try {
                         ds.createDocumentFromRevision(rev);
-                    } catch (DocumentException de) {
+                    } catch (Exception de) {
                         fail("Exception thrown when creating revision " + de);
                     }
                     // batch up index updates

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/MockMatcherQueryExecutor.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/MockMatcherQueryExecutor.java
@@ -15,6 +15,7 @@
 package com.cloudant.sync.internal.query;
 
 import com.cloudant.sync.documentstore.Database;
+import com.cloudant.sync.documentstore.DocumentStoreException;
 import com.cloudant.sync.query.Index;
 import com.cloudant.sync.internal.sqlite.SQLDatabase;
 import com.cloudant.sync.internal.sqlite.SQLDatabaseQueue;
@@ -35,11 +36,16 @@ import java.util.Set;
  */
 public class MockMatcherQueryExecutor extends QueryExecutor{
 
-    private final Set<String> docIds;
+    private Set<String> docIds;
 
     MockMatcherQueryExecutor(Database database, SQLDatabaseQueue queue) {
         super(database, queue);
-        docIds = new HashSet<String>(database.getAllDocumentIds());
+        try {
+            docIds = new HashSet<String>(database.getAllDocumentIds());
+        } catch (DocumentStoreException dse) {
+            ;// TODO
+        }
+
     }
 
     // return just a blank node (we don't execute it anyway).

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/UnreliableNetworkPushTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/UnreliableNetworkPushTest.java
@@ -78,7 +78,7 @@ public class UnreliableNetworkPushTest extends ProxyTestBase {
         this.stopProxy();
     }
 
-    private void createLocalDocument(String docid) throws DocumentException {
+    private void createLocalDocument(String docid) throws Exception {
         DocumentRevision mdr = new DocumentRevision(docid);
         Map<String, Object> doc = new HashMap<String, Object>();
         // TODO make a much more complex document


### PR DESCRIPTION
See also #418 #354

_What_: Declare and throw correct exceptions from `Database`. `DocumentStoreException` is the generic exception for underlying issues with the SQL database etc. `DocumentNotFoundException` etc are used to signal specific error conditions.

_Why_: Some methods throw incorrect exception (eg don't throw the underlying cause) or just return `null` under certain error conditions. This PR aims to fix that.

_Testing_: Existing tests pass, added `DatabaseImplExceptionsTest`.

Future PR
- Rename `DocumentStoreException` to be consistent with the class now being called `Database`.
- Update javadoc
- ~~Revisit empty catch blocks~~