### PR TITLE
Remove getDocumentsWithInternalIds

### DIFF
--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/DatabaseImpl.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/DatabaseImpl.java
@@ -332,25 +332,6 @@ public class DatabaseImpl implements Database {
         }
     }
 
-    /**
-     * Get list of documents for given list of numeric ids. The result list is ordered by
-     * sequence number,
-     * and only the current revisions are returned.
-     *
-     * @param docIds given list of internal ids
-     * @return list of documents ordered by sequence number
-     */
-    List<InternalDocumentRevision> getDocumentsWithInternalIds(final List<Long> docIds) {
-        Misc.checkNotNull(docIds, "Input document internal id list");
-
-        try {
-            return get(queue.submit(new GetDocumentsWithInternalIdsCallable(docIds, this.attachmentsDir, this.attachmentStreamFactory)));
-        } catch (ExecutionException e) {
-            logger.log(Level.SEVERE, "Failed to get documents using internal ids", e);
-        }
-        return null;
-    }
-
     @Override
     public List<DocumentRevision> read(final int offset, final int limit, final
     boolean descending) throws DocumentStoreException {

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/CrudImplDatabaseTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/CrudImplDatabaseTest.java
@@ -26,6 +26,7 @@ import com.cloudant.sync.documentstore.DocumentRevision;
 import com.cloudant.sync.documentstore.DocumentStoreException;
 import com.cloudant.sync.documentstore.InvalidDocumentException;
 import com.cloudant.sync.documentstore.LocalDocument;
+import com.cloudant.sync.internal.documentstore.callables.GetDocumentsWithInternalIdsCallable;
 import com.cloudant.sync.internal.sqlite.Cursor;
 import com.cloudant.sync.internal.sqlite.SQLDatabase;
 import com.cloudant.sync.internal.sqlite.SQLCallable;
@@ -450,7 +451,7 @@ public class CrudImplDatabaseTest extends BasicDatastoreTestBase {
         List<Long> ids = new ArrayList<Long>();
 
         {
-            List<? extends DocumentRevision> docs = datastore.getDocumentsWithInternalIds(ids);
+            List<? extends DocumentRevision> docs = datastore.runOnDbQueue(new GetDocumentsWithInternalIdsCallable(ids, null, null)).get();
             Assert.assertEquals(0, docs.size());
         }
     }
@@ -466,7 +467,7 @@ public class CrudImplDatabaseTest extends BasicDatastoreTestBase {
         ids.add(101L);
 
         {
-            List<? extends DocumentRevision> docs = datastore.getDocumentsWithInternalIds(ids);
+            List<? extends DocumentRevision> docs = datastore.runOnDbQueue(new GetDocumentsWithInternalIdsCallable(ids, null, null)).get();
             Assert.assertEquals(2, docs.size());
             Assert.assertEquals(dbObjects[0].getId(), docs.get(0).getId());
             Assert.assertEquals(dbObjects[1].getId(), docs.get(1).getId());
@@ -504,9 +505,9 @@ public class CrudImplDatabaseTest extends BasicDatastoreTestBase {
         };
         for (int[] test : tests) {
             int fromIndex = test[0], toIndex = test[0]+test[1];
-            List<InternalDocumentRevision> docs = datastore.getDocumentsWithInternalIds(
-                internal_ids.subList(fromIndex, toIndex)
-            );
+            List<? extends DocumentRevision> docs = datastore.runOnDbQueue(new
+                    GetDocumentsWithInternalIdsCallable(internal_ids.subList(fromIndex, toIndex),
+                    null, null)).get();
             Assert.assertEquals(test[1], docs.size());
         }
     }
@@ -521,7 +522,7 @@ public class CrudImplDatabaseTest extends BasicDatastoreTestBase {
         ids.add(102L);
 
         {
-            List<InternalDocumentRevision> docs = datastore.getDocumentsWithInternalIds(ids);
+            List<? extends DocumentRevision> docs = datastore.runOnDbQueue(new GetDocumentsWithInternalIdsCallable(ids, null, null)).get();
             Assert.assertEquals(0, docs.size());
         }
     }


### PR DESCRIPTION
See #352 

## What

Remove `getDocumentsWithInternalIds` method.

## Why

It was only being used by test code, so we call the `callable` directly. Because the tests which use it don't deal with attachments we can set `null` for the attachments directory and stream factory.

## Testing

Existing test pass; no requirement for new tests.
