### PR TITLE
Obtain query and database through getters

### DIFF
--- a/cloudant-sync-datastore-android-encryption/src/test/java/com/cloudant/sync/datastore/encryption/EndToEndEncryptionTest.java
+++ b/cloudant-sync-datastore-android-encryption/src/test/java/com/cloudant/sync/datastore/encryption/EndToEndEncryptionTest.java
@@ -133,7 +133,7 @@ public class EndToEndEncryptionTest {
         // database operation to ensure the database exists on disk before we look at
         // it.
 
-        Query im = this.database.query;
+        Query im = this.database.query();
         try {
             im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("age")));
         } finally {
@@ -158,7 +158,7 @@ public class EndToEndEncryptionTest {
     @Test
     public void indexDataEncrypted() throws IOException, QueryException {
 
-        Query im = this.database.query;
+        Query im = this.database.query();
         try {
             im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("age")));
         } finally {
@@ -199,7 +199,7 @@ public class EndToEndEncryptionTest {
                 expectedPlainText, "text/plain");
         rev.getAttachments().put("EncryptedAttachmentTest_plainText", attachment);
 
-        database.database.createDocumentFromRevision(rev);
+        database.database().createDocumentFromRevision(rev);
 
         File attachmentsFolder = new File(datastoreManagerDir
                 + File.separator + "EndToEndEncryptionTest"
@@ -261,11 +261,11 @@ public class EndToEndEncryptionTest {
         // Create
         DocumentRevision rev = new DocumentRevision(documentId);
         rev.setBody(DocumentBodyFactory.create(documentBody));
-        DocumentRevision saved = database.database.createDocumentFromRevision(rev);
+        DocumentRevision saved = database.database().createDocumentFromRevision(rev);
         assertNotNull(saved);
 
         // Read
-        DocumentRevision retrieved = database.database.getDocument(documentId);
+        DocumentRevision retrieved = database.database().getDocument(documentId);
         assertNotNull(retrieved);
         Map<String, Object> retrievedBody = retrieved.getBody().asMap();
         assertEquals("mike", retrievedBody.get("name"));
@@ -278,7 +278,7 @@ public class EndToEndEncryptionTest {
         Map<String, Object> updateBody = retrieved.getBody().asMap();
         updateBody.put("name", "fred");
         update.setBody(DocumentBodyFactory.create(updateBody));
-        DocumentRevision updated = database.database.updateDocumentFromRevision(update);
+        DocumentRevision updated = database.database().updateDocumentFromRevision(update);
         assertNotNull(updated);
         Map<String, Object> updatedBody = updated.getBody().asMap();
         assertEquals("fred", updatedBody.get("name"));
@@ -296,7 +296,7 @@ public class EndToEndEncryptionTest {
         atts.put("non-ascii", new UnsavedStreamAttachment(
                 new ByteArrayInputStream(nonAsciiText.getBytes()),
                 "non-ascii", "text/plain"));
-        DocumentRevision updatedWithAttachment = database.database.updateDocumentFromRevision(attachmentRevision);
+        DocumentRevision updatedWithAttachment = database.database().updateDocumentFromRevision(attachmentRevision);
         InputStream in = updatedWithAttachment.getAttachments().get(attachmentName).getInputStream();
         assertTrue("Saved attachment did not read correctly",
                 IOUtils.contentEquals(new FileInputStream(expectedPlainText), in));
@@ -305,7 +305,7 @@ public class EndToEndEncryptionTest {
                 IOUtils.contentEquals(new ByteArrayInputStream(nonAsciiText.getBytes()), in));
 
         // perform a query to ensure we can use special chars
-        Query query = database.query;
+        Query query = database.query();
         try {
             assertNotNull(query.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("pet")), "my index"));
 
@@ -319,12 +319,12 @@ public class EndToEndEncryptionTest {
         }
         // Delete
         try {
-            database.database.deleteDocumentFromRevision(saved);
+            database.database().deleteDocumentFromRevision(saved);
             fail("Deleting document from old revision succeeded");
         } catch (ConflictException ex) {
             // Expected exception
         }
-        DocumentRevision deleted = database.database.deleteDocumentFromRevision(updatedWithAttachment);
+        DocumentRevision deleted = database.database().deleteDocumentFromRevision(updatedWithAttachment);
         assertNotNull(deleted);
         assertEquals(true, deleted.isDeleted());
     }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/DocumentStore.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/DocumentStore.java
@@ -48,12 +48,12 @@ import java.util.logging.Logger;
  *
  * <p>
  * Users can perform CRUD (create, read, update, delete) operations on JSON documents and attachments
- * by invoking methods on the {@link #database} member.
+ * by invoking methods through {@link #database()}.
  * </p>
  *
  * <p>
- * Users can perform index and query operations on JSON documents by invoking methods on the
- * {@link #query} member.
+ * Users can perform index and query operations on JSON documents by invoking methods through
+ * {@link #query()}.
  * </p>
  *
  * <p>
@@ -70,8 +70,8 @@ public class DocumentStore {
 
     private static final String EXTENSIONS_LOCATION_NAME = "extensions";
 
-    public final Database database;
-    public final Query query;
+    private final Database database;
+    private final Query query;
     protected final String databaseName; // only used for events
     private final File location; // needed for close/delete
     private final File extensionsLocation; // for extensions: currently attachments and indexes
@@ -99,15 +99,6 @@ public class DocumentStore {
         } catch (SQLException e) {
             closeQuietlyOnException();
             throw e;
-        }
-    }
-
-    private void closeQuietlyOnException() {
-        if (database != null) {
-            ((DatabaseImpl) database).close();
-        }
-        if (query != null) {
-            ((QueryImpl) query).close();
         }
     }
 
@@ -182,6 +173,30 @@ public class DocumentStore {
         }
     }
 
+    /**
+     * Get a reference to the {@link Database} object.
+     *
+     * Users can perform CRUD (create, read, update, delete) operations on JSON documents and
+     * attachments by invoking methods on this object.
+     *
+     * @return a reference to the {@link Database} object
+     */
+    public Database database() {
+        return database;
+    }
+
+    /**
+     * Get a reference to the {@link Query} object.
+     *
+     * Users can perform index and query operations on JSON documents by invoking methods on this
+     * object
+     *
+     * @return a reference to the {@link Query} object
+     */
+    public Query query() {
+        return query;
+    }
+
     @SuppressWarnings("unchecked")
     public void close() {
         synchronized (documentStores) {
@@ -230,6 +245,15 @@ public class DocumentStore {
      */
     public static EventBus getEventBus() {
         return eventBus;
+    }
+
+    private void closeQuietlyOnException() {
+        if (database != null) {
+            ((DatabaseImpl) database).close();
+        }
+        if (query != null) {
+            ((QueryImpl) query).close();
+        }
     }
 
 }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/DocumentStore.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/DocumentStore.java
@@ -174,10 +174,14 @@ public class DocumentStore {
     }
 
     /**
+     * <p>
      * Get a reference to the {@link Database} object.
+     * </p>
      *
+     * <p>
      * Users can perform CRUD (create, read, update, delete) operations on JSON documents and
      * attachments by invoking methods on this object.
+     * </p>
      *
      * @return a reference to the {@link Database} object
      */
@@ -186,10 +190,14 @@ public class DocumentStore {
     }
 
     /**
+     * <p>
      * Get a reference to the {@link Query} object.
+     * </p>
      *
+     * <p>
      * Users can perform index and query operations on JSON documents by invoking methods on this
-     * object
+     * object.
+     * </p>
      *
      * @return a reference to the {@link Query} object
      */

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ReplicatorBuilder.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ReplicatorBuilder.java
@@ -17,7 +17,6 @@ package com.cloudant.sync.replication;
 import com.cloudant.http.interceptors.CookieInterceptor;
 import com.cloudant.http.HttpConnectionRequestInterceptor;
 import com.cloudant.http.HttpConnectionResponseInterceptor;
-import com.cloudant.sync.documentstore.Database;
 import com.cloudant.sync.documentstore.DocumentStore;
 import com.cloudant.sync.internal.replication.PullStrategy;
 import com.cloudant.sync.internal.replication.PushStrategy;
@@ -110,7 +109,7 @@ public abstract class ReplicatorBuilder<S, T, E> {
             // add cookie interceptor and remove creds from URI if required
             super.target = super.addCookieInterceptorIfRequired(super.target);
 
-            PushStrategy pushStrategy = new PushStrategy(super.source.database,
+            PushStrategy pushStrategy = new PushStrategy(super.source.database(),
                     super.target,
                     super.requestInterceptors,
                     super.responseInterceptors);
@@ -205,7 +204,7 @@ public abstract class ReplicatorBuilder<S, T, E> {
             super.source = super.addCookieInterceptorIfRequired(super.source);
 
             PullStrategy pullStrategy = new PullStrategy(super.source,
-                    super.target.database,
+                    super.target.database(),
                     pullPullFilter,
                     super.requestInterceptors,
                     super.responseInterceptors);

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/Database200MigrationTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/Database200MigrationTest.java
@@ -62,7 +62,7 @@ public class Database200MigrationTest {
     public void setUp() throws Exception {
         dir = TestUtils.createTempTestingDir(this.getClass().getName());
 
-        ds = (DatabaseImpl) (DocumentStore.getInstance(new File(dir, "complexTree"))).database;
+        ds = (DatabaseImpl) (DocumentStore.getInstance(new File(dir, "complexTree"))).database();
 
         // Return DB to schema version 100:
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatabaseManagerTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatabaseManagerTest.java
@@ -97,7 +97,7 @@ public class DatabaseManagerTest {
 
     private DocumentStore createAndAssertDatastore() throws Exception {
         DocumentStore d = DocumentStore.getInstance(TEST_PATH);
-        Database ds = d.database;
+        Database ds = d.database();
         Assert.assertNotNull(ds);
         boolean assertsFailed = true;
         try {
@@ -136,14 +136,14 @@ public class DatabaseManagerTest {
     @Test(expected = IllegalStateException.class)
     public void deleteDatastore_createDocumentUsingDeletedDatastore_exception() throws Exception {
         DocumentStore ds = createAndAssertDatastore();
-        DocumentRevision object = ds.database.createDocumentFromRevision(createDBBody("Tom"));
+        DocumentRevision object = ds.database().createDocumentFromRevision(createDBBody("Tom"));
         Assert.assertNotNull(object);
 
         ds.delete();
         String dbDir = TEST_PATH.getAbsolutePath();
         Assert.assertFalse(new File(dbDir).exists());
 
-        ds.database.createDocumentFromRevision(createDBBody("Jerry"));
+        ds.database().createDocumentFromRevision(createDBBody("Jerry"));
     }
 
     public DocumentRevision createDBBody(String name) throws IOException {
@@ -197,7 +197,7 @@ public class DatabaseManagerTest {
         try {
             ds2 = DocumentStore.getInstance(TEST_PATH);
             Assert.assertNotSame("The documentstore instances should not be the same.", ds1, ds2);
-            Assert.assertNotSame("The database instances should not be the same.", ds1.database, ds2.database);
+            Assert.assertNotSame("The database instances should not be the same.", ds1.database(), ds2.database());
         } finally {
             if (ds2 != null) ds2.close();
         }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatabaseNotificationsMoreTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatabaseNotificationsMoreTest.java
@@ -89,7 +89,7 @@ public class DatabaseNotificationsMoreTest {
             Assert.assertThat(documentStoreCreated.get(0).dbName, endsWith("test123"));
             Assert.assertThat(databaseOpened.get(0).dbName, endsWith("test123"));
 
-            ds1 = DocumentStore.getInstance(new File(datastoreManagerDir, "test123")).database;
+            ds1 = DocumentStore.getInstance(new File(datastoreManagerDir, "test123")).database();
             Assert.assertThat(documentStoreCreated, hasSize(1));
             Assert.assertThat(databaseOpened, hasSize(1));
             Assert.assertNotNull(ds1);

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatastoreSchemaTests.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatastoreSchemaTests.java
@@ -18,7 +18,6 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import com.cloudant.sync.documentstore.DocumentException;
 import com.cloudant.sync.internal.android.ContentValues;
 import com.cloudant.sync.documentstore.Attachment;
 import com.cloudant.sync.documentstore.Database;
@@ -199,7 +198,7 @@ public class DatastoreSchemaTests {
 
         // Datastore manager the temp folder
         DatabaseImpl datastore = (DatabaseImpl) DocumentStore.getInstance(
-                new File(temp_folder+"/datastores", "testdb")).database;
+                new File(temp_folder + "/datastores", "testdb")).database();
 
         try {
             // Check migration worked
@@ -316,7 +315,7 @@ public class DatastoreSchemaTests {
 
         // Open the v100WithDuplicates datastore. Opening should perform the 100 to 200 migration.
         DatabaseImpl datastore = (DatabaseImpl) DocumentStore.getInstance(
-                new File(temp_folder + "/datastores", "v100DBWithDuplicates")).database;
+                new File(temp_folder + "/datastores", "v100DBWithDuplicates")).database();
 
         try {
 
@@ -430,7 +429,7 @@ public class DatastoreSchemaTests {
 
         // Open the v100WithDuplicates datastore. Opening should perform the 100 to 200 migration.
         DatabaseImpl datastore = (DatabaseImpl) DocumentStore.getInstance(
-                new File(temp_folder + "/datastores", "v100ComplexWithoutDuplicates")).database;
+                new File(temp_folder + "/datastores", "v100ComplexWithoutDuplicates")).database();
 
         try {
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatastoreTestBase.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatastoreTestBase.java
@@ -34,7 +34,8 @@ public abstract class DatastoreTestBase {
     @Before
     public void setUp() throws Exception {
         datastore_manager_dir = TestUtils.createTempTestingDir(this.getClass().getName());
-        this.datastore = (DatabaseImpl)(DocumentStore.getInstance(new File(datastore_manager_dir, getClass().getSimpleName()))).database;
+        this.datastore = (DatabaseImpl) (DocumentStore.getInstance(new File
+                (datastore_manager_dir, getClass().getSimpleName()))).database();
 
     }
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/MultipartAttachmentWriterTests.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/MultipartAttachmentWriterTests.java
@@ -68,7 +68,7 @@ public class MultipartAttachmentWriterTests {
     public void setUp() throws Exception {
         datastore_manager_dir = TestUtils.createTempTestingDir(this.getClass().getName());
         documentStore = DocumentStore.getInstance(new File(datastore_manager_dir, this.getClass().getName()));
-        database = documentStore.database;
+        database = documentStore.database();
         jsonData = "{\"body\":\"This is a body.\"}".getBytes();
         bodyOne = DocumentBodyImpl.bodyWith(jsonData);
     }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/AbstractIndexTestBase.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/AbstractIndexTestBase.java
@@ -41,9 +41,9 @@ public abstract class AbstractIndexTestBase {
         factoryPath = TestUtils.createTempTestingDir(AbstractIndexTestBase.class.getName());
         assertThat(factoryPath, is(notNullValue()));
         DocumentStore documentStore = DocumentStore.getInstance(new File(factoryPath));
-        ds = (DatabaseImpl) documentStore.database;
+        ds = (DatabaseImpl) documentStore.database();
         assertThat(ds, is(notNullValue()));
-        im = (QueryImpl) documentStore.query;
+        im = (QueryImpl) documentStore.query();
         assertThat(im, is(notNullValue()));
         indexManagerDatabaseQueue = TestUtils.getDBQueue(im);
         assertThat(indexManagerDatabaseQueue, is(notNullValue()));

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/AbstractQueryTestBase.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/AbstractQueryTestBase.java
@@ -58,8 +58,8 @@ public abstract class AbstractQueryTestBase {
         assertThat(factoryPath, is(notNullValue()));
         String datastoreName = AbstractQueryTestBase.class.getSimpleName();
         DocumentStore documentStore = DocumentStore.getInstance(new File(factoryPath));
-        ds = (DatabaseImpl) documentStore.database;
-        im = (QueryImpl) documentStore.query;
+        ds = (DatabaseImpl) documentStore.database();
+        im = (QueryImpl) documentStore.query();
         assertThat(ds, is(notNullValue()));
     }
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/AttachmentsConflictsTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/AttachmentsConflictsTest.java
@@ -70,7 +70,7 @@ public class AttachmentsConflictsTest extends ReplicationTestBase {
         this.push();
         this.documentStore.delete();
         this.documentStore = DocumentStore.getInstance(new File(this.datastoreManagerPath, "foo-bar-baz"));
-        this.datastore = (DatabaseImpl)documentStore.database;
+        this.datastore = (DatabaseImpl) documentStore.database();
         try {
             this.pull();
 
@@ -126,7 +126,7 @@ public class AttachmentsConflictsTest extends ReplicationTestBase {
         this.pull();
         this.documentStore.delete();
         this.documentStore = DocumentStore.getInstance(new File(this.datastoreManagerPath, "foo-bar-baz"));
-        this.datastore = (DatabaseImpl)documentStore.database;
+        this.datastore = (DatabaseImpl) documentStore.database();
         try {
             this.pull();
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/PullStrategyTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/PullStrategyTest.java
@@ -388,7 +388,7 @@ public class PullStrategyTest extends ReplicationTestBase {
 
         Assert.assertEquals(0, datastore.getDocumentCount());
 
-        QueryImpl im = (QueryImpl) documentStore.query;
+        QueryImpl im = (QueryImpl) documentStore.query();
         try {
             im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("diet")), "diet");
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/ReplicationTestBase.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/ReplicationTestBase.java
@@ -69,7 +69,7 @@ public abstract class ReplicationTestBase extends CouchTestBase {
     protected void createDatastore() throws Exception {
         datastoreManagerPath = TestUtils.createTempTestingDir(this.getClass().getName());
         documentStore = DocumentStore.getInstance(new File(this.datastoreManagerPath, this.getClass().getSimpleName()));
-        datastore = (DatabaseImpl)documentStore.database;
+        datastore = (DatabaseImpl) documentStore.database();
         datastoreWrapper = new DatastoreWrapper(datastore);
     }
 


### PR DESCRIPTION
Per discussion in #413 

- Change final fields `query` and `database` to getters with the same name. We are not using the javabeans `getX` convention for brevity.

- javadoc comments are provisional