### PR TITLE
Throw IllegalArgumentException instead of RuntimeException.

### DIFF
--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/DatabaseImpl.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/DatabaseImpl.java
@@ -368,6 +368,7 @@ public class DatabaseImpl implements Database {
             DocumentStoreException {
         Misc.checkState(this.isOpen(), "Database is closed");
         Misc.checkNotNull(docIds, "Input document id list");
+        Misc.checkArgument(!docIds.isEmpty(), "Input document id list must contain document ids");
         try {
             return get (queue.submit(new GetDocumentsWithIdsCallable(docIds, attachmentsDir, attachmentStreamFactory)));
         } catch (ExecutionException e) {
@@ -796,10 +797,12 @@ public class DatabaseImpl implements Database {
      * <a href="http://wiki.apache.org/couchdb/HttpPostRevsDiff">HttpPostRevsDiff documentation</a>
      * @param revisions a Multimap of document id → revision id
      * @return the subset of given the document id/revisions that are already stored in the database
+     * @throws IllegalArgumentException if {@code revisions} is empty.
      */
     public Map<String, List<String>> revsDiff(final Map<String, List<String>> revisions) {
         Misc.checkState(this.isOpen(), "Database is closed");
         Misc.checkNotNull(revisions, "Input revisions");
+        Misc.checkArgument(!revisions.isEmpty(), "revisions cannot be empty");
 
         // TODO hoist down queue.submit to just surround the call to RevsDiffBatchCallable
         try {

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/ChangesCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/ChangesCallable.java
@@ -25,6 +25,7 @@ import com.cloudant.sync.internal.util.DatabaseUtils;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
@@ -70,6 +71,11 @@ public class ChangesCallable implements SQLCallable<Changes> {
                 ids.add(cursor.getLong(0));
                 lastSequence = Math.max(lastSequence, cursor.getLong(1));
             }
+
+            if (ids.isEmpty()){
+                return new Changes(lastSequence, Collections.<InternalDocumentRevision>emptyList());
+            }
+
             List<InternalDocumentRevision> results = new GetDocumentsWithInternalIdsCallable(ids, attachmentsDir, attachmentStreamFactory).call(db);
             if (results.size() != ids.size()) {
                 throw new IllegalStateException(String.format(Locale.ENGLISH,

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/GetDocumentsWithIdsCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/GetDocumentsWithIdsCallable.java
@@ -21,6 +21,7 @@ import com.cloudant.sync.internal.documentstore.InternalDocumentRevision;
 import com.cloudant.sync.internal.sqlite.SQLCallable;
 import com.cloudant.sync.internal.sqlite.SQLDatabase;
 import com.cloudant.sync.internal.util.DatabaseUtils;
+import com.cloudant.sync.internal.util.Misc;
 
 import java.util.List;
 
@@ -38,6 +39,8 @@ public class GetDocumentsWithIdsCallable implements SQLCallable<List<DocumentRev
 
     public GetDocumentsWithIdsCallable(List<String> docIds, String attachmentsDir,
                                        AttachmentStreamFactory attachmentStreamFactory) {
+
+        Misc.checkArgument(!docIds.isEmpty(), "docIds list cannot be empty.");
         this.docIds = docIds;
         this.attachmentsDir = attachmentsDir;
         this.attachmentStreamFactory = attachmentStreamFactory;

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/GetDocumentsWithInternalIdsCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/GetDocumentsWithInternalIdsCallable.java
@@ -23,6 +23,7 @@ import com.cloudant.sync.internal.sqlite.SQLCallable;
 import com.cloudant.sync.internal.sqlite.SQLDatabase;
 import com.cloudant.sync.internal.util.CollectionUtils;
 import com.cloudant.sync.internal.util.DatabaseUtils;
+import com.cloudant.sync.internal.util.Misc;
 
 import java.io.Serializable;
 import java.util.ArrayList;

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/RevsDiffBatchCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/RevsDiffBatchCallable.java
@@ -19,6 +19,7 @@ import com.cloudant.sync.internal.sqlite.Cursor;
 import com.cloudant.sync.internal.sqlite.SQLCallable;
 import com.cloudant.sync.internal.sqlite.SQLDatabase;
 import com.cloudant.sync.internal.util.DatabaseUtils;
+import com.cloudant.sync.internal.util.Misc;
 
 import java.sql.SQLException;
 import java.util.Collection;
@@ -42,6 +43,7 @@ public class RevsDiffBatchCallable implements SQLCallable<Collection<String>> {
      * @param revs  the rev IDs to check
      */
     public RevsDiffBatchCallable(String docId, Collection<String> revs) {
+        Misc.checkArgument(!revs.isEmpty(), "revs must not be empty.");
         this.docId = docId;
         // Consider all missing to start
         this.missingRevs = new HashSet<String>(revs);

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/util/DatabaseUtils.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/util/DatabaseUtils.java
@@ -38,17 +38,13 @@ public  class DatabaseUtils {
     }
 
     public static String makePlaceholders(int len) {
-        if (len < 1) {
-            // It will lead to an invalid query anyway ..
-            throw new RuntimeException("No placeholders");
-        } else {
-            StringBuilder sb = new StringBuilder(len * 2 - 1);
-            sb.append("?");
-            for (int i = 1; i < len; i++) {
-                sb.append(",?");
-            }
-            return sb.toString();
+        Misc.checkArgument(len >= 1, "len needs to be greater than or equal to 1.");
+        StringBuilder sb = new StringBuilder(len * 2 - 1);
+        sb.append("?");
+        for (int i = 1; i < len; i++) {
+            sb.append(",?");
         }
+        return sb.toString();
     }
 
 }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatabaseImplRevsDiffTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatabaseImplRevsDiffTest.java
@@ -18,18 +18,23 @@ import com.cloudant.sync.documentstore.DocumentRevision;
 import com.cloudant.sync.internal.common.ValueListMap;
 
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.util.List;
 import java.util.Map;
 
 public class DatabaseImplRevsDiffTest extends BasicDatastoreTestBase{
 
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
     @Test
     public void revsDiff_emptyInput_returnEmpty() {
-        Map<String, List<String>> revs =
-                datastore.revsDiff(new ValueListMap<String, String>());
-        Assert.assertTrue(revs.size() == 0);
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("revisions cannot be empty");
+        datastore.revsDiff(new ValueListMap<String, String>());
     }
 
     @Test


### PR DESCRIPTION
Throw IllegalArgumentException instead of RuntimeException in DatabaseUtils because this class makes more sense than a plain RuntimeException. 