### PR TITLE
Query throws exceptions on errors

### DIFF
--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/QueryExecutor.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/QueryExecutor.java
@@ -87,8 +87,8 @@ class QueryExecutor {
 
         fields = normaliseFields(fields);
 
-        Misc.checkArgument(validateFields(fields),
-                "One or more fields are not valid: projection field cannot use dotted notation.");
+        // will throw IllegalArgumentException if there are invalid fields
+        validateFields(fields);
 
         // normalise and validate query by passing into the executors
 
@@ -165,20 +165,23 @@ class QueryExecutor {
     /**
      *  Checks if the fields are valid.
      */
-    private boolean validateFields(List<String> fields) {
+    private void validateFields(List<String> fields) {
         if (fields == null) {
-            return true;
+            return;
         }
+        List<String> badFields = new ArrayList<String>();
         for (String field: fields) {
             if (field.contains(".")) {
-                String msg = String.format("Projection field cannot use dotted notation: %s",
-                        field);
-                logger.log(Level.SEVERE, msg);
-                return false;
+                badFields.add(field);
             }
         }
 
-        return true;
+        if (!badFields.isEmpty()) {
+            String msg = String.format("Projection field(s) cannot use dotted notation: %s",
+                    Misc.join(", ", badFields));
+            logger.log(Level.SEVERE, msg);
+            throw new IllegalArgumentException(msg);
+        }
     }
 
     private List<String> normaliseFields(List<String> fields) {

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/QueryExecutor.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/QueryExecutor.java
@@ -87,13 +87,12 @@ class QueryExecutor {
 
         fields = normaliseFields(fields);
 
-        Misc.checkArgument(validateFields(fields), "TODO");
+        Misc.checkArgument(validateFields(fields),
+                "One or more fields are not valid: projection field cannot use dotted notation.");
 
         // normalise and validate query by passing into the executors
 
         query = QueryValidator.normaliseAndValidateQuery(query);
-
-        Misc.checkNotNull(query, "query");
 
         //
         // Execute the query
@@ -134,7 +133,6 @@ class QueryExecutor {
             throw new QueryException(message, e.getCause());
         }
 
-        // TODO null or empty?
         if (docIds == null) {
             return null;
         }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/QueryValidator.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/QueryValidator.java
@@ -498,22 +498,30 @@ class QueryValidator {
                 //  - $in is the only operator that expects a List
                 if (operator.equals(NOT)) {
                     if (!(clauseOperand instanceof Map)) {
-                        throw new QueryException("clauseOperand not instance of Map");
+                        throw new QueryException(String.format(Locale.ENGLISH,
+                                "clauseOperand %s is not an instance of Map",
+                                clauseOperand));
                     }
                     validateClause((Map) clauseOperand);
                 } else if (operator.equals(IN)) {
                     if (!(clauseOperand instanceof List)) {
-                        throw new QueryException("clauseOperand not instance of List");
+                        throw new QueryException(String.format(Locale.ENGLISH,
+                                "clauseOperand %s is not an instance of List",
+                                clauseOperand));
                     }
                     validateInListValues((List<Object>) clauseOperand);
                 } else {
                     validatePredicateValue(clauseOperand, operator);
                 }
             } else {
-                throw new QueryException(String.format(Locale.ENGLISH, "%s not a valid operator", operator));
+                throw new QueryException(String.format(Locale.ENGLISH,
+                        "operator %s is not a valid operator",
+                        operator));
             }
         } else {
-            throw new QueryException("Clause must only have one key");
+            throw new QueryException(String.format(Locale.ENGLISH,
+                    "Clause %s must only have one key",
+                    clause));
         }
 
     }
@@ -604,13 +612,13 @@ class QueryValidator {
 
     private static void validateExistsArgument(Object exists) throws QueryException {
         if (!(exists instanceof Boolean)) {
-            throw new QueryException("$exists operator expects true or false");
+            throw new QueryException("$exists operator requires operand to be true or false");
         }
     }
 
     private static void validateTextSearchArgument(Object textSearch) throws QueryException {
         if (!(textSearch instanceof String)) {
-            throw new QueryException("$search operator expects a String");
+            throw new QueryException("$search operator requires a String operand");
         }
     }
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/QueryValidator.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/QueryValidator.java
@@ -16,10 +16,13 @@ package com.cloudant.sync.internal.query;
 
 import static com.cloudant.sync.internal.query.QueryConstants.*;
 
+import com.cloudant.sync.query.QueryException;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -47,7 +50,7 @@ class QueryValidator {
      *  Expand implicit operators in a query, and validate
      */
     @SuppressWarnings("unchecked")
-    public static Map<String, Object> normaliseAndValidateQuery(Map<String, Object> query) {
+    public static Map<String, Object> normaliseAndValidateQuery(Map<String, Object> query) throws QueryException{
         boolean isWildCard = false;
         if (query.isEmpty()) {
             isWildCard = true;
@@ -98,11 +101,11 @@ class QueryValidator {
 
         Map<String, Object> selector = new HashMap<String, Object>();
         selector.put(compoundOperator, predicates);
-        if (isWildCard || validateSelector(selector)) {
-            return selector;
+        if (!isWildCard) {
+            validateSelector(selector);
         }
 
-        return null;
+        return selector;
     }
 
     private static Map<String, Object> addImplicitAnd(Map<String, Object> query) {
@@ -395,21 +398,19 @@ class QueryValidator {
         return accumulator;
     }
 
-    private static boolean validateCompoundOperatorOperand(Object operand) {
+    private static void validateCompoundOperatorOperand(Object operand) throws QueryException {
         if (!(operand instanceof List)) {
             String msg = String.format("Argument to compound operator is not a List: %s",
                                        operand.toString());
-            logger.log(Level.SEVERE, msg);
-            return false;
+            throw new QueryException(msg);
         }
-        return true;
     }
 
     /**
      *  we are going to need to walk the query tree to validate it before executing it
      */
     @SuppressWarnings("unchecked")
-    private static boolean validateSelector(Map<String, Object> selector) {
+    private static void validateSelector(Map<String, Object> selector) throws QueryException {
         String topLevelOp = (String) selector.keySet().toArray()[0];
 
         // top level op can only be $and or $or after normalisation
@@ -417,12 +418,10 @@ class QueryValidator {
             Object topLevelArg = selector.get(topLevelOp);
             if (topLevelArg instanceof List) {
                 // safe we know its a List
-                return validateCompoundOperatorClauses((List<Object>) topLevelArg,
+                validateCompoundOperatorClauses((List<Object>) topLevelArg,
                                                        new Boolean[]{ false });
             }
         }
-
-        return false;
     }
 
     /**
@@ -436,60 +435,49 @@ class QueryValidator {
      * @return true/false whether the list of clauses passed validation.
      */
     @SuppressWarnings("unchecked")
-    private static boolean validateCompoundOperatorClauses(List<Object> clauses,
-                                                           Boolean[] textClauseLimitReached) {
-        boolean valid = false;
+    private static void validateCompoundOperatorClauses(List<Object> clauses,
+                                                           Boolean[] textClauseLimitReached) throws QueryException {
 
         for (Object obj : clauses) {
-            valid = false;
             if (!(obj instanceof Map)) {
                 String msg = String.format("Operator argument must be a Map %s",
                                            clauses.toString());
-                logger.log(Level.SEVERE, msg);
-                break;
+                throw new QueryException(msg);
             }
             Map<String, Object> clause = (Map<String, Object>) obj;
             if (clause.size() != 1) {
                 String msg;
                 msg = String.format("Operator argument clause should have one key value pair: %s",
                                     clauses.toString());
-                logger.log(Level.SEVERE, msg);
-                break;
+                throw new QueryException(msg);
             }
 
             String key = (String) clause.keySet().toArray()[0];
             if (Arrays.asList(OR, NOT, AND).contains(key)) {
                 // this should have a list as top level type
                 Object compoundClauses = clause.get(key);
-                if (validateCompoundOperatorOperand(compoundClauses)) {
-                    // validate list
-                    valid = validateCompoundOperatorClauses((List<Object>) compoundClauses,
+                validateCompoundOperatorOperand(compoundClauses);
+                // validate list
+                validateCompoundOperatorClauses((List<Object>) compoundClauses,
                                                             textClauseLimitReached);
-                }
             } else if (!(key.startsWith("$"))) {
                 // this should have a map
                 // send this for validation
-                valid = validateClause((Map<String, Object>) clause.get(key));
+                validateClause((Map<String, Object>) clause.get(key));
             } else if (key.equalsIgnoreCase(TEXT)) {
                 // this should have a map
                 // send this for validation
-                valid = validateTextClause(clause.get(key), textClauseLimitReached);
+                validateTextClause(clause.get(key), textClauseLimitReached);
             } else {
                 String msg = String.format("%s operator cannot be a top level operator", key);
-                logger.log(Level.SEVERE, msg);
-                break;
+                throw new QueryException(msg);
             }
 
-            if (!valid) {
-                break;  // if we have gotten here with valid being false, we should abort
-            }
         }
-
-        return valid;
     }
 
     @SuppressWarnings("unchecked")
-    private static boolean validateClause(Map<String, Object> clause) {
+    private static void validateClause(Map<String, Object> clause) throws QueryException {
         List<String> validOperators = Arrays.asList(EQ,
                                                     LT,
                                                     GT,
@@ -509,17 +497,25 @@ class QueryValidator {
                 //  - $not is the only operator that expects a Map
                 //  - $in is the only operator that expects a List
                 if (operator.equals(NOT)) {
-                    return clauseOperand instanceof Map && validateClause((Map) clauseOperand);
+                    if (!(clauseOperand instanceof Map)) {
+                        throw new QueryException("clauseOperand not instance of Map");
+                    }
+                    validateClause((Map) clauseOperand);
                 } else if (operator.equals(IN)) {
-                    return clauseOperand instanceof List &&
-                           validateInListValues((List<Object>) clauseOperand);
+                    if (!(clauseOperand instanceof List)) {
+                        throw new QueryException("clauseOperand not instance of List");
+                    }
+                    validateInListValues((List<Object>) clauseOperand);
                 } else {
-                    return validatePredicateValue(clauseOperand, operator);
+                    validatePredicateValue(clauseOperand, operator);
                 }
+            } else {
+                throw new QueryException(String.format(Locale.ENGLISH, "%s not a valid operator", operator));
             }
+        } else {
+            throw new QueryException("Clause must only have one key");
         }
 
-        return false;
     }
 
     /**
@@ -534,70 +530,62 @@ class QueryValidator {
      * @return true/false whether the clause is valid
      */
     @SuppressWarnings("unchecked")
-    private static boolean validateTextClause(Object clause,
-                                              Boolean[] textClauseLimitReached) {
+    private static void validateTextClause(Object clause,
+                                              Boolean[] textClauseLimitReached) throws QueryException {
         Map<String, Object> textClause;
         if (!(clause instanceof Map)) {
             String msg = String.format("Text search expects a Map, found %s instead.", clause);
-            logger.log(Level.SEVERE, msg);
-            return false;
+            throw new QueryException(msg);
         }
 
         textClause = (Map<String, Object>) clause;
         if (textClause.size() != 1) {
             String msg = String.format("Unexpected content %s in text search.", textClause);
-            logger.log(Level.SEVERE, msg);
-            return false;
+            throw new QueryException(msg);
         }
 
         String operator = (String) textClause.keySet().toArray()[0];
         if (!operator.equals(SEARCH)) {
             String msg = String.format("Invalid operator %s in text search", operator);
-            logger.log(Level.SEVERE, msg);
-            return false;
+            throw new QueryException(msg);
         }
 
 
         if (textClauseLimitReached[0]) {
-            logger.log(Level.SEVERE, "Multiple text search clauses not allowed in a query.  " +
-                                     "Rewrite query to contain at most one text search clause.");
-            return false;
+            String msg = "Multiple text search clauses not allowed in a query.  " +
+                                     "Rewrite query to contain at most one text search clause.";
+            throw new QueryException(msg);
         }
 
         textClauseLimitReached[0] = true;
-        return validatePredicateValue(textClause.get(operator), operator);
+        validatePredicateValue(textClause.get(operator), operator);
     }
 
-    private static boolean validateInListValues(List<Object> inListValues) {
-        boolean valid = true;
-
+    private static void validateInListValues(List<Object> inListValues) throws QueryException {
         for (Object value : inListValues) {
-            if (!validatePredicateValue(value, IN)) {
-                valid = false;
-                break;
+            validatePredicateValue(value, IN);
+        }
+    }
+
+    private static void validatePredicateValue(Object predicateValue, String operator) throws QueryException {
+        if (operator.equals(EXISTS)) {
+             validateExistsArgument(predicateValue);
+        } else if (operator.equals(SEARCH)) {
+             validateTextSearchArgument(predicateValue);
+        } else if (operator.equals(MOD)) {
+             validateModArgument(predicateValue);
+        } else {
+            validateNotAFloat(predicateValue);
+            // if we got here, the value needs to be one of these:
+            if (!(predicateValue instanceof String || predicateValue instanceof Number || predicateValue instanceof Boolean)) {
+
+                throw new QueryException(String.format(Locale.ENGLISH, "Predicate value %s was not a String, Number, or Boolean", predicateValue));
             }
         }
 
-        return valid;
     }
 
-    private static boolean validatePredicateValue(Object predicateValue, String operator) {
-        if (operator.equals(EXISTS)) {
-            return validateExistsArgument(predicateValue);
-        } else if (operator.equals(SEARCH)) {
-            return validateTextSearchArgument(predicateValue);
-        } else if (operator.equals(MOD)) {
-            return validateModArgument(predicateValue);
-        } else if (validateNotAFloat(predicateValue)) {
-            return (predicateValue instanceof String || predicateValue instanceof Number || predicateValue instanceof Boolean);
-        }
-
-        return false;
-    }
-
-    private static boolean validateModArgument(Object modulus) {
-        boolean valid = true;
-
+    private static void validateModArgument(Object modulus) throws QueryException {
         // The argument must be a list containing two number elements.  The two elements
         // a.k.a the divisor and remainder, are treated as integers by the query engine.
         // The divisor, however, cannot be 0, since division by 0 is not a valid
@@ -607,46 +595,29 @@ class QueryValidator {
             !(((List)modulus).get(0) instanceof Number) ||
             !(((List)modulus).get(1) instanceof Number) ||
             ((Number)(((List)modulus).get(0))).intValue() == 0) {
-            valid = false;
-            logger.log(Level.SEVERE, "$mod operator requires a two element List containing " +
+            throw new QueryException("$mod operator requires a two element List containing " +
                                      "numbers where the first number, the divisor, is not zero.  " +
                                      "As in: { \"$mod\" : [ 2, 1 ] }.  Where 2 is the divisor " +
                                      "and 1 is the remainder.");
         }
-        return valid;
     }
 
-    private static boolean validateExistsArgument(Object exists) {
-        boolean valid = true;
-
+    private static void validateExistsArgument(Object exists) throws QueryException {
         if (!(exists instanceof Boolean)) {
-            valid = false;
-            logger.log(Level.SEVERE, "$exists operator expects true or false");
+            throw new QueryException("$exists operator expects true or false");
         }
-
-        return valid;
     }
 
-    private static boolean validateTextSearchArgument(Object textSearch) {
-        boolean valid = true;
-
+    private static void validateTextSearchArgument(Object textSearch) throws QueryException {
         if (!(textSearch instanceof String)) {
-            valid = false;
-            logger.log(Level.SEVERE, "$search operator expects a String");
+            throw new QueryException("$search operator expects a String");
         }
-
-        return valid;
     }
 
-    private static boolean validateNotAFloat(Object value) {
-        boolean valid = true;
-
+    private static void validateNotAFloat(Object value) throws QueryException {
         if (value instanceof Float) {
-            valid = false;
-            logger.log(Level.SEVERE, "Float value found in query: %f - Use Double instead.", value);
+            throw new QueryException(String.format(Locale.ENGLISH, "Float value found in query: %f - Use Double instead.", value));
         }
-
-        return valid;
     }
 
 }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/IndexTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/IndexTest.java
@@ -61,13 +61,14 @@ public class IndexTest {
         assertThat(index.tokenize, is("simple"));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void returnsNullWhenNoFields() {
-        Index index = new Index(null, indexName);
-        assertThat(index, is(nullValue()));
+        Index index = new Index(new ArrayList<FieldSort>(), indexName);
+    }
 
-        index = new Index(new ArrayList<FieldSort>(), indexName);
-        assertThat(index, is(nullValue()));
+    @Test(expected = NullPointerException.class)
+    public void returnsNullWhenNullFields() {
+        Index index = new Index(null, indexName);
     }
 
     @Test

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/QueryCoveringIndexesTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/QueryCoveringIndexesTest.java
@@ -27,6 +27,7 @@ import com.cloudant.sync.documentstore.DocumentBodyFactory;
 import com.cloudant.sync.documentstore.DocumentRevision;
 import com.cloudant.sync.query.FieldSort;
 import com.cloudant.sync.query.Query;
+import com.cloudant.sync.query.QueryException;
 import com.cloudant.sync.query.QueryResult;
 import com.cloudant.sync.util.SQLDatabaseTestUtils;
 import com.cloudant.sync.util.TestUtils;
@@ -106,7 +107,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         idxMgr.find(null);
     }
 
-    @Test
+    @Test(expected = QueryException.class)
     // Since Floats are not allowed, the query is rejected when a Float is encountered as a value.
     public void returnsNullWhenQueryContainsInvalidValue() throws Exception {
         setUpBasicQueryData();
@@ -118,7 +119,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         Map<String, Object> ageOperator = new HashMap<String, Object>();
         ageOperator.put("$eq", 12.0f);
         query.put("age", ageOperator);
-        assertThat(idxMgr.find(query), is(nullValue()));
+        idxMgr.find(query);
     }
 
     @Test
@@ -326,7 +327,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         assertThat(queryResult.size(), is(0));
     }
 
-    @Test
+    @Test(expected = QueryException.class)
     public void failsWhenUsingUnsupportedOperator() throws Exception {
         setUpBasicQueryData();
         // query - { "age" : { "$blah" : 12 } }
@@ -334,8 +335,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         operator.put("$blah", 12);
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("age", operator);
-        QueryResult queryResult = idxMgr.find(query);
-        assertThat(queryResult, is(nullValue()));
+        idxMgr.find(query);
     }
 
     @Test
@@ -1395,7 +1395,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         assertThat(queryResult.documentIds(), containsInAnyOrder("fred34", "fred12", "john44"));
     }
 
-    @Test
+    @Test(expected = QueryException.class)
     public void returnsNullWhenUsingArrayInQuery() throws Exception {
         setUpArrayIndexingData();
         // query - { "pet" : { "$not" : { "$eq" : [ "dog" ] } } }
@@ -1405,8 +1405,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         notDog.put("$not", eqDog);
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("pet", notDog);
-        QueryResult queryResult = idxMgr.find(query);
-        assertThat(queryResult, is(nullValue()));
+        idxMgr.find(query);
     }
 
     // When querying using $exists operator
@@ -1602,7 +1601,6 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         assertThat(queryResult.documentIds(), containsInAnyOrder("mike31"));
     }
 
-    @Test
     public void returnsEmptyResultSetWhenMODAppliedToNonNumericField() throws Exception {
         setUpNumericOperationsQueryData();
         // query - { "name": { "$mod": [ 10, 1 ] } }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/QueryFilterFieldsTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/QueryFilterFieldsTest.java
@@ -92,17 +92,16 @@ public class QueryFilterFieldsTest extends AbstractQueryTestBase {
         }
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void returnsNullWhenUsingDottedNotation() throws QueryException {
         // query - { "name" : "mike" }
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", "mike");
-        QueryResult queryResult = im.find(query,
+        im.find(query,
                                           0,
                                           Long.MAX_VALUE,
                                           Arrays.asList("name.blah"),
                                           null);
-        assertThat(queryResult, is(nullValue()));
     }
 
     @Test

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/QuerySortTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/QuerySortTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.Matchers.nullValue;
 import com.cloudant.sync.query.FieldSort;
 import com.cloudant.sync.query.Index;
 import com.cloudant.sync.query.IndexType;
+import com.cloudant.sync.query.QueryException;
 import com.cloudant.sync.query.QueryResult;
 import com.cloudant.sync.util.SQLDatabaseTestUtils;
 import com.cloudant.sync.util.TestUtils;
@@ -98,7 +99,7 @@ public class QuerySortTest extends AbstractQueryTestBase {
     }
 
     // TODO check test can be deleted - i think it relates to the way the sort document is built up which is no longer relevant
-//    @Test
+    //@Test
     public void returnsNullWhenTooManyClauses() throws Exception{
         setUpSortingQueryData();
         Map<String, Object> query = new HashMap<String, Object>();
@@ -111,7 +112,7 @@ public class QuerySortTest extends AbstractQueryTestBase {
     // When generating ordering SQL
 
     @Test
-    public void smallDocSetForSingleFieldUsingAsc() {
+    public void smallDocSetForSingleFieldUsingAsc() throws QueryException {
         List<FieldSort> order = Arrays.<FieldSort>asList(new FieldSort("name", FieldSort.Direction.ASCENDING));
         SqlParts parts = sqlToSortIds(smallDocIdSet, order, indexes);
         String select = "SELECT DISTINCT _id FROM _t_cloudant_sync_query_index_a";
@@ -123,7 +124,7 @@ public class QuerySortTest extends AbstractQueryTestBase {
     }
 
     @Test
-    public void smallDocSetForSingleFieldUsingDesc() {
+    public void smallDocSetForSingleFieldUsingDesc() throws QueryException {
         List<FieldSort> order = Arrays.<FieldSort>asList(new FieldSort("y", FieldSort.Direction.DESCENDING));
         SqlParts parts = sqlToSortIds(smallDocIdSet, order, indexes);
         String select = "SELECT DISTINCT _id FROM _t_cloudant_sync_query_index_b";
@@ -135,7 +136,7 @@ public class QuerySortTest extends AbstractQueryTestBase {
     }
 
     @Test
-    public void smallDocSetForMultipleFieldUsingAsc() {
+    public void smallDocSetForMultipleFieldUsingAsc() throws QueryException {
         List<FieldSort> order = Arrays.<FieldSort>asList(new FieldSort("y", FieldSort.Direction.ASCENDING), new FieldSort("x", FieldSort.Direction.ASCENDING));
         SqlParts parts = sqlToSortIds(smallDocIdSet, order, indexes);
         String select = "SELECT DISTINCT _id FROM _t_cloudant_sync_query_index_b";
@@ -147,7 +148,7 @@ public class QuerySortTest extends AbstractQueryTestBase {
     }
 
     @Test
-    public void smallDocSetForMultipleFieldUsingDesc() {
+    public void smallDocSetForMultipleFieldUsingDesc() throws QueryException {
         List<FieldSort> order = Arrays.<FieldSort>asList(new FieldSort("y", FieldSort.Direction.DESCENDING), new FieldSort("x", FieldSort.Direction.DESCENDING));
         SqlParts parts = sqlToSortIds(smallDocIdSet, order, indexes);
         String select = "SELECT DISTINCT _id FROM _t_cloudant_sync_query_index_b";
@@ -159,7 +160,7 @@ public class QuerySortTest extends AbstractQueryTestBase {
     }
 
     @Test
-    public void smallDocSetForMultipleFieldUsingMixed() {
+    public void smallDocSetForMultipleFieldUsingMixed() throws QueryException {
         List<FieldSort> order = Arrays.<FieldSort>asList(new FieldSort("y", FieldSort.Direction.DESCENDING), new FieldSort("x", FieldSort.Direction.ASCENDING));
         SqlParts parts = sqlToSortIds(smallDocIdSet, order, indexes);
         String select = "SELECT DISTINCT _id FROM _t_cloudant_sync_query_index_b";
@@ -171,7 +172,7 @@ public class QuerySortTest extends AbstractQueryTestBase {
     }
 
     @Test
-    public void largeDocSetForSingleFieldUsingAsc() {
+    public void largeDocSetForSingleFieldUsingAsc() throws QueryException {
         List<FieldSort> order = Arrays.<FieldSort>asList(new FieldSort("name", FieldSort.Direction.ASCENDING));
         SqlParts parts = sqlToSortIds(largeDocIdSet, order, indexes);
         String select = "SELECT DISTINCT _id FROM _t_cloudant_sync_query_index_a";
@@ -182,7 +183,7 @@ public class QuerySortTest extends AbstractQueryTestBase {
     }
 
     @Test
-    public void largeDocSetForSingleFieldUsingDesc() {
+    public void largeDocSetForSingleFieldUsingDesc() throws QueryException {
         List<FieldSort> order = Arrays.<FieldSort>asList(new FieldSort("y", FieldSort.Direction.DESCENDING));
         SqlParts parts = sqlToSortIds(largeDocIdSet, order, indexes);
         String select = "SELECT DISTINCT _id FROM _t_cloudant_sync_query_index_b";
@@ -193,7 +194,7 @@ public class QuerySortTest extends AbstractQueryTestBase {
     }
 
     @Test
-    public void largeDocSetForMultipleFieldUsingAsc() {
+    public void largeDocSetForMultipleFieldUsingAsc() throws QueryException {
         List<FieldSort> order = Arrays.<FieldSort>asList(new FieldSort("y", FieldSort.Direction.ASCENDING), new FieldSort("x", FieldSort.Direction.ASCENDING));
         SqlParts parts = sqlToSortIds(largeDocIdSet, order, indexes);
         String select = "SELECT DISTINCT _id FROM _t_cloudant_sync_query_index_b";
@@ -204,7 +205,7 @@ public class QuerySortTest extends AbstractQueryTestBase {
     }
 
     @Test
-    public void largeDocSetForMultipleFieldUsingDesc() {
+    public void largeDocSetForMultipleFieldUsingDesc() throws QueryException {
         List<FieldSort> order = Arrays.<FieldSort>asList(new FieldSort("y", FieldSort.Direction.DESCENDING), new FieldSort("x", FieldSort.Direction.DESCENDING));
         SqlParts parts = sqlToSortIds(largeDocIdSet, order, indexes);
         String select = "SELECT DISTINCT _id FROM _t_cloudant_sync_query_index_b";
@@ -215,7 +216,7 @@ public class QuerySortTest extends AbstractQueryTestBase {
     }
 
     @Test
-    public void largeDocSetForMultipleFieldUsingMixed() {
+    public void largeDocSetForMultipleFieldUsingMixed() throws QueryException {
         List<FieldSort> order = Arrays.<FieldSort>asList(new FieldSort("y", FieldSort.Direction.DESCENDING), new FieldSort("x", FieldSort.Direction.ASCENDING));
         SqlParts parts = sqlToSortIds(largeDocIdSet, order, indexes);
         String select = "SELECT DISTINCT _id FROM _t_cloudant_sync_query_index_b";
@@ -225,24 +226,29 @@ public class QuerySortTest extends AbstractQueryTestBase {
         assertThat(parts.placeHolderValues, is(new String[]{}));
     }
 
-    @Test
-    public void failsWhenUsingUnindexedField() {
+    @Test(expected = QueryException.class)
+    public void failsWhenUsingUnindexedField() throws QueryException {
         List<FieldSort> order = Arrays.<FieldSort>asList(new FieldSort("apples", FieldSort.Direction.ASCENDING));
-        assertThat(sqlToSortIds(smallDocIdSet, order, indexes), is(nullValue()));
+        sqlToSortIds(smallDocIdSet, order, indexes);
     }
 
-    @Test
-    public void failsWhenFieldsNotInSingleIndex() {
+    @Test(expected = QueryException.class)
+    public void failsWhenFieldsNotInSingleIndex() throws QueryException {
         List<FieldSort> order = Arrays.<FieldSort>asList(new FieldSort("x", FieldSort.Direction.ASCENDING), new FieldSort("age", FieldSort.Direction.ASCENDING));
-        assertThat(sqlToSortIds(smallDocIdSet, order, indexes), is(nullValue()));
+        sqlToSortIds(smallDocIdSet, order, indexes);
     }
 
-    @Test
-    public void returnsNullWhenNoIndexes() {
+    @Test(expected = QueryException.class)
+    public void returnsNullWhenNoIndexes() throws QueryException {
         List<FieldSort> order = Arrays.<FieldSort>asList(new FieldSort("y", FieldSort.Direction.DESCENDING));
-        assertThat(sqlToSortIds(smallDocIdSet, order, new ArrayList<Index>()),
-                is(nullValue()));
-        assertThat(sqlToSortIds(smallDocIdSet, order, null), is(nullValue()));
+        sqlToSortIds(smallDocIdSet, order, new ArrayList<Index>());
     }
+
+    @Test(expected = QueryException.class)
+    public void returnsNullWhenNullIndexes() throws QueryException {
+        List<FieldSort> order = Arrays.<FieldSort>asList(new FieldSort("y", FieldSort.Direction.DESCENDING));
+        sqlToSortIds(smallDocIdSet, order, null);
+    }
+
 
 }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/QuerySqlTranslatorTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/QuerySqlTranslatorTest.java
@@ -64,7 +64,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
     // When creating a tree
 
     @Test
-    public void copesWhenNoMatchingIndex() {
+    public void copesWhenNoMatchingIndex() throws QueryException {
         // query - { "firstname" : "mike" }
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("firstname", "mike");
@@ -85,7 +85,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void copesWithSingleFieldQuery() {
+    public void copesWithSingleFieldQuery() throws QueryException {
         // query - { "name" : "mike" }
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", "mike");
@@ -106,7 +106,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void copesWithSingleLevelANDedQuery() {
+    public void copesWithSingleLevelANDedQuery() throws QueryException {
         // query - { "name" : "mike", "pet" : "cat" }
         Map<String, Object> query = new LinkedHashMap<String, Object>();
         query.put("name", "mike");
@@ -128,7 +128,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void copesWithLongHandSingleLevelANDedQuery() {
+    public void copesWithLongHandSingleLevelANDedQuery() throws QueryException {
         // query - { "$and" : [ { "name" : "mike" }, { "pet" : "cat" } ] }
         Map<String, Object> nameMap = new HashMap<String, Object>();
         nameMap.put("name", "mike");
@@ -154,7 +154,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void copesWithLongHandTwoLevelANDedQuery() {
+    public void copesWithLongHandTwoLevelANDedQuery() throws QueryException {
         // query - { "$and" : [ { "name" : "mike" },
         //                      { "pet" : "cat" },
         //                      { "$and" : [ { "name" : "mike" }, { "pet" : "cat" } ] } ] }
@@ -198,7 +198,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void ordersANDNodesLastInTrees() {
+    public void ordersANDNodesLastInTrees() throws QueryException {
         // query - { "$and" : [ { "$and" : [ { "name" : "mike" }, { "pet" : "cat" } ] },
         //                      { "name" : "mike" },
         //                      { "pet" : "cat" } ] }
@@ -242,7 +242,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void supportsOR() {
+    public void supportsOR() throws QueryException {
         // query - { "$or" : [ { "name" : "mike" }, { "pet" : "cat" } ] }
         Map<String, Object> nameMap = new HashMap<String, Object>();
         nameMap.put("name", "mike");
@@ -279,7 +279,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void supportsORInSubTrees() {
+    public void supportsORInSubTrees() throws QueryException {
         // query - { "$or" : [ { "name" : "mike" },
         //                      { "pet" : "cat" },
         //                      { "$or" : [ { "name" : "mike" }, { "pet" : "cat" } ] } ] }
@@ -334,7 +334,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void supportsANDAndORInSubTreesTwoLevel() {
+    public void supportsANDAndORInSubTreesTwoLevel() throws QueryException {
         // query - { "$or" : [ { "name" : "mike" },
         //                      { "pet" : "cat" },
         //                      { "$or" : [ { "name" : "mike" }, { "pet" : "cat" } ] },
@@ -401,7 +401,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void supportsANDAndORInSubTreesThreeLevel() {
+    public void supportsANDAndORInSubTreesThreeLevel() throws QueryException {
         // query - { "$or" : [ { "name" : "mike" },
         //                      { "pet" : "cat" },
         //                      { "$or" : [ { "name" : "mike" },
@@ -477,8 +477,10 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
 
     // When selecting an index to use
 
+    // NB returns null and doesn't throw exception:
+    // "No single index contains all of ... add index for these fields to query efficiently."
     @Test
-    public void indexSelectionFailsWhenNoIndexes() {
+    public void indexSelectionFailsWhenNoIndexes() throws QueryException {
         Map<String, Object> eq = new HashMap<String, Object>();
         eq.put("$eq", "mike");
         Map<String, Object> name = new HashMap<String, Object>();
@@ -487,8 +489,11 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
                    is(nullValue()));
     }
 
+    // NB returns null and doesn't throw exception:
+    // "No single index contains all of ... add index for these fields to query efficiently."
+    // TODO is this correct because it is just a projection?
     @Test
-    public void indexSelectionFailsWhenNoQueryKeys() {
+    public void indexSelectionFailsWhenNoQueryKeys() throws QueryException {
         Index index = new Index(Arrays.<FieldSort>asList(new FieldSort("name"),
                 new FieldSort("age"),
                 new FieldSort("pet")),
@@ -500,7 +505,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void selectsIndexForSingleFieldQuery() {
+    public void selectsIndexForSingleFieldQuery() throws QueryException {
         Index index = new Index(Arrays.<FieldSort>asList(new FieldSort("name")),
                 "named",
                 IndexType.JSON);
@@ -515,7 +520,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void selectsIndexForMultiFieldQuery() {
+    public void selectsIndexForMultiFieldQuery() throws QueryException {
         Index index = new Index(Arrays.<FieldSort>asList(new FieldSort("name"),
                 new FieldSort("age"),
                 new FieldSort("pet")),
@@ -533,7 +538,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void selectsIndexFromMultipleIndexesForMultiFieldQuery() {
+    public void selectsIndexFromMultipleIndexesForMultiFieldQuery() throws QueryException {
         Index index0 = new Index(Arrays.<FieldSort>asList(new FieldSort("name"),
                 new FieldSort("age"),
                 new FieldSort("pet")),
@@ -560,7 +565,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void selectsCorrectIndexWhenSeveralMatch() {
+    public void selectsCorrectIndexWhenSeveralMatch() throws QueryException {
         Index index0 = new Index(Arrays.<FieldSort>asList(new FieldSort("name"),
                 new FieldSort("age"),
                 new FieldSort("pet")),
@@ -588,7 +593,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void nullWhenNoSuitableIndexAvailable() {
+    public void nullWhenNoSuitableIndexAvailable() throws QueryException {
         Index index0 = new Index(Arrays.<FieldSort>asList(new FieldSort("name"),
                 new FieldSort("age")),
                 "named",
@@ -608,16 +613,20 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
 
     // When generating query WHERE clauses
 
-    @Test
-    public void nullWhereClauseWhenQueryEmpty() {
-        assertThat(QuerySqlTranslator.whereSqlForAndClause(null, indexName), is(nullValue()));
-        SqlParts where = QuerySqlTranslator.whereSqlForAndClause(new ArrayList<Object>(),
+    @Test(expected = IllegalArgumentException.class)
+    public void nullWhereClauseWhenQueryEmpty() throws QueryException {
+        QuerySqlTranslator.whereSqlForAndClause(new ArrayList<Object>(),
                                                                  indexName);
-                assertThat(where, is(nullValue()));
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void nullWhereClauseWhenQueryNull() throws QueryException {
+        QuerySqlTranslator.whereSqlForAndClause(null, indexName);
+    }
+
+
     @Test
-    public void validWhereClauseForSingleTermEQ() {
+    public void validWhereClauseForSingleTermEQ() throws QueryException {
         Map<String, Object> eq = new HashMap<String, Object>();
         eq.put("$eq", "mike");
         Map<String, Object> name = new HashMap<String, Object>();
@@ -629,7 +638,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void validWhereClauseForMultiTermEQ() {
+    public void validWhereClauseForMultiTermEQ() throws QueryException {
         Map<String, Object> nameEq = new HashMap<String, Object>();
         nameEq.put("$eq", "mike");
         Map<String, Object> name = new HashMap<String, Object>();
@@ -653,7 +662,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void usesCorrectSQLOperatorWhenUsingGT() {
+    public void usesCorrectSQLOperatorWhenUsingGT() throws QueryException {
         Map<String, Object> op = new HashMap<String, Object>();
         op.put("$gt", "mike");
         Map<String, Object> name = new HashMap<String, Object>();
@@ -667,7 +676,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void usesCorrectSQLOperatorWhenUsingGTE() {
+    public void usesCorrectSQLOperatorWhenUsingGTE() throws QueryException {
         Map<String, Object> op = new HashMap<String, Object>();
         op.put("$gte", "mike");
         Map<String, Object> name = new HashMap<String, Object>();
@@ -681,7 +690,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void usesCorrectSQLOperatorWhenUsingLT() {
+    public void usesCorrectSQLOperatorWhenUsingLT() throws QueryException {
         Map<String, Object> op = new HashMap<String, Object>();
         op.put("$lt", "mike");
         Map<String, Object> name = new HashMap<String, Object>();
@@ -695,7 +704,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void usesCorrectSQLOperatorWhenUsingLTE() {
+    public void usesCorrectSQLOperatorWhenUsingLTE() throws QueryException {
         Map<String, Object> op = new HashMap<String, Object>();
         op.put("$lte", "mike");
         Map<String, Object> name = new HashMap<String, Object>();
@@ -709,7 +718,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void usesCorrectSQLOperatorForEXISTSTrue() {
+    public void usesCorrectSQLOperatorForEXISTSTrue() throws QueryException {
         Map<String, Object> op = new HashMap<String, Object>();
         op.put("$exists", true);
         Map<String, Object> name = new HashMap<String, Object>();
@@ -722,7 +731,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void usesCorrectSQLOperatorForEXISTSFalse() {
+    public void usesCorrectSQLOperatorForEXISTSFalse() throws QueryException {
         Map<String, Object> op = new HashMap<String, Object>();
         op.put("$exists", false);
         Map<String, Object> name = new HashMap<String, Object>();
@@ -735,7 +744,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void usesCorrectSQLOperatorForNOTEXISTSFalse() {
+    public void usesCorrectSQLOperatorForNOTEXISTSFalse() throws QueryException {
         Map<String, Object> op = new HashMap<String, Object>();
         op.put("$exists", false);
         Map<String, Object> notOp = new HashMap<String, Object>();
@@ -750,7 +759,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void usesCorrectSQLOperatorForNOTEXISTSTrue() {
+    public void usesCorrectSQLOperatorForNOTEXISTSTrue() throws QueryException {
         Map<String, Object> op = new HashMap<String, Object>();
         op.put("$exists", true);
         Map<String, Object> notOp = new HashMap<String, Object>();
@@ -765,7 +774,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void constructsValidWhereClauseForINUsingSingleElement() {
+    public void constructsValidWhereClauseForINUsingSingleElement() throws QueryException {
         Map<String, Object> op = new HashMap<String, Object>();
         op.put("$in", Arrays.<Object>asList("mike"));
         Map<String, Object> name = new HashMap<String, Object>();
@@ -779,7 +788,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void constructsValidWhereClauseForINUsingMultipleElements() {
+    public void constructsValidWhereClauseForINUsingMultipleElements() throws QueryException {
         Map<String, Object> op = new HashMap<String, Object>();
         op.put("$in", Arrays.<Object>asList("mike", "fred"));
         Map<String, Object> name = new HashMap<String, Object>();
@@ -793,7 +802,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void usesCorrectSQLOperatorsWhenUsingMOD() {
+    public void usesCorrectSQLOperatorsWhenUsingMOD() throws QueryException {
         Map<String, Object> op = new HashMap<String, Object>();
         op.put("$mod", Arrays.<Object>asList(2, 1));
         Map<String, Object> age = new HashMap<String, Object>();
@@ -810,7 +819,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
     // When generating query WHERE clauses with $not
 
     @Test
-    public void validWhereNOTClauseForSingleTermEQ() {
+    public void validWhereNOTClauseForSingleTermEQ() throws QueryException {
         Map<String, Object> eq = new HashMap<String, Object>();
         eq.put("$eq", "mike");
         Map<String, Object> not = new HashMap<String, Object>();
@@ -826,7 +835,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void validWhereNOTClauseForMultiTermEQ() {
+    public void validWhereNOTClauseForMultiTermEQ() throws QueryException {
         Map<String, Object> eq = new HashMap<String, Object>();
         eq.put("$eq", "mike");
         Map<String, Object> not = new HashMap<String, Object>();
@@ -861,7 +870,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void usesCorrectSQLOperatorWhenUsingNOTGT() {
+    public void usesCorrectSQLOperatorWhenUsingNOTGT() throws QueryException {
         Map<String, Object> op = new HashMap<String, Object>();
         op.put("$gt", "mike");
         Map<String, Object> not = new HashMap<String, Object>();
@@ -878,7 +887,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void usesCorrectSQLOperatorWhenUsingNOTGTE() {
+    public void usesCorrectSQLOperatorWhenUsingNOTGTE() throws QueryException {
         Map<String, Object> op = new HashMap<String, Object>();
         op.put("$gte", "mike");
         Map<String, Object> not = new HashMap<String, Object>();
@@ -895,7 +904,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void usesCorrectSQLOperatorWhenUsingNOTLT() {
+    public void usesCorrectSQLOperatorWhenUsingNOTLT() throws QueryException {
         Map<String, Object> op = new HashMap<String, Object>();
         op.put("$lt", "mike");
         Map<String, Object> not = new HashMap<String, Object>();
@@ -912,7 +921,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void usesCorrectSQLOperatorWhenUsingNOTLTE() {
+    public void usesCorrectSQLOperatorWhenUsingNOTLTE() throws QueryException {
         Map<String, Object> op = new HashMap<String, Object>();
         op.put("$lte", "mike");
         Map<String, Object> not = new HashMap<String, Object>();
@@ -929,7 +938,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void constructsValidWhereClauseForNOTIN() {
+    public void constructsValidWhereClauseForNOTIN() throws QueryException {
         Map<String, Object> op = new HashMap<String, Object>();
         op.put("$in", Arrays.<Object>asList("mike", "fred"));
         Map<String, Object> notOp = new HashMap<String, Object>();
@@ -947,7 +956,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void returnsCorrectWhenTwoConditionsOneField() {
+    public void returnsCorrectWhenTwoConditionsOneField() throws QueryException {
         Map<String, Object> c1op = new HashMap<String, Object>();
         c1op.put("$eq", "mike");
         Map<String, Object> c1not = new HashMap<String, Object>();
@@ -970,7 +979,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void returnsCorrectWhenMultiConditionsMultiFields() {
+    public void returnsCorrectWhenMultiConditionsMultiFields() throws QueryException {
         Map<String, Object> c1op = new HashMap<String, Object>();
         c1op.put("$gt", 12);
         Map<String, Object> c1 = new HashMap<String, Object>();
@@ -1013,7 +1022,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void usesCorrectSQLOperatorsWhenUsingNOTMOD() {
+    public void usesCorrectSQLOperatorsWhenUsingNOTMOD() throws QueryException {
         Map<String, Object> op = new HashMap<String, Object>();
         op.put("$mod", Arrays.<Object>asList(2, 1));
         Map<String, Object> notOp = new HashMap<String, Object>();
@@ -1034,27 +1043,39 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
 
     // When generating query SELECT clauses
 
-    @Test
-    public void nullSelectClauseWhenQueryEmpty() {
-        assertThat(QuerySqlTranslator.selectStatementForAndClause(null, "named"), is(nullValue()));
-        SqlParts sql = QuerySqlTranslator.selectStatementForAndClause(new ArrayList<Object>(),
+    @Test(expected = IllegalArgumentException.class)
+    public void nullSelectClauseWhenQueryEmpty() throws QueryException {
+        QuerySqlTranslator.selectStatementForAndClause(new ArrayList<Object>(),
                                                                       "named");
-        assertThat(sql, is(nullValue()));
     }
 
-    @Test
-    public void nullSelectClauseWhenIndexEmpty() {
+    @Test(expected = IllegalArgumentException.class)
+    public void nullSelectClauseWhenQueryNull() throws QueryException {
+        QuerySqlTranslator.selectStatementForAndClause(null, "named");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void nullSelectClauseWhenIndexEmpty() throws QueryException {
         Map<String, Object> eq = new HashMap<String, Object>();
         eq.put("$eq", "mike");
         Map<String, Object> name = new HashMap<String, Object>();
         name.put("name", eq);
         List<Object> clause = Arrays.<Object>asList(name);
-        assertThat(QuerySqlTranslator.selectStatementForAndClause(clause, null), is(nullValue()));
-        assertThat(QuerySqlTranslator.selectStatementForAndClause(clause, ""), is(nullValue()));
+        QuerySqlTranslator.selectStatementForAndClause(clause, "");
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void nullSelectClauseWhenIndexNull() throws QueryException {
+        Map<String, Object> eq = new HashMap<String, Object>();
+        eq.put("$eq", "mike");
+        Map<String, Object> name = new HashMap<String, Object>();
+        name.put("name", eq);
+        List<Object> clause = Arrays.<Object>asList(name);
+        QuerySqlTranslator.selectStatementForAndClause(clause, null);
+    }
+    
     @Test
-    public void validSelectClauseForSingleTermEQ() {
+    public void validSelectClauseForSingleTermEQ() throws QueryException {
         Map<String, Object> eq = new HashMap<String, Object>();
         eq.put("$eq", "mike");
         Map<String, Object> name = new HashMap<String, Object>();
@@ -1067,7 +1088,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void validSelectClauseForMultiTermEQ() {
+    public void validSelectClauseForMultiTermEQ() throws QueryException {
         Map<String, Object> nameEq = new HashMap<String, Object>();
         nameEq.put("$eq", "mike");
         Map<String, Object> name = new HashMap<String, Object>();
@@ -1095,7 +1116,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
     // Dealing with Text searches
 
     @Test
-    public void supportsSingleTextSearch() {
+    public void supportsSingleTextSearch() throws QueryException {
         // query - { "$text" : { "$search" : "foo bar baz" } }
         Map<String, Object> searchMap = new HashMap<String, Object>();
         searchMap.put("$search", "foo bar baz");
@@ -1125,7 +1146,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void supportsANDWithTextSearch() {
+    public void supportsANDWithTextSearch() throws QueryException {
         // query - { "$and" : [ { "name" : "mike" }, { "$text" : { "$search" : "foo bar baz" } } ] }
         Map<String, Object> nameMap = new HashMap<String, Object>();
         nameMap.put("name", "mike");
@@ -1168,7 +1189,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void supportsORWithTextSearch() {
+    public void supportsORWithTextSearch() throws QueryException {
         // query - { "$or" : [ { "name" : "mike" }, { "$text" : { "$search" : "foo bar baz" } } ] }
         Map<String, Object> nameMap = new HashMap<String, Object>();
         nameMap.put("name", "mike");
@@ -1208,7 +1229,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         assertThat(sqlNode.sql.placeHolderValues, is(arrayContainingInAnyOrder("foo bar baz")));
     }
 
-    @Test
+    @Test(expected = IllegalStateException.class)
     public void nullWhenTextSearchDoesNotFindTextIndex() throws QueryException {
         im.deleteIndex("basic_text");
         // query - { "$text" : { "$search" : "foo bar baz" } }
@@ -1218,13 +1239,12 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         query.put("$text", searchMap);
         query = QueryValidator.normaliseAndValidateQuery(query);
 
-        QueryNode node = QuerySqlTranslator.translateQuery(query,
+        QuerySqlTranslator.translateQuery(query,
                                                            im.listIndexes(),
                                                            indexesCoverQuery);
-        assertThat(node, is(nullValue()));
     }
 
-    @Test
+    @Test(expected = IllegalStateException.class)
     public void nullWhenCompoundQueryIncludesTextSearchDoesNotFindJsonIndex() throws QueryException {
         im.deleteIndex("basic");
         // query - { "$and" : [ { "name" : "mike" }, { "$text" : { "$search" : "foo bar baz" } } ] }
@@ -1238,16 +1258,15 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
         query.put("$and", Arrays.<Object>asList(nameMap, textMap));
         query = QueryValidator.normaliseAndValidateQuery(query);
 
-        QueryNode node = QuerySqlTranslator.translateQuery(query,
+        QuerySqlTranslator.translateQuery(query,
                                                            im.listIndexes(),
                                                            indexesCoverQuery);
-        assertThat(node, is(nullValue()));
     }
 
     // When checking for a specific operator in a clause
 
     @Test
-    public void findsOperatorInClauseList() {
+    public void findsOperatorInClauseList() throws QueryException {
         Map<String, Object> nameMap = new HashMap<String, Object>();
         Map<String, Object> nameEqMap = new HashMap<String, Object>();
         nameEqMap.put("$eq", "mike");
@@ -1265,7 +1284,7 @@ public class QuerySqlTranslatorTest extends AbstractIndexTestBase {
     }
 
     @Test
-    public void doesNotFindOperatorWhenNotInClauseList() {
+    public void doesNotFindOperatorWhenNotInClauseList() throws QueryException {
         Map<String, Object> nameMap = new HashMap<String, Object>();
         Map<String, Object> nameEqMap = new HashMap<String, Object>();
         nameEqMap.put("$eq", "mike");

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/QueryTextSearchTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/QueryTextSearchTest.java
@@ -206,7 +206,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
                                                                  "fred12"));
     }
 
-    @Test
+    @Test(expected = IllegalStateException.class)
     public void nullForTextSearchQueryWithoutATextIndex() throws QueryException {
         assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name")), "basic"), is("basic"));
 
@@ -216,10 +216,10 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("name", "mike");
         query.put("$text", search);
-        assertThat(im.find(query), is(nullValue()));
+        im.find(query);
     }
 
-    @Test
+    @Test(expected = IllegalStateException.class)
     public void nullForTextSearchQueryWhenAJsonIndexIsMissing() throws QueryException {
         // All fields in a TEXT index only apply to the text search portion of any query.
         // So even though "name" exists in the text index, the clause that { "name" : "mike" }
@@ -238,7 +238,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("$or", Arrays.<Object>asList(name, text));
 
-        assertThat(im.find(query), is(nullValue()));
+        im.find(query);
     }
 
     @Test
@@ -388,7 +388,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
         assertThat(queryResult.documentIds(), containsInAnyOrder("mike12", "fred12"));
     }
 
-    @Test
+    @Test(expected = QueryException.class)
     public void returnsNullWhenSearchCriteriaNotAString() throws QueryException {
         // Text index on age field
         List<FieldSort> fields = Collections.<FieldSort>singletonList(new FieldSort("age"));
@@ -399,8 +399,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
         search.put("$search", 12);
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("$text", search);
-        QueryResult queryResult = im.find(query);
-        assertThat(queryResult, is(nullValue()));
+        im.find(query);
     }
 
     @Test

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/QueryWithoutCoveringIndexesTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/QueryWithoutCoveringIndexesTest.java
@@ -27,6 +27,7 @@ import static org.junit.runners.Parameterized.Parameters;
 import com.cloudant.sync.documentstore.DocumentBodyFactory;
 import com.cloudant.sync.documentstore.DocumentRevision;
 import com.cloudant.sync.query.Query;
+import com.cloudant.sync.query.QueryException;
 import com.cloudant.sync.query.QueryResult;
 import com.cloudant.sync.util.SQLDatabaseTestUtils;
 import com.cloudant.sync.util.TestUtils;
@@ -366,7 +367,7 @@ public class QueryWithoutCoveringIndexesTest extends AbstractQueryTestBase {
         assertThat(queryResult.documentIds(), is(empty()));
     }
 
-    @Test
+    @Test(expected = QueryException.class)
     public void returnsNullWhenArgumentIsInvalidUsingSIZE() throws Exception {
         setUpSizeOperatorQueryData();
         // query - { "pet" : { "$size" : [1] } }
@@ -374,7 +375,7 @@ public class QueryWithoutCoveringIndexesTest extends AbstractQueryTestBase {
         sizeOp.put("$size", Collections.singletonList(1));
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("pet", sizeOp);
-        assertThat(idxMgr.find(query), is(nullValue()));
+        idxMgr.find(query);
     }
 
     @Test

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/UnindexedMatcherTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/UnindexedMatcherTest.java
@@ -26,6 +26,7 @@ import com.cloudant.sync.documentstore.DocumentBody;
 import com.cloudant.sync.documentstore.DocumentBodyFactory;
 import com.cloudant.sync.documentstore.DocumentRevision;
 import com.cloudant.sync.internal.documentstore.DocumentRevisionBuilder;
+import com.cloudant.sync.query.QueryException;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -323,7 +324,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void singleEqMatch() {
+    public void singleEqMatch() throws QueryException {
         // Selector - { "name" : { "$eq" : "mike" } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> eq = new HashMap<String, Object>();
@@ -335,7 +336,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void singleEqNoMatch() {
+    public void singleEqNoMatch() throws QueryException {
         // Selector - { "name" : { "$eq" : "fred" } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> eq = new HashMap<String, Object>();
@@ -347,7 +348,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void singleEqNoMatchBadField() {
+    public void singleEqNoMatchBadField() throws QueryException {
         // Selector - { "species" : { "$eq" : "fred" } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> eq = new HashMap<String, Object>();
@@ -359,7 +360,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void singleImpliedEqMatch() {
+    public void singleImpliedEqMatch() throws QueryException {
         // Selector - { "name" : "mike" }
         Map<String, Object> selector = new HashMap<String, Object>();
         selector.put("name", "mike");
@@ -369,7 +370,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void singleImpliedEqNoMatch() {
+    public void singleImpliedEqNoMatch() throws QueryException {
         // Selector - { "name" : "fred" }
         Map<String, Object> selector = new HashMap<String, Object>();
         selector.put("name", "fred");
@@ -379,7 +380,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void singleImpliedEqNoMatchBadField() {
+    public void singleImpliedEqNoMatchBadField() throws QueryException {
         // Selector - { "species" : "fred" }
         Map<String, Object> selector = new HashMap<String, Object>();
         selector.put("species", "fred");
@@ -389,7 +390,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void singleNeMatch() {
+    public void singleNeMatch() throws QueryException {
         // Selector - { "name" : { "$ne" : "fred" } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> ne = new HashMap<String, Object>();
@@ -401,7 +402,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void singleNeNoMatch() {
+    public void singleNeNoMatch() throws QueryException {
         // Selector - { "name" : { "$ne" : "mike" } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> ne = new HashMap<String, Object>();
@@ -413,7 +414,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void singleNeMatchesOnBadField() {
+    public void singleNeMatchesOnBadField() throws QueryException {
         // Selector - { "species" : { "$ne" : "fred" } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> ne = new HashMap<String, Object>();
@@ -425,7 +426,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void singleGtStringMatch() {
+    public void singleGtStringMatch() throws QueryException {
         // Selector - { "name" : { "$gt" : "andy" } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> op = new HashMap<String, Object>();
@@ -437,7 +438,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void singleGtIntMatch() {
+    public void singleGtIntMatch() throws QueryException {
         // Selector - { "age" : { "$gt" : 12 } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> op = new HashMap<String, Object>();
@@ -449,7 +450,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void singleGtStringNoMatch() {
+    public void singleGtStringNoMatch() throws QueryException {
         // Selector - { "name" : { "$gt" : "robert" } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> op = new HashMap<String, Object>();
@@ -461,7 +462,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void singleGtIntNoMatch() {
+    public void singleGtIntNoMatch() throws QueryException {
         // Selector - { "age" : { "$gt" : 45 } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> op = new HashMap<String, Object>();
@@ -473,7 +474,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void singleGtNoMatchBadField() {
+    public void singleGtNoMatchBadField() throws QueryException {
         // Selector - { "species" : { "$gt" : "fred" } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> op = new HashMap<String, Object>();
@@ -485,7 +486,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void singleGteStringMatch() {
+    public void singleGteStringMatch() throws QueryException {
         // Selector - { "name" : { "$gte" : "andy" } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> op = new HashMap<String, Object>();
@@ -497,7 +498,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void singleGteStringMatchEq() {
+    public void singleGteStringMatchEq() throws QueryException {
         // Selector - { "name" : { "$gte" : "mike" } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> op = new HashMap<String, Object>();
@@ -509,7 +510,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void singleGteIntMatch() {
+    public void singleGteIntMatch() throws QueryException {
         // Selector - { "age" : { "$gte" : 12 } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> op = new HashMap<String, Object>();
@@ -521,7 +522,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void singleGteIntMatchEq() {
+    public void singleGteIntMatchEq() throws QueryException {
         // Selector - { "age" : { "$gte" : 31 } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> op = new HashMap<String, Object>();
@@ -533,7 +534,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void singleGteStringNoMatch() {
+    public void singleGteStringNoMatch() throws QueryException {
         // Selector - { "name" : { "$gte" : "robert" } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> op = new HashMap<String, Object>();
@@ -545,7 +546,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void singleGteIntNoMatch() {
+    public void singleGteIntNoMatch() throws QueryException {
         // Selector - { "age" : { "$gte" : 45 } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> op = new HashMap<String, Object>();
@@ -557,7 +558,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void singleGteNoMatchBadField() {
+    public void singleGteNoMatchBadField() throws QueryException {
         // Selector - { "species" : { "$gte" : "fred" } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> op = new HashMap<String, Object>();
@@ -569,7 +570,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void singleLtStringMatch() {
+    public void singleLtStringMatch() throws QueryException {
         // Selector - { "name" : { "$lt" : "robert" } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> op = new HashMap<String, Object>();
@@ -581,7 +582,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void singleLtIntMatch() {
+    public void singleLtIntMatch() throws QueryException {
         // Selector - { "age" : { "$lt" : 45 } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> op = new HashMap<String, Object>();
@@ -593,7 +594,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void singleLtStringNoMatch() {
+    public void singleLtStringNoMatch() throws QueryException {
         // Selector - { "name" : { "$lt" : "andy" } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> op = new HashMap<String, Object>();
@@ -605,7 +606,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void singleLtIntNoMatch() {
+    public void singleLtIntNoMatch() throws QueryException {
         // Selector - { "age" : { "$lt" : 12 } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> op = new HashMap<String, Object>();
@@ -617,7 +618,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void singleLtNoMatchBadField() {
+    public void singleLtNoMatchBadField() throws QueryException {
         // Selector - { "species" : { "$lt" : "fred" } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> op = new HashMap<String, Object>();
@@ -629,7 +630,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void singleLteStringMatch() {
+    public void singleLteStringMatch() throws QueryException {
         // Selector - { "name" : { "$lte" : "robert" } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> op = new HashMap<String, Object>();
@@ -641,7 +642,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void singleLteStringMatchEq() {
+    public void singleLteStringMatchEq() throws QueryException {
         // Selector - { "name" : { "$lte" : "mike" } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> op = new HashMap<String, Object>();
@@ -653,7 +654,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void singleLteIntMatch() {
+    public void singleLteIntMatch() throws QueryException {
         // Selector - { "age" : { "$lte" : 45 } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> op = new HashMap<String, Object>();
@@ -665,7 +666,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void singleLteIntMatchEq() {
+    public void singleLteIntMatchEq() throws QueryException {
         // Selector - { "age" : { "$lte" : 31 } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> op = new HashMap<String, Object>();
@@ -677,7 +678,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void singleLteStringNoMatch() {
+    public void singleLteStringNoMatch() throws QueryException {
         // Selector - { "name" : { "$lte" : "andy" } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> op = new HashMap<String, Object>();
@@ -689,7 +690,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void singleLteIntNoMatch() {
+    public void singleLteIntNoMatch() throws QueryException {
         // Selector - { "age" : { "$lte" : 12 } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> op = new HashMap<String, Object>();
@@ -701,7 +702,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void singleLteNoMatchBadField() {
+    public void singleLteNoMatchBadField() throws QueryException {
         // Selector - { "species" : { "$lte" : "fred" } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> op = new HashMap<String, Object>();
@@ -713,7 +714,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void singleExistsMatch() {
+    public void singleExistsMatch() throws QueryException {
         // Selector - { "name" : { "$exists" : true } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> exists = new HashMap<String, Object>();
@@ -725,7 +726,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void singleExistsNoMatch() {
+    public void singleExistsNoMatch() throws QueryException {
         // Selector - { "name" : { "$exists" : false } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> exists = new HashMap<String, Object>();
@@ -737,7 +738,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void singleExistsMatchOnMissing() {
+    public void singleExistsMatchOnMissing() throws QueryException {
         // Selector - { "species" : { "$exists" : false } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> exists = new HashMap<String, Object>();
@@ -749,7 +750,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void singleExistsNoMatchOnMissing() {
+    public void singleExistsNoMatchOnMissing() throws QueryException {
         // Selector - { "species" : { "$exists" : true } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> exists = new HashMap<String, Object>();
@@ -761,7 +762,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void matchWhenUsingIntegerDivisorWithMOD() {
+    public void matchWhenUsingIntegerDivisorWithMOD() throws QueryException {
         // Selector - { "age": { "$mod":  [ 3, 1 ] } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> mod = new HashMap<String, Object>();
@@ -773,7 +774,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void matchWhenUsingNegativeDivisorWithMOD() {
+    public void matchWhenUsingNegativeDivisorWithMOD() throws QueryException {
         // Selector - { "age": { "$mod":  [ -3, 1 ] } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> mod = new HashMap<String, Object>();
@@ -785,7 +786,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void matchByTruncatingADoubleDivisorWithMOD() {
+    public void matchByTruncatingADoubleDivisorWithMOD() throws QueryException {
         // Selector - { "age": { "$mod":  [ 3.6, 1.0 ] } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> mod = new HashMap<String, Object>();
@@ -802,7 +803,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void noMatchWhenUsingIntegerDivisorWithMOD() {
+    public void noMatchWhenUsingIntegerDivisorWithMOD() throws QueryException {
         // Selector - { "age": { "$mod":  [ 3, 2 ] } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> mod = new HashMap<String, Object>();
@@ -814,7 +815,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void noMatchWhenUsingNegativeDivisorWithMOD() {
+    public void noMatchWhenUsingNegativeDivisorWithMOD() throws QueryException {
         // Selector - { "age": { "$mod":  [ -3, 2 ] } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> mod = new HashMap<String, Object>();
@@ -826,7 +827,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void noMatchWhenUsingDoubleDivisorWithMOD() {
+    public void noMatchWhenUsingDoubleDivisorWithMOD() throws QueryException {
         // Selector - { "age": { "$mod":  [ 3.6, 2.0 ] } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> mod = new HashMap<String, Object>();
@@ -843,7 +844,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void matchOnNegativeFieldWhenUsingIntegerDivisorWithMOD() {
+    public void matchOnNegativeFieldWhenUsingIntegerDivisorWithMOD() throws QueryException {
         // Selector - { "score": { "$mod":  [ 2, -1 ] } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> mod = new HashMap<String, Object>();
@@ -855,7 +856,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void matchOnNegativeFieldWhenUsingNegativeDivisorWithMOD() {
+    public void matchOnNegativeFieldWhenUsingNegativeDivisorWithMOD() throws QueryException {
         // Selector - { "score": { "$mod":  [ -2, -1 ] } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> mod = new HashMap<String, Object>();
@@ -867,7 +868,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void noMatchOnNegativeFieldWhenUsingIntegerDivisorWithMOD() {
+    public void noMatchOnNegativeFieldWhenUsingIntegerDivisorWithMOD() throws QueryException {
         // Selector - { "score": { "$mod":  [ 3, -1 ] } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> mod = new HashMap<String, Object>();
@@ -879,7 +880,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void noMatchOnNegativeFieldWhenUsingPositiveRemainderWithMOD() {
+    public void noMatchOnNegativeFieldWhenUsingPositiveRemainderWithMOD() throws QueryException {
         // Selector - { "score": { "$mod":  [ -2, 1 ] } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> mod = new HashMap<String, Object>();
@@ -891,7 +892,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void noMatchOnNegativeFieldWhenUsingNegativeDivisorWithMOD() {
+    public void noMatchOnNegativeFieldWhenUsingNegativeDivisorWithMOD() throws QueryException {
         // Selector - { "score": { "$mod":  [ -3, -1 ] } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> mod = new HashMap<String, Object>();
@@ -903,7 +904,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void matchWhenUsingAPositiveIntegerWithSIZE() {
+    public void matchWhenUsingAPositiveIntegerWithSIZE() throws QueryException {
         // Selector - { "pets": { "$size":  2 } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> sizeOp = new HashMap<String, Object>();
@@ -915,7 +916,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void noMatchWhenUsingAPositiveIntegerWithSIZE() {
+    public void noMatchWhenUsingAPositiveIntegerWithSIZE() throws QueryException {
         // Selector - { "pets": { "$size":  3 } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> sizeOp = new HashMap<String, Object>();
@@ -927,7 +928,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void noMatchWhenFieldIsNotAnArrayWithSIZE() {
+    public void noMatchWhenFieldIsNotAnArrayWithSIZE() throws QueryException {
         // Selector - { "name": { "$size":  1 } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> sizeOp = new HashMap<String, Object>();
@@ -939,7 +940,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void noMatchWhenUsingANegativeIntegerWithSIZE() {
+    public void noMatchWhenUsingANegativeIntegerWithSIZE() throws QueryException {
         // Selector - { "pets": { "$size":  -2 } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> sizeOp = new HashMap<String, Object>();
@@ -951,7 +952,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void matchWhenUsingZeroWithSIZE() {
+    public void matchWhenUsingZeroWithSIZE() throws QueryException {
         // Selector - { "hobbies": { "$size":  0 } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> sizeOp = new HashMap<String, Object>();
@@ -963,7 +964,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void noMatchWhenUsingZeroAndFieldMissingWithSIZE() {
+    public void noMatchWhenUsingZeroAndFieldMissingWithSIZE() throws QueryException {
         // Selector - { "books": { "$size":  0 } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> sizeOp = new HashMap<String, Object>();
@@ -975,7 +976,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void noMatchWhenUsingAStringWithSIZE() {
+    public void noMatchWhenUsingAStringWithSIZE() throws QueryException {
         // Selector - { "pets": { "$size":  "2" } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> sizeOp = new HashMap<String, Object>();
@@ -987,7 +988,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void noMatchWhenNotUsingAnIntegerWithSIZE() {
+    public void noMatchWhenNotUsingAnIntegerWithSIZE() throws QueryException {
         // Selector - { "pets": { "$size":  2.2 } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> sizeOp = new HashMap<String, Object>();
@@ -999,7 +1000,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void compoundAndMatchAll() {
+    public void compoundAndMatchAll() throws QueryException {
         // Selector - { "$and" : [ { "name" : { "$eq" : "mike" } }, { "age" : { "$eq" : 31 } } ] }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> eqName = new HashMap<String, Object>();
@@ -1017,7 +1018,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void compoundAndNoMatchSome() {
+    public void compoundAndNoMatchSome() throws QueryException {
         // Selector - { "$and" : [ { "name" : { "$eq" : "mike" } }, { "age" : { "$eq" : 12 } } ] }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> eqName = new HashMap<String, Object>();
@@ -1035,7 +1036,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void compoundAndNoMatchAny() {
+    public void compoundAndNoMatchAny() throws QueryException {
         // Selector - { "$and" : [ { "name" : { "$eq" : "fred" } }, { "age" : { "$eq" : 12 } } ] }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> eqName = new HashMap<String, Object>();
@@ -1053,7 +1054,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void compoundImplicitAndMatch() {
+    public void compoundImplicitAndMatch() throws QueryException {
         // Selector - { "name" : { "$eq" : "mike" }, "age" : { "$eq" : 31 } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> eqName = new HashMap<String, Object>();
@@ -1068,7 +1069,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void compoundImplicitAndNoMatch() {
+    public void compoundImplicitAndNoMatch() throws QueryException {
         // Selector - { "name" : { "$eq" : "mike" }, "age" : { "$eq" : 12 } }
         Map<String, Object> selector = new HashMap<String, Object>();
         Map<String, Object> eqName = new HashMap<String, Object>();
@@ -1083,7 +1084,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void orMatchAllFields() {
+    public void orMatchAllFields() throws QueryException {
         // Selector - { "$or" : [ { "name" : { "$eq" : "mike" } }, { "age" : { "$eq" : 31 } } ] }
         Map<String, Object> c1op = new HashMap<String, Object>();
         c1op.put("$eq", "mike");
@@ -1101,7 +1102,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void orMatchOnOneField() {
+    public void orMatchOnOneField() throws QueryException {
         // Selector - { "$or" : [ { "name" : { "$eq" : "mike" } }, { "age" : { "$eq" : 12 } } ] }
         Map<String, Object> c1op = new HashMap<String, Object>();
         c1op.put("$eq", "mike");
@@ -1119,7 +1120,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void orNoMatch() {
+    public void orNoMatch() throws QueryException {
         // Selector - { "$or" : [ { "name" : { "$eq" : "fred" } }, { "age" : { "$eq" : 12 } } ] }
         Map<String, Object> c1op = new HashMap<String, Object>();
         c1op.put("$eq", "fred");
@@ -1140,7 +1141,7 @@ public class UnindexedMatcherTest {
     // ($ne)  - $ne translates to $not..$eq
 
     @Test
-     public void noMatchNotEq() {
+     public void noMatchNotEq() throws QueryException {
         // Selector - { "name" : { "$not" : { "$eq" : "mike" } } }
         Map<String, Object> op = new HashMap<String, Object>();
         op.put("$eq", "mike");
@@ -1154,7 +1155,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void noMatchNe() {
+    public void noMatchNe() throws QueryException {
         // Selector - { "name" : { "$ne" : "mike" } }
         Map<String, Object> op = new HashMap<String, Object>();
         op.put("$ne", "mike");
@@ -1166,7 +1167,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void noMatchNotNe() {
+    public void noMatchNotNe() throws QueryException {
         // Selector - { "name" : { "$not" : { "$ne" : "fred" } } }
         Map<String, Object> op = new HashMap<String, Object>();
         op.put("$ne", "fred");
@@ -1180,7 +1181,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void matchNotEq() {
+    public void matchNotEq() throws QueryException {
         // Selector - { "name" : { "$not" : { "$eq" : "fred" } } }
         Map<String, Object> op = new HashMap<String, Object>();
         op.put("$eq", "fred");
@@ -1194,7 +1195,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void matchNe() {
+    public void matchNe() throws QueryException {
         // Selector - { "name" : { "$ne" : "fred" } }
         Map<String, Object> op = new HashMap<String, Object>();
         op.put("$ne", "fred");
@@ -1206,7 +1207,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void matchNotNe() {
+    public void matchNotNe() throws QueryException {
         // Selector - { "name" : { "$not" : { "$ne" : "mike" } } }
         Map<String, Object> op = new HashMap<String, Object>();
         op.put("$ne", "mike");
@@ -1220,7 +1221,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void matchNotEqBadField() {
+    public void matchNotEqBadField() throws QueryException {
         // Selector - { "species" : { "$not" : { "$eq" : "fred" } } }
         Map<String, Object> op = new HashMap<String, Object>();
         op.put("$eq", "fred");
@@ -1234,7 +1235,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void matchNeBadField() {
+    public void matchNeBadField() throws QueryException {
         // Selector - { "species" : { "$ne" : "fred" } }
         Map<String, Object> op = new HashMap<String, Object>();
         op.put("$ne", "fred");
@@ -1246,7 +1247,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void matchOnArrayFields() {
+    public void matchOnArrayFields() throws QueryException {
         // Selector - { "pets" : "white_cat" }
         Map<String, Object> selector = new HashMap<String, Object>();
         selector.put("pets", "white_cat");
@@ -1256,7 +1257,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void noMatchGoodItemWithNot() {
+    public void noMatchGoodItemWithNot() throws QueryException {
         // Selector - { "pets" : { "$not" : { "$eq" : "white_cat" } } }
         Map<String, Object> op = new HashMap<String, Object>();
         op.put("$eq", "white_cat");
@@ -1270,7 +1271,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void noMatchGoodItemWithNe() {
+    public void noMatchGoodItemWithNe() throws QueryException {
         // Selector - { "pets" : { "$ne" : "white_cat" } }
         Map<String, Object> op = new HashMap<String, Object>();
         op.put("$ne", "white_cat");
@@ -1282,7 +1283,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void noMatchOnBadItem() {
+    public void noMatchOnBadItem() throws QueryException {
         // Selector - { "pets" : "tabby_cat" }
         Map<String, Object> selector = new HashMap<String, Object>();
         selector.put("pets", "tabby_cat");
@@ -1292,7 +1293,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void matchBadItemWithNot() {
+    public void matchBadItemWithNot() throws QueryException {
         // Selector - { "pets" : { "$not" : { "$eq" : "tabby_cat" } } }
         Map<String, Object> op = new HashMap<String, Object>();
         op.put("$eq", "tabby_cat");
@@ -1306,7 +1307,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void matchBadItemWithNe() {
+    public void matchBadItemWithNe() throws QueryException {
         // Selector - { "pets" : { "$ne" : "tabby_cat" } }
         Map<String, Object> op = new HashMap<String, Object>();
         op.put("$ne", "tabby_cat");
@@ -1318,7 +1319,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void matchOnArrayUsingIn() {
+    public void matchOnArrayUsingIn() throws QueryException {
         // Selector - { "pets" : { "$in" : [ "white_cat", "tabby_cat" ] } }
         Map<String, Object> op = new HashMap<String, Object>();
         op.put("$in", Arrays.<Object>asList("white_cat", "tabby_cat"));
@@ -1330,7 +1331,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void noMatchOnArrayUsingIn() {
+    public void noMatchOnArrayUsingIn() throws QueryException {
         // Selector - { "pets" : { "$in" : [ "grey_cat", "tabby_cat" ] } }
         Map<String, Object> op = new HashMap<String, Object>();
         op.put("$in", Arrays.<Object>asList("grey_cat", "tabby_cat"));
@@ -1342,7 +1343,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void matchOnNonArrayUsingIn() {
+    public void matchOnNonArrayUsingIn() throws QueryException {
         // Selector - { "name" : { "$in" : [ "mike", "fred" ] } }
         Map<String, Object> op = new HashMap<String, Object>();
         op.put("$in", Arrays.<Object>asList("mike", "fred"));
@@ -1354,7 +1355,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void noMatchOnNonArrayUsingIn() {
+    public void noMatchOnNonArrayUsingIn() throws QueryException {
         // Selector - { "name" : { "$in" : [ "john", "fred" ] } }
         Map<String, Object> op = new HashMap<String, Object>();
         op.put("$in", Arrays.<Object>asList("john", "fred"));
@@ -1366,7 +1367,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void matchOnArrayUsingNotIn() {
+    public void matchOnArrayUsingNotIn() throws QueryException {
         // Selector - { "pets" : { "$not" : { "$in" : [ "grey_cat", "tabby_cat" ] } } }
         Map<String, Object> op = new HashMap<String, Object>();
         op.put("$in", Arrays.<Object>asList("grey_cat", "tabby_cat"));
@@ -1380,7 +1381,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void noMatchOnArrayUsingNotIn() {
+    public void noMatchOnArrayUsingNotIn() throws QueryException {
         // Selector - { "pets" : { "$not" : { "$in" : [ "white_cat", "tabby_cat" ] } } }
         Map<String, Object> op = new HashMap<String, Object>();
         op.put("$in", Arrays.<Object>asList("white_cat", "tabby_cat"));
@@ -1394,7 +1395,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void matchOnNonArrayUsingNotIn() {
+    public void matchOnNonArrayUsingNotIn() throws QueryException {
         // Selector - { "name" : { "$not" : { "$in" : [ "john", "fred" ] } } }
         Map<String, Object> op = new HashMap<String, Object>();
         op.put("$in", Arrays.<Object>asList("john", "fred"));
@@ -1408,7 +1409,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void noMatchOnNonArrayUsingNotIn() {
+    public void noMatchOnNonArrayUsingNotIn() throws QueryException {
         // Selector - { "name" : { "$not" : { "$in" : [ "mike", "fred" ] } } }
         Map<String, Object> op = new HashMap<String, Object>();
         op.put("$in", Arrays.<Object>asList("mike", "fred"));
@@ -1422,7 +1423,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void matchOnDottedFields() {
+    public void matchOnDottedFields() throws QueryException {
         // Selector - { "address.number" : "1" }
         Map<String, Object> selector = new HashMap<String, Object>();
         selector.put("address.number", "1");
@@ -1432,7 +1433,7 @@ public class UnindexedMatcherTest {
     }
 
     @Test
-    public void noMatchOnDottedFields() {
+    public void noMatchOnDottedFields() throws QueryException {
         // Selector - { "address.number" : "2" }
         Map<String, Object> selector = new HashMap<String, Object>();
         selector.put("address.number", "2");


### PR DESCRIPTION
See #424

_What_: Throw appropriate exceptions when error conditions are encountered in Query code.

Instances where `return null` signals an error condition have been replaced by throwing a `QueryException`. Where pre-conditions need to be checked, invoke the appropriate `Misc` checks resulting in `{IllegalArgument,IllegalState,NullPointer}Exception`s.

_Why_: Currently API clients can't distinguish between different error cases or between errors and where a null value is a valid result.

_Testing_: Modify tests which currently check for null on error condition to check for expected exceptions.
