### PR TITLE
New Credentials API for ReplicatorBuilder

### DIFF
--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ReplicatorBuilder.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ReplicatorBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2017 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -45,6 +45,9 @@ public abstract class ReplicatorBuilder<S, T, E> {
 
     private T target;
     private S source;
+    private String username;
+    private String password;
+
     private int id = ReplicatorImpl.NULL_ID;
     private List<HttpConnectionRequestInterceptor> requestInterceptors = new ArrayList
             <HttpConnectionRequestInterceptor>();
@@ -72,33 +75,39 @@ public abstract class ReplicatorBuilder<S, T, E> {
                     "Protocol %s not supported", uriProtocol));
         }
 
-        if (uri.getUserInfo() != null) {
+        if (uri.getUserInfo() != null && this.username == null && this.password == null) {
             String[] parts = uri.getUserInfo().split(":");
             if (parts.length == 2) {
+                this.username = parts[0];
+                this.password = parts[1];
+            }
+        }
 
-                String path = uri.getRawPath();
+        if(this.username == null && this.password == null){
+            return uri;
+        }
+
+
+
+        try {
+            String path = uriPath == null ? "" : uriPath;
+
+            if(path.length() > 0) {
                 int index = path.lastIndexOf("/");
                 if (index == path.length() - 1) {
                     // we need to go back one
                     path = path.substring(0, index);
                     index = path.lastIndexOf("/");
                 }
-
                 path = path.substring(0, index);
-
-                URI baseURI;
-
-                try {
-                    baseURI = new URI(uriProtocol, null, uriHost, uriPort, path, null, null);
-                } catch (URISyntaxException e) {
-                    throw new RuntimeException(e);
-                }
-
-
-                CookieInterceptor ci = new CookieInterceptor(parts[0], parts[1], baseURI.toString());
-                requestInterceptors.add(ci);
-                responseInterceptors.add(ci);
             }
+
+            URI baseURI = new URI(uriProtocol, null, uriHost, uriPort, path, null, null);
+            CookieInterceptor ci = new CookieInterceptor(username, password, baseURI.toString());
+            requestInterceptors.add(ci);
+            responseInterceptors.add(ci);
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
         }
 
         try {
@@ -371,6 +380,40 @@ public abstract class ReplicatorBuilder<S, T, E> {
         //noinspection unchecked
         return (E) this;
     }
+
+    /**
+     * Sets the username to use when authenticating with the server.
+     *
+     * Setting the username and password (using the {@link ReplicatorBuilder#password(String)}) method
+     * takes precedence over credentials passed via the URI.
+     * @param username The username to use when authenticating.
+     * @return The current instance of {@link ReplicatorBuilder}
+     * @throws NullPointerException if {@code username} is {@code null}.
+     */
+    public E username(String username) {
+        Misc.checkNotNull(username, "username");
+        this.username = username;
+        //noinspection unchecked
+        return (E) this;
+    }
+
+    /**
+     * Sets the password to use when authenticating with the server.
+     *
+     * Setting the username (using the {@link ReplicatorBuilder#username(String)}) and password method
+     * takes precedence over credentials passed via the URI.
+     *
+     * @param password The password to use when authenticating.
+     * @return The current instance of {@link ReplicatorBuilder}
+     * @throws NullPointerException if {@code password} is {@code null}.
+     */
+    public E password(String password) {
+        Misc.checkNotNull(password, "password");
+        this.password = password;
+        //noinspection unchecked
+        return (E) this;
+    }
+
 
     /**
      * Builds a replicator by calling {@link #build()} and then {@link Replicator#start()}

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/ClientTestUtils.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/ClientTestUtils.java
@@ -215,8 +215,10 @@ public class ClientTestUtils {
         }
     }
 
-    public static List<String> getRemoteRevisionIDs(URI uri) throws Exception{
+    public static List<String> getRemoteRevisionIDs(URI uri, CouchConfig config) throws Exception{
         HttpConnection connection = Http.GET(uri);
+        connection.requestInterceptors.addAll(config.getRequestInterceptors());
+        connection.responseInterceptors.addAll(config.getResponseInterceptors());
         InputStream in = connection.execute().responseAsInputStream();
 
         JSONObject jsonObject = new JSONObject(new JSONTokener(IOUtils.toString(in)));

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/SpecifiedCouch.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/SpecifiedCouch.java
@@ -29,6 +29,7 @@ import com.cloudant.http.HttpConnectionResponseInterceptor;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Collections;
 
 /**
  * Created by Rhys Short on 30/01/15.
@@ -47,25 +48,15 @@ public class SpecifiedCouch {
             if (COUCH_URI != null) {
                 uriString = String.format("%s/%s", COUCH_URI, dbName);
             }
-            // otherwise build the URI up, but skip username/password from URL if they aren't there
-            // or we are doing cookie auth
+            // otherwise build the URI up
             else {
-                if (COOKIE_AUTH || COUCH_USERNAME == null || COUCH_PASSWORD == null) {
-                    uriString = String.format("%s://%s:%s/%s", HTTP_PROTOCOL, COUCH_HOST, COUCH_PORT, dbName);
-                } else {
-                    uriString = String.format("%s://%s:%s@%s:%s/%s", HTTP_PROTOCOL, COUCH_USERNAME, COUCH_PASSWORD, COUCH_HOST, COUCH_PORT, dbName);
-                }
+                uriString = String.format("%s://%s:%s/%s", HTTP_PROTOCOL, COUCH_HOST, COUCH_PORT, dbName);
             }
-            CouchConfig config = new CouchConfig(new URI(uriString));
-            if (COOKIE_AUTH) {
-                ArrayList<HttpConnectionRequestInterceptor> requestInterceptors = new ArrayList<HttpConnectionRequestInterceptor>();
-                ArrayList<HttpConnectionResponseInterceptor> responseInterceptors = new ArrayList<HttpConnectionResponseInterceptor>();
-                CookieInterceptor cookieInterceptor = new CookieInterceptor(COUCH_USERNAME, COUCH_PASSWORD, uriString);
-                requestInterceptors.add(cookieInterceptor);
-                responseInterceptors.add(cookieInterceptor);
-                config.setRequestInterceptors(requestInterceptors);
-                config.setResponseInterceptors(responseInterceptors);
-            }
+            CouchConfig config = new CouchConfig(new URI(uriString),
+                    Collections.<HttpConnectionRequestInterceptor>emptyList(),
+                    Collections.<HttpConnectionResponseInterceptor>emptyList(),
+                    COUCH_USERNAME,
+                    COUCH_PASSWORD);
             return config;
         } catch (URISyntaxException e) {
             throw new IllegalArgumentException(e);

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/CompactedDBReplicationTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/CompactedDBReplicationTest.java
@@ -20,7 +20,6 @@ import com.cloudant.sync.internal.documentstore.InternalDocumentRevision;
 import com.cloudant.sync.internal.mazha.ClientTestUtils;
 import com.cloudant.sync.internal.mazha.CouchDbInfo;
 import com.cloudant.sync.internal.mazha.Response;
-import com.cloudant.sync.documentstore.DocumentRevision;
 import com.cloudant.sync.internal.documentstore.DocumentRevisionTree;
 import com.cloudant.sync.internal.util.AbstractTreeNode;
 
@@ -92,7 +91,7 @@ public class CompactedDBReplicationTest extends ReplicationTestBase {
 
         URI getURI = new URI(couchClient.getRootUri().toString() + "/" + documentName + "?revs_info=true");
 
-        List<String> remoteRevs = ClientTestUtils.getRemoteRevisionIDs(getURI);
+        List<String> remoteRevs = ClientTestUtils.getRemoteRevisionIDs(getURI, getCouchConfig(this.getDbName()));
         List<String> localRevs = new ArrayList<String>();
         DocumentRevisionTree localRevsTree = datastore.getAllRevisionsOfDocument(bar.getId());
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/DBWithSlashReplicationTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/DBWithSlashReplicationTest.java
@@ -83,7 +83,7 @@ public class DBWithSlashReplicationTest extends ReplicationTestBase {
         String dbURI = couchClient.getRootUri().toASCIIString();
         URI getURI = new URI(dbURI + "/" + documentName + "?revs_info=true");
 
-        List<String> remoteRevs = ClientTestUtils.getRemoteRevisionIDs(getURI);
+        List<String> remoteRevs = ClientTestUtils.getRemoteRevisionIDs(getURI, getCouchConfig(getDbName()));
         List<String> localRevs = new ArrayList<String>();
         DocumentRevisionTree localRevsTree = datastore.getAllRevisionsOfDocument(bar.getId());
 
@@ -117,7 +117,7 @@ public class DBWithSlashReplicationTest extends ReplicationTestBase {
         super.push();
 
         //compare local revs to remote
-        remoteRevs = ClientTestUtils.getRemoteRevisionIDs(getURI);
+        remoteRevs = ClientTestUtils.getRemoteRevisionIDs(getURI, getCouchConfig(getDbName()));
         localRevs = new ArrayList<String>();
         localRevsTree = datastore.getAllRevisionsOfDocument(bar.getId());
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/PushReplicatorTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/PushReplicatorTest.java
@@ -157,6 +157,28 @@ public class PushReplicatorTest extends ReplicationTestBase {
         Assert.assertEquals(3, remoteDb.couchClient.getDbInfo().getDocCount());
     }
 
+    @Test
+    public void testCredsAPIOverridesURL() throws Exception {
+        ReplicatorBuilder.Push push =  ReplicatorBuilder.push().from(documentStore)
+                .to(new URI("http://example:password@example.invalid"))
+                .username("user")
+                .password("examplePass");
+        ReplicatorImpl replicator = (ReplicatorImpl) push.build();
+
+        assertCookieInterceptorPresent(push, "name=user&password=examplePass");
+    }
+
+    @Test
+    public void testCredsAPIOverridesURLWithPath() throws Exception {
+        ReplicatorBuilder.Push push =  ReplicatorBuilder.push().from(documentStore)
+                .to(new URI("http://example:password@example.invalid/proxy"))
+                .username("user")
+                .password("examplePass");
+        ReplicatorImpl replicator = (ReplicatorImpl) push.build();
+
+        assertCookieInterceptorPresent(push, "name=user&password=examplePass");
+    }
+
 
     @Test
     public void replicatorBuilderAddsCookieInterceptorCustomPort() throws Exception {

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/ReplicationTestBase.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/ReplicationTestBase.java
@@ -16,6 +16,7 @@ package com.cloudant.sync.internal.replication;
 
 import com.cloudant.common.CouchTestBase;
 import com.cloudant.http.HttpConnectionRequestInterceptor;
+import com.cloudant.http.HttpConnectionResponseInterceptor;
 import com.cloudant.http.interceptors.CookieInterceptor;
 import com.cloudant.sync.internal.mazha.CouchClient;
 import com.cloudant.sync.internal.mazha.CouchConfig;
@@ -33,6 +34,10 @@ import org.junit.Before;
 
 import java.io.File;
 import java.lang.reflect.Field;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
 import java.util.List;
 
 public abstract class ReplicationTestBase extends CouchTestBase {
@@ -73,12 +78,22 @@ public abstract class ReplicationTestBase extends CouchTestBase {
         datastoreWrapper = new DatastoreWrapper(datastore);
     }
 
-    protected void createRemoteDB() {
+    protected void createRemoteDB() throws MalformedURLException, URISyntaxException {
         couchConfig = super.getCouchConfig(getDbName());
+
+        List<HttpConnectionResponseInterceptor> responseInterceptors = new ArrayList
+                <HttpConnectionResponseInterceptor>();
+        List<HttpConnectionRequestInterceptor> requestInterceptors = new ArrayList
+                <HttpConnectionRequestInterceptor>();
+
+        responseInterceptors.addAll(couchConfig.getResponseInterceptors());
+        requestInterceptors.addAll(couchConfig.getRequestInterceptors());
+
+
         remoteDb = new CouchClientWrapper(new CouchClient(
                 couchConfig.getRootUri(),
-                couchConfig.getRequestInterceptors(),
-                couchConfig.getResponseInterceptors()));
+                requestInterceptors,
+                responseInterceptors));
         remoteDb.createDatabase();
         couchClient = remoteDb.getCouchClient();
     }
@@ -109,28 +124,39 @@ public abstract class ReplicationTestBase extends CouchTestBase {
     }
 
     protected ReplicatorBuilder.Push getPushBuilder() {
-        return ReplicatorBuilder.push().
+        ReplicatorBuilder.Push push = ReplicatorBuilder.push().
                 from(this.documentStore).
-                to(this.couchConfig.getRootUri()).
-                addRequestInterceptors(couchConfig.getRequestInterceptors()).
-                addResponseInterceptors(couchConfig.getResponseInterceptors());
+                to(this.couchConfig.getRootUri())
+                .addRequestInterceptors(couchConfig.getRequestInterceptors(false))
+                .addResponseInterceptors(couchConfig.getResponseInterceptors(false));
+        if (couchConfig.getUsername() != null && couchConfig.getPassword() != null) {
+
+            push.username(couchConfig.getUsername())
+                    .password(couchConfig.getPassword());
+        }
+
+        return push;
     }
 
     protected ReplicatorBuilder.Pull getPullBuilder() {
-        return ReplicatorBuilder.pull().
-                to(this.documentStore).
-                from(this.couchConfig.getRootUri()).
-                addRequestInterceptors(couchConfig.getRequestInterceptors()).
-                addResponseInterceptors(couchConfig.getResponseInterceptors());
+        return this.getPullBuilder(null);
+
     }
 
     protected ReplicatorBuilder.Pull getPullBuilder(PullFilter filter) {
-        return ReplicatorBuilder.pull().
-                to(this.documentStore).
+        ReplicatorBuilder.Pull pull = ReplicatorBuilder.pull().
                 from(this.couchConfig.getRootUri()).
-                addRequestInterceptors(couchConfig.getRequestInterceptors()).
-                addResponseInterceptors(couchConfig.getResponseInterceptors()).
-                filter(filter);
+                to(this.documentStore)
+                .filter(filter)
+                .addRequestInterceptors(couchConfig.getRequestInterceptors(false))
+                .addResponseInterceptors(couchConfig.getResponseInterceptors(false));
+        if (couchConfig.getUsername() != null && couchConfig.getPassword() != null) {
+
+            pull.username(couchConfig.getUsername())
+                    .password(couchConfig.getPassword());
+        }
+
+        return pull;
     }
 
     protected PushStrategy getPushStrategy() {


### PR DESCRIPTION
Added a new credentials API to the ReplicatorBuilder class, to make it
easier to pass credentials to the replicator. The new methods `username`
and `password` do not require escaping of URL special characters, which
greatly improves the usability of the replicator with complex passwords.

Resolves #440