### PR TITLE
436 uri creds

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# Unreleased
+ - [FIXED] Issue with double encoding of restricted URL characters in credentials when using
+   `ReplicatorBuilder`.
+
 # 1.1.5 (2016-12-08)
 - [FIXED] Issue where replicator would not get the latest revision if `_bulk_get`
    was available.

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/PullReplicatorTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/PullReplicatorTest.java
@@ -239,12 +239,18 @@ public class PullReplicatorTest extends ReplicationTestBase {
        assertCookieInterceptorPresent(p, "name=%F0%9F%8D%B6&password=%F0%9F%8D%B6");
     }
 
+    /**
+     * Test that a username and password combination where both parts contain a series of URI
+     * reserved and other percent encoded characters is correctly encoded and not double encoded
+     * after going through the ReplicatorBuilder and CookieInterceptor.
+     *
+     * @throws Exception
+     */
     @Test
-    public void replicatorBuilderAddsCookieInterceptorSpecialCreds() throws Exception {
-        String encodedUsername = "user%3B%2F%3F%3A%40%3D%26%3C%3E%23%25%7B%7D%7C%5C%5E%7E%5B%5D" +
-                "+%C2%A9%F0%9F%94%92";
-        String encodedPassword = "password%3B%2F%3F%3A%40%3D%26%3C%3E%23%25%7B%7D%7C%5C%5E%7E%5B" +
-                "%5D+%C2%A9%F0%9F%94%92";
+    public void replicatorBuilderAddsCookieInterceptorCredsPercentEncoded() throws Exception {
+        String encodedUsername = "user" + PERCENT_ENCODED_URI_CHARS;
+        String encodedPassword = "password" + PERCENT_ENCODED_URI_CHARS;
+        System.out.println(encodedUsername);
         ReplicatorBuilder.Pull p = ReplicatorBuilder.pull().
                 from(new URI("http://" + encodedUsername + ":" + encodedPassword +
                         "@some-host/path%2Fsome-path-日本")).
@@ -257,7 +263,8 @@ public class PullReplicatorTest extends ReplicationTestBase {
                         getRootUri()).
                         toString()
         );
-        assertCookieInterceptorPresent(p, "name="+encodedUsername+"&password=" + encodedPassword);
+        assertCookieInterceptorPresent(p, "name=" + encodedUsername + "&password=" +
+                encodedPassword);
     }
 
 }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/PullReplicatorTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/PullReplicatorTest.java
@@ -239,4 +239,25 @@ public class PullReplicatorTest extends ReplicationTestBase {
        assertCookieInterceptorPresent(p, "name=%F0%9F%8D%B6&password=%F0%9F%8D%B6");
     }
 
+    @Test
+    public void replicatorBuilderAddsCookieInterceptorSpecialCreds() throws Exception {
+        String encodedUsername = "user%3B%2F%3F%3A%40%3D%26%3C%3E%23%25%7B%7D%7C%5C%5E%7E%5B%5D" +
+                "+%C2%A9%F0%9F%94%92";
+        String encodedPassword = "password%3B%2F%3F%3A%40%3D%26%3C%3E%23%25%7B%7D%7C%5C%5E%7E%5B" +
+                "%5D+%C2%A9%F0%9F%94%92";
+        ReplicatorBuilder.Pull p = ReplicatorBuilder.pull().
+                from(new URI("http://" + encodedUsername + ":" + encodedPassword +
+                        "@some-host/path%2Fsome-path-日本")).
+                to(datastore);
+        ReplicatorImpl r = (ReplicatorImpl) p.build();
+        // check that user/pass has been removed
+        Assert.assertEquals("http://some-host:80/path%2Fsome-path-日本",
+                (((CouchClientWrapper) (((PullStrategy) r.strategy).sourceDb)).
+                        getCouchClient().
+                        getRootUri()).
+                        toString()
+        );
+        assertCookieInterceptorPresent(p, "name="+encodedUsername+"&password=" + encodedPassword);
+    }
+
 }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/PullReplicatorTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/PullReplicatorTest.java
@@ -250,7 +250,6 @@ public class PullReplicatorTest extends ReplicationTestBase {
     public void replicatorBuilderAddsCookieInterceptorCredsPercentEncoded() throws Exception {
         String encodedUsername = "user" + PERCENT_ENCODED_URI_CHARS;
         String encodedPassword = "password" + PERCENT_ENCODED_URI_CHARS;
-        System.out.println(encodedUsername);
         ReplicatorBuilder.Pull p = ReplicatorBuilder.pull().
                 from(new URI("http://" + encodedUsername + ":" + encodedPassword +
                         "@some-host/path%2Fsome-path-日本")).

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/PushReplicatorTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/PushReplicatorTest.java
@@ -336,12 +336,17 @@ public class PushReplicatorTest extends ReplicationTestBase {
         assertLastSequence(replicator);
     }
 
+    /**
+     * Test that a username and password combination where both parts contain a series of URI
+     * reserved and other percent encoded characters is correctly encoded and not double encoded
+     * after going through the ReplicatorBuilder and CookieInterceptor.
+     *
+     * @throws Exception
+     */
     @Test
-    public void replicatorBuilderAddsCookieInterceptorSpecialCreds() throws Exception {
-        String encodedUsername = "user%3B%2F%3F%3A%40%3D%26%3C%3E%23%25%7B%7D%7C%5C%5E%7E%5B%5D" +
-                "+%C2%A9%F0%9F%94%92";
-        String encodedPassword = "password%3B%2F%3F%3A%40%3D%26%3C%3E%23%25%7B%7D%7C%5C%5E%7E%5B" +
-                "%5D+%C2%A9%F0%9F%94%92";
+    public void replicatorBuilderAddsCookieInterceptorCredsPercentEncoded() throws Exception {
+        String encodedUsername = "user" + PERCENT_ENCODED_URI_CHARS;
+        String encodedPassword = "password" + PERCENT_ENCODED_URI_CHARS;
         ReplicatorBuilder.Push p = ReplicatorBuilder.push().
                 from(datastore).
                 to(new URI("http://" + encodedUsername + ":" + encodedPassword +

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/ReplicationTestBase.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/replication/ReplicationTestBase.java
@@ -28,10 +28,27 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 
+import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Field;
+import java.net.URLEncoder;
 import java.util.List;
 
 public abstract class ReplicationTestBase extends CouchTestBase {
+
+    // A String of all the URI reserved and "unsafe" characters, plus © and an emoji. Encodes to:
+    // %21*%27%28%29%3B%3A%40%26%3D%2B%24%2C%2F%3F%23%5B%5D+%22%25
+    // -.%3C%3E%5C%5E_%60%7B%7C%7D%7E%C2%A9%F0%9F%94%92
+    protected static final String PERCENT_ENCODED_URI_CHARS;
+
+    static {
+        try {
+            PERCENT_ENCODED_URI_CHARS = URLEncoder.encode("!*'();:@&=+$,/?#[] \"%-" +
+                    ".<>\\^_`{|}~©\uD83D\uDD12", "UTF-8");
+
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
     public String datastoreManagerPath = null;
 
@@ -210,5 +227,4 @@ public abstract class ReplicationTestBase extends CouchTestBase {
         PullStrategy pullStrategy;
         TestStrategyListener listener;
     }
-
 }


### PR DESCRIPTION
*What*

Prevent double encoding of credentials extracted from source/target URL by `ReplicatorBuilder`.

*How*

Changed `ReplicatorBuilder` to `getRawUserInfo()` before splitting on “:” and change to URL
decode the username and password parts separately.
Updated `CHANGES.md`.

*Testing*

Added tests with URI containing user info with username and password containing more URI special characters 
* `PullReplicatorTest.replicatorBuilderAddsCookieInterceptorSpecialCreds`
* `PushReplicatorTest.replicatorBuilderAddsCookieInterceptorSpecialCreds`

*Issues*

Fixes #436 