### PR TITLE
Restore mocks in ReplicatorIdTest

### DIFF
--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/ReplicatorIdTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/ReplicatorIdTest.java
@@ -16,8 +16,15 @@ package com.cloudant.sync.replication;
 
 import static org.mockito.Mockito.mock;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import com.cloudant.common.CollectionFactory;
-import com.cloudant.sync.datastore.DatastoreImpl;
+import com.cloudant.sync.documentstore.Database;
+import com.cloudant.sync.documentstore.DocumentStore;
+import com.cloudant.sync.internal.documentstore.DatabaseImpl;
+import com.cloudant.sync.replication.PullFilter;
+import com.cloudant.sync.replication.ReplicatorBuilder;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -29,16 +36,30 @@ import java.net.URI;
  */
 public class ReplicatorIdTest {
 
+    DocumentStore mockDocumentStore;
+
+    @Before
+    public void before() {
+        mockDocumentStore = mock(DocumentStore.class);
+        // we have to mock DatabaseImpl because of a down-cast in the call to the DatastoreWrapper
+        // constructor
+        Database mockDatabase = mock(DatabaseImpl.class);
+        when(mockDocumentStore.database()).thenReturn(mockDatabase);
+        // the value of getPath() doesn't have to be valid, it just needs to be non-null to satisfy
+        // {Pull,Push}Strategy constructors when generating replicatorName
+        when(mockDatabase.getPath()).thenReturn(new File("/abc"));
+    }
+
     // source/target switched, so ids should be different
     @Test
     public void pullNotEqualToPush() throws Exception {
         PullStrategy pull = (PullStrategy) ((ReplicatorImpl) ReplicatorBuilder.pull()
                 .from(new URI
-                ("http://default-host/default-database")).to(mock(DatastoreImpl.class)).build
+                ("http://default-host/default-database")).to(mockDocumentStore).build
                         ()).strategy;
         PushStrategy push = (PushStrategy) ((ReplicatorImpl) ReplicatorBuilder.push()
                 .to(new URI
-                ("http://default-host/default-database")).from(mock(DatastoreImpl.class))
+                ("http://default-host/default-database")).from(mockDocumentStore)
                 .build()).strategy;
 
         Assert.assertNotEquals(pull.getReplicationId(),
@@ -50,11 +71,11 @@ public class ReplicatorIdTest {
     public void pullsEqual() throws Exception {
         PullStrategy pull1 = (PullStrategy) ((ReplicatorImpl) ReplicatorBuilder.pull()
                 .from(new URI
-                ("http://default-host/default-database")).to(mock(DatastoreImpl.class)).build
+                ("http://default-host/default-database")).to(mockDocumentStore).build
                         ()).strategy;
         PullStrategy pull2 = (PullStrategy) ((ReplicatorImpl) ReplicatorBuilder.pull()
                 .from(new URI
-                ("http://default-host/default-database")).to(mock(DatastoreImpl.class)).build
+                ("http://default-host/default-database")).to(mockDocumentStore).build
                         ()).strategy;
 
         Assert.assertEquals(pull1.getReplicationId(),
@@ -66,11 +87,11 @@ public class ReplicatorIdTest {
     public void pushesEqual() throws Exception {
         PushStrategy push1 = (PushStrategy) ((ReplicatorImpl) ReplicatorBuilder.push()
                 .to(new URI
-                ("http://default-host/default-database")).from(mock(DatastoreImpl.class))
+                ("http://default-host/default-database")).from(mockDocumentStore)
                 .build()).strategy;
         PushStrategy push2 = (PushStrategy) ((ReplicatorImpl) ReplicatorBuilder.push()
                 .to(new URI
-                ("http://default-host/default-database")).from(mock(DatastoreImpl.class))
+                ("http://default-host/default-database")).from(mockDocumentStore)
                 .build()).strategy;
         Assert.assertEquals(push1.getReplicationId(),
                 push2.getReplicationId());
@@ -81,11 +102,11 @@ public class ReplicatorIdTest {
     public void pushesDifferingTargetNotEqual() throws Exception {
         PushStrategy push1 = (PushStrategy) ((ReplicatorImpl) ReplicatorBuilder.push()
                 .to(new URI
-                ("http://a-host/a-database")).from(mock(DatastoreImpl.class)).build())
+                ("http://a-host/a-database")).from(mockDocumentStore).build())
                 .strategy;
         PushStrategy push2 = (PushStrategy) ((ReplicatorImpl) ReplicatorBuilder.push()
                 .to(new URI
-                ("http://another-host/another-database")).from(mock(DatastoreImpl.class))
+                ("http://another-host/another-database")).from(mockDocumentStore)
                 .build()).strategy;
 
         Assert.assertNotEquals(push1.getReplicationId(),
@@ -97,11 +118,11 @@ public class ReplicatorIdTest {
     public void pullsDifferingSourceNotEqual() throws Exception {
         PullStrategy pull1 = (PullStrategy) ((ReplicatorImpl) ReplicatorBuilder.pull()
                 .from(new URI
-                ("http://a-host/a-database")).to(mock(DatastoreImpl.class)).build())
+                ("http://a-host/a-database")).to(mockDocumentStore).build())
                 .strategy;
         PullStrategy pull2 = (PullStrategy) ((ReplicatorImpl) ReplicatorBuilder.pull()
                 .from(new URI
-                ("http://another-host/another-database")).to(mock(DatastoreImpl.class)).build
+                ("http://another-host/another-database")).to(mockDocumentStore).build
                         ()).strategy;
 
         Assert.assertNotEquals(pull1.getReplicationId(),
@@ -113,11 +134,11 @@ public class ReplicatorIdTest {
     public void pullWithFilterNotEqual() throws Exception {
         PullStrategy pull1 = (PullStrategy) ((ReplicatorImpl) ReplicatorBuilder.pull()
                 .from(new URI
-                ("http://default-host/default-database")).to(mock(DatastoreImpl.class)).build
+                ("http://default-host/default-database")).to(mockDocumentStore).build
                         ()).strategy;
         PullStrategy pull2 = (PullStrategy) ((ReplicatorImpl) ReplicatorBuilder.pull()
                 .from(new URI
-                ("http://default-host/default-database")).to(mock(DatastoreImpl.class))
+                ("http://default-host/default-database")).to(mockDocumentStore)
                 .filter(new PullFilter("animal/by_class",
                 CollectionFactory.MAP.of("class", "mammal"))).build()).strategy;
 
@@ -130,12 +151,12 @@ public class ReplicatorIdTest {
     public void pullWithDifferentFiltersNotEqual() throws Exception {
         PullStrategy pull1 = (PullStrategy) ((ReplicatorImpl) ReplicatorBuilder.pull()
                 .from(new URI
-                ("http://default-host/default-database")).to(mock(DatastoreImpl.class))
+                ("http://default-host/default-database")).to(mockDocumentStore)
                 .filter(new PullFilter("animal/by_class",
                 CollectionFactory.MAP.of("class", "mammal"))).build()).strategy;
         PullStrategy pull2 = (PullStrategy) ((ReplicatorImpl) ReplicatorBuilder.pull()
                 .from(new URI
-                ("http://default-host/default-database")).to(mock(DatastoreImpl.class))
+                ("http://default-host/default-database")).to(mockDocumentStore)
                 .filter(new PullFilter("animal/by_class",
                 CollectionFactory.MAP.of("class", "bird"))).build()).strategy;
 


### PR DESCRIPTION
Since merging #426 we can bring back the use of mocks in this test.