### PR TITLE
Wrapped stream operations with retries

### DIFF
--- a/AndroidTest/app/build.gradle
+++ b/AndroidTest/app/build.gradle
@@ -69,7 +69,7 @@ android {
     }
 
     adbOptions {
-        timeOutInMs 3*60*1000 // 3 minutes in ms.
+        timeOutInMs 5*60*1000 // 5 minutes in ms.
     }
 
 }

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [IMPROVED] Increased the resilience of replication to network failures.
+
 # 2.0.0 (2017-02-07)
 - [BREAKING CHANGE] With the release of version 2.0 of the library,
   there are a large number of breaking changes to package names,

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/mazha/CouchClient.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/mazha/CouchClient.java
@@ -21,17 +21,16 @@
 package com.cloudant.sync.internal.mazha;
 
 
-import com.cloudant.sync.internal.common.RetriableTask;
 import com.cloudant.http.Http;
 import com.cloudant.http.HttpConnection;
 import com.cloudant.http.HttpConnectionRequestInterceptor;
 import com.cloudant.http.HttpConnectionResponseInterceptor;
+import com.cloudant.sync.internal.common.RetriableTask;
 import com.cloudant.sync.internal.documentstore.DocumentRevsList;
 import com.cloudant.sync.internal.documentstore.MultipartAttachmentWriter;
 import com.cloudant.sync.internal.util.JSONUtils;
 import com.cloudant.sync.internal.util.Misc;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JavaType;
 
 import org.apache.commons.io.IOUtils;
 
@@ -49,6 +48,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class CouchClient  {
@@ -200,21 +200,38 @@ public class CouchClient  {
 
     // execute HTTP task with retries:
     // return an InputStream if successful or throw an exception
-    private InputStream executeToInputStreamWithRetry(final Callable<ExecuteResult> task) throws CouchException {
+    private <T> T executeWithRetry(final Callable<ExecuteResult> task,
+                                   InputStreamProcessor<T> processor) throws
+            CouchException {
         int attempts = 10;
-        CouchException lastException= null;
+        CouchException lastException = null;
         while (attempts-- > 0) {
             ExecuteResult result = null;
             try {
                 result = task.call();
+                if (result.stream != null) {
+                    // success - process the inputstream
+                    try {
+                        return processor.processStream(result.stream);
+                    } catch (Exception e) {
+                        // Error processing the input stream
+                        if (attempts > 0) {
+                            logger.log(Level.WARNING, "Received an exception during response " +
+                                    "stream processing. A retry will be attempted.", e);
+                        } else {
+                            logger.log(Level.SEVERE, "Response stream processing failed, no " +
+                                    "retries remaining.", e);
+                            throw e;
+                        }
+                    } finally {
+                        result.stream.close();
+                    }
+                }
             } catch (Exception e) {
                 throw new CouchException("Unexpected exception", e, -1);
             }
             lastException = result.exception;
-            if (result.stream != null) {
-                // success - return the inputstream
-                return result.stream;
-            } else if (result.fatal) {
+            if (result.fatal) {
                 // fatal exception - don't attempt any more retries
                 throw result.exception;
             }
@@ -222,30 +239,29 @@ public class CouchClient  {
         throw lastException;
     }
 
-    private <T> T executeToJsonObjectWithRetry(final HttpConnection connection,
-                                               Class<T> c) throws CouchException {
-        InputStream is = this.executeToInputStreamWithRetry(connection);
-        InputStreamReader isr = new InputStreamReader(is, Charset.forName("UTF-8"));
-        try {
-            T json = JSONUtils.fromJson(isr, c);
-            return json;
-        } finally {
-            IOUtils.closeQuietly(is);
-        }
+    private <T> T executeToJsonObjectWithRetry(final HttpConnection connection, final
+    TypeReference<T> type) throws CouchException {
+        return executeWithRetry(connection, new TypeInputStreamProcessor<T>(type));
     }
 
-    private InputStream executeToInputStreamWithRetry(final HttpConnection connection) throws CouchException {
+    private <T> T executeToJsonObjectWithRetry(final HttpConnection connection,
+                                               Class<T> c) throws CouchException {
+        return executeToJsonObjectWithRetry(connection, new CouchClientTypeReference<T>(c));
+    }
+
+    private <T> T executeWithRetry(final HttpConnection connection,
+                                                InputStreamProcessor<T> processor) throws
+            CouchException {
         // all CouchClient requests want to receive application/json responses
         connection.requestProperties.put("Accept", "application/json");
         connection.responseInterceptors.addAll(responseInterceptors);
         connection.requestInterceptors.addAll(requestInterceptors);
-        InputStream is = this.executeToInputStreamWithRetry(new Callable<ExecuteResult>() {
+        return this.executeWithRetry(new Callable<ExecuteResult>() {
             @Override
             public ExecuteResult call() throws Exception {
                 return execute(connection);
             }
-        });
-        return is;
+        }, processor);
     }
 
     public void createDb() {
@@ -307,7 +323,7 @@ public class CouchClient  {
         URI doc = this.uriHelper.documentUri(id);
         try {
             HttpConnection connection = Http.HEAD(doc);
-            this.executeToInputStreamWithRetry(connection);
+            this.executeWithRetry(connection, new NoOpInputStreamProcessor());
             return true;
         } catch (Exception e) {
             return false;
@@ -335,17 +351,7 @@ public class CouchClient  {
         }
     }
 
-    public InputStream getDocumentStream(String id, String rev) {
-        Misc.checkNotNullOrEmpty(id, "id");
-        Misc.checkNotNullOrEmpty(rev, "rev");
-        Map<String, Object> queries = new HashMap<String, Object>();
-        queries.put("rev", rev);
-        final URI doc = this.uriHelper.documentUri(id, queries);
-        HttpConnection connection = Http.GET(doc);
-        return executeToInputStreamWithRetry(connection);
-    }
-
-    public InputStream getAttachmentStream(String id, String rev, String attachmentName, final boolean acceptGzip) {
+    public <T> T processAttachmentStream(String id, String rev, String attachmentName, final boolean acceptGzip, InputStreamProcessor<T> processor) {
         Misc.checkNotNullOrEmpty(id, "id");
         Misc.checkNotNullOrEmpty(rev, "rev");
         Map<String, Object> queries = new HashMap<String, Object>();
@@ -355,7 +361,7 @@ public class CouchClient  {
         if (acceptGzip) {
             connection.requestProperties.put("Accept-Encoding", "gzip");
         }
-        return executeToInputStreamWithRetry(connection);
+        return executeWithRetry(connection, processor);
     }
 
     public void putAttachmentStream(String id, String rev, String attachmentName, String contentType, byte[] attachmentData) {
@@ -366,7 +372,8 @@ public class CouchClient  {
         URI doc = this.uriHelper.attachmentUri(id, queries, attachmentName);
         HttpConnection connection = Http.PUT(doc, contentType);
         connection.setRequestBody(attachmentData);
-        this.executeToInputStreamWithRetry(connection);
+        //TODO check result?
+        executeToJsonObjectWithRetry(connection, Response.class);
     }
 
     /**
@@ -385,7 +392,7 @@ public class CouchClient  {
     public Map<String,Object> getDocConflictRevs(String id)  {
         Map<String, Object> options = new HashMap<String, Object>();
         options.put("conflicts", true);
-        return this.getDocument(id, options, JSONUtils.mapStringToObject());
+        return this.getDocument(id, options, JSONUtils.STRING_MAP_TYPE_DEF);
     }
 
     /**
@@ -417,7 +424,7 @@ public class CouchClient  {
             options.put("att_encoding_info", true);
         }
         options.put("open_revs", JSONUtils.toJson(revisions));
-        return this.getDocument(id, options, JSONUtils.openRevisionList());
+        return this.getDocument(id, options, JSONUtils.OPEN_REVS_LIST_TYPE_DEF);
     }
 
     /**
@@ -478,30 +485,24 @@ public class CouchClient  {
     }
 
     public Map<String, Object> getDocument(String id) {
-        return this.getDocument(id, new HashMap<String, Object>(), JSONUtils.mapStringToObject());
+        return this.getDocument(id, new HashMap<String, Object>(), JSONUtils.STRING_MAP_TYPE_DEF);
     }
 
     public <T> T getDocument(String id, final Class<T> type)  {
-        JavaType javaType = JSONUtils.getTypeFactory().constructType(type);
-        return this.getDocument(id, new HashMap<String, Object>(), javaType);
+        return this.getDocument(id, new HashMap<String, Object>(),
+                new CouchClientTypeReference<T>(type));
     }
 
-    public <T> T getDocument(final String id, final Map<String, Object> options, final JavaType type) {
+    public <T> T getDocument(final String id, final Map<String, Object> options,
+                             final TypeReference<T> type) {
         Misc.checkNotNullOrEmpty(id, "id");
         Misc.checkNotNull(type, "Type");
 
         URI doc = uriHelper.documentUri(id, options);
-        InputStream is = null;
-        try {
-            HttpConnection connection = Http.GET(doc);
-            is = executeToInputStreamWithRetry(connection);
-            T returndoc = JSONUtils.fromJson(new InputStreamReader(is, Charset.forName("UTF-8"))
-                    , type);
-            logger.fine("get returning " + returndoc);
-            return returndoc;
-        } finally {
-            closeQuietly(is);
-        }
+        HttpConnection connection = Http.GET(doc);
+        T returndoc = executeToJsonObjectWithRetry(connection, type);
+        logger.fine("get returning " + returndoc);
+        return returndoc;
     }
 
     public Map<String, Object> getDocument(String id, String rev) {
@@ -513,16 +514,14 @@ public class CouchClient  {
         Misc.checkNotNullOrEmpty(rev, "rev");
         Misc.checkNotNull(type, "Type");
 
-        InputStream is = null;
-        try {
-            is = this.getDocumentStream(id, rev);
-            T returndoc = JSONUtils.fromJson(new InputStreamReader(is, Charset.forName("UTF-8"))
-                    , type);
-            logger.fine("get returning " + returndoc);
-            return returndoc;
-        } finally {
-            closeQuietly(is);
-        }
+        Map<String, Object> queries = new HashMap<String, Object>();
+        queries.put("rev", rev);
+        final URI doc = this.uriHelper.documentUri(id, queries);
+        HttpConnection connection = Http.GET(doc);
+        T returndoc = executeToJsonObjectWithRetry(connection, type);
+        logger.fine("get returning " + returndoc);
+        return returndoc;
+
     }
 
     public <T> T getDocument(String id, String rev, final Class<T> type) {
@@ -536,25 +535,19 @@ public class CouchClient  {
      *
      */
     public DocumentRevs getDocRevisions(String id, String rev) {
-        return getDocRevisions(id, rev, JSONUtils.documentRevs());
+        return getDocRevisions(id, rev,
+                new CouchClientTypeReference<DocumentRevs>(DocumentRevs.class));
     }
 
-    public <T> T getDocRevisions(String id, String rev, JavaType type) {
+    public <T> T getDocRevisions(String id, String rev, TypeReference<T> type) {
         Misc.checkNotNullOrEmpty(id, "id");
         Misc.checkNotNull(rev, "Revision ID");
         Map<String, Object> queries = new HashMap<String, Object>();
         queries.put("revs", "true");
         queries.put("rev", rev);
         URI findRevs = this.uriHelper.documentUri(id, queries);
-
-        InputStream is = null;
-        try {
-            HttpConnection connection = Http.GET(findRevs);
-            is = this.executeToInputStreamWithRetry(connection);
-            return JSONUtils.fromJson(new InputStreamReader(is, Charset.forName("UTF-8")), type);
-        } finally {
-            closeQuietly(is);
-        }
+        HttpConnection connection = Http.GET(findRevs);
+        return executeToJsonObjectWithRetry(connection, type);
     }
 
     // Document should be complete document include "_id" matches ID
@@ -583,40 +576,23 @@ public class CouchClient  {
         return executeToJsonObjectWithRetry(connection, Response.class);
     }
 
-    private void closeQuietly(InputStream is) {
-        try {
-            if (is != null) {
-                is.close();
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    }
-
-    private InputStream bulkCreateDocsInputStream(List<?> objects) {
-        Misc.checkNotNull(objects, "Object list");
-        String newEditsVal = "\"new_edits\": false, ";
-        URI uri = this.uriHelper.bulkDocsUri();
-        String payload = String.format("{%s%s%s}", newEditsVal, "\"docs\": ",
-                JSONUtils.toJson(objects));
-        HttpConnection connection = Http.POST(uri, "application/json");
-        connection.setRequestBody(payload);
-        return this.executeToInputStreamWithRetry(connection);
-    }
-
     public List<Response> bulkCreateDocs(Object... objects) {
         return bulkCreateDocs(Arrays.asList(objects));
     }
 
     public List<Response> bulkCreateDocs(List<?> objects) {
-        InputStream is = null;
-        try {
-            is = bulkCreateDocsInputStream(objects);
-            return JSONUtils.fromJsonToList(new InputStreamReader(is, Charset.forName("UTF-8")),
-                    new CouchClientTypeReference<List<Response>>());
-        } finally {
-            closeQuietly(is);
-        }
+        Misc.checkNotNull(objects, "Object list");
+        String newEditsVal = "\"new_edits\": false, ";
+        String payload = String.format("{%s%s%s}", newEditsVal, "\"docs\": ",
+                JSONUtils.toJson(objects));
+        return bulkCreateDocs(payload);
+    }
+
+    private List<Response> bulkCreateDocs(String payload) {
+        URI uri = this.uriHelper.bulkDocsUri();
+        HttpConnection connection = Http.POST(uri, "application/json");
+        connection.setRequestBody(payload);
+        return executeToJsonObjectWithRetry(connection, new CouchClientTypeReference<List<Response>>());
     }
 
     /**
@@ -641,17 +617,7 @@ public class CouchClient  {
     public List<Response> bulkCreateSerializedDocs(List<String> serializedDocs) {
         Misc.checkNotNull(serializedDocs, "Serialized doc list");
         String payload = generateBulkSerializedDocsPayload(serializedDocs);
-        URI uri = this.uriHelper.bulkDocsUri();
-        InputStream is = null;
-        HttpConnection connection = Http.POST(uri, "application/json");
-        connection.setRequestBody(payload);
-        try {
-            is = this.executeToInputStreamWithRetry(connection);
-            return JSONUtils.fromJsonToList(new InputStreamReader(is, Charset.forName("UTF-8")),
-                    new CouchClientTypeReference<List<Response>>());
-        } finally {
-            closeQuietly(is);
-        }
+        return bulkCreateDocs(payload);
     }
 
     private String generateBulkSerializedDocsPayload(List<String> serializedDocs) {
@@ -692,21 +658,13 @@ public class CouchClient  {
      * @see <a target="_blank" href="http://wiki.apache.org/couchdb/HttpPostRevsDiff">HttpPostRevsDiff documentation</a>
      */
     public Map<String, MissingRevisions> revsDiff(Map<String, Set<String>> revisions) {
-        Misc.checkNotNull(revisions,"Input revisions");
+        Misc.checkNotNull(revisions, "Input revisions");
         URI uri = this.uriHelper.revsDiffUri();
         String payload = JSONUtils.toJson(revisions);
-        InputStream is = null;
-        try {
-            HttpConnection connection = Http.POST(uri, "application/json");
-            connection.setRequestBody(payload);
-            is = executeToInputStreamWithRetry(connection);
 
-
-            return JSONUtils.fromJson(new InputStreamReader(is, Charset.forName("UTF-8")),
-                    JSONUtils.mapStringMissingRevisions());
-        } finally {
-            closeQuietly(is);
-        }
+        HttpConnection connection = Http.POST(uri, "application/json");
+        connection.setRequestBody(payload);
+        return executeToJsonObjectWithRetry(connection, JSONUtils.STRING_MISSING_REVS_MAP_TYPE_DEF);
     }
 
     public Response putMultipart(final MultipartAttachmentWriter mpw) {
@@ -742,6 +700,9 @@ public class CouchClient  {
         public Set<String> missing;
     }
 
+    public interface InputStreamProcessor<T> {
+        T processStream(InputStream stream) throws Exception;
+    }
 
     private static class CouchClientTypeReference<T> extends TypeReference<T> {
 
@@ -764,4 +725,29 @@ public class CouchClient  {
 
         }
     }
-}
+
+    private static final class TypeInputStreamProcessor<T> implements InputStreamProcessor<T> {
+
+        private final TypeReference<T> typeReference;
+        TypeInputStreamProcessor(TypeReference<T> typeReference) {
+            this.typeReference = typeReference;
+        }
+
+        @Override
+        public T processStream(InputStream stream) {
+            return JSONUtils.fromJson(new InputStreamReader(stream, Charset.forName
+                    ("UTF-8")), typeReference);
+        }
+    }
+
+    /**
+     * For use with e.g. HEAD requests where there is no InputStream
+     */
+    public static final class NoOpInputStreamProcessor implements InputStreamProcessor<Void> {
+
+        @Override
+        public Void processStream(InputStream stream) {
+            return null;
+        }
+    }
+ }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/replication/AttachmentPullProcessor.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/replication/AttachmentPullProcessor.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package com.cloudant.sync.internal.replication;
+
+import com.cloudant.sync.documentstore.Attachment;
+import com.cloudant.sync.documentstore.AttachmentException;
+import com.cloudant.sync.documentstore.UnsavedStreamAttachment;
+import com.cloudant.sync.internal.documentstore.PreparedAttachment;
+import com.cloudant.sync.internal.mazha.CouchClient;
+
+import java.io.InputStream;
+
+public class AttachmentPullProcessor implements CouchClient
+        .InputStreamProcessor<PreparedAttachment> {
+
+    private final DatastoreWrapper datastoreWrapper;
+    private final String contentType;
+    private final Attachment.Encoding encoding;
+    private final long length;
+    private final long encodedLength;
+
+    AttachmentPullProcessor(DatastoreWrapper wrapper, String name, String contentType, String
+            encoding, long length, long encodedLength) {
+        this.datastoreWrapper = wrapper;
+        this.contentType = contentType;
+        this.encoding = Attachment.getEncodingFromString(encoding);
+        this.length = length;
+        this.encodedLength = encodedLength;
+    }
+
+    @Override
+    public PreparedAttachment processStream(InputStream stream) throws AttachmentException {
+        UnsavedStreamAttachment usa = new UnsavedStreamAttachment(stream, contentType, encoding);
+        PreparedAttachment attachment = datastoreWrapper.prepareAttachment(usa, length,
+                encodedLength);
+        return attachment;
+    }
+}

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/replication/CouchClientWrapper.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/replication/CouchClientWrapper.java
@@ -241,6 +241,8 @@ public class CouchClientWrapper implements CouchDB {
         }
 
         List<Response> responses = couchClient.bulkCreateSerializedDocs(serializedDocs);
+        // N.B. The successful response to a _bulk_docs using new_edits:false is an empty array
+        // hence this unusual check and throw exception if any responses are returned.
         if(responses != null && responses.size() > 0) {
             logger.severe(String.format("Unknown bulkCreateDocs API error: %s for input: %s",responses,serializedDocs));
             throw new RuntimeException("Unknown bulkCreateDocs api error");

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/replication/CouchDB.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/replication/CouchDB.java
@@ -16,14 +16,13 @@
 
 package com.cloudant.sync.internal.replication;
 
+import com.cloudant.sync.internal.documentstore.InternalDocumentRevision;
+import com.cloudant.sync.internal.documentstore.DocumentRevsList;
+import com.cloudant.sync.internal.documentstore.MultipartAttachmentWriter;
 import com.cloudant.sync.internal.mazha.ChangesResult;
 import com.cloudant.sync.internal.mazha.CouchClient;
 import com.cloudant.sync.internal.mazha.DocumentRevs;
 import com.cloudant.sync.internal.mazha.Response;
-import com.cloudant.sync.internal.documentstore.InternalDocumentRevision;
-import com.cloudant.sync.internal.documentstore.DocumentRevsList;
-import com.cloudant.sync.internal.documentstore.MultipartAttachmentWriter;
-import com.cloudant.sync.documentstore.UnsavedStreamAttachment;
 import com.cloudant.sync.replication.PullFilter;
 
 import java.util.Collection;
@@ -58,10 +57,11 @@ interface CouchDB {
     void bulkCreateSerializedDocs(List<String> serializedDocs);
     List<Response> putMultiparts(List<MultipartAttachmentWriter> multiparts);
     Map<String, CouchClient.MissingRevisions> revsDiff(Map<String, Set<String>> revisions);
-    UnsavedStreamAttachment getAttachmentStream(String id, String rev, String attachmentName, String contentType, String encoding);
 
     Iterable<DocumentRevsList> bulkGetRevisions(List<BulkGetRequest> requests,
                                                    boolean pullAttachmentsInline);
     boolean isBulkSupported();
+
+    <T> T pullAttachmentWithRetry(String id, String rev, String name, CouchClient.InputStreamProcessor<T> streamProcessor);
 
 }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/replication/PullStrategy.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/replication/PullStrategy.java
@@ -18,23 +18,23 @@ package com.cloudant.sync.internal.replication;
 
 import com.cloudant.http.HttpConnectionRequestInterceptor;
 import com.cloudant.http.HttpConnectionResponseInterceptor;
-import com.cloudant.sync.internal.mazha.ChangesResult;
-import com.cloudant.sync.internal.mazha.CouchClient;
-import com.cloudant.sync.internal.mazha.DocumentRevs;
 import com.cloudant.sync.documentstore.Attachment;
 import com.cloudant.sync.documentstore.Database;
 import com.cloudant.sync.internal.documentstore.DatabaseImpl;
 import com.cloudant.sync.documentstore.DocumentStoreException;
 import com.cloudant.sync.documentstore.DocumentException;
+import com.cloudant.sync.event.EventBus;
 import com.cloudant.sync.internal.documentstore.DocumentRevsList;
 import com.cloudant.sync.internal.documentstore.PreparedAttachment;
-import com.cloudant.sync.documentstore.UnsavedStreamAttachment;
-import com.cloudant.sync.event.EventBus;
-import com.cloudant.sync.replication.DatabaseNotFoundException;
-import com.cloudant.sync.replication.PullFilter;
+import com.cloudant.sync.internal.mazha.ChangesResult;
+import com.cloudant.sync.internal.mazha.CouchClient;
+import com.cloudant.sync.internal.mazha.DocumentRevs;
 import com.cloudant.sync.internal.util.CollectionUtils;
 import com.cloudant.sync.internal.util.JSONUtils;
 import com.cloudant.sync.internal.util.Misc;
+import com.cloudant.sync.replication.DatabaseNotFoundException;
+import com.cloudant.sync.replication.PullFilter;
+
 
 import org.apache.commons.codec.binary.Hex;
 
@@ -382,15 +382,14 @@ public class PullStrategy implements ReplicationStrategy {
                                         }
 
                                     }
-                                    UnsavedStreamAttachment usa = this.sourceDb
-                                            .getAttachmentStream(documentRevs.getId(),
-                                                    documentRevs.getRev(), attachmentName,
-                                                    contentType, encoding);
 
                                     // by preparing the attachment here, it is downloaded outside
                                     // of the database transaction
-                                    preparedAtts.put(attachmentName, this.targetDb.prepareAttachment(usa, length,
-                                            encodedLength));
+                                    preparedAtts.put(attachmentName, this.sourceDb.pullAttachmentWithRetry
+                                            (documentRevs.getId(), documentRevs.getRev(), entry
+                                                    .getKey(), new AttachmentPullProcessor(this
+                                                    .targetDb, entry.getKey(), contentType,
+                                                    encoding, length, encodedLength)));
                                 }
                             }
                         } catch (Exception e) {

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/util/JSONUtils.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/util/JSONUtils.java
@@ -20,7 +20,6 @@ import com.cloudant.sync.internal.common.CouchConstants;
 import com.cloudant.sync.internal.common.PropertyFilterMixIn;
 import com.cloudant.sync.internal.mazha.CouchClient;
 import com.cloudant.sync.internal.mazha.Document;
-import com.cloudant.sync.internal.mazha.DocumentRevs;
 import com.cloudant.sync.internal.mazha.OpenRevision;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -32,7 +31,6 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.ser.FilterProvider;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
-import com.fasterxml.jackson.databind.type.TypeFactory;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -52,13 +50,18 @@ public class JSONUtils {
 
     private static final byte[] EMPTY_JSON = "{}".getBytes(Charset.forName("UTF-8"));
 
-
     public final static TypeReference<List<String>> STRING_LIST_TYPE_DEF =
             new TypeReference<List<String>>() {};
 
     public final static TypeReference<Map<String, Object>> STRING_MAP_TYPE_DEF =
             new TypeReference<Map<String, Object>>() {};
 
+    public final static TypeReference<Map<String, CouchClient
+            .MissingRevisions>> STRING_MISSING_REVS_MAP_TYPE_DEF =
+            new TypeReference<Map<String, CouchClient.MissingRevisions>>() {};
+
+    public final static TypeReference<List<OpenRevision>> OPEN_REVS_LIST_TYPE_DEF =
+            new TypeReference<List<OpenRevision>>() {};
 
     private static final ObjectMapper sMapper = new ObjectMapper();
 
@@ -237,26 +240,5 @@ public class JSONUtils {
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }
-    }
-
-    public static TypeFactory getTypeFactory(){
-        return sMapper.getTypeFactory();
-    }
-
-    public static JavaType mapStringToObject(){
-        return JSONUtils.getTypeFactory().constructParametricType(Map.class,String.class,Object.class);
-    }
-
-    public static JavaType mapStringMissingRevisions(){
-        return JSONUtils.getTypeFactory().constructParametricType(Map.class, String.class, CouchClient
-                .MissingRevisions.class);
-    }
-
-    public static JavaType openRevisionList() {
-        return JSONUtils.getTypeFactory().constructParametricType(List.class, OpenRevision.class);
-    }
-
-    public static JavaType documentRevs() {
-        return JSONUtils.getTypeFactory().constructType(DocumentRevs.class);
     }
 }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/BulkAPITest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/BulkAPITest.java
@@ -16,9 +16,11 @@
 
 package com.cloudant.sync.internal.mazha;
 
+import static org.hamcrest.CoreMatchers.hasItem;
+
+import com.cloudant.common.RequireRunningCouchDB;
 import com.cloudant.sync.internal.common.CouchConstants;
 import com.cloudant.sync.internal.common.CouchUtils;
-import com.cloudant.common.RequireRunningCouchDB;
 import com.cloudant.sync.internal.util.JSONUtils;
 import com.cloudant.sync.util.TestUtils;
 
@@ -32,8 +34,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-
-import static org.hamcrest.CoreMatchers.hasItem;
 
 @Category(RequireRunningCouchDB.class)
 public class BulkAPITest extends CouchClientTestBase {
@@ -82,7 +82,7 @@ public class BulkAPITest extends CouchClientTestBase {
         List<Response> responses = client.bulkCreateDocs(doc1);
         Assert.assertEquals(0, responses.size());
 
-        Map<String, Object> allRevs = client.getDocRevisions(res1.getId(), revision3, JSONUtils.mapStringToObject());
+        Map<String, Object> allRevs = client.getDocRevisions(res1.getId(), revision3, JSONUtils.STRING_MAP_TYPE_DEF);
 
         int revisionStart = (Integer) ((Map<String, Object>) allRevs.get(CouchConstants._revisions)).get
                 (CouchConstants.start);

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/CouchClientBasicTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/CouchClientBasicTest.java
@@ -26,15 +26,12 @@ import com.cloudant.common.RequireRunningCouchDB;
 import com.cloudant.sync.internal.util.JSONUtils;
 import com.cloudant.sync.internal.util.Misc;
 
-import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -171,18 +168,6 @@ public class CouchClientBasicTest extends CouchClientTestBase {
     }
 
     @Test
-    public void getDocumentInputStream_id_success() {
-        Response res = ClientTestUtils.createHelloWorldDoc(client);
-        InputStream is = client.getDocumentStream(res.getId(), res.getRev());
-        try {
-            Map<String, Object> doc = JSONUtils.fromJson(new InputStreamReader(is));
-            assertHelloWorldMapObject(res, doc);
-        } finally {
-            IOUtils.closeQuietly(is);
-        }
-    }
-
-    @Test
     public void getDocument_id_success() {
         Response res = ClientTestUtils.createHelloWorldDoc(client);
         Map<String, Object> doc = client.getDocument(res.getId());
@@ -196,11 +181,6 @@ public class CouchClientBasicTest extends CouchClientTestBase {
         Assert.assertEquals(res.getId(), doc.get(CouchConstants._id));
         Assert.assertTrue(doc.containsKey(CouchConstants._rev));
         Assert.assertEquals(res.getRev(), doc.get(CouchConstants._rev));
-    }
-
-    @Test(expected = NoResourceException.class)
-    public void getDocumentInputStream_idNotExist_exception() {
-        client.getDocumentStream("id_not_exist", "1-no_such_rev");
     }
 
     @Test(expected = NoResourceException.class)
@@ -245,24 +225,6 @@ public class CouchClientBasicTest extends CouchClientTestBase {
             Assert.assertNotNull(fooVersion1);
             Assert.assertThat(fooVersion1.getRevision(), startsWith("1-"));
         }
-    }
-
-    @Test
-    public void getDocumentInputStream_idRev_success() {
-        Response res = ClientTestUtils.createHelloWorldDoc(client);
-        InputStream is = client.getDocumentStream(res.getId(), res.getRev());
-        try {
-            Map<String, Object> doc = JSONUtils.fromJson(new InputStreamReader(is));
-            assertHelloWorldMapObject(res, doc);
-        } finally {
-            IOUtils.closeQuietly(is);
-        }
-    }
-
-    @Test(expected = NoResourceException.class)
-    public void getDocumentInputStream_idRevNotExist_exception() {
-        Response res = ClientTestUtils.createHelloWorldDoc(client);
-        client.getDocumentStream(res.getId(), "1-revnotexist");
     }
 
     @Test(expected = NoResourceException.class)

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/CouchClientBasicTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/CouchClientBasicTest.java
@@ -410,4 +410,11 @@ public class CouchClientBasicTest extends CouchClientTestBase {
             return false;
         }
     }
+
+    @Test
+    public void getRevision() {
+        Response res = ClientTestUtils.createHelloWorldDoc(client);
+        String rev = client.getDocumentRev(res.getId());
+        Assert.assertEquals("The revisions should be the same", res.getRev(), rev);
+    }
 }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/GetDocumentRevsTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/GetDocumentRevsTest.java
@@ -16,9 +16,16 @@
 
 package com.cloudant.sync.internal.mazha;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.core.Is.is;
+
+import com.cloudant.common.RequireRunningCouchDB;
 import com.cloudant.sync.internal.common.CouchConstants;
 import com.cloudant.sync.internal.common.CouchUtils;
-import com.cloudant.common.RequireRunningCouchDB;
 import com.cloudant.sync.internal.util.JSONUtils;
 
 import org.junit.Assert;
@@ -27,9 +34,6 @@ import org.junit.experimental.categories.Category;
 
 import java.util.List;
 import java.util.Map;
-
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.core.Is.is;
 
 @Category(RequireRunningCouchDB.class)
 public class GetDocumentRevsTest extends CouchClientTestBase {
@@ -53,7 +57,7 @@ public class GetDocumentRevsTest extends CouchClientTestBase {
     public void getDocRevisions_idAndRevAndMapClass_revsMustBeReturned() {
         Response[] responses = createAndUpdateDocumentAndReturnRevisions();
         Map<String, Object> revs = client.getDocRevisions(responses[1].getId(), responses[1].getRev(),
-                JSONUtils.mapStringToObject());
+                JSONUtils.STRING_MAP_TYPE_DEF);
 
         Assert.assertThat(revs.keySet(), hasItem(CouchConstants._revisions));
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/DBWithSlashReplicationTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/DBWithSlashReplicationTest.java
@@ -155,7 +155,7 @@ public class DBWithSlashReplicationTest extends ReplicationTestBase {
     }
 
     @Override
-    String getDbName() {
-        return "dbwith%2Faslash";
+    protected String getDbName() {
+        return "dbwith%2Faslash_" + super.getDbName();
     }
 }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/PullReplicationTerminationTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/PullReplicationTerminationTest.java
@@ -83,7 +83,7 @@ public class PullReplicationTerminationTest extends ReplicationTestBase {
     @Before
     public void customizeReplicatorAndPopulateDb() throws Exception {
         setupTerminationTestReplicator();
-        populateRemoteDb(DOC_BATCHES, DOCS_PER_BATCH);
+        populateRemoteDb();
     }
 
     private void setupTerminationTestReplicator() {
@@ -93,7 +93,7 @@ public class PullReplicationTerminationTest extends ReplicationTestBase {
     }
 
 
-    private void populateRemoteDb(int batches, int docsPerBatch) throws Exception {
+    private void populateRemoteDb() throws Exception {
         // Create documents in the remote db in batches
         for (List<Foo> batch : GENERATED_FOO_DOC_BATCHES) {
             remoteDb.getCouchClient().bulkCreateDocs(batch);


### PR DESCRIPTION
*What*

Proposal for wrapping response stream processing in the retry handling. This is an experimental change for which I am soliciting feedback at the very least more tests need to be added before merging. It would be nice to hit this branch with the network reliability testing as well before any attempt to really merge it.

*Why*

Intermittent failures of the `AttachmentsPullTest` (see #381)  reveal that our HTTP retries currently only operate up to the point of reading response codes. After that time any exception that happens during the handling of the HTTP response `InputStream` will not be retried. To make replications in the library more resilient to network issues the stream handling could also be included in the retries.

I think there is an argument that this code should really be included in the cloudant-http module, but as it stands we currently have two levels of retries in sync-android and it is less invasive to change it at the `CouchClient` retry than the `HttpConnection` retry.

*How*

* Wrapped stream operations with retries
    * Added `InputStreamProcessor` to enable retry around stream operations.
    * Wrapped stream operations in the existing retry block.
    * Added `AttachmentPullProcessor` to combine remote stream read and attachment preparation.
    * Updated `PullStrategy` to use new `AttachmentPullProcessor`.
* Added comment around unusual _bulk_docs result
* Streamlined remote document updates
* Improved resilience of remote checkpoint write

*Testing*

Refactored `CouchClientBasicTest` and `AttachmentsPushTest` for method signature changes.
Existing tests pass.
Ran unreliable network testing, which also passes except for issue #479.
Suppressed `412` exceptions during replication test remote DB create (so retries don't fail the test, they are uniquely named so it should only happen on retry cases).
Tweaked `PullReplicationTerminationTest` to remove unnecessary code.
Improved resilience of reading writes in `AttachmentsPullTest`.

*Issues*

Fixes #381 