### PR TITLE
Enforce Event bus restrictions at register time.

### DIFF
--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/event/notifications/DocumentModified.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/event/notifications/DocumentModified.java
@@ -19,7 +19,7 @@ import com.cloudant.sync.documentstore.DocumentRevision;
 /**
  * @api_public
  */
-public class DocumentModified {
+public class DocumentModified implements Notification {
 
     /**
      * Generic event for document create/update/delete

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/event/notifications/DocumentStoreModified.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/event/notifications/DocumentStoreModified.java
@@ -17,7 +17,7 @@ package com.cloudant.sync.event.notifications;
 /**
  * @api_public
  */
-public class DocumentStoreModified {
+public class DocumentStoreModified implements Notification {
 
     /**
      * Generic event for database create/delete

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/event/notifications/Notification.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/event/notifications/Notification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cloudant, Inc. All rights reserved.
+ * Copyright © 2016 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -10,18 +10,13 @@
  * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
  * either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
+ *
  */
 
-package com.cloudant.sync.internal.replication;
+package com.cloudant.sync.event.notifications;
 
-import com.cloudant.sync.event.notifications.Notification;
-
-class ReplicationStrategyCompleted implements Notification {
-
-    protected ReplicationStrategyCompleted(ReplicationStrategy replicationStrategy) {
-        this.replicationStrategy = replicationStrategy;
-    }
-
-    protected final ReplicationStrategy replicationStrategy;
-    
+/**
+ * Marker interface for events.
+ */
+public interface Notification {
 }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/event/notifications/ReplicationCompleted.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/event/notifications/ReplicationCompleted.java
@@ -27,7 +27,7 @@ import com.cloudant.sync.replication.Replicator;
  *
  * @api_public
  */
-public class ReplicationCompleted {
+public class ReplicationCompleted implements Notification {
 
     public ReplicationCompleted(Replicator replicator,
                                 int documentsReplicated,

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/event/notifications/ReplicationErrored.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/event/notifications/ReplicationErrored.java
@@ -28,7 +28,7 @@ import com.cloudant.sync.replication.Replicator;
  *
  * @api_public
  */
-public class ReplicationErrored {
+public class ReplicationErrored implements Notification {
 
     public ReplicationErrored(Replicator replicator, Throwable errorInfo) {
         this.replicator = replicator;

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/replication/ReplicationStrategyErrored.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/replication/ReplicationStrategyErrored.java
@@ -15,7 +15,9 @@
 package com.cloudant.sync.internal.replication;
 
 
-class ReplicationStrategyErrored {
+import com.cloudant.sync.event.notifications.Notification;
+
+class ReplicationStrategyErrored implements Notification {
 
     protected ReplicationStrategyErrored(ReplicationStrategy replicationStrategy, Throwable errorInfo) {
         this.replicationStrategy = replicationStrategy;

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/event/EventBusTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/event/EventBusTest.java
@@ -18,38 +18,23 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
+import com.cloudant.sync.event.notifications.Notification;
+
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class EventBusTest {
 
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
     public EventBus bus;
     public TestBusSubscriber sub;
-
-    private static class TestEvent {
-
-    }
-
-    private static class ExtendedTestEvent extends TestEvent {
-
-    }
-
-    private static class TestBusSubscriber {
-
-        List<Object> eventsReceived = new ArrayList<Object>();
-
-        protected void onEvent(Object event) {
-            eventsReceived.add(event);
-        }
-
-        @Subscribe
-        public void onEvent(TestEvent event) {
-            onEvent((Object) event);
-        }
-    }
 
     @Before
     public void newBus() throws Exception {
@@ -84,7 +69,8 @@ public class EventBusTest {
         bus.register(sub);
 
         // Post an event (of type Object) - we are subscribed to TestEvent
-        Object e = new Object();
+        Notification e = new Notification() {
+        };
         bus.post(e);
 
         assertTrue("There should be no events", sub.eventsReceived.isEmpty());
@@ -162,19 +148,210 @@ public class EventBusTest {
      */
     @Test
     public void subscriberException() throws Exception {
-        bus.register(new Object() {
-
-            @Subscribe
-            public void throwOnEvent(TestEvent event) throws Exception {
-                throw new Exception("Test subscriber exception");
-            }
-        });
+        bus.register(new ThrowingSubscriber());
 
         // Post an event
         TestEvent e = new TestEvent();
         bus.post(e);
 
         // Test passes if no exception is thrown
+    }
+
+    /**
+     * Test that a class with the access level private is rejected.
+     * @throws Exception
+     */
+    @Test
+    public  void privateSubscriber() throws Exception {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Event Subscriber class com.cloudant.sync.event.EventBusTest$PrivateSubscriber needs to be public");
+
+        bus.register(new PrivateSubscriber());
+    }
+
+    /**
+     * Test that a class with the access level protected is rejected.
+     * @throws Exception
+     */
+    @Test
+    public void protectedSubcriber() throws Exception {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Event Subscriber class com.cloudant.sync.event.EventBusTest$ProtectedSubScriber needs to be public");
+        bus.register(new ProtectedSubScriber());
+    }
+
+    /**
+     * Test that an anonymous inner class is rejected, this is because Anonymous inner classess cannot be public.
+     * @throws Exception
+     */
+    @Test
+    public void anonymousClass() throws Exception {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Event Subscriber class com.cloudant.sync.event.EventBusTest$2 needs to be public");
+        bus.register(new Object(){
+            @Subscribe
+            public void doNothing(Object object){
+
+            }
+        });
+    }
+
+    /**
+     * Test that a class with the default or "package protected" access scope is rejected.
+     * @throws Exception
+     */
+    @Test
+    public void packageProtectedSubScriber() throws Exception {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Event Subscriber class com.cloudant.sync.event.EventBusTest$PackageProtectedSubscriber needs to be public");
+
+        bus.register(new PackageProtectedSubscriber());
+    }
+
+    /**
+     * Test that a public class with a subscribing method with default or "package protected" access scope is rejected
+     */
+    @Test
+    public void packageProtectedSubMethod(){
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Subscriber method com.cloudant.sync.event.EventBusTest$PackageProtectedMethodSubscriber#doNothing is required to be public");
+
+        bus.register(new PackageProtectedMethodSubscriber());
+    }
+
+    /**
+     * Test that a public class with a protected subscribing method is rejected.
+     */
+    @Test
+    public void protectedSubMehtod(){
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Subscriber method com.cloudant.sync.event.EventBusTest$ProtectedMethodSub#doNothing is required to be public");
+        bus.register(new ProtectedMethodSub());
+    }
+
+    /**
+     * Test that a public class with a private subscribing method is rejected.
+     */
+    @Test
+    public void privateSubMethod(){
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Subscriber method com.cloudant.sync.event.EventBusTest$PrivateMethodSub#doNothing is required to be public");
+        bus.register(new PrivateMethodSub());
+    }
+
+    /**
+     * Test that a public class with a public subscriber method with 2 parameters is rejected.
+     */
+    @Test
+    public void subMethodWith2Parameters(){
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Subscriber method  com.cloudant.sync.event.EventBusTest$SubscriberMethod2Params#doNothing2Arg is required to have only 1 parameter");
+
+        bus.register(new SubscriberMethod2Params());
+    }
+
+    /**
+     * Test that a public class with a public subscriber method with 0 parameters is rejected.
+     */
+    @Test
+    public void subMethodWith0Parameters(){
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Subscriber method  com.cloudant.sync.event.EventBusTest$SubscriberMethod0Params#doNothing0Arg is required to have only 1 parameter");
+
+        bus.register(new SubscriberMethod0Params());
+    }
+
+    @Test
+    public void subMethodWithObjectTypeParameter(){
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Subscriber method com.cloudant.sync.event.EventBusTest$UnassignableToNotificationSubscriber#doNothing parameter is required to be assignable com.cloudant.sync.event.notifications.Notification");
+
+        bus.register(new UnassignableToNotificationSubscriber());
+    }
+
+    private static class TestEvent implements Notification {
+
+    }
+
+    private static class ExtendedTestEvent extends TestEvent {
+
+    }
+
+    public static class TestBusSubscriber {
+
+        List<Object> eventsReceived = new ArrayList<Object>();
+
+        protected void onEvent(Object event) {
+            eventsReceived.add(event);
+        }
+
+        @Subscribe
+        public void onEvent(TestEvent event) {
+            onEvent((Object) event);
+        }
+    }
+
+    public static class ThrowingSubscriber {
+
+        @Subscribe
+        public void throwOnEvent(TestEvent event) throws Exception {
+            throw new Exception("Test subscriber exception");
+        }
+    }
+
+
+    public static class SubscriberMethod2Params{
+        @Subscribe
+        public void doNothing2Arg(Notification notification, Notification notification2){
+
+        }
+
+    }
+
+    public static class SubscriberMethod0Params{
+        @Subscribe
+        public void doNothing0Arg(){
+
+        }
+
+    }
+
+    private static class PrivateSubscriber {
+
+    }
+
+    protected static class ProtectedSubScriber{
+    }
+
+    static class PackageProtectedSubscriber {
+    }
+
+    public static class PackageProtectedMethodSubscriber {
+        @Subscribe
+        void doNothing(Notification notification){
+
+        }
+    }
+
+    public static class ProtectedMethodSub {
+        @Subscribe
+        protected void doNothing(Notification notification){
+
+        }
+    }
+
+    public static class PrivateMethodSub {
+        @Subscribe
+        private void doNothing(Notification notification){
+
+        }
+    }
+
+    public static class UnassignableToNotificationSubscriber{
+        @Subscribe
+        public void doNothing(Object object){
+
+        }
     }
 
 }

--- a/doc/events.md
+++ b/doc/events.md
@@ -39,12 +39,15 @@ eventBus.register(dnc);
 ```
 
 Next, add the methods you want to be called when each event occurs and decorate them with the
-`@Subscribe` annotation. These methods must be visible to the EventBus class.
+`@Subscribe` annotation. These methods and the containing class must be marked public. This means
+that anonymous inner classes cannot be used as event subscribers.
 
 Here the `DocumentNotificationClient` is subscribing to the `DocumentCreated` event. Because the
 events are just classes, they obey the type hierarchy. This means that it is also possible to
 subscribe to the generic `DocumentModified` event to be notified of all Created/Deleted/Updated
-events and then use reflection and downcasting if needed.
+events and then use reflection and downcasting if needed, however if you want to listen for multiple 
+event types eg `DocumentCreated` and `DatastoreCreated` using the same subscriber method, the 
+`Notification` marker interface needs to be used instead.
 
 ```java
 public class DocumentNotificationClient {


### PR DESCRIPTION
## What
Enforce event bus restrictions when a subscriber is being registered to the bus.

## Why 
Enforcing the event bus restrictions when registering means the `IllegalAccessException` thrown
when attempting to invoke a method on the subscriber should not occur during normal operation, so it becomes safe to throw a `RuntimeException` when an `IllegalAccessException` is caught.

## How
Make sure subscribing instances conform to the following restrictions when the register method is
called or throw an `IllegalArgumentException`.

- Subscriber class *must* be public
- Methods with the @Subscribe annotation *must* be public.
- Method with the @Subscribe annotation *must* have only one parameter.

Note: Previously the method and subscriber only needed to be visible to the EventBus class, this
has now been restricted to enforce public access for the subscription method and subscription class. This makes it easier to perform validation if


## Testing

New tests added to the EventBusTest which test exception cases.