### PR TITLE
Add latest flag to _bulk_get calls

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# Unreleased
+- [FIXED] Issue where replicator would not get the latest revision if `_bulk_get`
+   was available.
+
 # 1.1.4 (2016-11-23)
 - [FIXED] Issue performing cookie authentication in version 1.1.3.
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/mazha/CouchClient.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/mazha/CouchClient.java
@@ -445,6 +445,7 @@ public class CouchClient  {
                                                                     boolean pullAttachmentsInline) {
         Map<String, Object> options = new HashMap<String, Object>();
         options.put("revs", true);
+        options.put("latest", true);
 
         if (pullAttachmentsInline) {
             options.put("attachments", true);

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/MissingRevsReplicationTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/MissingRevsReplicationTest.java
@@ -54,7 +54,6 @@ public class MissingRevsReplicationTest extends ReplicationTestBase {
         return s;
     }
 
-    @Ignore //pending resolution of case 79041
     @Test
     public void testReplicationWithMissingRevision() throws Exception {
         // Create doc


### PR DESCRIPTION
Add latest flag to _bulk_get calls to get the latest child revision
from the server instead of just the revision requested and its ancestor

Fixes #421