### PR TITLE
Throw DocumentStoreException when revsDiff fails.

### DIFF
--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/DatabaseImpl.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/DatabaseImpl.java
@@ -798,8 +798,9 @@ public class DatabaseImpl implements Database {
      * @param revisions a Multimap of document id → revision id
      * @return the subset of given the document id/revisions that are already stored in the database
      * @throws IllegalArgumentException if {@code revisions} is empty.
+     * @throws DocumentStoreException If it was not possible to calculate the difference between revs.
      */
-    public Map<String, List<String>> revsDiff(final Map<String, List<String>> revisions) {
+    public Map<String, List<String>> revsDiff(final Map<String, List<String>> revisions) throws DocumentStoreException {
         Misc.checkState(this.isOpen(), "Database is closed");
         Misc.checkNotNull(revisions, "Input revisions");
         Misc.checkArgument(!revisions.isEmpty(), "revisions cannot be empty");
@@ -808,10 +809,10 @@ public class DatabaseImpl implements Database {
         try {
             return get(queue.submit(new RevsDiffCallable(revisions)));
         } catch (ExecutionException e) {
-            logger.log(Level.SEVERE, "Failed to do revsdiff", e);
+            String message = "Failed to calculate difference in revisions";
+            logger.log(Level.SEVERE, message, e);
+            throw new DocumentStoreException(message, e);
         }
-
-        return null;
     }
 
     @Override

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/replication/PullStrategy.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/replication/PullStrategy.java
@@ -294,7 +294,7 @@ public class PullStrategy implements ReplicationStrategy {
     }
 
     private int processOneChangesBatch(ChangesResultWrapper changeFeeds)
-            throws ExecutionException, InterruptedException, DocumentException {
+            throws ExecutionException, InterruptedException, DocumentException, DocumentStoreException {
         String feed = String.format(
                 "Change feed: { last_seq: %s, change size: %s}",
                 changeFeeds.getLastSeq(),

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatabaseImplRevsDiffTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatabaseImplRevsDiffTest.java
@@ -31,7 +31,8 @@ public class DatabaseImplRevsDiffTest extends BasicDatastoreTestBase{
     public ExpectedException thrown = ExpectedException.none();
 
     @Test
-    public void revsDiff_emptyInput_returnEmpty() {
+    public void revsDiff_emptyInput_returnEmpty() throws Exception
+    {
         thrown.expect(IllegalArgumentException.class);
         thrown.expectMessage("revisions cannot be empty");
         datastore.revsDiff(new ValueListMap<String, String>());


### PR DESCRIPTION
Throw DocumentStoreException when revsDiff queue task throws an ExecutionException.

Fixes #444