### PR TITLE
Extract remaining Database Callables.

### DIFF
--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/DatabaseImpl.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/DatabaseImpl.java
@@ -47,10 +47,10 @@ import com.cloudant.sync.internal.documentstore.callables.GetConflictedDocumentI
 import com.cloudant.sync.internal.documentstore.callables.GetDocumentCallable;
 import com.cloudant.sync.internal.documentstore.callables.GetDocumentCountCallable;
 import com.cloudant.sync.internal.documentstore.callables.GetDocumentsWithIdsCallable;
-import com.cloudant.sync.internal.documentstore.callables.GetDocumentsWithInternalIdsCallable;
 import com.cloudant.sync.internal.documentstore.callables.GetLastSequenceCallable;
 import com.cloudant.sync.internal.documentstore.callables.GetLocalDocumentCallable;
 import com.cloudant.sync.internal.documentstore.callables.GetPossibleAncestorRevisionIdsCallable;
+import com.cloudant.sync.internal.documentstore.callables.GetPublicIdentifierCallable;
 import com.cloudant.sync.internal.documentstore.callables.GetSequenceCallable;
 import com.cloudant.sync.internal.documentstore.callables.InsertDocumentIDCallable;
 import com.cloudant.sync.internal.documentstore.callables.InsertLocalDocumentCallable;
@@ -1216,25 +1216,6 @@ public class DatabaseImpl implements Database {
         }
     }
 
-
-    private static class GetPublicIdentifierCallable implements SQLCallable<String> {
-        @Override
-        public String call(SQLDatabase db) throws Exception {
-            Cursor cursor = null;
-            try {
-                cursor = db.rawQuery("SELECT value FROM info WHERE key='publicUUID'", null);
-                if (cursor.moveToFirst()) {
-                    return "touchdb_" + cursor.getString(0);
-                } else {
-                    throw new IllegalStateException("Error querying PublicUUID, " +
-                            "it is probably because the sqlDatabase is not probably " +
-                            "initialized.");
-                }
-            } finally {
-                DatabaseUtils.closeCursorQuietly(cursor);
-            }
-        }
-    }
 
     private static class RevsDiffCallable implements SQLCallable<Map<String, List<String>>> {
         private final Map<String, List<String>> revisions;

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/GetPublicIdentifierCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/GetPublicIdentifierCallable.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ *  except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ */
+
+package com.cloudant.sync.internal.documentstore.callables;
+
+import com.cloudant.sync.internal.sqlite.Cursor;
+import com.cloudant.sync.internal.sqlite.SQLCallable;
+import com.cloudant.sync.internal.sqlite.SQLDatabase;
+import com.cloudant.sync.internal.util.DatabaseUtils;
+
+/**
+ * Callable to get the publicUUID for the database.
+ */
+public class GetPublicIdentifierCallable implements SQLCallable<String> {
+    @Override
+    public String call(SQLDatabase db) throws Exception {
+        Cursor cursor = null;
+        try {
+            cursor = db.rawQuery("SELECT value FROM info WHERE key='publicUUID'", null);
+            if (cursor.moveToFirst()) {
+                return "touchdb_" + cursor.getString(0);
+            } else {
+                throw new IllegalStateException("Error querying PublicUUID, " +
+                        "it is probably because the sqlDatabase is not properly " +
+                        "initialized.");
+            }
+        } finally {
+            DatabaseUtils.closeCursorQuietly(cursor);
+        }
+    }
+}


### PR DESCRIPTION
## What

Extract remaining Database Callables.

## How

- GetPublicIdentifierCallable extracted to its own class from DatabaseImpl.
- Collapse RevsDiff callable into revsDiff method, calling RevsDiffBatch callable after the list of revisions has been partitioned

## Testing 

All existing tests pass

## Issues

Part of #291 