### PR TITLE
Better exception handling and error checking in ReplicationBuilder

### DIFF
--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/PullReplicatorTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/PullReplicatorTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -240,6 +241,30 @@ public class PullReplicatorTest extends ReplicationTestBase {
                         toString()
         );
        assertCookieInterceptorPresent(p, "name=%F0%9F%8D%B6&password=%F0%9F%8D%B6");
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void replicatorBuilderNoSource() {
+        ReplicatorBuilder.Pull p = ReplicatorBuilder.pull().
+                from(null).
+                to(documentStore);
+        p.build();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void replicatorBuilderNoTarget() throws URISyntaxException {
+        ReplicatorBuilder.Pull p = ReplicatorBuilder.pull().
+                from(new URI("http://localhost/abc")).
+                to(null);
+        p.build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void replicatorBuilderUnknownProtocol() throws URISyntaxException {
+        ReplicatorBuilder.Pull p = ReplicatorBuilder.pull().
+                from(new URI("gopher://localhost/abc")).
+                to(documentStore);
+        p.build();
     }
 
 }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/PushReplicatorTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/PushReplicatorTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.concurrent.TimeUnit;
 
 @Category(RequireRunningCouchDB.class)
@@ -337,6 +338,30 @@ public class PushReplicatorTest extends ReplicationTestBase {
                 .batchesReplicated);
 
         assertLastSequence(replicator);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void replicatorBuilderNoSource() throws URISyntaxException {
+        ReplicatorBuilder.Push p = ReplicatorBuilder.push().
+                from(null).
+                to(new URI("http://localhost/abc"));
+        p.build();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void replicatorBuilderNoTarget() {
+        ReplicatorBuilder.Push p = ReplicatorBuilder.push().
+                from(documentStore).
+                to(null);
+        p.build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void replicatorBuilderUnknownProtocol() throws URISyntaxException {
+        ReplicatorBuilder.Push p = ReplicatorBuilder.push().
+                from(documentStore).
+                to(new URI("gopher://localhost/abc"));
+        p.build();
     }
 
 }


### PR DESCRIPTION
See #280 

## What 
- Add message to clarify RuntimeException when redacting URL for cookie interceptor
- Use `Misc.checkArgument` when checking default port
- Use `Misc.checkState` when checking both source and target are non-null

## Why
- As outlined in the parent issue, we are over-reliant on `RuntimeException`s which are often not appropriate

## Tests
- See new tests in `{Pull,Push}ReplicatorTest`
