### PR TITLE
Simplify `Database` method names

### DIFF
--- a/cloudant-sync-datastore-android-encryption/src/test/java/com/cloudant/sync/datastore/encryption/EndToEndEncryptionTest.java
+++ b/cloudant-sync-datastore-android-encryption/src/test/java/com/cloudant/sync/datastore/encryption/EndToEndEncryptionTest.java
@@ -265,7 +265,7 @@ public class EndToEndEncryptionTest {
         assertNotNull(saved);
 
         // Read
-        DocumentRevision retrieved = database.database().get(documentId);
+        DocumentRevision retrieved = database.database().read(documentId);
         assertNotNull(retrieved);
         Map<String, Object> retrievedBody = retrieved.getBody().asMap();
         assertEquals("mike", retrievedBody.get("name"));

--- a/cloudant-sync-datastore-android-encryption/src/test/java/com/cloudant/sync/datastore/encryption/EndToEndEncryptionTest.java
+++ b/cloudant-sync-datastore-android-encryption/src/test/java/com/cloudant/sync/datastore/encryption/EndToEndEncryptionTest.java
@@ -199,7 +199,7 @@ public class EndToEndEncryptionTest {
                 expectedPlainText, "text/plain");
         rev.getAttachments().put("EncryptedAttachmentTest_plainText", attachment);
 
-        database.database().createDocumentFromRevision(rev);
+        database.database().create(rev);
 
         File attachmentsFolder = new File(datastoreManagerDir
                 + File.separator + "EndToEndEncryptionTest"
@@ -261,11 +261,11 @@ public class EndToEndEncryptionTest {
         // Create
         DocumentRevision rev = new DocumentRevision(documentId);
         rev.setBody(DocumentBodyFactory.create(documentBody));
-        DocumentRevision saved = database.database().createDocumentFromRevision(rev);
+        DocumentRevision saved = database.database().create(rev);
         assertNotNull(saved);
 
         // Read
-        DocumentRevision retrieved = database.database().getDocument(documentId);
+        DocumentRevision retrieved = database.database().get(documentId);
         assertNotNull(retrieved);
         Map<String, Object> retrievedBody = retrieved.getBody().asMap();
         assertEquals("mike", retrievedBody.get("name"));
@@ -278,7 +278,7 @@ public class EndToEndEncryptionTest {
         Map<String, Object> updateBody = retrieved.getBody().asMap();
         updateBody.put("name", "fred");
         update.setBody(DocumentBodyFactory.create(updateBody));
-        DocumentRevision updated = database.database().updateDocumentFromRevision(update);
+        DocumentRevision updated = database.database().update(update);
         assertNotNull(updated);
         Map<String, Object> updatedBody = updated.getBody().asMap();
         assertEquals("fred", updatedBody.get("name"));
@@ -296,7 +296,7 @@ public class EndToEndEncryptionTest {
         atts.put("non-ascii", new UnsavedStreamAttachment(
                 new ByteArrayInputStream(nonAsciiText.getBytes()),
                 "non-ascii", "text/plain"));
-        DocumentRevision updatedWithAttachment = database.database().updateDocumentFromRevision(attachmentRevision);
+        DocumentRevision updatedWithAttachment = database.database().update(attachmentRevision);
         InputStream in = updatedWithAttachment.getAttachments().get(attachmentName).getInputStream();
         assertTrue("Saved attachment did not read correctly",
                 IOUtils.contentEquals(new FileInputStream(expectedPlainText), in));
@@ -319,12 +319,12 @@ public class EndToEndEncryptionTest {
         }
         // Delete
         try {
-            database.database().deleteDocumentFromRevision(saved);
+            database.database().delete(saved);
             fail("Deleting document from old revision succeeded");
         } catch (ConflictException ex) {
             // Expected exception
         }
-        DocumentRevision deleted = database.database().deleteDocumentFromRevision(updatedWithAttachment);
+        DocumentRevision deleted = database.database().delete(updatedWithAttachment);
         assertNotNull(deleted);
         assertEquals(true, deleted.isDeleted());
     }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/ConflictResolver.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/ConflictResolver.java
@@ -43,7 +43,7 @@ public interface ConflictResolver {
      *                  current winner
      * @return resolved DocumentRevision
      *
-     * @see Database#resolveConflictsForDocument(String, ConflictResolver)
+     * @see Database#resolveConflicts(String, ConflictResolver)
      */
     DocumentRevision resolve(String docId, List<? extends DocumentRevision> conflicts);
 }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/Database.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/Database.java
@@ -48,7 +48,7 @@ import java.util.List;
  * the same document in-between replications. MVCC exposes these branches as
  * conflicted documents. These conflicts should be resolved by user-code, by
  * marking all but one of the leaf nodes of the branches as "deleted", using
- * the {@link Database#deleteDocumentFromRevision(DocumentRevision)}
+ * the {@link Database#delete(DocumentRevision)}
  * method. When the
  * datastore is next replicated with a remote datastore, this fix will be
  * propagated, thereby resolving the conflicted document across the set of
@@ -78,7 +78,7 @@ public interface Database {
      * <p>Returns the current winning revision of a document.</p>
      *
      * <p>Previously deleted documents can be retrieved
-     * (via tombstones, see {@link Database#deleteDocumentFromRevision(DocumentRevision)})
+     * (via tombstones, see {@link Database#delete(DocumentRevision)})
      * </p>
      *
      * @param documentId ID of document to retrieve.
@@ -86,7 +86,7 @@ public interface Database {
      * @throws DocumentNotFoundException if the document specified was not found
      * @throws DocumentStoreException if there was an error accessing database
      */
-    DocumentRevision getDocument(String documentId) throws DocumentNotFoundException, DocumentStoreException;
+    DocumentRevision get(String documentId) throws DocumentNotFoundException, DocumentStoreException;
 
     /**
      * <p>Retrieves a given revision of a document.</p>
@@ -96,7 +96,7 @@ public interface Database {
      * revision may contain the metadata but not content of the revision.</p>
      *
      * <p>Previously deleted documents can be retrieved
-     * (via tombstones, see {@link Database#deleteDocumentFromRevision(DocumentRevision)})
+     * (via tombstones, see {@link Database#delete(DocumentRevision)})
      * </p>
      *
      * @param documentId ID of the document
@@ -105,7 +105,7 @@ public interface Database {
      * @throws DocumentNotFoundException if the document specified was not found
      * @throws DocumentStoreException if there was an error reading the document
      */
-    DocumentRevision getDocument(String documentId, String revisionId) throws
+    DocumentRevision get(String documentId, String revisionId) throws
             DocumentNotFoundException, DocumentStoreException;
 
     /**
@@ -120,7 +120,7 @@ public interface Database {
      *         in the datastore, {@code false} otherwise.
      * @throws DocumentStoreException if there was an error reading from the database
      */
-    boolean containsDocument(String documentId, String revisionId) throws DocumentStoreException;
+    boolean contains(String documentId, String revisionId) throws DocumentStoreException;
 
     /**
      * <p>Returns whether this datastore contains any revisions of a document.
@@ -133,7 +133,7 @@ public interface Database {
      *         in the datastore, {@code false} otherwise.
      * @throws DocumentStoreException if there was an error reading from the database
      */
-    boolean containsDocument(String documentId) throws DocumentStoreException;
+    boolean contains(String documentId) throws DocumentStoreException;
 
     /**
      * <p>Enumerates the current winning revision for all documents in the
@@ -151,7 +151,7 @@ public interface Database {
      * @return list of {@code DBObjects}, maximum length {@code limit}.
      * @throws DocumentStoreException if there was an error reading the documents
      */
-    List<DocumentRevision> getAllDocuments(int offset, int limit, boolean descending) throws DocumentStoreException;
+    List<DocumentRevision> getAll(int offset, int limit, boolean descending) throws DocumentStoreException;
 
     /**
      * <p>Enumerates the current winning revision for all documents in the
@@ -160,7 +160,7 @@ public interface Database {
      * @return list of {@code String}.
      * @throws DocumentStoreException if there was an error reading the document IDs
      */
-    List<String> getAllDocumentIds() throws DocumentStoreException;
+    List<String> getAllIds() throws DocumentStoreException;
 
     /**
      * <p>Returns the current winning revisions for a set of documents.</p>
@@ -174,7 +174,7 @@ public interface Database {
      * @throws DocumentStoreException if there was an error retrieving the
      * documents.
      */
-    List<DocumentRevision> getDocumentsWithIds(List<String> documentIds) throws DocumentStoreException;
+    List<DocumentRevision> getAllWithIds(List<String> documentIds) throws DocumentStoreException;
 
     /**
      * <p>Retrieves the datastore's current sequence number.</p>
@@ -227,7 +227,7 @@ public interface Database {
      *
      * @see <a href="http://wiki.apache.org/couchdb/Replication_and_conflicts">Replication and conflicts</a>
      */
-    Iterator<String> getConflictedDocumentIds() throws DocumentStoreException;
+    Iterator<String> getConflictedIds() throws DocumentStoreException;
 
     /**
      * <p>
@@ -246,7 +246,7 @@ public interface Database {
      *
      * @see ConflictResolver
      */
-    void resolveConflictsForDocument(String docId, ConflictResolver resolver)
+    void resolveConflicts(String docId, ConflictResolver resolver)
         throws ConflictException;
 
     /**
@@ -267,7 +267,7 @@ public interface Database {
      * @throws DocumentStoreException if there was an error creating the document
      * @see Database#getEventBus()
      */
-    DocumentRevision createDocumentFromRevision(DocumentRevision rev) throws AttachmentException,
+    DocumentRevision create(DocumentRevision rev) throws AttachmentException,
             InvalidDocumentException, ConflictException, DocumentStoreException;
 
     /**
@@ -288,7 +288,7 @@ public interface Database {
      * @throws DocumentStoreException if there was an error updating the document
      * @see Database#getEventBus()
      */
-    DocumentRevision updateDocumentFromRevision(DocumentRevision rev) throws ConflictException,
+    DocumentRevision update(DocumentRevision rev) throws ConflictException,
             AttachmentException, DocumentStoreException;
 
     /**
@@ -305,7 +305,7 @@ public interface Database {
      * <p>If the input revision is already deleted, nothing will be changed. </p>
      *
      * <p>When resolving conflicts, this method can be used to delete any non-deleted
-     * leaf revision of a document. {@link Database#resolveConflictsForDocument} handles this
+     * leaf revision of a document. {@link Database#resolveConflicts} handles this
      * deletion step during conflict resolution, so it's not usually necessary to call this
      * method in this way from client code. See the doc/conflicts.md document for
      * more details.</p>
@@ -316,25 +316,25 @@ public interface Database {
      * @throws DocumentNotFoundException if the <code>DocumentRevision</code> was already deleted
      * @throws DocumentStoreException if there was an error deleting the document
      * @see Database#getEventBus()
-     * @see Database#resolveConflictsForDocument
+     * @see Database#resolveConflicts
      */
-    DocumentRevision deleteDocumentFromRevision(DocumentRevision rev) throws ConflictException, DocumentNotFoundException,
+    DocumentRevision delete(DocumentRevision rev) throws ConflictException, DocumentNotFoundException,
             DocumentStoreException;
 
     /**
      * <p>Delete all leaf revisions for the document</p>
      *
      * <p>This is equivalent to calling
-     * {@link Database#deleteDocumentFromRevision(DocumentRevision)
-     * deleteDocumentFromRevision} on all leaf revisions</p>
+     * {@link Database#delete(DocumentRevision)
+     * delete} on all leaf revisions</p>
      *
      * @param id the ID of the document to delete leaf nodes for
      * @return a List of a <code>DocumentRevision</code>s - the deleted or "tombstone" documents
      * @throws DocumentStoreException if there was an error deleting the document
      * @see Database#getEventBus()
-     * @see Database#deleteDocumentFromRevision(DocumentRevision)
+     * @see Database#delete(DocumentRevision)
      */
-    List<DocumentRevision> deleteDocument(String id) throws DocumentStoreException;
+    List<DocumentRevision> delete(String id) throws DocumentStoreException;
 
     /**
      * Compacts the SQL database and disk storage by removing the bodies and attachments of obsolete revisions.

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/Database.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/Database.java
@@ -86,7 +86,7 @@ public interface Database {
      * @throws DocumentNotFoundException if the document specified was not found
      * @throws DocumentStoreException if there was an error accessing database
      */
-    DocumentRevision get(String documentId) throws DocumentNotFoundException, DocumentStoreException;
+    DocumentRevision read(String documentId) throws DocumentNotFoundException, DocumentStoreException;
 
     /**
      * <p>Retrieves a given revision of a document.</p>
@@ -105,7 +105,7 @@ public interface Database {
      * @throws DocumentNotFoundException if the document specified was not found
      * @throws DocumentStoreException if there was an error reading the document
      */
-    DocumentRevision get(String documentId, String revisionId) throws
+    DocumentRevision read(String documentId, String revisionId) throws
             DocumentNotFoundException, DocumentStoreException;
 
     /**
@@ -151,7 +151,7 @@ public interface Database {
      * @return list of {@code DBObjects}, maximum length {@code limit}.
      * @throws DocumentStoreException if there was an error reading the documents
      */
-    List<DocumentRevision> get(int offset, int limit, boolean descending) throws DocumentStoreException;
+    List<DocumentRevision> read(int offset, int limit, boolean descending) throws DocumentStoreException;
 
     /**
      * <p>Enumerates the current winning revision for all documents in the
@@ -174,7 +174,7 @@ public interface Database {
      * @throws DocumentStoreException if there was an error retrieving the
      * documents.
      */
-    List<DocumentRevision> get(List<String> documentIds) throws DocumentStoreException;
+    List<DocumentRevision> read(List<String> documentIds) throws DocumentStoreException;
 
     /**
      * <p>Retrieves the datastore's current sequence number.</p>

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/Database.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/Database.java
@@ -151,7 +151,7 @@ public interface Database {
      * @return list of {@code DBObjects}, maximum length {@code limit}.
      * @throws DocumentStoreException if there was an error reading the documents
      */
-    List<DocumentRevision> getAll(int offset, int limit, boolean descending) throws DocumentStoreException;
+    List<DocumentRevision> get(int offset, int limit, boolean descending) throws DocumentStoreException;
 
     /**
      * <p>Enumerates the current winning revision for all documents in the
@@ -160,7 +160,7 @@ public interface Database {
      * @return list of {@code String}.
      * @throws DocumentStoreException if there was an error reading the document IDs
      */
-    List<String> getAllIds() throws DocumentStoreException;
+    List<String> getIds() throws DocumentStoreException;
 
     /**
      * <p>Returns the current winning revisions for a set of documents.</p>
@@ -174,7 +174,7 @@ public interface Database {
      * @throws DocumentStoreException if there was an error retrieving the
      * documents.
      */
-    List<DocumentRevision> getAllWithIds(List<String> documentIds) throws DocumentStoreException;
+    List<DocumentRevision> get(List<String> documentIds) throws DocumentStoreException;
 
     /**
      * <p>Retrieves the datastore's current sequence number.</p>

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/DocumentRevision.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/DocumentRevision.java
@@ -70,7 +70,7 @@ public class DocumentRevision {
     protected DocumentBody body;
 
     public DocumentRevision() {
-        // BasicDatastore#createDocumentFromRevision will assign an id
+        // BasicDatastore#create will assign an id
         this(null);
     }
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/event/notifications/DocumentCreated.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/event/notifications/DocumentCreated.java
@@ -26,7 +26,7 @@ public class DocumentCreated extends DocumentModified {
      * Event for document create
      * 
      * <p>This event is posted by
-     * {@link Database#createDocumentFromRevision(DocumentRevision)}
+     * {@link Database#create(DocumentRevision)}
      * </p>
      *
      * @param newDocument

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/event/notifications/DocumentDeleted.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/event/notifications/DocumentDeleted.java
@@ -26,7 +26,7 @@ public class DocumentDeleted extends DocumentModified {
      * Event for document delete
      *
      * <p>This event is posted by
-     * {@link Database#deleteDocument deleteDocument}.</p>
+     * {@link Database#delete delete}.</p>
      * 
      * @param prevDocument
      *            Previous document revision

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/event/notifications/DocumentUpdated.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/event/notifications/DocumentUpdated.java
@@ -26,7 +26,7 @@ public class DocumentUpdated extends DocumentModified {
      * Event for document update
      * 
      * <p>This event is posted by
-     * {@link Database#updateDocumentFromRevision(DocumentRevision)}
+     * {@link Database#update(DocumentRevision)}
      * </p>
      *
      * @param prevDocument

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/DatabaseImpl.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/DatabaseImpl.java
@@ -257,7 +257,7 @@ public class DatabaseImpl implements Database {
         Misc.checkState(this.isOpen(), "Database is closed");
         try {
             // TODO this can be made quicker than getting the whole document
-            get(docId, revId);
+            read(docId, revId);
             return true;
         } catch (DocumentNotFoundException e) {
             return false;
@@ -269,7 +269,7 @@ public class DatabaseImpl implements Database {
         Misc.checkState(this.isOpen(), "Database is closed");
         try {
             // TODO this can be made quicker than getting the whole document
-            get(docId);
+            read(docId);
             return true;
         } catch (DocumentNotFoundException e) {
             return false;
@@ -277,13 +277,13 @@ public class DatabaseImpl implements Database {
     }
 
     @Override
-    public InternalDocumentRevision get(String id) throws DocumentNotFoundException, DocumentStoreException {
+    public InternalDocumentRevision read(String id) throws DocumentNotFoundException, DocumentStoreException {
         Misc.checkState(this.isOpen(), "Database is closed");
-        return get(id, null);
+        return read(id, null);
     }
 
     @Override
-    public InternalDocumentRevision get(final String id, final String rev) throws
+    public InternalDocumentRevision read(final String id, final String rev) throws
             DocumentNotFoundException, DocumentStoreException {
         Misc.checkState(this.isOpen(), "Database is closed");
         Misc.checkNotNullOrEmpty(id, "Document id");
@@ -352,7 +352,7 @@ public class DatabaseImpl implements Database {
     }
 
     @Override
-    public List<DocumentRevision> get(final int offset, final int limit, final
+    public List<DocumentRevision> read(final int offset, final int limit, final
     boolean descending) throws DocumentStoreException {
         Misc.checkState(this.isOpen(), "Database is closed");
         if (offset < 0) {
@@ -383,7 +383,7 @@ public class DatabaseImpl implements Database {
     }
 
     @Override
-    public List<DocumentRevision> get(final List<String> docIds) throws
+    public List<DocumentRevision> read(final List<String> docIds) throws
             DocumentStoreException {
         Misc.checkState(this.isOpen(), "Database is closed");
         Misc.checkNotNull(docIds, "Input document id list");
@@ -1158,7 +1158,7 @@ public class DatabaseImpl implements Database {
 
             if (revision != null) {
                 try {
-                    eventBus.post(new DocumentUpdated(get(rev.getId(), rev.getRevision()),
+                    eventBus.post(new DocumentUpdated(read(rev.getId(), rev.getRevision()),
                             revision));
                 } catch (DocumentStoreException de) {
                     ; // TODO couldn't re-fetch document to post event

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/DatabaseImpl.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/DatabaseImpl.java
@@ -253,11 +253,11 @@ public class DatabaseImpl implements Database {
     }
 
     @Override
-    public boolean containsDocument(String docId, String revId) throws DocumentStoreException {
+    public boolean contains(String docId, String revId) throws DocumentStoreException {
         Misc.checkState(this.isOpen(), "Database is closed");
         try {
             // TODO this can be made quicker than getting the whole document
-            getDocument(docId, revId);
+            get(docId, revId);
             return true;
         } catch (DocumentNotFoundException e) {
             return false;
@@ -265,11 +265,11 @@ public class DatabaseImpl implements Database {
     }
 
     @Override
-    public boolean containsDocument(String docId) throws DocumentStoreException {
+    public boolean contains(String docId) throws DocumentStoreException {
         Misc.checkState(this.isOpen(), "Database is closed");
         try {
             // TODO this can be made quicker than getting the whole document
-            getDocument(docId);
+            get(docId);
             return true;
         } catch (DocumentNotFoundException e) {
             return false;
@@ -277,13 +277,13 @@ public class DatabaseImpl implements Database {
     }
 
     @Override
-    public InternalDocumentRevision getDocument(String id) throws DocumentNotFoundException, DocumentStoreException {
+    public InternalDocumentRevision get(String id) throws DocumentNotFoundException, DocumentStoreException {
         Misc.checkState(this.isOpen(), "Database is closed");
-        return getDocument(id, null);
+        return get(id, null);
     }
 
     @Override
-    public InternalDocumentRevision getDocument(final String id, final String rev) throws
+    public InternalDocumentRevision get(final String id, final String rev) throws
             DocumentNotFoundException, DocumentStoreException {
         Misc.checkState(this.isOpen(), "Database is closed");
         Misc.checkNotNullOrEmpty(id, "Document id");
@@ -352,7 +352,7 @@ public class DatabaseImpl implements Database {
     }
 
     @Override
-    public List<DocumentRevision> getAllDocuments(final int offset, final int limit, final
+    public List<DocumentRevision> getAll(final int offset, final int limit, final
     boolean descending) throws DocumentStoreException {
         Misc.checkState(this.isOpen(), "Database is closed");
         if (offset < 0) {
@@ -371,7 +371,7 @@ public class DatabaseImpl implements Database {
     }
 
     @Override
-    public List<String> getAllDocumentIds() throws DocumentStoreException {
+    public List<String> getAllIds() throws DocumentStoreException {
         Misc.checkState(this.isOpen(), "Database is closed");
         try {
             return get(queue.submit(new GetAllDocumentIdsCallable()));
@@ -383,7 +383,7 @@ public class DatabaseImpl implements Database {
     }
 
     @Override
-    public List<DocumentRevision> getDocumentsWithIds(final List<String> docIds) throws
+    public List<DocumentRevision> getAllWithIds(final List<String> docIds) throws
             DocumentStoreException {
         Misc.checkState(this.isOpen(), "Database is closed");
         Misc.checkNotNull(docIds, "Input document id list");
@@ -831,7 +831,7 @@ public class DatabaseImpl implements Database {
     }
 
     @Override
-    public Iterator<String> getConflictedDocumentIds() throws DocumentStoreException {
+    public Iterator<String> getConflictedIds() throws DocumentStoreException {
         try {
             return get(queue.submit(new GetConflictedDocumentIdsCallable())).iterator();
         } catch (ExecutionException e) {
@@ -842,7 +842,7 @@ public class DatabaseImpl implements Database {
     }
 
     @Override
-    public void resolveConflictsForDocument(final String docId, final ConflictResolver resolver)
+    public void resolveConflicts(final String docId, final ConflictResolver resolver)
             throws ConflictException {
 
 
@@ -1068,7 +1068,7 @@ public class DatabaseImpl implements Database {
     }
 
     @Override
-    public DocumentRevision createDocumentFromRevision(final DocumentRevision rev)
+    public DocumentRevision create(final DocumentRevision rev)
             throws AttachmentException, InvalidDocumentException, ConflictException, DocumentStoreException {
         Misc.checkNotNull(rev, "DocumentRevision");
         Misc.checkState(isOpen(), "Datastore is closed");
@@ -1132,7 +1132,7 @@ public class DatabaseImpl implements Database {
     }
 
     @Override
-    public DocumentRevision updateDocumentFromRevision(final DocumentRevision rev)
+    public DocumentRevision update(final DocumentRevision rev)
             throws AttachmentException, DocumentStoreException, ConflictException {
 
         Misc.checkNotNull(rev, "DocumentRevision");
@@ -1158,7 +1158,7 @@ public class DatabaseImpl implements Database {
 
             if (revision != null) {
                 try {
-                    eventBus.post(new DocumentUpdated(getDocument(rev.getId(), rev.getRevision()),
+                    eventBus.post(new DocumentUpdated(get(rev.getId(), rev.getRevision()),
                             revision));
                 } catch (DocumentStoreException de) {
                     ; // TODO couldn't re-fetch document to post event
@@ -1181,7 +1181,7 @@ public class DatabaseImpl implements Database {
     }
 
     @Override
-    public DocumentRevision deleteDocumentFromRevision(final DocumentRevision rev) throws
+    public DocumentRevision delete(final DocumentRevision rev) throws
             ConflictException, DocumentNotFoundException, DocumentStoreException {
         Misc.checkNotNull(rev, "DocumentRevision");
         Misc.checkState(isOpen(), "Datastore is closed");
@@ -1205,7 +1205,7 @@ public class DatabaseImpl implements Database {
 
     // delete all leaf nodes
     @Override
-    public List<DocumentRevision> deleteDocument(final String id)
+    public List<DocumentRevision> delete(final String id)
             throws DocumentStoreException {
         Misc.checkNotNull(id, "ID");
         try {

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/DatabaseImpl.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/DatabaseImpl.java
@@ -352,7 +352,7 @@ public class DatabaseImpl implements Database {
     }
 
     @Override
-    public List<DocumentRevision> getAll(final int offset, final int limit, final
+    public List<DocumentRevision> get(final int offset, final int limit, final
     boolean descending) throws DocumentStoreException {
         Misc.checkState(this.isOpen(), "Database is closed");
         if (offset < 0) {
@@ -371,7 +371,7 @@ public class DatabaseImpl implements Database {
     }
 
     @Override
-    public List<String> getAllIds() throws DocumentStoreException {
+    public List<String> getIds() throws DocumentStoreException {
         Misc.checkState(this.isOpen(), "Database is closed");
         try {
             return get(queue.submit(new GetAllDocumentIdsCallable()));
@@ -383,7 +383,7 @@ public class DatabaseImpl implements Database {
     }
 
     @Override
-    public List<DocumentRevision> getAllWithIds(final List<String> docIds) throws
+    public List<DocumentRevision> get(final List<String> docIds) throws
             DocumentStoreException {
         Misc.checkState(this.isOpen(), "Database is closed");
         Misc.checkNotNull(docIds, "Input document id list");

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/DocumentRevisionTree.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/DocumentRevisionTree.java
@@ -80,13 +80,13 @@ import java.util.TreeMap;
  * <p>In this case, to resolve the conflict the application would need to:</p>
  *
  * <ol>
- *     <li>Call {@link Database#getDocument(String, String)} to get the
+ *     <li>Call {@link Database#get(String, String)} to get the
  *     revisions {@code 4} and {@code 3^}.</li>
  *     <li>Merge these documents together in some way.</li>
  *     <li>Save a new revision in the {@code 4} branch using
- *     {@link Database#updateDocumentFromRevision(DocumentRevision)}</li>
+ *     {@link Database#update(DocumentRevision)}</li>
  *     <li>Delete the {@code 3^} revision using
- *     {@link Database#deleteDocumentFromRevision(DocumentRevision)} </li>
+ *     {@link Database#delete(DocumentRevision)} </li>
  * </ol>
  *
  * <p>This process leaves us still with two branches. Because only one
@@ -138,7 +138,7 @@ import java.util.TreeMap;
  *
  *  <p><strong>Note: This class is not thread safe.</strong></p>
  *
- * @see Database#resolveConflictsForDocument(String, ConflictResolver)
+ * @see Database#resolveConflicts(String, ConflictResolver)
  * @see ConflictResolver
  *
  * @api_private

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/ProjectedDocumentRevision.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/ProjectedDocumentRevision.java
@@ -18,7 +18,6 @@ package com.cloudant.sync.internal.documentstore;
 import com.cloudant.sync.documentstore.Attachment;
 import com.cloudant.sync.documentstore.Database;
 import com.cloudant.sync.documentstore.DocumentBody;
-import com.cloudant.sync.documentstore.DocumentException;
 import com.cloudant.sync.documentstore.DocumentNotFoundException;
 import com.cloudant.sync.documentstore.DocumentRevision;
 import com.cloudant.sync.documentstore.DocumentStoreException;
@@ -61,7 +60,7 @@ public class ProjectedDocumentRevision extends InternalDocumentRevision {
 
     @Override
     public DocumentRevision toFullRevision() throws DocumentNotFoundException, DocumentStoreException {
-        return this.database.getDocument(this.id,this.revision);
+        return this.database.get(this.id,this.revision);
     }
 
     @Override

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/ProjectedDocumentRevision.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/ProjectedDocumentRevision.java
@@ -60,7 +60,7 @@ public class ProjectedDocumentRevision extends InternalDocumentRevision {
 
     @Override
     public DocumentRevision toFullRevision() throws DocumentNotFoundException, DocumentStoreException {
-        return this.database.get(this.id,this.revision);
+        return this.database.read(this.id,this.revision);
     }
 
     @Override

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/DeleteAllRevisionsCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/DeleteAllRevisionsCallable.java
@@ -63,7 +63,7 @@ public class DeleteAllRevisionsCallable implements SQLCallable<List<DocumentRevi
             }
             return deleted;
         } catch (SQLException sqe) {
-            throw new DocumentStoreException("SQLException in deleteDocument, not " +
+            throw new DocumentStoreException("SQLException in delete, not " +
                     "deleting revisions", sqe);
         } finally {
             DatabaseUtils.closeCursorQuietly(cursor);

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/mazha/CouchClient.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/mazha/CouchClient.java
@@ -497,7 +497,7 @@ public class CouchClient  {
             is = executeToInputStreamWithRetry(connection);
             T returndoc = jsonHelper.fromJson(new InputStreamReader(is, Charset.forName("UTF-8"))
                     , type);
-            logger.fine("getDocument returning " + returndoc);
+            logger.fine("get returning " + returndoc);
             return returndoc;
         } finally {
             closeQuietly(is);
@@ -518,7 +518,7 @@ public class CouchClient  {
             is = this.getDocumentStream(id, rev);
             T returndoc = jsonHelper.fromJson(new InputStreamReader(is, Charset.forName("UTF-8"))
                     , type);
-            logger.fine("getDocument returning " + returndoc);
+            logger.fine("get returning " + returndoc);
             return returndoc;
         } finally {
             closeQuietly(is);

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/QueryExecutor.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/QueryExecutor.java
@@ -256,7 +256,7 @@ class QueryExecutor {
                 } else {
                     // No SQL exists so we are now forced to go directly to the
                     // document datastore to retrieve the list of document ids.
-                    docIds = database.getAllIds();
+                    docIds = database.getIds();
                 }
 
                 return new HashSet<String>(docIds);

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/QueryExecutor.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/QueryExecutor.java
@@ -256,7 +256,7 @@ class QueryExecutor {
                 } else {
                     // No SQL exists so we are now forced to go directly to the
                     // document datastore to retrieve the list of document ids.
-                    docIds = database.getAllDocumentIds();
+                    docIds = database.getAllIds();
                 }
 
                 return new HashSet<String>(docIds);

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/QueryResult.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/QueryResult.java
@@ -152,7 +152,7 @@ public class QueryResult implements Iterable<DocumentRevision> {
                     range.length = Math.min(DEFAULT_BATCH_SIZE, originalDocIds.size() - range.location);
                     List<String> batch = originalDocIds.subList(range.location,
                         range.location + range.length);
-                    List<? extends DocumentRevision> docs = database.getAllWithIds(batch);
+                    List<? extends DocumentRevision> docs = database.get(batch);
                     for (DocumentRevision rev : docs) {
                         DocumentRevision innerRev;
                         innerRev = rev;  // Allows us to replace later if projecting

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/QueryResult.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/QueryResult.java
@@ -17,7 +17,6 @@ package com.cloudant.sync.query;
 import com.cloudant.sync.documentstore.Attachment;
 import com.cloudant.sync.documentstore.Database;
 import com.cloudant.sync.documentstore.DocumentBodyFactory;
-import com.cloudant.sync.documentstore.DocumentException;
 import com.cloudant.sync.documentstore.DocumentRevision;
 import com.cloudant.sync.documentstore.DocumentStoreException;
 import com.cloudant.sync.internal.documentstore.DocumentRevisionBuilder;
@@ -153,7 +152,7 @@ public class QueryResult implements Iterable<DocumentRevision> {
                     range.length = Math.min(DEFAULT_BATCH_SIZE, originalDocIds.size() - range.location);
                     List<String> batch = originalDocIds.subList(range.location,
                         range.location + range.length);
-                    List<? extends DocumentRevision> docs = database.getDocumentsWithIds(batch);
+                    List<? extends DocumentRevision> docs = database.getAllWithIds(batch);
                     for (DocumentRevision rev : docs) {
                         DocumentRevision innerRev;
                         innerRev = rev;  // Allows us to replace later if projecting

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/QueryResult.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/QueryResult.java
@@ -152,7 +152,7 @@ public class QueryResult implements Iterable<DocumentRevision> {
                     range.length = Math.min(DEFAULT_BATCH_SIZE, originalDocIds.size() - range.location);
                     List<String> batch = originalDocIds.subList(range.location,
                         range.location + range.length);
-                    List<? extends DocumentRevision> docs = database.get(batch);
+                    List<? extends DocumentRevision> docs = database.read(batch);
                     for (DocumentRevision rev : docs) {
                         DocumentRevision innerRev;
                         innerRev = rev;  // Allows us to replace later if projecting

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/AttachmentTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/AttachmentTest.java
@@ -50,14 +50,14 @@ public class AttachmentTest extends BasicDatastoreTestBase {
         String attachmentName = "attachment_1.txt";
         DocumentRevision rev_1Mut = new DocumentRevision();
         rev_1Mut.setBody(bodyOne);
-        DocumentRevision rev_1 = datastore.createDocumentFromRevision(rev_1Mut);
+        DocumentRevision rev_1 = datastore.create(rev_1Mut);
         File f = TestUtils.loadFixture("fixture/"+attachmentName);
         Attachment att = new UnsavedFileAttachment(f, "text/plain");
         DocumentRevision newRevision = null;
         try {
             DocumentRevision rev1_mut = rev_1;
             rev1_mut.getAttachments().put(attachmentName, att);
-            newRevision = datastore.updateDocumentFromRevision(rev1_mut);
+            newRevision = datastore.update(rev1_mut);
         } catch (ConflictException ce){
             Assert.fail("ConflictException thrown: "+ce);
         }
@@ -86,7 +86,7 @@ public class AttachmentTest extends BasicDatastoreTestBase {
     public void setBadAttachmentsTest() throws Exception {
         DocumentRevision rev_1Mut = new DocumentRevision();
         rev_1Mut.setBody(bodyOne);
-        DocumentRevision rev_1 = datastore.createDocumentFromRevision(rev_1Mut);
+        DocumentRevision rev_1 = datastore.create(rev_1Mut);
         Attachment att1 = new UnsavedFileAttachment(TestUtils.loadFixture("fixture/attachment_1.txt"), "text/plain");
         Attachment att2 = new UnsavedFileAttachment(TestUtils.loadFixture("fixture/nonexistentfile"), "text/plain");
         Attachment att3 = new UnsavedFileAttachment(TestUtils.loadFixture("fixture/attachment_2.txt"), "text/plain");
@@ -96,7 +96,7 @@ public class AttachmentTest extends BasicDatastoreTestBase {
             rev1_mut.getAttachments().put(att1.name, att1);
             rev1_mut.getAttachments().put(att2.name, att2);
             rev1_mut.getAttachments().put(att3.name, att3);
-            newRevision = datastore.updateDocumentFromRevision(rev1_mut);
+            newRevision = datastore.update(rev1_mut);
             Assert.fail("FileNotFoundException not thrown");
         } catch (AttachmentException ae) {
             // now check that things got rolled back
@@ -120,13 +120,13 @@ public class AttachmentTest extends BasicDatastoreTestBase {
         String attachmentName = "attachment_1.txt";
         DocumentRevision rev_1Mut = new DocumentRevision();
         rev_1Mut.setBody(bodyOne);
-        DocumentRevision rev_1 = datastore.createDocumentFromRevision(rev_1Mut);
+        DocumentRevision rev_1 = datastore.create(rev_1Mut);
 
         DocumentRevision rev_2;
         try {
             DocumentRevision rev_1_mut = rev_1;
             rev_1_mut.setBody(bodyTwo);
-            rev_2 = datastore.updateDocumentFromRevision(rev_1_mut);
+            rev_2 = datastore.update(rev_1_mut);
         } catch (ConflictException ce) {
             Assert.fail("ConflictException thrown: "+ce);
         }
@@ -134,7 +134,7 @@ public class AttachmentTest extends BasicDatastoreTestBase {
         Attachment att = new UnsavedFileAttachment(f, "text/plain");
         DocumentRevision newRevision = rev_1;
         newRevision.getAttachments().put(attachmentName, att);
-        datastore.updateDocumentFromRevision(newRevision);
+        datastore.update(newRevision);
     }
 
     @Test
@@ -142,7 +142,7 @@ public class AttachmentTest extends BasicDatastoreTestBase {
 
         DocumentRevision rev_1Mut = new DocumentRevision();
         rev_1Mut.setBody(bodyOne);
-        DocumentRevision rev_1 = datastore.createDocumentFromRevision(rev_1Mut);
+        DocumentRevision rev_1 = datastore.create(rev_1Mut);
         Attachment att1 = new UnsavedFileAttachment(TestUtils.loadFixture("fixture/attachment_1.txt"), "text/plain");
         Attachment att2 = new UnsavedFileAttachment(TestUtils.loadFixture("fixture/attachment_2.txt"), "text/plain");
         Attachment att3 = new UnsavedFileAttachment(TestUtils.loadFixture("fixture/bonsai-boston.jpg"), "image/jpeg");
@@ -152,14 +152,14 @@ public class AttachmentTest extends BasicDatastoreTestBase {
         rev_1_mut.getAttachments().put(att1.name, att1);
         rev_1_mut.getAttachments().put(att2.name, att2);
         rev_1_mut.getAttachments().put(att3.name, att3);
-        rev2 = datastore.updateDocumentFromRevision(rev_1_mut);
+        rev2 = datastore.update(rev_1_mut);
         Assert.assertNotNull("Revision null", rev2);
 
         DocumentRevision rev3 = null;
 
         DocumentRevision rev2_mut = rev2;
         rev2_mut.getAttachments().remove(att1.name);
-        rev3 = datastore.updateDocumentFromRevision(rev2_mut);
+        rev3 = datastore.update(rev2_mut);
         datastore.compact();
         Assert.assertNotNull("Revision null", rev3);
 
@@ -193,13 +193,13 @@ public class AttachmentTest extends BasicDatastoreTestBase {
         String attachmentName = "attachment_1.txt";
         DocumentRevision rev_1Mut = new DocumentRevision();
         rev_1Mut.setBody(bodyOne);
-        DocumentRevision rev_1 = datastore.createDocumentFromRevision(rev_1Mut);
+        DocumentRevision rev_1 = datastore.create(rev_1Mut);
         File f = TestUtils.loadFixture("fixture/"+attachmentName);
         Attachment att = new UnsavedFileAttachment(f, "text/plain");
         DocumentRevision rev2 = null;
         DocumentRevision rev_1_mut = rev_1;
         rev_1_mut.getAttachments().put(att.name, att);
-        rev2 = datastore.updateDocumentFromRevision(rev_1_mut);
+        rev2 = datastore.update(rev_1_mut);
         Assert.assertNotNull("Revision null", rev2);
 
         DocumentRevision rev3 = null;
@@ -210,7 +210,7 @@ public class AttachmentTest extends BasicDatastoreTestBase {
         }
         DocumentRevision rev2_mut = rev2;
         rev2_mut.getAttachments().remove(attachmentName);
-        rev3 = datastore.updateDocumentFromRevision(rev2_mut);
+        rev3 = datastore.update(rev2_mut);
         Assert.assertNotNull("Revision null", rev3);
 
         // check that there are no attachments now associated with this doc
@@ -222,7 +222,7 @@ public class AttachmentTest extends BasicDatastoreTestBase {
     public void attachmentsForRevisionTest() throws Exception {
         DocumentRevision rev_1Mut = new DocumentRevision();
         rev_1Mut.setBody(bodyOne);
-        DocumentRevision rev_1 = datastore.createDocumentFromRevision(rev_1Mut);
+        DocumentRevision rev_1 = datastore.create(rev_1Mut);
 
         Attachment att1 = new UnsavedFileAttachment(TestUtils.loadFixture("fixture/attachment_1.txt"), "text/plain");
         Attachment att2 = new UnsavedFileAttachment(TestUtils.loadFixture("fixture/attachment_2.txt"), "text/plain");
@@ -231,7 +231,7 @@ public class AttachmentTest extends BasicDatastoreTestBase {
             DocumentRevision rev_1_mut = rev_1;
             rev_1_mut.getAttachments().put(att1.name, att1);
             rev_1_mut.getAttachments().put(att2.name, att2);
-            newRevision = datastore.updateDocumentFromRevision(rev_1_mut);
+            newRevision = datastore.update(rev_1_mut);
             List<? extends Attachment> attsForRev = datastore.attachmentsForRevision((InternalDocumentRevision)newRevision);
             Assert.assertEquals("Didn't get expected number of attachments", 2, attsForRev.size());
         } catch (ConflictException ce){
@@ -244,10 +244,10 @@ public class AttachmentTest extends BasicDatastoreTestBase {
 
         DocumentRevision doc1Rev1Mut = new DocumentRevision();
         doc1Rev1Mut.setBody(bodyOne);
-        DocumentRevision doc1Rev1 = datastore.createDocumentFromRevision(doc1Rev1Mut);
+        DocumentRevision doc1Rev1 = datastore.create(doc1Rev1Mut);
         DocumentRevision doc2Rev1Mut = new DocumentRevision();
         doc2Rev1Mut.setBody(bodyTwo);
-        DocumentRevision doc2Rev1 = datastore.createDocumentFromRevision(doc2Rev1Mut);
+        DocumentRevision doc2Rev1 = datastore.create(doc2Rev1Mut);
 
         File attachmentFile = TestUtils.loadFixture("fixture/attachment_1.txt");
         Attachment att1 = new UnsavedFileAttachment(attachmentFile, "text/plain");
@@ -259,7 +259,7 @@ public class AttachmentTest extends BasicDatastoreTestBase {
         try {
             DocumentRevision doc1Rev1_mut = doc1Rev1;
             doc1Rev1_mut.getAttachments().put(att1.name, att1);
-            newRevisionDoc1 = datastore.updateDocumentFromRevision(doc1Rev1_mut);
+            newRevisionDoc1 = datastore.update(doc1Rev1_mut);
             Assert.assertNotNull("Doc1 revision is null", newRevisionDoc1);
             List<? extends Attachment> attsForRev = datastore
                 .attachmentsForRevision((InternalDocumentRevision)newRevisionDoc1);
@@ -268,7 +268,7 @@ public class AttachmentTest extends BasicDatastoreTestBase {
 
             DocumentRevision doc2Rev1_mut = doc2Rev1;
             doc2Rev1_mut.getAttachments().put(att2.name, att2);
-            newRevisionDoc2 = datastore.updateDocumentFromRevision(doc2Rev1_mut);
+            newRevisionDoc2 = datastore.update(doc2Rev1_mut);
             Assert.assertNotNull("Doc2 revision is null", newRevisionDoc2);
             attsForRev = datastore.attachmentsForRevision((InternalDocumentRevision)newRevisionDoc2);
             Assert.assertEquals("Didn't get expected number of attachments", 1,

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/BasicDBCoreObservableTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/BasicDBCoreObservableTest.java
@@ -76,21 +76,21 @@ public class BasicDBCoreObservableTest {
 
         DocumentRevision doc1Mut = new DocumentRevision();
         doc1Mut.setBody(bodyOne);
-        DocumentRevision doc1 = core.createDocumentFromRevision(doc1Mut);
+        DocumentRevision doc1 = core.create(doc1Mut);
         Assert.assertNotNull(doc1);
         Assert.assertEquals(1L, core.getLastSequence());
         Assert.assertEquals(1L, testObserver.getSequence());
 
         DocumentRevision doc2Mut = new DocumentRevision();
         doc2Mut.setBody(bodyOne);
-        DocumentRevision doc2 = core.createDocumentFromRevision(doc2Mut);
+        DocumentRevision doc2 = core.create(doc2Mut);
         Assert.assertNotNull(doc2);
         Assert.assertEquals(2L, core.getLastSequence());
         Assert.assertEquals(2L, testObserver.getSequence());
 
         DocumentRevision doc1_1Mut = doc1;
         doc1_1Mut.setBody(bodyTwo);
-        DocumentRevision doc1_1 = core.updateDocumentFromRevision(doc1_1Mut);
+        DocumentRevision doc1_1 = core.update(doc1_1Mut);
         Assert.assertNotNull(doc1_1);
         Assert.assertEquals(3L, core.getLastSequence());
         Assert.assertEquals(3L, testObserver.getSequence());

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/BasicDatastoreTestBase.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/BasicDatastoreTestBase.java
@@ -52,31 +52,31 @@ public abstract class BasicDatastoreTestBase extends DatastoreTestBase {
     void createTwoDocuments() throws Exception {
         DocumentRevision rev_1Mut = new DocumentRevision();
         rev_1Mut.setBody(bodyOne);
-        DocumentRevision rev_1 = datastore.createDocumentFromRevision(rev_1Mut);
+        DocumentRevision rev_1 = datastore.create(rev_1Mut);
         validateNewlyCreatedDocument(rev_1);
         DocumentRevision rev_2Mut = new DocumentRevision();
         rev_2Mut.setBody(bodyTwo);
-        DocumentRevision rev_2 = datastore.createDocumentFromRevision(rev_2Mut);
+        DocumentRevision rev_2 = datastore.create(rev_2Mut);
         validateNewlyCreatedDocument(rev_2);
     }
 
     InternalDocumentRevision[] createThreeDocuments() throws Exception {
         DocumentRevision rev_1 = new DocumentRevision();
         rev_1.setBody(bodyOne);
-        InternalDocumentRevision rev_1_i = (InternalDocumentRevision)datastore.createDocumentFromRevision(rev_1);
+        InternalDocumentRevision rev_1_i = (InternalDocumentRevision)datastore.create(rev_1);
         validateNewlyCreatedDocument(rev_1_i);
 
         DocumentRevision rev_2 = new DocumentRevision();
         rev_2.setBody(bodyTwo);
-        InternalDocumentRevision rev_2_i = (InternalDocumentRevision)datastore.createDocumentFromRevision(rev_2);
+        InternalDocumentRevision rev_2_i = (InternalDocumentRevision)datastore.create(rev_2);
         validateNewlyCreatedDocument(rev_1_i);
 
         DocumentRevision rev_3 = new DocumentRevision();
         rev_3.setBody(bodyTwo);
-        DocumentRevision rev_3_a = datastore.createDocumentFromRevision(rev_3);
+        DocumentRevision rev_3_a = datastore.create(rev_3);
         validateNewlyCreatedDocument(rev_3_a);
         rev_3_a.setBody(bodyOne);
-        InternalDocumentRevision rev_3_i = (InternalDocumentRevision)datastore.updateDocumentFromRevision(rev_3_a);
+        InternalDocumentRevision rev_3_i = (InternalDocumentRevision)datastore.update(rev_3_a);
         Assert.assertNotNull(rev_3_i);
 
         return new InternalDocumentRevision[] { rev_1_i, rev_2_i, rev_3_i };

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/CrudImplDatabaseTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/CrudImplDatabaseTest.java
@@ -413,7 +413,7 @@ public class CrudImplDatabaseTest extends BasicDatastoreTestBase {
         ids.add(rev_2.getId());
 
         {
-            List<? extends DocumentRevision> docs = datastore.getAllWithIds(ids);
+            List<? extends DocumentRevision> docs = datastore.get(ids);
             Assert.assertEquals(2, docs.size());
             assertIdAndRevisionAndShallowContent(rev_1_2, (InternalDocumentRevision)docs.get(0));
         }
@@ -423,7 +423,7 @@ public class CrudImplDatabaseTest extends BasicDatastoreTestBase {
         ids2.add(rev_1.getId());
 
         {
-            List<? extends DocumentRevision> docs = datastore.getAllWithIds(ids2);
+            List<? extends DocumentRevision> docs = datastore.get(ids2);
             Assert.assertEquals(2, docs.size());
             assertIdAndRevisionAndShallowContent(rev_2, (InternalDocumentRevision)docs.get(0));
         }
@@ -560,14 +560,14 @@ public class CrudImplDatabaseTest extends BasicDatastoreTestBase {
 
     @Test
     public void getAllDocumentIds() throws Exception {
-        Assert.assertTrue(datastore.getAllIds().isEmpty());
+        Assert.assertTrue(datastore.getIds().isEmpty());
         DocumentRevision rev = new DocumentRevision("document-one");
         rev.setBody(bodyOne);
         datastore.create(rev);
         rev = new DocumentRevision("document-two");
         rev.setBody(bodyTwo);
         datastore.create(rev);
-        Assert.assertThat(datastore.getAllIds(), containsInAnyOrder("document-one",
+        Assert.assertThat(datastore.getIds(), containsInAnyOrder("document-one",
                                                                             "document-two"));
     }
 
@@ -611,57 +611,57 @@ public class CrudImplDatabaseTest extends BasicDatastoreTestBase {
 
         // Count
         count = 10;
-        result = datastore.getAll(offset, count, descending);
+        result = datastore.get(offset, count, descending);
         getAllDocuments_compareResult(expectedDocumentRevisions, result, count, offset);
 
         count = 47;
-        result = datastore.getAll(offset, count, descending);
+        result = datastore.get(offset, count, descending);
         getAllDocuments_compareResult(expectedDocumentRevisions, result, count, offset);
 
         count = objectCount;
-        result = datastore.getAll(offset, count, descending);
+        result = datastore.get(offset, count, descending);
         getAllDocuments_compareResult(expectedDocumentRevisions, result, count, offset);
 
         count = objectCount * 12;
-        result = datastore.getAll(offset, count, descending);
+        result = datastore.get(offset, count, descending);
         getAllDocuments_compareResult(expectedDocumentRevisions, result, objectCount, offset);
 
 
         // Offsets
         offset = 10; count = 10;
-        result = datastore.getAll(offset, count, descending);
+        result = datastore.get(offset, count, descending);
         getAllDocuments_compareResult(expectedDocumentRevisions, result, count, offset);
 
         offset = 20; count = 30;
-        result = datastore.getAll(offset, count, descending);
+        result = datastore.get(offset, count, descending);
         getAllDocuments_compareResult(expectedDocumentRevisions, result, count, offset);
 
         offset = objectCount - 3; count = 10;
-        result = datastore.getAll(offset, count, descending);
+        result = datastore.get(offset, count, descending);
         getAllDocuments_compareResult(expectedDocumentRevisions, result, 3, offset);
 
         offset = objectCount + 5; count = 10;
-        result = datastore.getAll(offset, count, descending);
+        result = datastore.get(offset, count, descending);
         getAllDocuments_compareResult(expectedDocumentRevisions, result, 0, 0);
 
         // Error cases
         try {
             offset = 0; count = -10;
-            datastore.getAll(offset, count, descending);
+            datastore.get(offset, count, descending);
             Assert.fail("IllegalArgumentException not thrown");
         } catch (IllegalArgumentException ex) {
             // All fine
         }
         try {
             offset = -10; count = 10;
-            datastore.getAll(offset, count, descending);
+            datastore.get(offset, count, descending);
             Assert.fail("IllegalArgumentException not thrown");
         } catch (IllegalArgumentException ex) {
             // All fine
         }
         try {
             offset = 50; count = -10;
-            datastore.getAll(offset, count, descending);
+            datastore.get(offset, count, descending);
             Assert.fail("IllegalArgumentException not thrown");
         } catch (IllegalArgumentException ex) {
             // All fine

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/CrudImplDatabaseTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/CrudImplDatabaseTest.java
@@ -146,7 +146,7 @@ public class CrudImplDatabaseTest extends BasicDatastoreTestBase {
         Assert.assertEquals(2, CouchUtils.generationFromRevId(rev_2.getRevision()));
         Assert.assertTrue(((DocumentRevision)rev_2).isCurrent()); // new revision is current revision
 
-        DocumentRevision rev_1_again = datastore.get(rev_1.getId(), rev_1.getRevision());
+        DocumentRevision rev_1_again = datastore.read(rev_1.getId(), rev_1.getRevision());
         Assert.assertTrue(((DocumentRevision)rev_1).isCurrent()); // rev_1 is still marked as "current", and developer need query db to get the latest data, yikes :(
         Assert.assertFalse(rev_1_again.isCurrent());
 
@@ -187,7 +187,7 @@ public class CrudImplDatabaseTest extends BasicDatastoreTestBase {
         DocumentRevision rev_2 = datastore.update(rev_2Mut);
         Assert.assertEquals(2, CouchUtils.generationFromRevId(rev_2.getRevision()));
 
-        rev_1 = datastore.get(rev_1.getId(), rev_1.getRevision());
+        rev_1 = datastore.read(rev_1.getId(), rev_1.getRevision());
         Assert.assertFalse(((InternalDocumentRevision)rev_1).isCurrent());
         rev_1Mut = rev_1;
         rev_1Mut.setBody(bodyOne);
@@ -287,7 +287,7 @@ public class CrudImplDatabaseTest extends BasicDatastoreTestBase {
         }
 
         Assert.assertEquals(3, CouchUtils.generationFromRevId(newInsertedRevisionId));
-        DocumentRevision newInsertedRevision = this.datastore.get(rev1a.getId(), newInsertedRevisionId);
+        DocumentRevision newInsertedRevision = this.datastore.read(rev1a.getId(), newInsertedRevisionId);
         Assert.assertTrue(newInsertedRevision.isDeleted());
         Assert.assertFalse(newInsertedRevision.isCurrent());
     }
@@ -325,21 +325,21 @@ public class CrudImplDatabaseTest extends BasicDatastoreTestBase {
         DocumentRevision rev_1 = datastore.create(rev_1Mut);
         validateNewlyCreatedDocument(rev_1);
 
-        DocumentRevision revRead_1 = datastore.get(rev_1.getId(), rev_1.getRevision());
+        DocumentRevision revRead_1 = datastore.read(rev_1.getId(), rev_1.getRevision());
         Assert.assertTrue(revRead_1.isCurrent());
 
         DocumentRevision rev_2Mut = rev_1;
         rev_2Mut.setBody(bodyTwo);
         datastore.update(rev_2Mut);
 
-        DocumentRevision revRead_2 = datastore.get(rev_1.getId(), rev_1.getRevision());
+        DocumentRevision revRead_2 = datastore.read(rev_1.getId(), rev_1.getRevision());
         Assert.assertFalse(revRead_2.isCurrent());
 
-        DocumentRevision revRead_3 = datastore.get(rev_1.getId());
+        DocumentRevision revRead_3 = datastore.read(rev_1.getId());
         Assert.assertTrue(revRead_3.isCurrent());
         Assert.assertEquals(2, CouchUtils.generationFromRevId(revRead_3.getRevision()));
 
-        DocumentRevision revRead_3_2 = datastore.get(rev_1.getId());
+        DocumentRevision revRead_3_2 = datastore.read(rev_1.getId());
         Assert.assertTrue(revRead_3_2.isCurrent());
         Assert.assertEquals(2, CouchUtils.generationFromRevId(revRead_3_2.getRevision()));
     }
@@ -413,7 +413,7 @@ public class CrudImplDatabaseTest extends BasicDatastoreTestBase {
         ids.add(rev_2.getId());
 
         {
-            List<? extends DocumentRevision> docs = datastore.get(ids);
+            List<? extends DocumentRevision> docs = datastore.read(ids);
             Assert.assertEquals(2, docs.size());
             assertIdAndRevisionAndShallowContent(rev_1_2, (InternalDocumentRevision)docs.get(0));
         }
@@ -423,7 +423,7 @@ public class CrudImplDatabaseTest extends BasicDatastoreTestBase {
         ids2.add(rev_1.getId());
 
         {
-            List<? extends DocumentRevision> docs = datastore.get(ids2);
+            List<? extends DocumentRevision> docs = datastore.read(ids2);
             Assert.assertEquals(2, docs.size());
             assertIdAndRevisionAndShallowContent(rev_2, (InternalDocumentRevision)docs.get(0));
         }
@@ -595,7 +595,7 @@ public class CrudImplDatabaseTest extends BasicDatastoreTestBase {
         datastore.compact();
 
         // re-fetch and check root and leafs: root should not have a body but leafs should
-        root = datastore.get(root.getId(), root.getRevision());
+        root = datastore.read(root.getId(), root.getRevision());
         Assert.assertEquals("root body must be empty after compaction", 0, root.getBody().asMap().size());
         for (DocumentRevision leaf : datastore.getAllRevisionsOfDocument(docId).leafRevisions()) {
             Assert.assertTrue("leaf body must not be empty after compaction", leaf.getBody().asMap().size() > 0);
@@ -611,57 +611,57 @@ public class CrudImplDatabaseTest extends BasicDatastoreTestBase {
 
         // Count
         count = 10;
-        result = datastore.get(offset, count, descending);
+        result = datastore.read(offset, count, descending);
         getAllDocuments_compareResult(expectedDocumentRevisions, result, count, offset);
 
         count = 47;
-        result = datastore.get(offset, count, descending);
+        result = datastore.read(offset, count, descending);
         getAllDocuments_compareResult(expectedDocumentRevisions, result, count, offset);
 
         count = objectCount;
-        result = datastore.get(offset, count, descending);
+        result = datastore.read(offset, count, descending);
         getAllDocuments_compareResult(expectedDocumentRevisions, result, count, offset);
 
         count = objectCount * 12;
-        result = datastore.get(offset, count, descending);
+        result = datastore.read(offset, count, descending);
         getAllDocuments_compareResult(expectedDocumentRevisions, result, objectCount, offset);
 
 
         // Offsets
         offset = 10; count = 10;
-        result = datastore.get(offset, count, descending);
+        result = datastore.read(offset, count, descending);
         getAllDocuments_compareResult(expectedDocumentRevisions, result, count, offset);
 
         offset = 20; count = 30;
-        result = datastore.get(offset, count, descending);
+        result = datastore.read(offset, count, descending);
         getAllDocuments_compareResult(expectedDocumentRevisions, result, count, offset);
 
         offset = objectCount - 3; count = 10;
-        result = datastore.get(offset, count, descending);
+        result = datastore.read(offset, count, descending);
         getAllDocuments_compareResult(expectedDocumentRevisions, result, 3, offset);
 
         offset = objectCount + 5; count = 10;
-        result = datastore.get(offset, count, descending);
+        result = datastore.read(offset, count, descending);
         getAllDocuments_compareResult(expectedDocumentRevisions, result, 0, 0);
 
         // Error cases
         try {
             offset = 0; count = -10;
-            datastore.get(offset, count, descending);
+            datastore.read(offset, count, descending);
             Assert.fail("IllegalArgumentException not thrown");
         } catch (IllegalArgumentException ex) {
             // All fine
         }
         try {
             offset = -10; count = 10;
-            datastore.get(offset, count, descending);
+            datastore.read(offset, count, descending);
             Assert.fail("IllegalArgumentException not thrown");
         } catch (IllegalArgumentException ex) {
             // All fine
         }
         try {
             offset = 50; count = -10;
-            datastore.get(offset, count, descending);
+            datastore.read(offset, count, descending);
             Assert.fail("IllegalArgumentException not thrown");
         } catch (IllegalArgumentException ex) {
             // All fine

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/Database200MigrationTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/Database200MigrationTest.java
@@ -107,7 +107,7 @@ public class Database200MigrationTest {
 
         DocumentRevision rev = new DocumentRevision();
         rev.setBody(DocumentBodyFactory.create(body));
-        rootRevision = ds.createDocumentFromRevision(rev);
+        rootRevision = ds.create(rev);
     }
 
     @After
@@ -188,7 +188,7 @@ public class Database200MigrationTest {
         Map<String, Object> body = rootRevision.getBody().asMap();
         body.put("My", "otherBody");
         rootRevision.setBody(DocumentBodyFactory.create(body));
-        DocumentRevision rev = ds.updateDocumentFromRevision(rootRevision);
+        DocumentRevision rev = ds.update(rootRevision);
 
 
         final String changeParent = "UPDATE revs SET parent=2 where parent = 1";
@@ -241,7 +241,7 @@ public class Database200MigrationTest {
         Map<String, Object> body = rootRevision.getBody().asMap();
         body.put("My", "otherBody");
         rootRevision.setBody(DocumentBodyFactory.create(body));
-        DocumentRevision rev = ds.updateDocumentFromRevision(rootRevision);
+        DocumentRevision rev = ds.update(rootRevision);
 
 
         final String changeParent = "UPDATE revs SET parent=2 where parent = 1";
@@ -278,7 +278,7 @@ public class Database200MigrationTest {
         Map<String, Object> body = rootRevision.getBody().asMap();
         body.put("My", "otherBody");
         rootRevision.setBody(DocumentBodyFactory.create(body));
-        final DocumentRevision rev = ds.updateDocumentFromRevision(rootRevision); // 2x
+        final DocumentRevision rev = ds.update(rootRevision); // 2x
 
         final String updateCurrent = "UPDATE revs SET current=0 where sequence=2 or sequence=3";
 
@@ -318,11 +318,11 @@ public class Database200MigrationTest {
         Map<String, Object> body = rootRevision.getBody().asMap();
         body.put("My", "otherBody");
         rootRevision.setBody(DocumentBodyFactory.create(body));
-        final DocumentRevision rev = ds.updateDocumentFromRevision(rootRevision); // 2x
+        final DocumentRevision rev = ds.update(rootRevision); // 2x
 
         body.put("My", "thirdBody");
         rev.setBody(DocumentBodyFactory.create(body));
-        DocumentRevision updated = ds.updateDocumentFromRevision(rev);
+        DocumentRevision updated = ds.update(rev);
 
         final String sql = "INSERT INTO revs (doc_id, parent, current, deleted, available, revid," +
                 " json) SELECT doc_id, parent, current, deleted, available, revid, json FROM revs";
@@ -379,7 +379,7 @@ public class Database200MigrationTest {
         Map<String, Object> body = rootRevision.getBody().asMap();
         body.put("My", "otherBody");
         rootRevision.setBody(DocumentBodyFactory.create(body));
-        final DocumentRevision rev = ds.updateDocumentFromRevision(rootRevision); // 2x
+        final DocumentRevision rev = ds.update(rootRevision); // 2x
 
         final String updateCurrent = "UPDATE revs SET current=0";
 
@@ -392,7 +392,7 @@ public class Database200MigrationTest {
             }
         }).get();
 
-        ds.deleteDocument(rev.getId());
+        ds.delete(rev.getId());
 
 
         final String changeParent = "UPDATE revs SET parent=3 where sequence = 5";
@@ -429,7 +429,7 @@ public class Database200MigrationTest {
         Map<String, Object> body = rootRevision.getBody().asMap();
         body.put("My", "otherBody");
         rootRevision.setBody(DocumentBodyFactory.create(body));
-        final DocumentRevision rev = ds.updateDocumentFromRevision(rootRevision); // 2x
+        final DocumentRevision rev = ds.update(rootRevision); // 2x
 
         final String updateCurrent = "UPDATE revs SET current=0;";
         final String setCurrent = "UPDATE revs SET current=1 where sequence=2";
@@ -447,7 +447,7 @@ public class Database200MigrationTest {
 
         body.put("myAwesomeness", "level 0");
         rev.setBody(DocumentBodyFactory.create(body));
-        final DocumentRevision secondUpdate = ds.updateDocumentFromRevision(rev);
+        final DocumentRevision secondUpdate = ds.update(rev);
         // parent needs to be changed for the above, then a new revision will need to be genreated.
         final String changeParent = "UPDATE revs SET parent=2 where parent = 3";
         ds.runOnDbQueue(new SQLCallable<Void>() {
@@ -535,9 +535,9 @@ public class Database200MigrationTest {
                 rootRevision.getBody(), null);
         ds.forceInsert(rev, rootRevision.getRevision());
 
-        rev = ds.getDocument("awesomeness");
+        rev = ds.get("awesomeness");
         rev.setBody(DocumentBodyFactory.create(body));
-        DocumentRevision update = ds.updateDocumentFromRevision(rev);
+        DocumentRevision update = ds.update(rev);
 
         runMigration();
 
@@ -588,7 +588,7 @@ public class Database200MigrationTest {
         ds.forceInsert(rev1a, "1-x");
 
         // fetch back the document we just inserted because we need the numeric id
-        final long doc_id = ds.getDocument(OBJECT_ID).getInternalNumericId();
+        final long doc_id = ds.get(OBJECT_ID).getInternalNumericId();
 
         // Now insert a duplicate (don't use forceInsert because that will protect against
         // duplicate entries).
@@ -607,7 +607,7 @@ public class Database200MigrationTest {
         ds.forceInsert(rev2, "1-x", "2-x");
 
         // Get the document
-        DocumentRevision doc = ds.getDocument(OBJECT_ID);
+        DocumentRevision doc = ds.get(OBJECT_ID);
         // If there is no winner an exception would be thrown.
 
         // We favour non-deleted nodes so the winner should be a 1-x

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/Database200MigrationTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/Database200MigrationTest.java
@@ -535,7 +535,7 @@ public class Database200MigrationTest {
                 rootRevision.getBody(), null);
         ds.forceInsert(rev, rootRevision.getRevision());
 
-        rev = ds.get("awesomeness");
+        rev = ds.read("awesomeness");
         rev.setBody(DocumentBodyFactory.create(body));
         DocumentRevision update = ds.update(rev);
 
@@ -588,7 +588,7 @@ public class Database200MigrationTest {
         ds.forceInsert(rev1a, "1-x");
 
         // fetch back the document we just inserted because we need the numeric id
-        final long doc_id = ds.get(OBJECT_ID).getInternalNumericId();
+        final long doc_id = ds.read(OBJECT_ID).getInternalNumericId();
 
         // Now insert a duplicate (don't use forceInsert because that will protect against
         // duplicate entries).
@@ -607,7 +607,7 @@ public class Database200MigrationTest {
         ds.forceInsert(rev2, "1-x", "2-x");
 
         // Get the document
-        DocumentRevision doc = ds.get(OBJECT_ID);
+        DocumentRevision doc = ds.read(OBJECT_ID);
         // If there is no winner an exception would be thrown.
 
         // We favour non-deleted nodes so the winner should be a 1-x

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatabaseImplConflictsTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatabaseImplConflictsTest.java
@@ -202,8 +202,8 @@ public class DatabaseImplConflictsTest extends BasicDatastoreTestBase {
         long expectedSequence = this.datastore.getLastSequence() + 1;
 
         // check the winner is the one without attachments
-        Assert.assertEquals("Jerry", this.datastore.get(docId).asMap().get("name"));
-        Assert.assertTrue(this.datastore.get(docId).getAttachments().isEmpty());
+        Assert.assertEquals("Jerry", this.datastore.read(docId).asMap().get("name"));
+        Assert.assertTrue(this.datastore.read(docId).getAttachments().isEmpty());
 
         this.datastore.resolveConflicts(docId, new ConflictResolver() {
             @Override
@@ -238,8 +238,8 @@ public class DatabaseImplConflictsTest extends BasicDatastoreTestBase {
         long expectedSequence = this.datastore.getLastSequence() + 1;
 
         // check the winner is the one with attachments
-        Assert.assertEquals("Jerry With Attachments", this.datastore.get(docId).asMap().get("name"));
-        Assert.assertEquals(1, this.datastore.get(docId).getAttachments().size());
+        Assert.assertEquals("Jerry With Attachments", this.datastore.read(docId).asMap().get("name"));
+        Assert.assertEquals(1, this.datastore.read(docId).getAttachments().size());
 
         this.datastore.resolveConflicts(docId, new ConflictResolver() {
             @Override
@@ -424,13 +424,13 @@ public class DatabaseImplConflictsTest extends BasicDatastoreTestBase {
         InternalDocumentRevision newRev2 = this.createDetachedDocumentRevision(rev.getId(), "2-b", "Carl", ts + 2);
         this.datastore.forceInsert(newRev2, "1-b", "2-b");
 
-        DocumentRevision oldWinner = this.datastore.get(rev.getId());
+        DocumentRevision oldWinner = this.datastore.read(rev.getId());
         Assert.assertEquals("4-a", oldWinner.getRevision());
         Assert.assertEquals("Jerry", oldWinner.getBody().asMap().get("name"));
 
         this.datastore.resolveConflicts(rev.getId(), new TimestampBasedConflictsResolver());
 
-        DocumentRevision newWinner = this.datastore.get(rev.getId());
+        DocumentRevision newWinner = this.datastore.read(rev.getId());
         Assert.assertEquals("Carl", newWinner.getBody().asMap().get("name"));
         int generation = CouchUtils.generationFromRevId(newWinner.getRevision());
         // last (by timestamp) to be inserted was Carl, 2-b
@@ -479,9 +479,9 @@ public class DatabaseImplConflictsTest extends BasicDatastoreTestBase {
         for (int i=0; i<count; i++) {
             InternalDocumentRevision newRev = this.createDetachedDocumentRevision(rev.getId(), (String.format("2-%c",'a'+i)), "Jerry");
             this.datastore.forceInsert(newRev, rev.getRevision(), newRev.getRevision());
-            DocumentRevision retrieved = this.datastore.get(newRev.getId(), newRev.getRevision());
+            DocumentRevision retrieved = this.datastore.read(newRev.getId(), newRev.getRevision());
         }
-        DocumentRevision winner = this.datastore.get(rev.getId());
+        DocumentRevision winner = this.datastore.read(rev.getId());
         DocumentRevision deleted = this.datastore.delete(winner);
         DocumentRevision newRev = new DocumentRevision(rev.getId());
         newRev.setBody(DocumentBodyFactory.create("{\"data\": \"I am the resurrection\"}".getBytes()));
@@ -501,7 +501,7 @@ public class DatabaseImplConflictsTest extends BasicDatastoreTestBase {
         for (int i=0; i<count; i++) {
             InternalDocumentRevision newRev = this.createDetachedDocumentRevision(rev.getId(), (String.format("2-%c",'a'+i)), "Jerry");
             this.datastore.forceInsert(newRev, rev.getRevision(), newRev.getRevision());
-            DocumentRevision retrieved = this.datastore.get(newRev.getId(), newRev.getRevision());
+            DocumentRevision retrieved = this.datastore.read(newRev.getId(), newRev.getRevision());
         }
         // first guaranteed to be non-winner since winner is last to sort lexigraphically
         DocumentRevision nonWinner = this.datastore.getAllRevisionsOfDocument(rev.getId()).leafRevisions().get(0);
@@ -550,7 +550,7 @@ public class DatabaseImplConflictsTest extends BasicDatastoreTestBase {
         DocumentRevision rev = this.createDocumentRevision("Tom");
         InternalDocumentRevision newRev = this.createDetachedDocumentRevision(rev.getId(), "2-a", "Jerry");
         this.datastore.forceInsert(newRev, "1-a", "2-a");
-        DocumentRevision current = this.datastore.get(rev.getId());
+        DocumentRevision current = this.datastore.read(rev.getId());
         DocumentRevision rev2 = this.updateDocumentRevisionWithAttachment(rev.getId(), current.getRevision(), "Jerry With Attachments");
         return rev.getId();
     }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatabaseImplExceptionsTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatabaseImplExceptionsTest.java
@@ -97,22 +97,22 @@ public class DatabaseImplExceptionsTest extends BasicDatastoreTestBase {
         this.datastore.contains("nosuchdocument", "nosuchrevid");
     }
 
-    // getAll after we remove the underlying SQL database should throw
+    // get after we remove the underlying SQL database should throw
     // DocumentStoreException
     @Test(expected = DocumentStoreException.class)
     public void getAllDocumentsShouldThrowDocumentStoreException() throws Exception {
         // remove the underlying database, triggering a SQL Exception
         dropRevs();
-        this.datastore.getAll(0, 100, true);
+        this.datastore.get(0, 100, true);
     }
 
-    // getAllIds after we remove the underlying SQL database should throw
+    // getIds after we remove the underlying SQL database should throw
     // DocumentStoreException
     @Test(expected = DocumentStoreException.class)
     public void getAllDocumentIdsShouldThrowDocumentStoreException() throws Exception {
         // remove the underlying database, triggering a SQL Exception
         dropRevs();
-        this.datastore.getAllIds();
+        this.datastore.getIds();
     }
 
     // getLastSequence after we remove the underlying SQL database should throw

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatabaseImplExceptionsTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatabaseImplExceptionsTest.java
@@ -15,13 +15,11 @@
 package com.cloudant.sync.internal.documentstore;
 
 import com.cloudant.sync.documentstore.DocumentBodyFactory;
-import com.cloudant.sync.documentstore.DocumentException;
 import com.cloudant.sync.documentstore.DocumentNotFoundException;
 import com.cloudant.sync.documentstore.DocumentRevision;
 import com.cloudant.sync.documentstore.DocumentStoreException;
 import com.cloudant.sync.internal.sqlite.SQLCallable;
 import com.cloudant.sync.internal.sqlite.SQLDatabase;
-import com.cloudant.sync.util.TestUtils;
 
 import org.junit.Test;
 
@@ -50,71 +48,71 @@ public class DatabaseImplExceptionsTest extends BasicDatastoreTestBase {
         });
     }
 
-    // getDocument on non-existent document should throw DocumentNotFoundException
+    // get on non-existent document should throw DocumentNotFoundException
     @Test(expected = DocumentNotFoundException.class)
     public void getDocumentShouldThrowDocumentNotFoundException() throws Exception {
-        this.datastore.getDocument("nosuchdocument");
+        this.datastore.get("nosuchdocument");
     }
 
-    // getDocument after we remove the underlying SQL database should throw DocumentStoreException
+    // get after we remove the underlying SQL database should throw DocumentStoreException
     @Test(expected = DocumentStoreException.class)
     public void getDocumentShouldThrowDocumentStoreException() throws Exception {
         // remove the underlying database, triggering a SQL Exception
         dropRevs();
-        this.datastore.getDocument("nosuchdocument");
+        this.datastore.get("nosuchdocument");
     }
 
-    // getDocument on non-existent revid should throw DocumentNotFoundException
+    // get on non-existent revid should throw DocumentNotFoundException
     @Test(expected = DocumentNotFoundException.class)
     public void getDocumentWithRevisionShouldThrowDocumentNotFoundException() throws Exception {
         DocumentRevision dr = new DocumentRevision("doc1");
         dr.setBody(DocumentBodyFactory.create("{\"hello\":\"world\"}".getBytes()));
-        this.datastore.createDocumentFromRevision(dr);
-        this.datastore.getDocument(dr.getId(), "nosuchrevid");
+        this.datastore.create(dr);
+        this.datastore.get(dr.getId(), "nosuchrevid");
     }
 
-    // getDocument after we remove the underlying SQL database should throw DocumentStoreException
+    // get after we remove the underlying SQL database should throw DocumentStoreException
     @Test(expected = DocumentStoreException.class)
     public void getDocumentWithRevisionShouldThrowDocumentStoreException() throws Exception {
         // remove the underlying database, triggering a SQL Exception
         dropRevs();
-        this.datastore.getDocument("nosuchdocument", "nosuchrevid");
+        this.datastore.get("nosuchdocument", "nosuchrevid");
     }
 
-    // containsDocument after we remove the underlying SQL database should throw
+    // contains after we remove the underlying SQL database should throw
     // DocumentStoreException
     @Test(expected = DocumentStoreException.class)
     public void containsDocumentShouldThrowDocumentStoreException() throws Exception {
         // remove the underlying database, triggering a SQL Exception
         dropRevs();
-        this.datastore.containsDocument("nosuchdocument");
+        this.datastore.contains("nosuchdocument");
     }
 
-    // containsDocument after we remove the underlying SQL database should throw
+    // contains after we remove the underlying SQL database should throw
     // DocumentStoreException
     @Test(expected = DocumentStoreException.class)
     public void containsDocumentWithRevisionShouldThrowDocumentStoreException() throws Exception {
         // remove the underlying database, triggering a SQL Exception
         dropRevs();
-        this.datastore.containsDocument("nosuchdocument", "nosuchrevid");
+        this.datastore.contains("nosuchdocument", "nosuchrevid");
     }
 
-    // getAllDocuments after we remove the underlying SQL database should throw
+    // getAll after we remove the underlying SQL database should throw
     // DocumentStoreException
     @Test(expected = DocumentStoreException.class)
     public void getAllDocumentsShouldThrowDocumentStoreException() throws Exception {
         // remove the underlying database, triggering a SQL Exception
         dropRevs();
-        this.datastore.getAllDocuments(0, 100, true);
+        this.datastore.getAll(0, 100, true);
     }
 
-    // getAllDocumentIds after we remove the underlying SQL database should throw
+    // getAllIds after we remove the underlying SQL database should throw
     // DocumentStoreException
     @Test(expected = DocumentStoreException.class)
     public void getAllDocumentIdsShouldThrowDocumentStoreException() throws Exception {
         // remove the underlying database, triggering a SQL Exception
         dropRevs();
-        this.datastore.getAllDocumentIds();
+        this.datastore.getAllIds();
     }
 
     // getLastSequence after we remove the underlying SQL database should throw
@@ -135,16 +133,16 @@ public class DatabaseImplExceptionsTest extends BasicDatastoreTestBase {
         this.datastore.getDocumentCount();
     }
 
-    // getConflictedDocumentIds after we remove the underlying SQL database should throw
+    // getConflictedIds after we remove the underlying SQL database should throw
     // DocumentStoreException
     @Test(expected = DocumentStoreException.class)
     public void getConflictedDocumentIdsShouldThrowDocumentStoreException() throws Exception {
         // remove the underlying database, triggering a SQL Exception
         dropRevs();
-        this.datastore.getConflictedDocumentIds();
+        this.datastore.getConflictedIds();
     }
 
-    // createDocumentFromRevision after we remove the underlying SQL database should throw
+    // create after we remove the underlying SQL database should throw
     // DocumentStoreException
     @Test(expected = DocumentStoreException.class)
     public void createDocumentFromRevisionShouldThrowDocumentStoreException() throws Exception {
@@ -152,44 +150,44 @@ public class DatabaseImplExceptionsTest extends BasicDatastoreTestBase {
         dropRevs();
         DocumentRevision dr = new DocumentRevision("doc1");
         dr.setBody(DocumentBodyFactory.create("{\"hello\":\"world\"}".getBytes()));
-        this.datastore.createDocumentFromRevision(dr);
+        this.datastore.create(dr);
     }
 
-    // updateDocumentFromRevision after we remove the underlying SQL database should throw
+    // update after we remove the underlying SQL database should throw
     // DocumentStoreException
     @Test(expected = DocumentStoreException.class)
     public void updateDocumentFromRevisionShouldThrowDocumentStoreException() throws Exception {
         DocumentRevision dr = new DocumentRevision("doc1");
         dr.setBody(DocumentBodyFactory.create("{\"hello\":\"world\"}".getBytes()));
-        dr = this.datastore.createDocumentFromRevision(dr);
+        dr = this.datastore.create(dr);
         // remove the underlying database, triggering a SQL Exception
         dropRevs();
         dr.setBody(DocumentBodyFactory.create("{\"hello\":\"updated\"}".getBytes()));
-        this.datastore.updateDocumentFromRevision(dr);
+        this.datastore.update(dr);
     }
 
-    // deleteDocumentFromRevision after we remove the underlying SQL database should throw
+    // delete after we remove the underlying SQL database should throw
     // DocumentStoreException
     @Test(expected = DocumentStoreException.class)
     public void deleteDocumentFromRevisionShouldThrowDocumentStoreException() throws Exception {
         DocumentRevision dr = new DocumentRevision("doc1");
         dr.setBody(DocumentBodyFactory.create("{\"hello\":\"world\"}".getBytes()));
-        dr = this.datastore.createDocumentFromRevision(dr);
+        dr = this.datastore.create(dr);
         // remove the underlying database, triggering a SQL Exception
         dropRevs();
-        this.datastore.deleteDocumentFromRevision(dr);
+        this.datastore.delete(dr);
     }
 
-    // deleteDocument after we remove the underlying SQL database should throw
+    // delete after we remove the underlying SQL database should throw
     // DocumentStoreException
     @Test(expected = DocumentStoreException.class)
     public void deleteDocumentShouldThrowDocumentStoreException() throws Exception {
         DocumentRevision dr = new DocumentRevision("doc1");
         dr.setBody(DocumentBodyFactory.create("{\"hello\":\"world\"}".getBytes()));
-        dr = this.datastore.createDocumentFromRevision(dr);
+        dr = this.datastore.create(dr);
         // remove the underlying database, triggering a SQL Exception
         dropRevs();
-        this.datastore.deleteDocument(dr.getId());
+        this.datastore.delete(dr.getId());
     }
 
     @Test(expected = DocumentStoreException.class)

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatabaseImplExceptionsTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatabaseImplExceptionsTest.java
@@ -51,7 +51,7 @@ public class DatabaseImplExceptionsTest extends BasicDatastoreTestBase {
     // get on non-existent document should throw DocumentNotFoundException
     @Test(expected = DocumentNotFoundException.class)
     public void getDocumentShouldThrowDocumentNotFoundException() throws Exception {
-        this.datastore.get("nosuchdocument");
+        this.datastore.read("nosuchdocument");
     }
 
     // get after we remove the underlying SQL database should throw DocumentStoreException
@@ -59,7 +59,7 @@ public class DatabaseImplExceptionsTest extends BasicDatastoreTestBase {
     public void getDocumentShouldThrowDocumentStoreException() throws Exception {
         // remove the underlying database, triggering a SQL Exception
         dropRevs();
-        this.datastore.get("nosuchdocument");
+        this.datastore.read("nosuchdocument");
     }
 
     // get on non-existent revid should throw DocumentNotFoundException
@@ -68,7 +68,7 @@ public class DatabaseImplExceptionsTest extends BasicDatastoreTestBase {
         DocumentRevision dr = new DocumentRevision("doc1");
         dr.setBody(DocumentBodyFactory.create("{\"hello\":\"world\"}".getBytes()));
         this.datastore.create(dr);
-        this.datastore.get(dr.getId(), "nosuchrevid");
+        this.datastore.read(dr.getId(), "nosuchrevid");
     }
 
     // get after we remove the underlying SQL database should throw DocumentStoreException
@@ -76,7 +76,7 @@ public class DatabaseImplExceptionsTest extends BasicDatastoreTestBase {
     public void getDocumentWithRevisionShouldThrowDocumentStoreException() throws Exception {
         // remove the underlying database, triggering a SQL Exception
         dropRevs();
-        this.datastore.get("nosuchdocument", "nosuchrevid");
+        this.datastore.read("nosuchdocument", "nosuchrevid");
     }
 
     // contains after we remove the underlying SQL database should throw
@@ -103,7 +103,7 @@ public class DatabaseImplExceptionsTest extends BasicDatastoreTestBase {
     public void getAllDocumentsShouldThrowDocumentStoreException() throws Exception {
         // remove the underlying database, triggering a SQL Exception
         dropRevs();
-        this.datastore.get(0, 100, true);
+        this.datastore.read(0, 100, true);
     }
 
     // getIds after we remove the underlying SQL database should throw

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatabaseImplForceInsertTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatabaseImplForceInsertTest.java
@@ -150,7 +150,7 @@ public class DatabaseImplForceInsertTest {
             InternalDocumentRevision rev = createDbObject();
             datastore.forceInsert(rev, "1-rev", "2-rev", "4-rev");
 
-            DocumentRevision insertedObj = datastore.get(OBJECT_ID);
+            DocumentRevision insertedObj = datastore.read(OBJECT_ID);
             insertedObj.setBody(bodyTwo);
             DocumentRevision updatedObj = datastore.update(insertedObj);
 
@@ -180,7 +180,7 @@ public class DatabaseImplForceInsertTest {
             InternalDocumentRevision rev = createDbObject();
             datastore.forceInsert(rev, "1-rev", "2-rev", "4-rev");
 
-            DocumentRevision insertedObj = datastore.get(OBJECT_ID);
+            DocumentRevision insertedObj = datastore.read(OBJECT_ID);
             insertedObj.setBody(bodyTwo);
             DocumentRevision updateObj = datastore.update(insertedObj);
             insertedObj.setBody(bodyTwo);
@@ -204,7 +204,7 @@ public class DatabaseImplForceInsertTest {
 
         assertDBObjectIsCorrect(OBJECT_ID, 6, bodyTwo);
 
-        DocumentRevision p = datastore.get(OBJECT_ID, "5-rev");
+        DocumentRevision p = datastore.read(OBJECT_ID, "5-rev");
         Assert.assertNotNull(p);
         Assert.assertEquals("5-rev", p.getRevision());
         Assert.assertTrue(Arrays.equals(bodyOne.asBytes(), p.getBody().asBytes()));
@@ -216,7 +216,7 @@ public class DatabaseImplForceInsertTest {
             InternalDocumentRevision rev = createDbObject();
             datastore.forceInsert(rev, "1-rev", "2-rev", "3-rev", "4-rev");
 
-            DocumentRevision insertedObj = datastore.get(OBJECT_ID);
+            DocumentRevision insertedObj = datastore.read(OBJECT_ID);
             insertedObj.setBody(bodyTwo);
             DocumentRevision updateObj = datastore.update(insertedObj);
             insertedObj.setBody(bodyTwo);
@@ -257,7 +257,7 @@ public class DatabaseImplForceInsertTest {
             datastore.forceInsert(newRev, "1-rev", "2-rev", "3-rev", "4-rev", "5-rev", remoteRevisionId6);
         }
 
-        DocumentRevision obj = datastore.get(OBJECT_ID);
+        DocumentRevision obj = datastore.read(OBJECT_ID);
         Assert.assertEquals(remoteRevisionId6, obj.getRevision());
         Assert.assertTrue(Arrays.equals(bodyOne.asBytes(), obj.getBody().asBytes()));
     }
@@ -279,7 +279,7 @@ public class DatabaseImplForceInsertTest {
             InternalDocumentRevision rev = createDbObject();
             datastore.forceInsert(rev, "1-rev", "2-rev", "3-rev", "4-rev");
 
-            DocumentRevision insertedObj = datastore.get(OBJECT_ID);
+            DocumentRevision insertedObj = datastore.read(OBJECT_ID);
             insertedObj.setBody(bodyTwo);
             DocumentRevision updateObj = datastore.update(insertedObj);
             insertedObj.setBody(bodyTwo);
@@ -321,7 +321,7 @@ public class DatabaseImplForceInsertTest {
                     remoteRevisionId6);
         }
 
-        DocumentRevision obj = datastore.get(OBJECT_ID);
+        DocumentRevision obj = datastore.read(OBJECT_ID);
         Assert.assertEquals(localRevisionId6, obj.getRevision());
         Assert.assertTrue(Arrays.equals(bodyTwo.asBytes(), obj.getBody().asBytes()));
     }
@@ -337,7 +337,7 @@ public class DatabaseImplForceInsertTest {
             InternalDocumentRevision rev = createDbObject();
             datastore.forceInsert(rev, "1-rev", "2-rev", "4-rev");
 
-            DocumentRevision insertedObj = datastore.get(OBJECT_ID);
+            DocumentRevision insertedObj = datastore.read(OBJECT_ID);
             insertedObj.setBody(bodyTwo);
             DocumentRevision updateObj = datastore.update(insertedObj);
             updateObj.setBody(bodyTwo);
@@ -346,7 +346,7 @@ public class DatabaseImplForceInsertTest {
 
             // Delete the document from the local database
             datastore.delete(updateObj2);
-            DocumentRevision deletedObj = datastore.get(OBJECT_ID);
+            DocumentRevision deletedObj = datastore.read(OBJECT_ID);
             Assert.assertTrue(deletedObj.isDeleted());
         }
 
@@ -370,7 +370,7 @@ public class DatabaseImplForceInsertTest {
             InternalDocumentRevision rev = createDbObject();
             datastore.forceInsert(rev, "1-rev", "2-rev", "4-rev");
 
-            DocumentRevision insertedObj = datastore.get(OBJECT_ID);
+            DocumentRevision insertedObj = datastore.read(OBJECT_ID);
             insertedObj.setBody(bodyTwo);
             DocumentRevision updateObj = datastore.update(insertedObj);
             updateObj.setBody(bodyTwo);
@@ -394,7 +394,7 @@ public class DatabaseImplForceInsertTest {
     }
 
     private void assertDBObjectIsCorrect(String docId, int revGeneration, DocumentBody body) throws Exception {
-        DocumentRevision obj = datastore.get(docId);
+        DocumentRevision obj = datastore.read(docId);
         Assert.assertNotNull(obj);
         Assert.assertEquals(revGeneration, CouchUtils.generationFromRevId(obj.getRevision()));
         Assert.assertTrue(Arrays.equals(body.asBytes(), obj.getBody().asBytes()));
@@ -405,7 +405,7 @@ public class DatabaseImplForceInsertTest {
         {
             InternalDocumentRevision rev = createDbObject("1-a", bodyOne);
             datastore.forceInsert(rev, "1-a" );
-            DocumentRevision insertedObj = datastore.get(OBJECT_ID);
+            DocumentRevision insertedObj = datastore.read(OBJECT_ID);
             Assert.assertEquals("1-a", insertedObj.getRevision());
         }
 
@@ -425,7 +425,7 @@ public class DatabaseImplForceInsertTest {
         {
             InternalDocumentRevision rev = createDbObject("1-x", bodyOne);
             datastore.forceInsert(rev, "1-x" );
-            DocumentRevision insertedObj = datastore.get(OBJECT_ID);
+            DocumentRevision insertedObj = datastore.read(OBJECT_ID);
             Assert.assertEquals("1-x", insertedObj.getRevision());
         }
 
@@ -445,7 +445,7 @@ public class DatabaseImplForceInsertTest {
         {
             InternalDocumentRevision rev = createDbObject("1-x", bodyOne);
             datastore.forceInsert(rev, "1-x");
-            DocumentRevision insertedObj = datastore.get(OBJECT_ID);
+            DocumentRevision insertedObj = datastore.read(OBJECT_ID);
             Assert.assertEquals("1-x", insertedObj.getRevision());
         }
 
@@ -458,7 +458,7 @@ public class DatabaseImplForceInsertTest {
         Assert.assertThat(tree.leafs(), hasSize(2));
         Assert.assertThat(tree.leafRevisionIds(), hasItems("1-x", "2-c"));
 
-        InternalDocumentRevision leaf = datastore.get(OBJECT_ID, "2-c");
+        InternalDocumentRevision leaf = datastore.read(OBJECT_ID, "2-c");
         Assert.assertThat(tree.getPath(leaf.getSequence()), equalTo(Arrays.asList("2-c", "1-a")));
 
         assertDocumentHasRevAndBody(OBJECT_ID, "2-c", bodyTwo);
@@ -494,7 +494,7 @@ public class DatabaseImplForceInsertTest {
         datastore.forceInsert(rev2_alt, "1-x", "2-y");
         datastore.forceInsert(rev7, "6-x", "7-x");
 
-        Assert.assertEquals(datastore.get(OBJECT_ID).getRevision(), "2-y");
+        Assert.assertEquals(datastore.read(OBJECT_ID).getRevision(), "2-y");
     }
 
     @Test
@@ -523,7 +523,7 @@ public class DatabaseImplForceInsertTest {
         datastore.forceInsert(rev7, "6-x", "7-x");
         datastore.forceInsert(rev2_alt, "1-x", "2-y");
 
-        Assert.assertEquals(datastore.get(OBJECT_ID).getRevision(), "2-y");
+        Assert.assertEquals(datastore.read(OBJECT_ID).getRevision(), "2-y");
     }
 
     @Test
@@ -560,7 +560,7 @@ public class DatabaseImplForceInsertTest {
         while((leafs = (datastore.getAllRevisionsOfDocument(OBJECT_ID).leafRevisions(true))).size() != 0) {
             // get() should never return a deleted document:
             // under previous behaviour of pickWinnerOfConflicts, this would fail
-            DocumentRevision currentLeaf = datastore.get(OBJECT_ID);
+            DocumentRevision currentLeaf = datastore.read(OBJECT_ID);
             Assert.assertFalse("Current revision should not have been marked as deleted. Current leaf: " +
                     currentLeaf +
                     ". Current state of all leaf nodes: "+leafs,
@@ -588,7 +588,7 @@ public class DatabaseImplForceInsertTest {
                     }
                 }
             });
-            currentLeaf = datastore.get(OBJECT_ID);
+            currentLeaf = datastore.read(OBJECT_ID);
 
             if (leafs.size() == 0) {
                 break;
@@ -611,11 +611,11 @@ public class DatabaseImplForceInsertTest {
         Assert.assertEquals(
                 "RevId should have been highest expected value. Current state of all sorted leaf nodes: "+leafs,
                 expectedRevId,
-                datastore.get(OBJECT_ID).getRevision());
+                datastore.read(OBJECT_ID).getRevision());
     }
 
     private void assertDocumentHasRevAndBody(String id, String rev, DocumentBody body) throws Exception {
-        DocumentRevision obj = datastore.get(id);
+        DocumentRevision obj = datastore.read(id);
         Assert.assertEquals(rev, obj.getRevision());
         Assert.assertTrue(Arrays.equals(obj.getBody().asBytes(), body.asBytes()));
     }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatabaseImplForceInsertTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatabaseImplForceInsertTest.java
@@ -150,9 +150,9 @@ public class DatabaseImplForceInsertTest {
             InternalDocumentRevision rev = createDbObject();
             datastore.forceInsert(rev, "1-rev", "2-rev", "4-rev");
 
-            DocumentRevision insertedObj = datastore.getDocument(OBJECT_ID);
+            DocumentRevision insertedObj = datastore.get(OBJECT_ID);
             insertedObj.setBody(bodyTwo);
-            DocumentRevision updatedObj = datastore.updateDocumentFromRevision(insertedObj);
+            DocumentRevision updatedObj = datastore.update(insertedObj);
 
             Assert.assertNotNull(updatedObj);
 
@@ -180,11 +180,11 @@ public class DatabaseImplForceInsertTest {
             InternalDocumentRevision rev = createDbObject();
             datastore.forceInsert(rev, "1-rev", "2-rev", "4-rev");
 
-            DocumentRevision insertedObj = datastore.getDocument(OBJECT_ID);
+            DocumentRevision insertedObj = datastore.get(OBJECT_ID);
             insertedObj.setBody(bodyTwo);
-            DocumentRevision updateObj = datastore.updateDocumentFromRevision(insertedObj);
+            DocumentRevision updateObj = datastore.update(insertedObj);
             insertedObj.setBody(bodyTwo);
-            DocumentRevision updateObj2 = datastore.updateDocumentFromRevision(updateObj);
+            DocumentRevision updateObj2 = datastore.update(updateObj);
 
             Assert.assertNotNull(updateObj2);
 
@@ -204,7 +204,7 @@ public class DatabaseImplForceInsertTest {
 
         assertDBObjectIsCorrect(OBJECT_ID, 6, bodyTwo);
 
-        DocumentRevision p = datastore.getDocument(OBJECT_ID, "5-rev");
+        DocumentRevision p = datastore.get(OBJECT_ID, "5-rev");
         Assert.assertNotNull(p);
         Assert.assertEquals("5-rev", p.getRevision());
         Assert.assertTrue(Arrays.equals(bodyOne.asBytes(), p.getBody().asBytes()));
@@ -216,11 +216,11 @@ public class DatabaseImplForceInsertTest {
             InternalDocumentRevision rev = createDbObject();
             datastore.forceInsert(rev, "1-rev", "2-rev", "3-rev", "4-rev");
 
-            DocumentRevision insertedObj = datastore.getDocument(OBJECT_ID);
+            DocumentRevision insertedObj = datastore.get(OBJECT_ID);
             insertedObj.setBody(bodyTwo);
-            DocumentRevision updateObj = datastore.updateDocumentFromRevision(insertedObj);
+            DocumentRevision updateObj = datastore.update(insertedObj);
             insertedObj.setBody(bodyTwo);
-            DocumentRevision updateObj2 = datastore.updateDocumentFromRevision(updateObj);
+            DocumentRevision updateObj2 = datastore.update(updateObj);
 
             Assert.assertNotNull(updateObj2);
 
@@ -257,7 +257,7 @@ public class DatabaseImplForceInsertTest {
             datastore.forceInsert(newRev, "1-rev", "2-rev", "3-rev", "4-rev", "5-rev", remoteRevisionId6);
         }
 
-        DocumentRevision obj = datastore.getDocument(OBJECT_ID);
+        DocumentRevision obj = datastore.get(OBJECT_ID);
         Assert.assertEquals(remoteRevisionId6, obj.getRevision());
         Assert.assertTrue(Arrays.equals(bodyOne.asBytes(), obj.getBody().asBytes()));
     }
@@ -279,11 +279,11 @@ public class DatabaseImplForceInsertTest {
             InternalDocumentRevision rev = createDbObject();
             datastore.forceInsert(rev, "1-rev", "2-rev", "3-rev", "4-rev");
 
-            DocumentRevision insertedObj = datastore.getDocument(OBJECT_ID);
+            DocumentRevision insertedObj = datastore.get(OBJECT_ID);
             insertedObj.setBody(bodyTwo);
-            DocumentRevision updateObj = datastore.updateDocumentFromRevision(insertedObj);
+            DocumentRevision updateObj = datastore.update(insertedObj);
             insertedObj.setBody(bodyTwo);
-            DocumentRevision updateObj2 = datastore.updateDocumentFromRevision(updateObj);
+            DocumentRevision updateObj2 = datastore.update(updateObj);
 
             Assert.assertNotNull(updateObj2);
 
@@ -321,7 +321,7 @@ public class DatabaseImplForceInsertTest {
                     remoteRevisionId6);
         }
 
-        DocumentRevision obj = datastore.getDocument(OBJECT_ID);
+        DocumentRevision obj = datastore.get(OBJECT_ID);
         Assert.assertEquals(localRevisionId6, obj.getRevision());
         Assert.assertTrue(Arrays.equals(bodyTwo.asBytes(), obj.getBody().asBytes()));
     }
@@ -337,16 +337,16 @@ public class DatabaseImplForceInsertTest {
             InternalDocumentRevision rev = createDbObject();
             datastore.forceInsert(rev, "1-rev", "2-rev", "4-rev");
 
-            DocumentRevision insertedObj = datastore.getDocument(OBJECT_ID);
+            DocumentRevision insertedObj = datastore.get(OBJECT_ID);
             insertedObj.setBody(bodyTwo);
-            DocumentRevision updateObj = datastore.updateDocumentFromRevision(insertedObj);
+            DocumentRevision updateObj = datastore.update(insertedObj);
             updateObj.setBody(bodyTwo);
-            DocumentRevision updateObj2 = datastore.updateDocumentFromRevision(updateObj);
+            DocumentRevision updateObj2 = datastore.update(updateObj);
             Assert.assertNotNull(updateObj2);
 
             // Delete the document from the local database
-            datastore.deleteDocumentFromRevision(updateObj2);
-            DocumentRevision deletedObj = datastore.getDocument(OBJECT_ID);
+            datastore.delete(updateObj2);
+            DocumentRevision deletedObj = datastore.get(OBJECT_ID);
             Assert.assertTrue(deletedObj.isDeleted());
         }
 
@@ -370,11 +370,11 @@ public class DatabaseImplForceInsertTest {
             InternalDocumentRevision rev = createDbObject();
             datastore.forceInsert(rev, "1-rev", "2-rev", "4-rev");
 
-            DocumentRevision insertedObj = datastore.getDocument(OBJECT_ID);
+            DocumentRevision insertedObj = datastore.get(OBJECT_ID);
             insertedObj.setBody(bodyTwo);
-            DocumentRevision updateObj = datastore.updateDocumentFromRevision(insertedObj);
+            DocumentRevision updateObj = datastore.update(insertedObj);
             updateObj.setBody(bodyTwo);
-            DocumentRevision updateObj2 = datastore.updateDocumentFromRevision(updateObj);
+            DocumentRevision updateObj2 = datastore.update(updateObj);
             Assert.assertNotNull(updateObj2);
         }
 
@@ -394,7 +394,7 @@ public class DatabaseImplForceInsertTest {
     }
 
     private void assertDBObjectIsCorrect(String docId, int revGeneration, DocumentBody body) throws Exception {
-        DocumentRevision obj = datastore.getDocument(docId);
+        DocumentRevision obj = datastore.get(docId);
         Assert.assertNotNull(obj);
         Assert.assertEquals(revGeneration, CouchUtils.generationFromRevId(obj.getRevision()));
         Assert.assertTrue(Arrays.equals(body.asBytes(), obj.getBody().asBytes()));
@@ -405,7 +405,7 @@ public class DatabaseImplForceInsertTest {
         {
             InternalDocumentRevision rev = createDbObject("1-a", bodyOne);
             datastore.forceInsert(rev, "1-a" );
-            DocumentRevision insertedObj = datastore.getDocument(OBJECT_ID);
+            DocumentRevision insertedObj = datastore.get(OBJECT_ID);
             Assert.assertEquals("1-a", insertedObj.getRevision());
         }
 
@@ -425,7 +425,7 @@ public class DatabaseImplForceInsertTest {
         {
             InternalDocumentRevision rev = createDbObject("1-x", bodyOne);
             datastore.forceInsert(rev, "1-x" );
-            DocumentRevision insertedObj = datastore.getDocument(OBJECT_ID);
+            DocumentRevision insertedObj = datastore.get(OBJECT_ID);
             Assert.assertEquals("1-x", insertedObj.getRevision());
         }
 
@@ -445,7 +445,7 @@ public class DatabaseImplForceInsertTest {
         {
             InternalDocumentRevision rev = createDbObject("1-x", bodyOne);
             datastore.forceInsert(rev, "1-x");
-            DocumentRevision insertedObj = datastore.getDocument(OBJECT_ID);
+            DocumentRevision insertedObj = datastore.get(OBJECT_ID);
             Assert.assertEquals("1-x", insertedObj.getRevision());
         }
 
@@ -458,7 +458,7 @@ public class DatabaseImplForceInsertTest {
         Assert.assertThat(tree.leafs(), hasSize(2));
         Assert.assertThat(tree.leafRevisionIds(), hasItems("1-x", "2-c"));
 
-        InternalDocumentRevision leaf = datastore.getDocument(OBJECT_ID, "2-c");
+        InternalDocumentRevision leaf = datastore.get(OBJECT_ID, "2-c");
         Assert.assertThat(tree.getPath(leaf.getSequence()), equalTo(Arrays.asList("2-c", "1-a")));
 
         assertDocumentHasRevAndBody(OBJECT_ID, "2-c", bodyTwo);
@@ -494,7 +494,7 @@ public class DatabaseImplForceInsertTest {
         datastore.forceInsert(rev2_alt, "1-x", "2-y");
         datastore.forceInsert(rev7, "6-x", "7-x");
 
-        Assert.assertEquals(datastore.getDocument(OBJECT_ID).getRevision(), "2-y");
+        Assert.assertEquals(datastore.get(OBJECT_ID).getRevision(), "2-y");
     }
 
     @Test
@@ -523,7 +523,7 @@ public class DatabaseImplForceInsertTest {
         datastore.forceInsert(rev7, "6-x", "7-x");
         datastore.forceInsert(rev2_alt, "1-x", "2-y");
 
-        Assert.assertEquals(datastore.getDocument(OBJECT_ID).getRevision(), "2-y");
+        Assert.assertEquals(datastore.get(OBJECT_ID).getRevision(), "2-y");
     }
 
     @Test
@@ -558,9 +558,9 @@ public class DatabaseImplForceInsertTest {
         // fetch non-deleted leafs until there are none left
         List<InternalDocumentRevision> leafs;
         while((leafs = (datastore.getAllRevisionsOfDocument(OBJECT_ID).leafRevisions(true))).size() != 0) {
-            // getDocument() should never return a deleted document:
+            // get() should never return a deleted document:
             // under previous behaviour of pickWinnerOfConflicts, this would fail
-            DocumentRevision currentLeaf = datastore.getDocument(OBJECT_ID);
+            DocumentRevision currentLeaf = datastore.get(OBJECT_ID);
             Assert.assertFalse("Current revision should not have been marked as deleted. Current leaf: " +
                     currentLeaf +
                     ". Current state of all leaf nodes: "+leafs,
@@ -588,7 +588,7 @@ public class DatabaseImplForceInsertTest {
                     }
                 }
             });
-            currentLeaf = datastore.getDocument(OBJECT_ID);
+            currentLeaf = datastore.get(OBJECT_ID);
 
             if (leafs.size() == 0) {
                 break;
@@ -611,11 +611,11 @@ public class DatabaseImplForceInsertTest {
         Assert.assertEquals(
                 "RevId should have been highest expected value. Current state of all sorted leaf nodes: "+leafs,
                 expectedRevId,
-                datastore.getDocument(OBJECT_ID).getRevision());
+                datastore.get(OBJECT_ID).getRevision());
     }
 
     private void assertDocumentHasRevAndBody(String id, String rev, DocumentBody body) throws Exception {
-        DocumentRevision obj = datastore.getDocument(id);
+        DocumentRevision obj = datastore.get(id);
         Assert.assertEquals(rev, obj.getRevision());
         Assert.assertTrue(Arrays.equals(obj.getBody().asBytes(), body.asBytes()));
     }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatabaseImplRevsDiffTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatabaseImplRevsDiffTest.java
@@ -36,7 +36,7 @@ public class DatabaseImplRevsDiffTest extends BasicDatastoreTestBase{
     public void revsDiff_oneDocOneRev_returnNothing() throws Exception {
         DocumentRevision revMut = new DocumentRevision();
         revMut.setBody(bodyOne);
-        DocumentRevision rev = datastore.createDocumentFromRevision(revMut);
+        DocumentRevision rev = datastore.create(revMut);
         ValueListMap<String, String> revs = new ValueListMap<String, String>();
         revs.addValueToKey(rev.getId(), rev.getRevision());
         Map<String, List<String>> missingRevs = datastore.revsDiff(revs);
@@ -47,7 +47,7 @@ public class DatabaseImplRevsDiffTest extends BasicDatastoreTestBase{
     public void revsDiff_oneDocOneRev_returnOne() throws Exception {
         DocumentRevision revMut = new DocumentRevision();
         revMut.setBody(bodyOne);
-        DocumentRevision rev = datastore.createDocumentFromRevision(revMut);
+        DocumentRevision rev = datastore.create(revMut);
         ValueListMap<String, String> revs = new ValueListMap<String, String>();
         revs.addValueToKey(rev.getId(), "2-a");
         Map<String, List<String>> missingRevs = datastore.revsDiff(revs);
@@ -59,10 +59,10 @@ public class DatabaseImplRevsDiffTest extends BasicDatastoreTestBase{
     public void revsDiff_oneDocTwoRevs_returnNothing() throws Exception {
         DocumentRevision revMut1 = new DocumentRevision();
         revMut1.setBody(bodyOne);
-        DocumentRevision rev1 = datastore.createDocumentFromRevision(revMut1);
+        DocumentRevision rev1 = datastore.create(revMut1);
         DocumentRevision rev2Mut = rev1;
         rev2Mut.setBody(bodyTwo);
-        DocumentRevision rev2 = datastore.updateDocumentFromRevision(rev2Mut);
+        DocumentRevision rev2 = datastore.update(rev2Mut);
         ValueListMap<String, String> revs = new ValueListMap<String, String>();
         revs.addValueToKey(rev1.getId(), rev1.getRevision());
         revs.addValueToKey(rev2.getId(), rev2.getRevision());
@@ -74,10 +74,10 @@ public class DatabaseImplRevsDiffTest extends BasicDatastoreTestBase{
     public void revsDiff_twoDoc_returnOneDoc() throws Exception {
         DocumentRevision revMut1 = new DocumentRevision();
         revMut1.setBody(bodyOne);
-        DocumentRevision rev1 = datastore.createDocumentFromRevision(revMut1);
+        DocumentRevision rev1 = datastore.create(revMut1);
         DocumentRevision revMut2 = new DocumentRevision();
         revMut2.setBody(bodyTwo);
-        DocumentRevision rev2 = datastore.createDocumentFromRevision(revMut2);
+        DocumentRevision rev2 = datastore.create(revMut2);
         ValueListMap<String, String> revs = new ValueListMap<String, String>();
         revs.addValueToKey(rev1.getId(), rev1.getRevision());
         revs.addValueToKey(rev1.getId(), "2-a");
@@ -92,10 +92,10 @@ public class DatabaseImplRevsDiffTest extends BasicDatastoreTestBase{
     public void revsDiff_twoDoc_returnTwoDocs() throws Exception {
         DocumentRevision revMut1 = new DocumentRevision();
         revMut1.setBody(bodyOne);
-        DocumentRevision rev1 = datastore.createDocumentFromRevision(revMut1);
+        DocumentRevision rev1 = datastore.create(revMut1);
         DocumentRevision revMut2 = new DocumentRevision();
         revMut2.setBody(bodyTwo);
-        DocumentRevision rev2 = datastore.createDocumentFromRevision(revMut2);
+        DocumentRevision rev2 = datastore.create(revMut2);
 
         ValueListMap<String, String> revs = new ValueListMap<String, String>();
         revs.addValueToKey(rev1.getId(), rev1.getRevision());
@@ -113,10 +113,10 @@ public class DatabaseImplRevsDiffTest extends BasicDatastoreTestBase{
     public void revsDiff_oneDocWithManyRevisions_onlyNonExistingRevisionsReturned() throws Exception {
         DocumentRevision revMut1 = new DocumentRevision();
         revMut1.setBody(bodyOne);
-        DocumentRevision rev1 = datastore.createDocumentFromRevision(revMut1);
+        DocumentRevision rev1 = datastore.create(revMut1);
         DocumentRevision revMut2 = new DocumentRevision();
         revMut2.setBody(bodyTwo);
-        DocumentRevision rev2 = datastore.createDocumentFromRevision(revMut2);
+        DocumentRevision rev2 = datastore.create(revMut2);
 
         ValueListMap<String, String> revs = new ValueListMap<String, String>();
         // Add two existing revisions first, and then add many

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatabaseManagerTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatabaseManagerTest.java
@@ -136,14 +136,14 @@ public class DatabaseManagerTest {
     @Test(expected = IllegalStateException.class)
     public void deleteDatastore_createDocumentUsingDeletedDatastore_exception() throws Exception {
         DocumentStore ds = createAndAssertDatastore();
-        DocumentRevision object = ds.database().createDocumentFromRevision(createDBBody("Tom"));
+        DocumentRevision object = ds.database().create(createDBBody("Tom"));
         Assert.assertNotNull(object);
 
         ds.delete();
         String dbDir = TEST_PATH.getAbsolutePath();
         Assert.assertFalse(new File(dbDir).exists());
 
-        ds.database().createDocumentFromRevision(createDBBody("Jerry"));
+        ds.database().create(createDBBody("Jerry"));
     }
 
     public DocumentRevision createDBBody(String name) throws IOException {

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatastoreSchemaTests.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatastoreSchemaTests.java
@@ -379,7 +379,7 @@ public class DatastoreSchemaTests {
             // lowest seq.
             // Validate that after migration only one remains and it is of the correct name
             List<? extends Attachment> attachments = datastore.attachmentsForRevision(datastore
-                    .get("d834ca038de24bf0ac9f708fcdb63e21"));
+                    .read("d834ca038de24bf0ac9f708fcdb63e21"));
             Assert.assertEquals("There should only be one copy of the attachment", 1, attachments
                     .size());
             Attachment a = attachments.get(0);
@@ -389,7 +389,7 @@ public class DatastoreSchemaTests {
             // highest seq.
             // Validate that after migration only one remains and it is of the correct name
             attachments = datastore.attachmentsForRevision(datastore
-                    .get("a2359c3503e34c008ec448834583e482"));
+                    .read("a2359c3503e34c008ec448834583e482"));
             Assert.assertEquals("There should only be one copy of the attachment", 1, attachments
                     .size());
             a = attachments.get(0);
@@ -399,7 +399,7 @@ public class DatastoreSchemaTests {
             // two seqs.
             // Validate that after migration two different attachments remain
             attachments = datastore.attachmentsForRevision(datastore
-                    .get("badad1b3842e4056b013587b49c93308"));
+                    .read("badad1b3842e4056b013587b49c93308"));
             Assert.assertEquals("There should only be two attachments", 2, attachments
                     .size());
             Assert.assertNotEquals("The attachment names should be different", attachments.get(0)
@@ -610,7 +610,7 @@ public class DatastoreSchemaTests {
                 leafRevisionIds();
         for (String revId : revIds) {
             try {
-                actualAttachmentCount += database.get(docId, revId).getAttachments().size();
+                actualAttachmentCount += database.read(docId, revId).getAttachments().size();
             } catch (DocumentNotFoundException dnfe) {
                 Assert.fail("Failed to find revision for document ID " + docId + " and revision ID "
                         + revId);
@@ -623,7 +623,7 @@ public class DatastoreSchemaTests {
 
     private void assertWinner(Database database, String docId, String expectedRevId) throws DocumentNotFoundException, DocumentStoreException {
         try {
-            String actualRevId = database.get(docId).getRevision();
+            String actualRevId = database.read(docId).getRevision();
             Assert.assertEquals("Should get the expected winning revision ID", expectedRevId,
                     actualRevId);
         } catch (DocumentNotFoundException dnfe) {

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatastoreSchemaTests.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatastoreSchemaTests.java
@@ -379,7 +379,7 @@ public class DatastoreSchemaTests {
             // lowest seq.
             // Validate that after migration only one remains and it is of the correct name
             List<? extends Attachment> attachments = datastore.attachmentsForRevision(datastore
-                    .getDocument("d834ca038de24bf0ac9f708fcdb63e21"));
+                    .get("d834ca038de24bf0ac9f708fcdb63e21"));
             Assert.assertEquals("There should only be one copy of the attachment", 1, attachments
                     .size());
             Attachment a = attachments.get(0);
@@ -389,7 +389,7 @@ public class DatastoreSchemaTests {
             // highest seq.
             // Validate that after migration only one remains and it is of the correct name
             attachments = datastore.attachmentsForRevision(datastore
-                    .getDocument("a2359c3503e34c008ec448834583e482"));
+                    .get("a2359c3503e34c008ec448834583e482"));
             Assert.assertEquals("There should only be one copy of the attachment", 1, attachments
                     .size());
             a = attachments.get(0);
@@ -399,7 +399,7 @@ public class DatastoreSchemaTests {
             // two seqs.
             // Validate that after migration two different attachments remain
             attachments = datastore.attachmentsForRevision(datastore
-                    .getDocument("badad1b3842e4056b013587b49c93308"));
+                    .get("badad1b3842e4056b013587b49c93308"));
             Assert.assertEquals("There should only be two attachments", 2, attachments
                     .size());
             Assert.assertNotEquals("The attachment names should be different", attachments.get(0)
@@ -610,7 +610,7 @@ public class DatastoreSchemaTests {
                 leafRevisionIds();
         for (String revId : revIds) {
             try {
-                actualAttachmentCount += database.getDocument(docId, revId).getAttachments().size();
+                actualAttachmentCount += database.get(docId, revId).getAttachments().size();
             } catch (DocumentNotFoundException dnfe) {
                 Assert.fail("Failed to find revision for document ID " + docId + " and revision ID "
                         + revId);
@@ -623,7 +623,7 @@ public class DatastoreSchemaTests {
 
     private void assertWinner(Database database, String docId, String expectedRevId) throws DocumentNotFoundException, DocumentStoreException {
         try {
-            String actualRevId = database.getDocument(docId).getRevision();
+            String actualRevId = database.get(docId).getRevision();
             Assert.assertEquals("Should get the expected winning revision ID", expectedRevId,
                     actualRevId);
         } catch (DocumentNotFoundException dnfe) {

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DocumentNotificationsTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DocumentNotificationsTest.java
@@ -44,7 +44,7 @@ public class DocumentNotificationsTest extends BasicDatastoreTestBase {
     public void notification_document_created() throws Exception {
         DocumentRevision rev = new DocumentRevision();
         rev.setBody(bodyOne);
-        datastore.createDocumentFromRevision(rev);
+        datastore.create(rev);
         boolean ok = NotificationTestUtils.waitForSignal(documentCreated);
         Assert.assertTrue("Didn't receive document created event", ok);
     }
@@ -53,12 +53,12 @@ public class DocumentNotificationsTest extends BasicDatastoreTestBase {
     public void notification_document_updated() throws Exception {
         DocumentRevision rev_1Mut = new DocumentRevision();
         rev_1Mut.setBody(bodyOne);
-        DocumentRevision rev_1 = datastore.createDocumentFromRevision(rev_1Mut);
+        DocumentRevision rev_1 = datastore.create(rev_1Mut);
         validateNewlyCreatedDocument(rev_1);
         try {
             DocumentRevision rev_2Mut = rev_1;
             rev_2Mut.setBody(bodyTwo);
-            datastore.updateDocumentFromRevision(rev_2Mut);
+            datastore.update(rev_2Mut);
         } catch (ConflictException ce) {
             Assert.fail("Got ConflictException when updating");
         }
@@ -70,9 +70,9 @@ public class DocumentNotificationsTest extends BasicDatastoreTestBase {
     public void notification_document_deleted() throws Exception {
         DocumentRevision rev_1Mut = new DocumentRevision();
         rev_1Mut.setBody(bodyOne);
-        DocumentRevision rev_1 = datastore.createDocumentFromRevision(rev_1Mut);
+        DocumentRevision rev_1 = datastore.create(rev_1Mut);
         try {
-            datastore.deleteDocumentFromRevision(rev_1);
+            datastore.delete(rev_1);
         } catch (ConflictException ce) {
             Assert.fail("Got ConflictException when deleting");
         }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/ForceInsertTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/ForceInsertTest.java
@@ -49,7 +49,7 @@ public class ForceInsertTest extends BasicDatastoreTestBase {
         // create a document and insert the first revision
         DocumentRevision doc1_rev1 = new DocumentRevision();
         doc1_rev1.setBody(bodyOne);
-        doc1_rev1 = datastore.createDocumentFromRevision(doc1_rev1);
+        doc1_rev1 = datastore.create(doc1_rev1);
 
         ArrayList<String> revisionHistory = new ArrayList<String>();
         revisionHistory.add(doc1_rev1.getRevision());
@@ -79,7 +79,7 @@ public class ForceInsertTest extends BasicDatastoreTestBase {
         // create a document and insert the 1-revision
         DocumentRevision doc1_rev1Mut = new DocumentRevision();
         doc1_rev1Mut.setBody(bodyOne);
-        DocumentRevision doc1_rev1 = datastore.createDocumentFromRevision(doc1_rev1Mut);
+        DocumentRevision doc1_rev1 = datastore.create(doc1_rev1Mut);
         Map<String, Object> atts = new HashMap<String, Object>();
         Map<String, Object> att1 = new HashMap<String, Object>();
 
@@ -123,7 +123,7 @@ public class ForceInsertTest extends BasicDatastoreTestBase {
 
         DocumentRevision doc1_rev1Mut = new DocumentRevision();
         doc1_rev1Mut.setBody(bodyOne);
-        DocumentRevision doc1_rev1 = datastore.createDocumentFromRevision(doc1_rev1Mut);
+        DocumentRevision doc1_rev1 = datastore.create(doc1_rev1Mut);
         Map<String, Object> atts = new HashMap<String, Object>();
         Map<String, Object> att1 = new HashMap<String, Object>();
 
@@ -144,7 +144,7 @@ public class ForceInsertTest extends BasicDatastoreTestBase {
         }
 
         // adding the attachment should have failed transactionally, so the rev should not exist as well
-        Assert.assertFalse(datastore.containsDocument(doc1_rev1.getId(), doc1_rev1.getRevision()));
+        Assert.assertFalse(datastore.contains(doc1_rev1.getId(), doc1_rev1.getRevision()));
 
         Attachment storedAtt = datastore.getAttachment(doc1_rev1.getId(), doc1_rev1.getRevision(), "att1");
         Assert.assertNull(storedAtt);

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/MultipartAttachmentWriterTests.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/MultipartAttachmentWriterTests.java
@@ -83,7 +83,7 @@ public class MultipartAttachmentWriterTests {
     public void Add1000TextAttachmentsTest() throws Exception {
         DocumentRevision docMut = new DocumentRevision();
         docMut.setBody(bodyOne);
-        DocumentRevision doc = database.createDocumentFromRevision(docMut);
+        DocumentRevision doc = database.create(docMut);
 
         MultipartAttachmentWriter mpw = new MultipartAttachmentWriter();
         mpw.setBody(doc.getBody().asMap());
@@ -122,7 +122,7 @@ public class MultipartAttachmentWriterTests {
     public void AddImageAttachmentTest() throws Exception {
         DocumentRevision docMut = new DocumentRevision();
         docMut.setBody(bodyOne);
-        InternalDocumentRevision doc = (InternalDocumentRevision)database.createDocumentFromRevision(docMut);
+        InternalDocumentRevision doc = (InternalDocumentRevision)database.create(docMut);
 
         MultipartAttachmentWriter mpw = new MultipartAttachmentWriter();
         mpw.setBody(doc.asMap());

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/MutableDocumentDeleteTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/MutableDocumentDeleteTest.java
@@ -39,13 +39,13 @@ public class MutableDocumentDeleteTest extends BasicDatastoreTestBase {
         super.setUp();
         DocumentRevision rev = new DocumentRevision("doc1");
         rev.setBody(bodyOne);
-        saved = datastore.createDocumentFromRevision(rev);
+        saved = datastore.create(rev);
     }
 
     // Delete a MutableCopy
     @Test
     public void deleteFromRevision() throws Exception {
-        DocumentRevision deleted = datastore.deleteDocumentFromRevision(saved);
+        DocumentRevision deleted = datastore.delete(saved);
         Assert.assertNotNull("Deleted DocumentRevision is null", deleted);
         Assert.assertTrue("Deleted DocumentRevision is not flagged as deleted", deleted.isDeleted());
     }
@@ -54,7 +54,7 @@ public class MutableDocumentDeleteTest extends BasicDatastoreTestBase {
     @Test
     public void deleteNullRevision() throws Exception {
         try {
-            DocumentRevision deleted = datastore.deleteDocumentFromRevision(null);
+            DocumentRevision deleted = datastore.delete((DocumentRevision)null);
             Assert.fail("NullPointerException expected");
         } catch (NullPointerException npe) {
             ;
@@ -66,14 +66,14 @@ public class MutableDocumentDeleteTest extends BasicDatastoreTestBase {
     public void deleteConflictRevision() throws Exception {
         DocumentRevision update = saved;
         update.setBody(bodyTwo);
-        DocumentRevision updatedStale = datastore.updateDocumentFromRevision(update);
+        DocumentRevision updatedStale = datastore.update(update);
         DocumentRevision updateStale = updatedStale;
         updateStale.setAttachments(null);
         updateStale.setBody(DocumentBodyFactory.create("{\"description\": \"this update will get committed\"}".getBytes()));
         // this won't delete, will throw conflictexception
-        datastore.updateDocumentFromRevision(updateStale);
+        datastore.update(updateStale);
         try {
-            datastore.deleteDocumentFromRevision(updatedStale);
+            datastore.delete(updatedStale);
             Assert.fail("Expected ConflictException; not thrown");
         } catch (ConflictException ce) {
             ;
@@ -104,7 +104,7 @@ public class MutableDocumentDeleteTest extends BasicDatastoreTestBase {
             Assert.assertTrue("Expected rev to not be deleted", !rev.isDeleted());
         }
         // do the delete
-        List<? extends DocumentRevision> deleted = datastore.deleteDocument(saved.getId());
+        List<? extends DocumentRevision> deleted = datastore.delete(saved.getId());
         // assert on deleted documents returned
         Assert.assertEquals("Expected 10 leaves", 10, deleted.size());
         for(DocumentRevision rev : deleted) {
@@ -119,7 +119,7 @@ public class MutableDocumentDeleteTest extends BasicDatastoreTestBase {
     @Test
     public void deleteAllNullRevision() throws Exception {
         try {
-            List<? extends DocumentRevision> deleted = datastore.deleteDocument(null);
+            List<? extends DocumentRevision> deleted = datastore.delete((String)null);
             Assert.fail("NullPointerException expected");
         } catch (NullPointerException npe) {
             ;
@@ -128,7 +128,7 @@ public class MutableDocumentDeleteTest extends BasicDatastoreTestBase {
 
     @Test
     public void deleteAllNonExistentRevision() throws Exception {
-        List<? extends DocumentRevision> deleted = datastore.deleteDocument("abc123");
+        List<? extends DocumentRevision> deleted = datastore.delete("abc123");
         Assert.assertEquals("Deleted list should be empty", true, deleted.isEmpty());
 
     }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/MutableDocumentNoInitialAttachmentsTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/MutableDocumentNoInitialAttachmentsTest.java
@@ -127,7 +127,7 @@ public class MutableDocumentNoInitialAttachmentsTest extends BasicDatastoreTestB
         }
         // document should not be updated
         Assert.assertNull("Updated DocumentRevision is not null", updated);
-        DocumentRevision retrieved = this.datastore.get(saved.getId());
+        DocumentRevision retrieved = this.datastore.read(saved.getId());
         Assert.assertEquals("Document should not be updated", retrieved.getRevision(), saved.getRevision());
         // also get the attachments through the documentrev
         Assert.assertEquals("Revision should have 0 attachments", 0, retrieved.getAttachments().size());

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/MutableDocumentNoInitialAttachmentsTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/MutableDocumentNoInitialAttachmentsTest.java
@@ -16,7 +16,6 @@ package com.cloudant.sync.internal.documentstore;
 
 import com.cloudant.sync.documentstore.Attachment;
 import com.cloudant.sync.documentstore.AttachmentException;
-import com.cloudant.sync.documentstore.DocumentException;
 import com.cloudant.sync.documentstore.DocumentRevision;
 import com.cloudant.sync.documentstore.DocumentStoreException;
 import com.cloudant.sync.documentstore.UnsavedFileAttachment;
@@ -41,7 +40,7 @@ public class MutableDocumentNoInitialAttachmentsTest extends BasicDatastoreTestB
         super.setUp();
         DocumentRevision rev = new DocumentRevision("doc1");
         rev.setBody(bodyOne);
-        saved = datastore.createDocumentFromRevision(rev);
+        saved = datastore.create(rev);
     }
 
     // Update revision with updated body
@@ -49,7 +48,7 @@ public class MutableDocumentNoInitialAttachmentsTest extends BasicDatastoreTestB
     public void updateBody() throws Exception {
         DocumentRevision update = saved;
         update.setBody(bodyTwo);
-        DocumentRevision updated = datastore.updateDocumentFromRevision(update);
+        DocumentRevision updated = datastore.update(update);
         Assert.assertNotNull("Updated DocumentRevision is null", updated);
     }
 
@@ -59,7 +58,7 @@ public class MutableDocumentNoInitialAttachmentsTest extends BasicDatastoreTestB
     public void updateBodyNull() throws Exception {
         DocumentRevision update = saved;
         update.setBody(null);
-        DocumentRevision updated = datastore.updateDocumentFromRevision(update);
+        DocumentRevision updated = datastore.update(update);
     }
 
     // Update revision with updated body and new attachment
@@ -71,7 +70,7 @@ public class MutableDocumentNoInitialAttachmentsTest extends BasicDatastoreTestB
         File f = TestUtils.loadFixture("fixture/" + attachmentName);
         Attachment att = new UnsavedFileAttachment(f, "text/plain");
         update.getAttachments().put(attachmentName, att);
-        DocumentRevision updated = datastore.updateDocumentFromRevision(update);
+        DocumentRevision updated = datastore.update(update);
         Assert.assertNotNull("Updated DocumentRevision is null", updated);
         Attachment retrievedAtt = datastore.getAttachment(updated.getId(), updated.getRevision(), attachmentName);
         Assert.assertNotNull("Retrieved attachment is null", retrievedAtt);
@@ -86,7 +85,7 @@ public class MutableDocumentNoInitialAttachmentsTest extends BasicDatastoreTestB
         DocumentRevision update = saved;
         update.setBody(bodyTwo);
         update.setAttachments(null);
-        DocumentRevision updated = datastore.updateDocumentFromRevision(update);
+        DocumentRevision updated = datastore.update(update);
         Assert.assertNotNull("Updated DocumentRevision is null", updated);
         // also get the attachments through the documentrev
         Assert.assertEquals("Revision should have 0 attachments", 0, updated.getAttachments().size());
@@ -100,7 +99,7 @@ public class MutableDocumentNoInitialAttachmentsTest extends BasicDatastoreTestB
         File f = TestUtils.loadFixture("fixture/"+attachmentName);
         Attachment att = new UnsavedFileAttachment(f, "text/plain");
         update.getAttachments().put(attachmentName, att);
-        DocumentRevision updated = datastore.updateDocumentFromRevision(update);
+        DocumentRevision updated = datastore.update(update);
         Assert.assertNotNull("Updated DocumentRevision is null", updated);
         Attachment retrievedAtt = datastore.getAttachment(updated.getId(), updated.getRevision(), attachmentName);
         Assert.assertNotNull("Retrieved attachment is null", retrievedAtt);
@@ -121,14 +120,14 @@ public class MutableDocumentNoInitialAttachmentsTest extends BasicDatastoreTestB
         update.getAttachments().put(attachmentName, att);
         DocumentRevision updated = null;
         try {
-            updated = datastore.updateDocumentFromRevision(update);
+            updated = datastore.update(update);
             Assert.fail("Expected AttachmentException; not thrown");
         } catch (AttachmentException e) {
             ;
         }
         // document should not be updated
         Assert.assertNull("Updated DocumentRevision is not null", updated);
-        DocumentRevision retrieved = this.datastore.getDocument(saved.getId());
+        DocumentRevision retrieved = this.datastore.get(saved.getId());
         Assert.assertEquals("Document should not be updated", retrieved.getRevision(), saved.getRevision());
         // also get the attachments through the documentrev
         Assert.assertEquals("Revision should have 0 attachments", 0, retrieved.getAttachments().size());

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/AbstractQueryTestBase.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/AbstractQueryTestBase.java
@@ -89,7 +89,7 @@ public abstract class AbstractQueryTestBase {
         bodyMap.put("age", 12);
         bodyMap.put("pet", "cat");
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
 
         rev = new DocumentRevision("mike34");
@@ -98,7 +98,7 @@ public abstract class AbstractQueryTestBase {
         bodyMap.put("age", 34);
         bodyMap.put("pet", "dog");
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
 
         rev = new DocumentRevision("mike72");
@@ -107,7 +107,7 @@ public abstract class AbstractQueryTestBase {
         bodyMap.put("age", 72);
         bodyMap.put("pet", "cat");
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
 
         rev = new DocumentRevision("fred34");
@@ -116,7 +116,7 @@ public abstract class AbstractQueryTestBase {
         bodyMap.put("age", 34);
         bodyMap.put("pet", "cat");
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
 
         rev = new DocumentRevision("fred12");
@@ -124,7 +124,7 @@ public abstract class AbstractQueryTestBase {
         bodyMap.put("name", "fred");
         bodyMap.put("age", 12);
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
 
         assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("age")), "basic"), is("basic"));
@@ -152,7 +152,7 @@ public abstract class AbstractQueryTestBase {
         bodyMap.put("pet", "cat");
         rev.setBody(DocumentBodyFactory.create(bodyMap));
 
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
 
         rev = new DocumentRevision("mike34");
@@ -161,7 +161,7 @@ public abstract class AbstractQueryTestBase {
         bodyMap.put("age", 34);
         bodyMap.put("pet", "dog");
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
 
         rev = new DocumentRevision("mike72");
@@ -170,7 +170,7 @@ public abstract class AbstractQueryTestBase {
         bodyMap.put("age", 72);
         bodyMap.put("pet", "cat");
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
 
         rev = new DocumentRevision("اسم34");
@@ -179,21 +179,21 @@ public abstract class AbstractQueryTestBase {
         bodyMap.put("age", 34);
         bodyMap.put("pet", "cat");
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         rev = new DocumentRevision("fred12");
         bodyMap.clear();
         bodyMap.put("name", "fred");
         bodyMap.put("age", 12);
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         rev = new DocumentRevision("fredarabic");
         bodyMap.clear();
         bodyMap.put("اسم", "fred");
         bodyMap.put("age", 12);
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
 
         rev = new DocumentRevision("freddatatype");
@@ -201,7 +201,7 @@ public abstract class AbstractQueryTestBase {
         bodyMap.put("datatype", "fred");
         bodyMap.put("age", 12);
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
     }
 
@@ -227,7 +227,7 @@ public abstract class AbstractQueryTestBase {
         bodyMap.put("age", 12);
         bodyMap.put("pet", "cat");
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         rev = new DocumentRevision("mike23");
         bodyMap.clear();
@@ -235,7 +235,7 @@ public abstract class AbstractQueryTestBase {
         bodyMap.put("age", 23);
         bodyMap.put("pet", "parrot");
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         rev = new DocumentRevision("mike34");
         bodyMap.clear();
@@ -243,7 +243,7 @@ public abstract class AbstractQueryTestBase {
         bodyMap.put("age", 34);
         bodyMap.put("pet", "dog");
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         rev = new DocumentRevision("john34");
         bodyMap.clear();
@@ -251,7 +251,7 @@ public abstract class AbstractQueryTestBase {
         bodyMap.put("age", 34);
         bodyMap.put("pet", "fish");
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         rev = new DocumentRevision("fred43");
         bodyMap.clear();
@@ -259,14 +259,14 @@ public abstract class AbstractQueryTestBase {
         bodyMap.put("age", 43);
         bodyMap.put("pet", "snake");
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         rev = new DocumentRevision("fred12");
         bodyMap.clear();
         bodyMap.put("name", "fred");
         bodyMap.put("age", 12);
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("age"), new FieldSort("pet"), new FieldSort("name")), "basic"),
                 is("basic"));
@@ -282,7 +282,7 @@ public abstract class AbstractQueryTestBase {
         bodyMap.put("age", 12);
         bodyMap.put("pet", Arrays.<String>asList("cat", "dog"));
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         rev = new DocumentRevision("fred34");
         bodyMap.clear();
@@ -290,7 +290,7 @@ public abstract class AbstractQueryTestBase {
         bodyMap.put("age", 34);
         bodyMap.put("pet", "parrot");
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         rev = new DocumentRevision("mike34");
         bodyMap.clear();
@@ -298,14 +298,14 @@ public abstract class AbstractQueryTestBase {
         bodyMap.put("age", 34);
         bodyMap.put("pet", Arrays.<String>asList("cat", "dog", "fish"));
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         rev = new DocumentRevision("fred12");
         bodyMap.clear();
         bodyMap.put("name", "fred");
         bodyMap.put("age", 12);
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         rev = new DocumentRevision("john44");
         bodyMap.clear();
@@ -313,7 +313,7 @@ public abstract class AbstractQueryTestBase {
         bodyMap.put("age", 44);
         bodyMap.put("pet", Arrays.<String>asList("hamster", "snake"));
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         rev = new DocumentRevision("john22");
         bodyMap.clear();
@@ -321,7 +321,7 @@ public abstract class AbstractQueryTestBase {
         bodyMap.put("age", 22);
         bodyMap.put("pet", "cat");
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("pet"), new FieldSort("age")), "pet"),
                 is("pet"));
@@ -335,70 +335,70 @@ public abstract class AbstractQueryTestBase {
         bodyMap.put("name", "mike");
         bodyMap.put("score", 31);
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         rev = new DocumentRevision("fred11");
         bodyMap.clear();
         bodyMap.put("name", "fred");
         bodyMap.put("score", 11);
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         rev = new DocumentRevision("john15");
         bodyMap.clear();
         bodyMap.put("name", "john");
         bodyMap.put("score", 15);
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         rev = new DocumentRevision("john-15");
         bodyMap.clear();
         bodyMap.put("name", "john");
         bodyMap.put("score", -15);
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         rev = new DocumentRevision("john15.2");
         bodyMap.clear();
         bodyMap.put("name", "john");
         bodyMap.put("score", 15.2);
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         rev = new DocumentRevision("john15.6");
         bodyMap.clear();
         bodyMap.put("name", "john");
         bodyMap.put("score", 15.6);
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         rev = new DocumentRevision("john0");
         bodyMap.clear();
         bodyMap.put("name", "john");
         bodyMap.put("score", 0);
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         rev = new DocumentRevision("john0.0");
         bodyMap.clear();
         bodyMap.put("name", "john");
         bodyMap.put("score", 0.0);
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         rev = new DocumentRevision("john0.6");
         bodyMap.clear();
         bodyMap.put("name", "john");
         bodyMap.put("score", 0.6);
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         rev = new DocumentRevision("john-0.6");
         bodyMap.clear();
         bodyMap.put("name", "john");
         bodyMap.put("score", -0.6);
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("score")), "name_score"),
                                     is("name_score"));
@@ -413,7 +413,7 @@ public abstract class AbstractQueryTestBase {
             bodyMap.put("large_field", "cat");
             bodyMap.put("idx", i);
             rev.setBody(DocumentBodyFactory.create(bodyMap));
-            ds.createDocumentFromRevision(rev);
+            ds.create(rev);
         }
         assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("large_field"), new FieldSort("idx")), "large"),
                 is("large"));
@@ -429,7 +429,7 @@ public abstract class AbstractQueryTestBase {
         bodyMap.put("age", 12);
         bodyMap.put("pet", "cat");
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         rev = new DocumentRevision("mike34");
         bodyMap.clear();
@@ -437,7 +437,7 @@ public abstract class AbstractQueryTestBase {
         bodyMap.put("age", 34);
         bodyMap.put("pet", "dog");
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         rev = new DocumentRevision("mike72");
         bodyMap.clear();
@@ -446,7 +446,7 @@ public abstract class AbstractQueryTestBase {
         bodyMap.put("pet", "cat");
         bodyMap.put("town", "bristol");
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         rev = new DocumentRevision("fred34");
         bodyMap.clear();
@@ -454,7 +454,7 @@ public abstract class AbstractQueryTestBase {
         bodyMap.put("age", 34);
         bodyMap.put("pet", "cat");
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         rev = new DocumentRevision("fred12");
         bodyMap.clear();
@@ -462,7 +462,7 @@ public abstract class AbstractQueryTestBase {
         bodyMap.put("age", 12);
         bodyMap.put("town", "bristol");
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("age")), "basic"), is("basic"));
         assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("pet")), "pet"), is("pet"));
@@ -477,7 +477,7 @@ public abstract class AbstractQueryTestBase {
         bodyMap.put("age", 24);
         bodyMap.put("pet", Collections.singletonList("cat"));
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         rev = new DocumentRevision("mike12");
         bodyMap.clear();
@@ -485,7 +485,7 @@ public abstract class AbstractQueryTestBase {
         bodyMap.put("age", 12);
         bodyMap.put("pet", Arrays.asList("cat", "dog"));
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         rev = new DocumentRevision("fred34");
         bodyMap.clear();
@@ -493,7 +493,7 @@ public abstract class AbstractQueryTestBase {
         bodyMap.put("age", 34);
         bodyMap.put("pet", Arrays.asList("cat", "dog"));
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         rev = new DocumentRevision("john44");
         bodyMap.clear();
@@ -501,7 +501,7 @@ public abstract class AbstractQueryTestBase {
         bodyMap.put("age", 44);
         bodyMap.put("pet", "cat");
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         rev = new DocumentRevision("fred72");
         bodyMap.clear();
@@ -509,14 +509,14 @@ public abstract class AbstractQueryTestBase {
         bodyMap.put("age", 72);
         bodyMap.put("pet", Collections.singletonList("dog"));
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         rev = new DocumentRevision("john12");
         bodyMap.clear();
         bodyMap.put("name", "john");
         bodyMap.put("age", 12);
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         rev = new DocumentRevision("bill34");
         bodyMap.clear();
@@ -524,7 +524,7 @@ public abstract class AbstractQueryTestBase {
         bodyMap.put("age", 34);
         bodyMap.put("pet", Arrays.asList("cat", "parrot"));
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         rev = new DocumentRevision("fred11");
         bodyMap.clear();
@@ -532,7 +532,7 @@ public abstract class AbstractQueryTestBase {
         bodyMap.put("age", 11);
         bodyMap.put("pet", new ArrayList<Object>());
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("pet"), new FieldSort("age")), "basic"), is("basic"));
     }
@@ -547,7 +547,7 @@ public abstract class AbstractQueryTestBase {
         bodyMap.put("age", Arrays.<FieldSort>asList(new FieldSort("cat"), new FieldSort("dog")));
         bodyMap.put("same", "all");
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         rev = new DocumentRevision("fred34");
         bodyMap.clear();
@@ -556,7 +556,7 @@ public abstract class AbstractQueryTestBase {
         bodyMap.put("pet", "parrot");
         bodyMap.put("same", "all");
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         rev = new DocumentRevision("fred11");
         bodyMap.clear();
@@ -565,7 +565,7 @@ public abstract class AbstractQueryTestBase {
         bodyMap.put("pet", "fish");
         bodyMap.put("same", "all");
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         assertThat(im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("pet"), new FieldSort("age"), new FieldSort("same")), "pet"),
                 is("pet"));
@@ -581,7 +581,7 @@ public abstract class AbstractQueryTestBase {
         petMap.put("name", "mike");
         bodyMap.put("pet", petMap);
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         rev = new DocumentRevision("mike23");
         bodyMap.clear();
@@ -594,7 +594,7 @@ public abstract class AbstractQueryTestBase {
         petMap.put("name", petNameMap);
         bodyMap.put("pet", petMap);
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         rev = new DocumentRevision("mike34");
         bodyMap.clear();
@@ -605,7 +605,7 @@ public abstract class AbstractQueryTestBase {
         petMap.put("name", "mike");
         bodyMap.put("pet", petMap);
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         rev = new DocumentRevision("mike72");
         bodyMap.clear();
@@ -613,7 +613,7 @@ public abstract class AbstractQueryTestBase {
         bodyMap.put("age", 72);
         bodyMap.put("pet", "cat");
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         rev = new DocumentRevision("fred34");
         bodyMap.clear();
@@ -621,14 +621,14 @@ public abstract class AbstractQueryTestBase {
         bodyMap.put("age", 34);
         bodyMap.put("pet", "cat");
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         rev = new DocumentRevision("fred12");
         bodyMap.clear();
         bodyMap.put("name", "fred");
         bodyMap.put("age", 12);
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
     }
 
 }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/IndexUpdaterTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/IndexUpdaterTest.java
@@ -29,7 +29,6 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.fail;
 
 import com.cloudant.sync.documentstore.DocumentBodyFactory;
-import com.cloudant.sync.documentstore.DocumentException;
 import com.cloudant.sync.documentstore.DocumentRevision;
 import com.cloudant.sync.documentstore.encryption.NullKeyProvider;
 import com.cloudant.sync.query.FieldSort;
@@ -119,7 +118,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         bodyMap.put("name", "mike");
         rev.setBody(DocumentBodyFactory.create(bodyMap));
         final DocumentRevision saved;
-        saved = ds.createDocumentFromRevision(rev);
+        saved = ds.create(rev);
 
 
         IndexUpdater.updateIndex("basic", fields, ds, indexManagerDatabaseQueue);
@@ -204,7 +203,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
                     }
                     rev.setBody(DocumentBodyFactory.create(bodyMap));
                     try {
-                        ds.createDocumentFromRevision(rev);
+                        ds.create(rev);
                     } catch (Exception e) {
                         fail("Exception thrown when creating revision " + e);
                     }
@@ -307,7 +306,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         bodyMap.put("age", 12);
         rev.setBody(DocumentBodyFactory.create(bodyMap));
         final DocumentRevision saved;
-        saved = ds.createDocumentFromRevision(rev);
+        saved = ds.create(rev);
 
         IndexUpdater.updateIndex("basic", fields, ds, indexManagerDatabaseQueue);
         assertThat(getIndexSequenceNumber("basic"), is(1l));
@@ -377,7 +376,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         bodyMap.put("ignored", "something");
         rev.setBody(DocumentBodyFactory.create(bodyMap));
         final DocumentRevision saved;
-        saved = ds.createDocumentFromRevision(rev);
+        saved = ds.create(rev);
 
         IndexUpdater.updateIndex("basic", fields, ds, indexManagerDatabaseQueue);
         assertThat(getIndexSequenceNumber("basic"), is(1l));
@@ -446,7 +445,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         bodyMap.put("ignored", "something");
         rev.setBody(DocumentBodyFactory.create(bodyMap));
         final DocumentRevision saved;
-        saved = ds.createDocumentFromRevision(rev);
+        saved = ds.create(rev);
 
         IndexUpdater.updateIndex("basic", fields, ds, indexManagerDatabaseQueue);
         assertThat(getIndexSequenceNumber("basic"), is(1l));
@@ -515,7 +514,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         bodyMap.put("ignored", "something");
         rev.setBody(DocumentBodyFactory.create(bodyMap));
         final DocumentRevision saved;
-        saved = ds.createDocumentFromRevision(rev);
+        saved = ds.create(rev);
 
         IndexUpdater.updateIndex("basic", fields, ds, indexManagerDatabaseQueue);
         assertThat(getIndexSequenceNumber("basic"), is(1l));
@@ -582,7 +581,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         bodyMap.put("pet", pets);
         rev.setBody(DocumentBodyFactory.create(bodyMap));
         final DocumentRevision saved;
-        saved = ds.createDocumentFromRevision(rev);
+        saved = ds.create(rev);
 
         IndexUpdater.updateIndex("basic", fields, ds, indexManagerDatabaseQueue);
         assertThat(getIndexSequenceNumber("basic"), is(1l));
@@ -651,7 +650,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         bodyMap.put("pet", pets);
         rev.setBody(DocumentBodyFactory.create(bodyMap));
         final DocumentRevision saved;
-        saved = ds.createDocumentFromRevision(rev);
+        saved = ds.create(rev);
 
         IndexUpdater.updateIndex("basic", fields, ds, indexManagerDatabaseQueue);
         assertThat(getIndexSequenceNumber("basic"), is(1l));
@@ -727,8 +726,8 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         badBodyMap.put("pet", pets);
         badBodyMap.put("pet2", pets);
         badRev.setBody(DocumentBodyFactory.create(badBodyMap));
-        saved = ds.createDocumentFromRevision(goodRev);
-        ds.createDocumentFromRevision(badRev);
+        saved = ds.create(goodRev);
+        ds.create(badRev);
 
         IndexUpdater.updateIndex("basic", fields, ds, indexManagerDatabaseQueue);
         assertThat(getIndexSequenceNumber("basic"), is(2l));
@@ -799,7 +798,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         bodyMap.put("pet", new ArrayList<Object>());
         rev.setBody(DocumentBodyFactory.create(bodyMap));
         final DocumentRevision saved;
-        saved = ds.createDocumentFromRevision(rev);
+        saved = ds.create(rev);
 
         IndexUpdater.updateIndex("basic", fields, ds, indexManagerDatabaseQueue);
         assertThat(getIndexSequenceNumber("basic"), is(1l));
@@ -867,7 +866,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         bodyMap.put("pet", pets);
         rev.setBody(DocumentBodyFactory.create(bodyMap));
         final DocumentRevision saved;
-        saved = ds.createDocumentFromRevision(rev);
+        saved = ds.create(rev);
 
         IndexUpdater.updateIndex("basic", fields, ds, indexManagerDatabaseQueue);
         assertThat(getIndexSequenceNumber("basic"), is(1l));
@@ -909,7 +908,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         bodyMap.put("age", 12);
         bodyMap.put("pet", "cat");
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         rev = new DocumentRevision("mike23");
         // body content: { "name" : "mike",  "age" : 23, "pet" : "parrot" }
@@ -918,7 +917,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         bodyMap.put("age", 23);
         bodyMap.put("pet", "cat");
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         rev = new DocumentRevision("mike34");
         // body content: { "name" : "mike",  "age" : 34, "pet" : "dog" }
@@ -927,7 +926,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         bodyMap.put("age", 34);
         bodyMap.put("pet", "dog");
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         rev = new DocumentRevision("john72");
         // body content: { "name" : "john",  "age" : 72, "pet" : "fish" }
@@ -936,7 +935,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         bodyMap.put("age", 72);
         bodyMap.put("pet", "fish");
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         rev = new DocumentRevision("fred34");
         // body content: { "name" : "fred",  "age" : 34, "pet" : "snake" }
@@ -945,7 +944,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         bodyMap.put("age", 34);
         bodyMap.put("pet", "snake");
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         rev = new DocumentRevision("fred12");
         // body content: { "name" : "fred",  "age" : 12 }
@@ -953,7 +952,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
         bodyMap.put("name", "fred");
         bodyMap.put("age", 12);
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         // Test index updates for multiple json indexes as well as
         // index updates for co-existing json and text indexes.
@@ -1012,7 +1011,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
 
         rev = new DocumentRevision("newdoc");
         rev.setBody(DocumentBodyFactory.EMPTY);
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         im.updateAllIndexes();
 
@@ -1065,7 +1064,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
             bodyMap.put("age", 12);
             bodyMap.put("pet", "cat");
             rev.setBody(DocumentBodyFactory.create(bodyMap));
-            ds.createDocumentFromRevision(rev);
+            ds.create(rev);
 
             createIndex("testIndex", Collections.singletonList((FieldSort) new FieldSort("name")));
             exepctedSequence = getIndexSequenceNumber("testIndex");
@@ -1106,7 +1105,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
             bodyMap.put("age", 12);
             bodyMap.put("pet", "cat");
             rev.setBody(DocumentBodyFactory.create(bodyMap));
-            ds.createDocumentFromRevision(rev);
+            ds.create(rev);
 
             createIndex("testIndex", Collections.singletonList((FieldSort) new FieldSort("name")));
             exepctedSequence = getIndexSequenceNumber("testIndex");
@@ -1129,7 +1128,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
             bodyMap.put("age", 23);
             bodyMap.put("pet", "cat");
             rev.setBody(DocumentBodyFactory.create(bodyMap));
-            ds.createDocumentFromRevision(rev);
+            ds.create(rev);
 
             im.updateAllIndexes();
             exepctedSequence = getIndexSequenceNumber("testIndex");

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/MockMatcherQueryExecutor.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/MockMatcherQueryExecutor.java
@@ -41,7 +41,7 @@ public class MockMatcherQueryExecutor extends QueryExecutor{
     MockMatcherQueryExecutor(Database database, SQLDatabaseQueue queue) {
         super(database, queue);
         try {
-            docIds = new HashSet<String>(database.getAllDocumentIds());
+            docIds = new HashSet<String>(database.getAllIds());
         } catch (DocumentStoreException dse) {
             ;// TODO
         }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/MockMatcherQueryExecutor.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/MockMatcherQueryExecutor.java
@@ -41,7 +41,7 @@ public class MockMatcherQueryExecutor extends QueryExecutor{
     MockMatcherQueryExecutor(Database database, SQLDatabaseQueue queue) {
         super(database, queue);
         try {
-            docIds = new HashSet<String>(database.getAllIds());
+            docIds = new HashSet<String>(database.getIds());
         } catch (DocumentStoreException dse) {
             ;// TODO
         }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/QueryCoveringIndexesTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/QueryCoveringIndexesTest.java
@@ -1081,7 +1081,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
     @Test
     public void queryUsing_revWorksAsASingleClause() throws Exception {
         setUpBasicQueryData();
-        String docRev = ds.get("mike12").getRevision();
+        String docRev = ds.read("mike12").getRevision();
         // query - { "_rev" : <docRev> }
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("_rev", docRev);
@@ -1092,7 +1092,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
     @Test
     public void queryUsing_revWorksWithOtherClauses() throws Exception {
         setUpBasicQueryData();
-        String docRev = ds.get("mike12").getRevision();
+        String docRev = ds.read("mike12").getRevision();
         // query - { "_rev" : <docRev>, "name" : "mike" }
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("_rev", docRev);

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/QueryCoveringIndexesTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/QueryCoveringIndexesTest.java
@@ -132,7 +132,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         bodyMap.put("pet", "cat");
         bodyMap.put("married", true);
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
         assertThat(idxMgr.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("age"), new FieldSort("married")), "married"), is("married"));
         // query - { "married" : { "eq" : true } }
         Map<String, Object> marriedOperator = new HashMap<String, Object>();
@@ -152,7 +152,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
         bodyMap.put("age", 12);
         bodyMap.put("pet", "cat");
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
         assertThat(idxMgr.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("age")), "basic index"), is
                 ("basic index"));
 
@@ -1081,7 +1081,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
     @Test
     public void queryUsing_revWorksAsASingleClause() throws Exception {
         setUpBasicQueryData();
-        String docRev = ds.getDocument("mike12").getRevision();
+        String docRev = ds.get("mike12").getRevision();
         // query - { "_rev" : <docRev> }
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("_rev", docRev);
@@ -1092,7 +1092,7 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
     @Test
     public void queryUsing_revWorksWithOtherClauses() throws Exception {
         setUpBasicQueryData();
-        String docRev = ds.getDocument("mike12").getRevision();
+        String docRev = ds.get("mike12").getRevision();
         // query - { "_rev" : <docRev>, "name" : "mike" }
         Map<String, Object> query = new HashMap<String, Object>();
         query.put("_rev", docRev);

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/QueryFilterFieldsTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/QueryFilterFieldsTest.java
@@ -157,12 +157,12 @@ public class QueryFilterFieldsTest extends AbstractQueryTestBase {
             assertThat(revBody.keySet(), contains("name"));
             assertThat((String) revBody.get("name"), is("mike"));
 
-            DocumentRevision original = ds.getDocument(rev.getId());
+            DocumentRevision original = ds.get(rev.getId());
             DocumentRevision update = original;
             Map<String, Object> updateBody = original.getBody().asMap();
             updateBody.put("name", "charles");
             update.setBody(DocumentBodyFactory.create(updateBody));
-            assertThat(ds.updateDocumentFromRevision(update), is(notNullValue()));
+            assertThat(ds.update(update), is(notNullValue()));
             assertThat(rev.isFullRevision(),is(false));
             DocumentRevision fullRevision = rev.toFullRevision();
             assertThat(fullRevision.isFullRevision(),is(true));
@@ -187,7 +187,7 @@ public class QueryFilterFieldsTest extends AbstractQueryTestBase {
 
             try {
                 DocumentRevision deleted;
-                deleted = ds.deleteDocumentFromRevision((ProjectedDocumentRevision) rev);
+                deleted = ds.delete((ProjectedDocumentRevision) rev);
                 assertThat(deleted, is(notNullValue()));
             } catch (ConflictException e) {
                 Assert.fail("Failed to delete document revision");
@@ -212,7 +212,7 @@ public class QueryFilterFieldsTest extends AbstractQueryTestBase {
         for (DocumentRevision rev : queryResult) {
             assertThat(rev, is(instanceOf(ProjectedDocumentRevision.class)));
             try {
-                ds.updateDocumentFromRevision(rev);
+                ds.update(rev);
                 Assert.fail("IllegalArgumentException not thrown");
             } catch(IllegalArgumentException iae) {
                 ; // exception thrown - can't update from a projected revision

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/QueryFilterFieldsTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/QueryFilterFieldsTest.java
@@ -157,7 +157,7 @@ public class QueryFilterFieldsTest extends AbstractQueryTestBase {
             assertThat(revBody.keySet(), contains("name"));
             assertThat((String) revBody.get("name"), is("mike"));
 
-            DocumentRevision original = ds.get(rev.getId());
+            DocumentRevision original = ds.read(rev.getId());
             DocumentRevision update = original;
             Map<String, Object> updateBody = original.getBody().asMap();
             updateBody.put("name", "charles");

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/QueryTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/QueryTest.java
@@ -223,7 +223,7 @@ public class QueryTest extends AbstractIndexTestBase {
             petMap.put("name", "mike");
             bodyMap.put("pet", petMap);
             rev.setBody(DocumentBodyFactory.create(bodyMap));
-            ds.createDocumentFromRevision(rev);
+            ds.create(rev);
         }
 
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "basic");
@@ -244,7 +244,7 @@ public class QueryTest extends AbstractIndexTestBase {
             petMap.put("name", "mike");
             bodyMap.put("pet", petMap);
             rev.setBody(DocumentBodyFactory.create(bodyMap));
-            ds.createDocumentFromRevision(rev);
+            ds.create(rev);
         }
 
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "basic");
@@ -270,7 +270,7 @@ public class QueryTest extends AbstractIndexTestBase {
             petMap.put("name", "mike");
             bodyMap.put("pet", petMap);
             rev.setBody(DocumentBodyFactory.create(bodyMap));
-            ds.createDocumentFromRevision(rev);
+            ds.create(rev);
         }
 
         im.ensureIndexed(Arrays.<FieldSort>asList(new FieldSort("name"), new FieldSort("address")), "basic", IndexType.TEXT);

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/QueryTextSearchTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/QueryTextSearchTest.java
@@ -60,7 +60,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
         bodyMap.put("pet", "cat");
         bodyMap.put("comment", "He lives in Bristol, UK and his best friend is Fred.");
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         rev = new DocumentRevision("mike34");
         bodyMap.clear();
@@ -69,7 +69,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
         bodyMap.put("pet", "dog");
         bodyMap.put("comment", "He lives in a van down by the river in Bristol.");
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         rev = new DocumentRevision("mike72");
         bodyMap.clear();
@@ -79,7 +79,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
         bodyMap.put("comment",
                     "He's retired and has memories of spending time with his cat Remus.");
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         rev = new DocumentRevision("fred34");
         bodyMap.clear();
@@ -89,7 +89,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
         bodyMap.put("comment",
                     "He lives next door to Mike and his cat Romulus is brother to Remus.");
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         rev = new DocumentRevision("fred12");
         bodyMap.clear();
@@ -97,7 +97,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
         bodyMap.put("age", 12);
         bodyMap.put("comment", "He lives in Bristol, UK and his best friend is Mike.");
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
 
         rev = new DocumentRevision("john34");
         bodyMap.clear();
@@ -106,7 +106,7 @@ public class QueryTextSearchTest extends AbstractQueryTestBase {
         bodyMap.put("pet", "cat");
         bodyMap.put("comment", "وهو يعيش في بريستول، المملكة المتحدة، وأفضل صديق له هو مايك.");
         rev.setBody(DocumentBodyFactory.create(bodyMap));
-        ds.createDocumentFromRevision(rev);
+        ds.create(rev);
     }
 
     @Test

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/QueryWithoutCoveringIndexesTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/QueryWithoutCoveringIndexesTest.java
@@ -129,7 +129,7 @@ public class QueryWithoutCoveringIndexesTest extends AbstractQueryTestBase {
             bodyMap.put("pet", "cat");
             bodyMap.put("town", "cardiff");
             rev.setBody(DocumentBodyFactory.create(bodyMap));
-            ds.createDocumentFromRevision(rev);
+            ds.create(rev);
         }
 
         Map<String, Object> query = new HashMap<String, Object>();
@@ -162,7 +162,7 @@ public class QueryWithoutCoveringIndexesTest extends AbstractQueryTestBase {
                 bodyMap.put("town", "bristol"); //+2
             }
             rev.setBody(DocumentBodyFactory.create(bodyMap));
-            ds.createDocumentFromRevision(rev);
+            ds.create(rev);
         }
 
         Map<String, Object> query = new HashMap<String, Object>();

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/AttachmentsConflictsTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/AttachmentsConflictsTest.java
@@ -74,7 +74,7 @@ public class AttachmentsConflictsTest extends ReplicationTestBase {
         try {
             this.pull();
 
-            DocumentRevision gotRev = this.datastore.get("doc-a");
+            DocumentRevision gotRev = this.datastore.read("doc-a");
 
             Assert.assertEquals(gotRev.getAttachments().size(), 1);
             // local one is guaranteed to be winner because its revision tree is longer
@@ -130,7 +130,7 @@ public class AttachmentsConflictsTest extends ReplicationTestBase {
         try {
             this.pull();
 
-            DocumentRevision gotRev = this.datastore.get("doc-a");
+            DocumentRevision gotRev = this.datastore.read("doc-a");
             Assert.assertEquals(gotRev.getAttachments().size(), 1);
         } finally {
             this.datastore.close();

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/AttachmentsConflictsTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/AttachmentsConflictsTest.java
@@ -60,13 +60,13 @@ public class AttachmentsConflictsTest extends ReplicationTestBase {
         // create local (1-rev and 2-rev)
         DocumentRevision rev = new DocumentRevision("doc-a");
         rev.setBody(DocumentBodyFactory.create("{\"foo\": \"local\"}".getBytes()));
-        DocumentRevision rev2 = this.datastore.createDocumentFromRevision(rev);
+        DocumentRevision rev2 = this.datastore.create(rev);
         rev2.getAttachments().put("att1", new UnsavedStreamAttachment(
                         new ByteArrayInputStream("hello universe".getBytes()),
                         "att1",
                         "text/plain")
         );
-        this.datastore.updateDocumentFromRevision(rev2);
+        this.datastore.update(rev2);
         this.push();
         this.documentStore.delete();
         this.documentStore = DocumentStore.getInstance(new File(this.datastoreManagerPath, "foo-bar-baz"));
@@ -74,7 +74,7 @@ public class AttachmentsConflictsTest extends ReplicationTestBase {
         try {
             this.pull();
 
-            DocumentRevision gotRev = this.datastore.getDocument("doc-a");
+            DocumentRevision gotRev = this.datastore.get("doc-a");
 
             Assert.assertEquals(gotRev.getAttachments().size(), 1);
             // local one is guaranteed to be winner because its revision tree is longer
@@ -114,9 +114,9 @@ public class AttachmentsConflictsTest extends ReplicationTestBase {
                         "att1",
                         "text/plain")
         );
-        this.datastore.createDocumentFromRevision(rev);
+        this.datastore.create(rev);
         this.pull();
-        this.datastore.resolveConflictsForDocument("doc-a", new ConflictResolver() {
+        this.datastore.resolveConflicts("doc-a", new ConflictResolver() {
             @Override
             public DocumentRevision resolve(String docId, List<? extends DocumentRevision> conflicts) {
                 return conflicts.get(0);
@@ -130,7 +130,7 @@ public class AttachmentsConflictsTest extends ReplicationTestBase {
         try {
             this.pull();
 
-            DocumentRevision gotRev = this.datastore.getDocument("doc-a");
+            DocumentRevision gotRev = this.datastore.get("doc-a");
             Assert.assertEquals(gotRev.getAttachments().size(), 1);
         } finally {
             this.datastore.close();

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/AttachmentsPushTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/AttachmentsPushTest.java
@@ -107,7 +107,7 @@ public class AttachmentsPushTest extends ReplicationTestBase {
 
 
     public String updateDocInDatastore(String id, String data) throws Exception {
-        DocumentRevision rev = datastore.get(id);
+        DocumentRevision rev = datastore.read(id);
         Map<String, String> m = new HashMap<String, String>();
         m.put("data", data);
         rev.setBody(DocumentBodyFactory.create(m));
@@ -121,7 +121,7 @@ public class AttachmentsPushTest extends ReplicationTestBase {
         populateSomeDataInLocalDatastore();
         File f = TestUtils.loadFixture("fixture/"+attachmentName);
         Attachment att = new UnsavedFileAttachment(f, "text/plain");
-        DocumentRevision oldRevision = datastore.get(id1);
+        DocumentRevision oldRevision = datastore.read(id1);
         DocumentRevision newRevision = null;
         // set attachment
         DocumentRevision oldRevision_mut = oldRevision;
@@ -145,7 +145,7 @@ public class AttachmentsPushTest extends ReplicationTestBase {
         populateSomeDataInLocalDatastore();
         File f = TestUtils.loadFixture("fixture/"+ attachmentName);
         Attachment att = new UnsavedFileAttachment(f, "image/jpeg");
-        DocumentRevision oldRevision = datastore.get(id1);
+        DocumentRevision oldRevision = datastore.read(id1);
         DocumentRevision newRevision = null;
         // set attachment
         DocumentRevision oldRevision_mut = oldRevision;
@@ -177,7 +177,7 @@ public class AttachmentsPushTest extends ReplicationTestBase {
         File f2 = TestUtils.loadFixture("fixture/"+ attachmentName2);
         Attachment att1 = new UnsavedFileAttachment(f1, "image/jpeg");
         Attachment att2 = new UnsavedFileAttachment(f2, "text/plain");
-        DocumentRevision oldRevision = datastore.get(id1);
+        DocumentRevision oldRevision = datastore.read(id1);
         DocumentRevision newRevision = null;
         // set attachment
         oldRevision.getAttachments().put(attachmentName1, att1);
@@ -206,7 +206,7 @@ public class AttachmentsPushTest extends ReplicationTestBase {
         File f2 = TestUtils.loadFixture("fixture/"+ attachmentName2);
         Attachment att1 = new UnsavedFileAttachment(f1, "text/plain");
         Attachment att2 = new UnsavedFileAttachment(f2, "text/plain");
-        DocumentRevision rev1 = datastore.get(id1);
+        DocumentRevision rev1 = datastore.read(id1);
         DocumentRevision rev2 = null;
         // set attachment
         DocumentRevision rev1_mut = rev1;
@@ -264,7 +264,7 @@ public class AttachmentsPushTest extends ReplicationTestBase {
         File f2 = TestUtils.loadFixture("fixture/"+ attachmentName2);
         Attachment att1 = new UnsavedFileAttachment(f1, "text/plain");
         Attachment att2 = new UnsavedFileAttachment(f2, "text/plain");
-        DocumentRevision rev1 = datastore.get(id1);
+        DocumentRevision rev1 = datastore.read(id1);
         DocumentRevision rev2 = null;
         // set attachment
         DocumentRevision rev1_mut = rev1;

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/AttachmentsPushTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/AttachmentsPushTest.java
@@ -102,16 +102,16 @@ public class AttachmentsPushTest extends ReplicationTestBase {
         Map<String, String> m = new HashMap<String, String>();
         m.put("data", d);
         rev.setBody(DocumentBodyFactory.create(m));
-        return datastore.createDocumentFromRevision(rev).getId();
+        return datastore.create(rev).getId();
     }
 
 
     public String updateDocInDatastore(String id, String data) throws Exception {
-        DocumentRevision rev = datastore.getDocument(id);
+        DocumentRevision rev = datastore.get(id);
         Map<String, String> m = new HashMap<String, String>();
         m.put("data", data);
         rev.setBody(DocumentBodyFactory.create(m));
-        return datastore.updateDocumentFromRevision(rev).getId();
+        return datastore.update(rev).getId();
     }
 
     @Test
@@ -121,12 +121,12 @@ public class AttachmentsPushTest extends ReplicationTestBase {
         populateSomeDataInLocalDatastore();
         File f = TestUtils.loadFixture("fixture/"+attachmentName);
         Attachment att = new UnsavedFileAttachment(f, "text/plain");
-        DocumentRevision oldRevision = datastore.getDocument(id1);
+        DocumentRevision oldRevision = datastore.get(id1);
         DocumentRevision newRevision = null;
         // set attachment
         DocumentRevision oldRevision_mut = oldRevision;
         oldRevision_mut.getAttachments().put(attachmentName, att);
-        newRevision = datastore.updateDocumentFromRevision(oldRevision_mut);
+        newRevision = datastore.update(oldRevision_mut);
 
 
         // push replication
@@ -145,12 +145,12 @@ public class AttachmentsPushTest extends ReplicationTestBase {
         populateSomeDataInLocalDatastore();
         File f = TestUtils.loadFixture("fixture/"+ attachmentName);
         Attachment att = new UnsavedFileAttachment(f, "image/jpeg");
-        DocumentRevision oldRevision = datastore.getDocument(id1);
+        DocumentRevision oldRevision = datastore.get(id1);
         DocumentRevision newRevision = null;
         // set attachment
         DocumentRevision oldRevision_mut = oldRevision;
         oldRevision_mut.getAttachments().put(attachmentName, att);
-        newRevision = datastore.updateDocumentFromRevision(oldRevision_mut);
+        newRevision = datastore.update(oldRevision_mut);
 
 
         // push replication
@@ -177,12 +177,12 @@ public class AttachmentsPushTest extends ReplicationTestBase {
         File f2 = TestUtils.loadFixture("fixture/"+ attachmentName2);
         Attachment att1 = new UnsavedFileAttachment(f1, "image/jpeg");
         Attachment att2 = new UnsavedFileAttachment(f2, "text/plain");
-        DocumentRevision oldRevision = datastore.getDocument(id1);
+        DocumentRevision oldRevision = datastore.get(id1);
         DocumentRevision newRevision = null;
         // set attachment
         oldRevision.getAttachments().put(attachmentName1, att1);
         oldRevision.getAttachments().put(attachmentName2, att2);
-        newRevision = datastore.updateDocumentFromRevision(oldRevision);
+        newRevision = datastore.update(oldRevision);
 
         // push replication
         push();
@@ -206,18 +206,18 @@ public class AttachmentsPushTest extends ReplicationTestBase {
         File f2 = TestUtils.loadFixture("fixture/"+ attachmentName2);
         Attachment att1 = new UnsavedFileAttachment(f1, "text/plain");
         Attachment att2 = new UnsavedFileAttachment(f2, "text/plain");
-        DocumentRevision rev1 = datastore.getDocument(id1);
+        DocumentRevision rev1 = datastore.get(id1);
         DocumentRevision rev2 = null;
         // set attachment
         DocumentRevision rev1_mut = rev1;
         rev1_mut.getAttachments().put(attachmentName1, att1);
-        rev2 = datastore.updateDocumentFromRevision(rev1_mut);
+        rev2 = datastore.update(rev1_mut);
 
         // push replication - att1 should be uploaded
         push();
 
         DocumentRevision rev2_mut = rev2;
-        DocumentRevision rev3 = datastore.updateDocumentFromRevision(rev2_mut);
+        DocumentRevision rev3 = datastore.update(rev2_mut);
 
         // push replication - no atts should be uploaded
         push();
@@ -226,7 +226,7 @@ public class AttachmentsPushTest extends ReplicationTestBase {
         // set attachment
         DocumentRevision rev3_mut = rev3;
         rev3_mut.getAttachments().put(attachmentName2, att2);
-        rev4 = datastore.updateDocumentFromRevision(rev3_mut);
+        rev4 = datastore.update(rev3_mut);
 
         // push replication - att2 should be uploaded
         push();
@@ -264,21 +264,21 @@ public class AttachmentsPushTest extends ReplicationTestBase {
         File f2 = TestUtils.loadFixture("fixture/"+ attachmentName2);
         Attachment att1 = new UnsavedFileAttachment(f1, "text/plain");
         Attachment att2 = new UnsavedFileAttachment(f2, "text/plain");
-        DocumentRevision rev1 = datastore.getDocument(id1);
+        DocumentRevision rev1 = datastore.get(id1);
         DocumentRevision rev2 = null;
         // set attachment
         DocumentRevision rev1_mut = rev1;
         rev1_mut.getAttachments().put(attachmentName1, att1);
-        rev2 = datastore.updateDocumentFromRevision(rev1_mut);
+        rev2 = datastore.update(rev1_mut);
 
         DocumentRevision rev2_mut = rev2;
-        DocumentRevision rev3 = datastore.updateDocumentFromRevision(rev2_mut);
+        DocumentRevision rev3 = datastore.update(rev2_mut);
 
         DocumentRevision rev4 = null;
         // set attachment
         DocumentRevision rev3_mut = rev3;
         rev3_mut.getAttachments().put(attachmentName2, att2);
-        rev4 = datastore.updateDocumentFromRevision(rev3_mut);
+        rev4 = datastore.update(rev3_mut);
 
         // push replication - att1 & att2 should be uploaded
         push();

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/BarUtils.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/BarUtils.java
@@ -118,7 +118,7 @@ public class BarUtils {
         bar.setName(name);
         bar.setAge(age);
 
-        DocumentRevision rev = db.get(id);
+        DocumentRevision rev = db.read(id);
         DocumentRevision revMut = rev;
         int oldGeneration = CouchUtils.generationFromRevId(rev.getRevision());
         Map<String, Object> m = new HashMap<String, Object>();

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/BarUtils.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/BarUtils.java
@@ -91,7 +91,7 @@ public class BarUtils {
         m.put("name", name);
         m.put("age", age);
         rev.setBody(DocumentBodyFactory.create(m));
-        DocumentRevision saved = db.createDocumentFromRevision(rev);
+        DocumentRevision saved = db.create(rev);
         bar.setRevision(saved.getRevision());
         bar.setId(saved.getId());
 
@@ -118,14 +118,14 @@ public class BarUtils {
         bar.setName(name);
         bar.setAge(age);
 
-        DocumentRevision rev = db.getDocument(id);
+        DocumentRevision rev = db.get(id);
         DocumentRevision revMut = rev;
         int oldGeneration = CouchUtils.generationFromRevId(rev.getRevision());
         Map<String, Object> m = new HashMap<String, Object>();
         m.put("name", name);
         m.put("age", age);
         revMut.setBody(DocumentBodyFactory.create(m));
-        DocumentRevision saved = db.updateDocumentFromRevision(revMut);
+        DocumentRevision saved = db.update(revMut);
 
         bar.setRevision(saved.getRevision());
         bar.setId(saved.getId());
@@ -146,7 +146,7 @@ public class BarUtils {
     }
 
     public static void deleteBar(Database db, String id) throws Exception {
-        db.deleteDocument(id);
+        db.delete(id);
     }
 
     /**

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/BasicPullStrategyTest2.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/BasicPullStrategyTest2.java
@@ -88,7 +88,7 @@ public class BasicPullStrategyTest2 extends ReplicationTestBase {
     private void assertDataDeleted() throws Exception {
         for(String id : cache.getAllDeletedIds()) {
             logger.info("Deleted id: " + id);
-            DocumentRevision obj = datastore.get(id);
+            DocumentRevision obj = datastore.read(id);
             logger.info("Deleted: " + obj.isDeleted());
             Assert.assertTrue(obj.isDeleted());
         }
@@ -98,7 +98,7 @@ public class BasicPullStrategyTest2 extends ReplicationTestBase {
         for(String id : cache.getAllDocumentIds()) {
             Bar bar = cache.getData(id);
             logger.info("Id: " + bar);
-            DocumentRevision obj = datastore.get(bar.getId(), bar.getRevision());
+            DocumentRevision obj = datastore.read(bar.getId(), bar.getRevision());
             Assert.assertNotNull(obj);
         }
     }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/BasicPullStrategyTest2.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/BasicPullStrategyTest2.java
@@ -88,7 +88,7 @@ public class BasicPullStrategyTest2 extends ReplicationTestBase {
     private void assertDataDeleted() throws Exception {
         for(String id : cache.getAllDeletedIds()) {
             logger.info("Deleted id: " + id);
-            DocumentRevision obj = datastore.getDocument(id);
+            DocumentRevision obj = datastore.get(id);
             logger.info("Deleted: " + obj.isDeleted());
             Assert.assertTrue(obj.isDeleted());
         }
@@ -98,7 +98,7 @@ public class BasicPullStrategyTest2 extends ReplicationTestBase {
         for(String id : cache.getAllDocumentIds()) {
             Bar bar = cache.getData(id);
             logger.info("Id: " + bar);
-            DocumentRevision obj = datastore.getDocument(bar.getId(), bar.getRevision());
+            DocumentRevision obj = datastore.get(bar.getId(), bar.getRevision());
             Assert.assertNotNull(obj);
         }
     }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/BasicPushStrategyTest2.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/BasicPushStrategyTest2.java
@@ -68,7 +68,7 @@ public class BasicPushStrategyTest2 extends ReplicationTestBase {
     }
 
     public String updateDocInDatastore(String id, String data) throws Exception {
-        DocumentRevision rev = datastore.get(id);
+        DocumentRevision rev = datastore.read(id);
         Map<String, String> m = new HashMap<String, String>();
         m.put("data", data);
         rev.setBody(DocumentBodyFactory.create(m));
@@ -146,7 +146,7 @@ public class BasicPushStrategyTest2 extends ReplicationTestBase {
     }
 
     public void checkDocumentIsSynced(String id) throws Exception{
-        DocumentRevision fooLocal = this.datastore.get(id);
+        DocumentRevision fooLocal = this.datastore.read(id);
         Map fooRemote = remoteDb.get(Map.class, id);
         Assert.assertEquals(fooLocal.getId(), fooRemote.get("_id"));
         Assert.assertEquals(fooLocal.getRevision(), fooRemote.get("_rev"));

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/BasicPushStrategyTest2.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/BasicPushStrategyTest2.java
@@ -64,15 +64,15 @@ public class BasicPushStrategyTest2 extends ReplicationTestBase {
         Map<String, String> m = new HashMap<String, String>();
         m.put("data", d);
         rev.setBody(DocumentBodyFactory.create(m));
-        return datastore.createDocumentFromRevision(rev).getId();
+        return datastore.create(rev).getId();
     }
 
     public String updateDocInDatastore(String id, String data) throws Exception {
-        DocumentRevision rev = datastore.getDocument(id);
+        DocumentRevision rev = datastore.get(id);
         Map<String, String> m = new HashMap<String, String>();
         m.put("data", data);
         rev.setBody(DocumentBodyFactory.create(m));
-        return datastore.updateDocumentFromRevision(rev).getId();
+        return datastore.update(rev).getId();
     }
 
     // check that we can correctly push after compaction
@@ -82,7 +82,7 @@ public class BasicPushStrategyTest2 extends ReplicationTestBase {
         populateSomeDataInLocalDatastore();
         super.push();
 
-        datastore.deleteDocument(id1);
+        datastore.delete(id1);
         datastore.compact();
 
         super.push();
@@ -146,7 +146,7 @@ public class BasicPushStrategyTest2 extends ReplicationTestBase {
     }
 
     public void checkDocumentIsSynced(String id) throws Exception{
-        DocumentRevision fooLocal = this.datastore.getDocument(id);
+        DocumentRevision fooLocal = this.datastore.get(id);
         Map fooRemote = remoteDb.get(Map.class, id);
         Assert.assertEquals(fooLocal.getId(), fooRemote.get("_id"));
         Assert.assertEquals(fooLocal.getRevision(), fooRemote.get("_rev"));

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/DBWithSlashReplicationTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/DBWithSlashReplicationTest.java
@@ -102,7 +102,7 @@ public class DBWithSlashReplicationTest extends ReplicationTestBase {
         }
 
         //now create some local revs
-        DocumentRevision revision = datastore.getDocument(documentName);
+        DocumentRevision revision = datastore.get(documentName);
 
         for (int i = 0; i < 10; i++) {
             Map<String, Object> body = revision.getBody().asMap();
@@ -110,7 +110,7 @@ public class DBWithSlashReplicationTest extends ReplicationTestBase {
             age = age.intValue() + 1;
             body.put("age", age);
             revision.setBody(DocumentBodyFactory.create(body));
-            revision = datastore.updateDocumentFromRevision(revision);
+            revision = datastore.update(revision);
         }
 
         // push the changes to the remote

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/DBWithSlashReplicationTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/DBWithSlashReplicationTest.java
@@ -102,7 +102,7 @@ public class DBWithSlashReplicationTest extends ReplicationTestBase {
         }
 
         //now create some local revs
-        DocumentRevision revision = datastore.get(documentName);
+        DocumentRevision revision = datastore.read(documentName);
 
         for (int i = 0; i < 10; i++) {
             Map<String, Object> body = revision.getBody().asMap();

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/DatabaseAssert.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/DatabaseAssert.java
@@ -186,7 +186,7 @@ public class DatabaseAssert {
      * Assert the specified document is deleted in both remote CouchDb and local datastore.
      */
     static void checkBothDeleted(String id, DatabaseImpl datastore, CouchClient client) throws Exception {
-        DocumentRevision documentRevision = datastore.get(id);
+        DocumentRevision documentRevision = datastore.read(id);
         Assert.assertTrue(documentRevision.isDeleted());
 
         Map<String, Object> m = client.getDocument(id, documentRevision.getRevision());
@@ -241,7 +241,7 @@ public class DatabaseAssert {
      */
     static void checkWinningRevisionSame(String documentId, DatabaseImpl datastore,
                                          CouchClient client) throws Exception{
-        Map<String, Object> doc1 = ((DocumentRevision)datastore.get(documentId)).getBody().asMap();
+        Map<String, Object> doc1 = ((DocumentRevision)datastore.read(documentId)).getBody().asMap();
         Map<String, Object> doc2 = client.getDocument(documentId);
         doc2.remove(CouchConstants._attachments);
         DatabaseAssert.assertSameStringMap(doc1, doc2);

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/DatabaseAssert.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/DatabaseAssert.java
@@ -186,7 +186,7 @@ public class DatabaseAssert {
      * Assert the specified document is deleted in both remote CouchDb and local datastore.
      */
     static void checkBothDeleted(String id, DatabaseImpl datastore, CouchClient client) throws Exception {
-        DocumentRevision documentRevision = datastore.getDocument(id);
+        DocumentRevision documentRevision = datastore.get(id);
         Assert.assertTrue(documentRevision.isDeleted());
 
         Map<String, Object> m = client.getDocument(id, documentRevision.getRevision());
@@ -241,7 +241,7 @@ public class DatabaseAssert {
      */
     static void checkWinningRevisionSame(String documentId, DatabaseImpl datastore,
                                          CouchClient client) throws Exception{
-        Map<String, Object> doc1 = ((DocumentRevision)datastore.getDocument(documentId)).getBody().asMap();
+        Map<String, Object> doc1 = ((DocumentRevision)datastore.get(documentId)).getBody().asMap();
         Map<String, Object> doc2 = client.getDocument(documentId);
         doc2.remove(CouchConstants._attachments);
         DatabaseAssert.assertSameStringMap(doc1, doc2);

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/PullStrategyTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/PullStrategyTest.java
@@ -49,7 +49,7 @@ import java.util.concurrent.TimeUnit;
 public class PullStrategyTest extends ReplicationTestBase {
 
     private Bar getDocument(String id) throws Exception {
-        DocumentRevision rev = this.datastore.get(id);
+        DocumentRevision rev = this.datastore.read(id);
         Bar bar = new Bar();
         Map<String, Object> m = rev.getBody().asMap();
         bar.setAge((Integer)m.get("age"));
@@ -172,7 +172,7 @@ public class PullStrategyTest extends ReplicationTestBase {
         Bar bar1 = oneDocCreatedAndThenPulled(replicator);
         Response res = BarUtils.deleteBar(remoteDb, bar1.getId());
         this.pull(replicator, 1);
-        DocumentRevision object = datastore.get(res.getId(), res.getRev());
+        DocumentRevision object = datastore.read(res.getId(), res.getRev());
         Assert.assertNotNull(object);
         Assert.assertTrue(object.isDeleted());
     }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/PullStrategyTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/PullStrategyTest.java
@@ -445,6 +445,6 @@ public class PullStrategyTest extends ReplicationTestBase {
 
         // Assert that the number of documents is correct
         Assert.assertEquals("There should be one document after replication.", 1,
-                datastore.getAllIds().size());
+                datastore.getIds().size());
     }
 }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/PullStrategyTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/PullStrategyTest.java
@@ -49,7 +49,7 @@ import java.util.concurrent.TimeUnit;
 public class PullStrategyTest extends ReplicationTestBase {
 
     private Bar getDocument(String id) throws Exception {
-        DocumentRevision rev = this.datastore.getDocument(id);
+        DocumentRevision rev = this.datastore.get(id);
         Bar bar = new Bar();
         Map<String, Object> m = rev.getBody().asMap();
         bar.setAge((Integer)m.get("age"));
@@ -172,7 +172,7 @@ public class PullStrategyTest extends ReplicationTestBase {
         Bar bar1 = oneDocCreatedAndThenPulled(replicator);
         Response res = BarUtils.deleteBar(remoteDb, bar1.getId());
         this.pull(replicator, 1);
-        DocumentRevision object = datastore.getDocument(res.getId(), res.getRev());
+        DocumentRevision object = datastore.get(res.getId(), res.getRev());
         Assert.assertNotNull(object);
         Assert.assertTrue(object.isDeleted());
     }
@@ -305,7 +305,7 @@ public class PullStrategyTest extends ReplicationTestBase {
         Assert.assertEquals(2, datastore.getDocumentCount());
         String[] birds = {"snipe", "kookaburra"};
         for(String mammal : birds) {
-            Assert.assertTrue(datastore.containsDocument(mammal));
+            Assert.assertTrue(datastore.contains(mammal));
         }
     }
 
@@ -324,7 +324,7 @@ public class PullStrategyTest extends ReplicationTestBase {
         Assert.assertEquals(8, datastore.getDocumentCount());
         String[] mammals = {"aardvark", "badger", "elephant", "giraffe", "lemur", "llama", "panda", "zebra"};
         for(String mammal : mammals) {
-            Assert.assertTrue(datastore.containsDocument(mammal));
+            Assert.assertTrue(datastore.contains(mammal));
         }
     }
 
@@ -343,7 +343,7 @@ public class PullStrategyTest extends ReplicationTestBase {
         Assert.assertEquals(6, datastore.getDocumentCount());
         String[] mammals = {"badger", "kookaburra", "lemur", "llama", "panda", "snipe"};
         for(String mammal : mammals) {
-            Assert.assertTrue(mammal + " should be in the datastore", datastore.containsDocument(mammal));
+            Assert.assertTrue(mammal + " should be in the datastore", datastore.contains(mammal));
         }
     }
 
@@ -362,7 +362,7 @@ public class PullStrategyTest extends ReplicationTestBase {
         Assert.assertEquals(1, datastore.getDocumentCount());
         String[] mammals = {"panda"};
         for(String mammal : mammals) {
-            Assert.assertTrue(mammal + " should be in the datastore", datastore.containsDocument(mammal));
+            Assert.assertTrue(mammal + " should be in the datastore", datastore.contains(mammal));
         }
     }
 
@@ -445,6 +445,6 @@ public class PullStrategyTest extends ReplicationTestBase {
 
         // Assert that the number of documents is correct
         Assert.assertEquals("There should be one document after replication.", 1,
-                datastore.getAllDocumentIds().size());
+                datastore.getAllIds().size());
     }
 }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/PushStrategyTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/PushStrategyTest.java
@@ -314,7 +314,7 @@ public class PushStrategyTest extends ReplicationTestBase {
         String id = "\u738b\u4e1c\u5347";
         DocumentRevision rev = new DocumentRevision(id);
         rev.setBody(createDBBody("Tom"));
-        DocumentRevision saved = datastore.createDocumentFromRevision(rev);
+        DocumentRevision saved = datastore.create(rev);
 
         this.push(replicator, 1);
         assertPushReplicationStatus(replicator, 1, 2, "1");

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/ResurrectedDocumentTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/ResurrectedDocumentTest.java
@@ -59,7 +59,7 @@ public class ResurrectedDocumentTest extends ReplicationTestBase {
         for (int i=0; i<100; i++) {
             DocumentRevision rev = new DocumentRevision("doc-a-"+i);
             rev.setBody(DocumentBodyFactory.create("{\"test\": \"content\"}".getBytes()));
-            DocumentRevision newRev = datastore.createDocumentFromRevision(rev);
+            DocumentRevision newRev = datastore.create(rev);
             Assert.assertEquals(3, CouchUtils.generationFromRevId(newRev.getRevision()));
         }
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/UnreliableNetworkPullTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/UnreliableNetworkPullTest.java
@@ -47,7 +47,7 @@ public class UnreliableNetworkPullTest extends ProxyTestBase {
         }
         this.addToxic();
         super.pull();
-        Assert.assertEquals(nDocs, this.datastore.getAllIds().size());
+        Assert.assertEquals(nDocs, this.datastore.getIds().size());
         // TODO a number of extra document updates and pulls to ensure checkpointing is correct
     }
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/UnreliableNetworkPullTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/UnreliableNetworkPullTest.java
@@ -47,7 +47,7 @@ public class UnreliableNetworkPullTest extends ProxyTestBase {
         }
         this.addToxic();
         super.pull();
-        Assert.assertEquals(nDocs, this.datastore.getAllDocumentIds().size());
+        Assert.assertEquals(nDocs, this.datastore.getAllIds().size());
         // TODO a number of extra document updates and pulls to ensure checkpointing is correct
     }
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/UnreliableNetworkPushTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/UnreliableNetworkPushTest.java
@@ -18,7 +18,6 @@ import com.cloudant.common.ProxyTestBase;
 import com.cloudant.common.RequireRunningProxy;
 import com.cloudant.http.Http;
 import com.cloudant.sync.documentstore.DocumentBodyFactory;
-import com.cloudant.sync.documentstore.DocumentException;
 import com.cloudant.sync.documentstore.DocumentRevision;
 
 import org.junit.After;
@@ -87,7 +86,7 @@ public class UnreliableNetworkPushTest extends ProxyTestBase {
             doc.put("key_"+i, "value_"+i);
         }
         mdr.setBody(DocumentBodyFactory.create(doc));
-        datastore.createDocumentFromRevision(mdr);
+        datastore.create(mdr);
     }
 
     private void addToxic() throws Exception {


### PR DESCRIPTION
As per #413 "naming proposal for Database methods (create, delete) instead of createDocumentFromRevision"

Should we also rename others: "getEventBus()" → "eventBus" and "getPath" → "getPath"?