### PR TITLE
Travis dependency caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,7 @@ services:
 
 before_install:
   - export TERM=dumb
+
+cache:
+  directories:
+  - $HOME/.m2

--- a/build.gradle
+++ b/build.gradle
@@ -66,9 +66,6 @@ subprojects {
         repositories {
             mavenCentral()
         }
-        dependencies {
-            classpath "net.saliman:gradle-cobertura-plugin:2.1.0"
-        }
     }
 
     sourceCompatibility = 1.6


### PR DESCRIPTION
*What*

Enabled maven repository caching for Travis.

*Why*

Recently travis builds have been failing with `403 Forbidden` we should cache the downloads so we don't get as broken if they fail.

*How*

Added maven home cache to `.travis.yml`.
Removed unused gradle-cobertura-plugin dependency.

*Testing*
The travis build still didn't pass, but we'll need a build to succeed with the necessary 