### PR TITLE
Add 2017 IBM copyright to all files where missing

### DIFF
--- a/AndroidTest/app/src/main/java/cloudant/com/androidtest/TestActivity.java
+++ b/AndroidTest/app/src/main/java/cloudant/com/androidtest/TestActivity.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-android-encryption/src/main/java/com/cloudant/sync/internal/sqlite/android/AndroidSQLCipherSQLite.java
+++ b/cloudant-sync-datastore-android-encryption/src/main/java/com/cloudant/sync/internal/sqlite/android/AndroidSQLCipherSQLite.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-android/src/main/java/com/cloudant/sync/internal/sqlite/android/AndroidSQLiteCursor.java
+++ b/cloudant-sync-datastore-android/src/main/java/com/cloudant/sync/internal/sqlite/android/AndroidSQLiteCursor.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/Attachment.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/Attachment.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2014 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/Changes.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/Changes.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/ConflictException.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/ConflictException.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/ConflictResolver.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/ConflictResolver.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/DocumentBodyFactory.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/DocumentBodyFactory.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/DocumentNotFoundException.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/DocumentNotFoundException.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/UnsavedFileAttachment.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/UnsavedFileAttachment.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2014 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/UnsavedStreamAttachment.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/UnsavedStreamAttachment.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2014 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/encryption/SimpleKeyProvider.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/encryption/SimpleKeyProvider.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/event/notifications/DocumentCreated.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/event/notifications/DocumentCreated.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/event/notifications/DocumentDeleted.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/event/notifications/DocumentDeleted.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/event/notifications/DocumentModified.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/event/notifications/DocumentModified.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/event/notifications/DocumentStoreClosed.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/event/notifications/DocumentStoreClosed.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/event/notifications/DocumentStoreCreated.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/event/notifications/DocumentStoreCreated.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/event/notifications/DocumentStoreDeleted.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/event/notifications/DocumentStoreDeleted.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/event/notifications/DocumentStoreModified.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/event/notifications/DocumentStoreModified.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/event/notifications/DocumentStoreOpened.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/event/notifications/DocumentStoreOpened.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/event/notifications/DocumentUpdated.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/event/notifications/DocumentUpdated.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/event/notifications/ReplicationCompleted.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/event/notifications/ReplicationCompleted.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/event/notifications/ReplicationErrored.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/event/notifications/ReplicationErrored.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/android/Base64InputStreamFactory.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/android/Base64InputStreamFactory.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/android/Base64OutputStreamFactory.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/android/Base64OutputStreamFactory.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/android/ContentValues.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/android/ContentValues.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Modifications allow class to work outside Android framework by
  * Cloudant, Inc., Copyright © 2013 Cloudant, Inc.
  *

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/common/CouchConstants.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/common/CouchConstants.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/common/CouchUtils.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/common/CouchUtils.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/common/PropertyFilterMixIn.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/common/PropertyFilterMixIn.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/common/RetriableTask.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/common/RetriableTask.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/common/RetryException.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/common/RetryException.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/AttachmentManager.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/AttachmentManager.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2014 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/DocumentRevisionBuilder.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/DocumentRevisionBuilder.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/DocumentRevisionTree.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/DocumentRevisionTree.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/DocumentRevsList.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/DocumentRevsList.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/DocumentRevsUtils.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/DocumentRevsUtils.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/PreparedAttachment.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/PreparedAttachment.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/ProjectedDocumentRevision.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/ProjectedDocumentRevision.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/SavedAttachment.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/SavedAttachment.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2014 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/mazha/ChangesResult.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/mazha/ChangesResult.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant
  *
  * Copyright © 2011 Ahmed Yehia (ahmed.yehia.m@gmail.com)

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/mazha/CouchDbInfo.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/mazha/CouchDbInfo.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant
  *
  * Copyright © 2011 Ahmed Yehia (ahmed.yehia.m@gmail.com)

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/mazha/CouchException.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/mazha/CouchException.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant
  *
  * Copyright © 2011 Ahmed Yehia (ahmed.yehia.m@gmail.com)

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/mazha/CouchURIHelper.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/mazha/CouchURIHelper.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant
  *
  * Copyright © 2011 Ahmed Yehia (ahmed.yehia.m@gmail.com)

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/mazha/DBOperationResponse.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/mazha/DBOperationResponse.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant
  *
  * Copyright © 2011 Ahmed Yehia (ahmed.yehia.m@gmail.com)

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/mazha/Document.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/mazha/Document.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant
  *
  * Copyright © 2011 Ahmed Yehia (ahmed.yehia.m@gmail.com)

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/mazha/DocumentConflictException.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/mazha/DocumentConflictException.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant
  *
  * Copyright © 2011 Ahmed Yehia (ahmed.yehia.m@gmail.com)

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/mazha/DocumentRevs.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/mazha/DocumentRevs.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant
  *
  * Copyright © 2011 Ahmed Yehia (ahmed.yehia.m@gmail.com)

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/mazha/GetOpenRevisionsResponse.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/mazha/GetOpenRevisionsResponse.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant
  *
  * Copyright © 2011 Ahmed Yehia (ahmed.yehia.m@gmail.com)

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/mazha/MissingOpenRevision.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/mazha/MissingOpenRevision.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/mazha/NoResourceException.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/mazha/NoResourceException.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/mazha/OkOpenRevision.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/mazha/OkOpenRevision.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/mazha/OpenRevision.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/mazha/OpenRevision.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/mazha/Response.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/mazha/Response.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant
  *
  * Copyright © 2011 Ahmed Yehia (ahmed.yehia.m@gmail.com)

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/mazha/ServerException.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/mazha/ServerException.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant
  *
  * Copyright © 2011 Ahmed Yehia (ahmed.yehia.m@gmail.com)

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/mazha/json/OpenRevisionDeserializer.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/mazha/json/OpenRevisionDeserializer.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/AndQueryNode.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/AndQueryNode.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2014 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/ChildrenQueryNode.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/ChildrenQueryNode.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2014 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/OperatorExpressionNode.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/OperatorExpressionNode.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/OrQueryNode.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/OrQueryNode.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2014 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/QueryConstants.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/QueryConstants.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/QueryExecutor.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/QueryExecutor.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2014 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/QueryNode.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/QueryNode.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2014 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/QuerySqlTranslator.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/QuerySqlTranslator.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2014 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/QueryValidator.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/QueryValidator.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2014 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/SqlParts.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/SqlParts.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2014 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/SqlQueryNode.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/SqlQueryNode.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2014 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/TranslatorState.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/TranslatorState.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2014 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/UnindexedMatcher.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/UnindexedMatcher.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/ValueExtractor.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/ValueExtractor.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2014 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/replication/CouchDB.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/replication/CouchDB.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/replication/DatastoreWrapper.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/replication/DatastoreWrapper.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/replication/GetRevisionTaskBulk.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/replication/GetRevisionTaskBulk.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/replication/PullStrategy.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/replication/PullStrategy.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/replication/RemoteCheckpointDoc.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/replication/RemoteCheckpointDoc.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/replication/ReplicationStrategy.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/replication/ReplicationStrategy.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/replication/ReplicationStrategyCompleted.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/replication/ReplicationStrategyCompleted.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/replication/ReplicationStrategyErrored.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/replication/ReplicationStrategyErrored.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/replication/ReplicatorImpl.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/replication/ReplicatorImpl.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/sqlite/Cursor.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/sqlite/Cursor.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/sqlite/SQLDatabase.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/sqlite/SQLDatabase.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc.
  *
  * Copyright © 2006 The Android Open Source Project

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/sqlite/sqlite4java/DBUtils.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/sqlite/sqlite4java/DBUtils.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/sqlite/sqlite4java/QueryBuilder.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/sqlite/sqlite4java/QueryBuilder.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/sqlite/sqlite4java/SQLiteCursor.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/sqlite/sqlite4java/SQLiteCursor.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/sqlite/sqlite4java/Tuple.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/sqlite/sqlite4java/Tuple.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/util/AbstractTreeNode.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/util/AbstractTreeNode.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/util/DatabaseUtils.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/util/DatabaseUtils.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/util/JSONUtils.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/util/JSONUtils.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/util/JacksonModule.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/util/JacksonModule.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/util/Misc.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/util/Misc.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/util/ThreadUtils.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/util/ThreadUtils.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/Index.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/Index.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/QueryResult.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/QueryResult.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2014 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/DatabaseNotFoundException.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/DatabaseNotFoundException.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Part of the library is derived from TouchDB: http://touchdb.org/.

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/Replicator.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/Replicator.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/common/CouchTestBase.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/common/CouchTestBase.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/common/PerformanceTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/common/PerformanceTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/common/RequireRunningCouchDB.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/common/RequireRunningCouchDB.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/common/RetriableTaskTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/common/RetriableTaskTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/common/SystemTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/common/SystemTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/encryption/HelperSimpleKeyProvider.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/datastore/encryption/HelperSimpleKeyProvider.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/AttachmentTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/AttachmentTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2014 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/BasicDBBodyTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/BasicDBBodyTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/BasicDBCoreObservableTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/BasicDBCoreObservableTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/BasicDBObjectTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/BasicDBObjectTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/BasicDatastoreTestBase.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/BasicDatastoreTestBase.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/ChangesTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/ChangesTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/CrudImplDatabaseTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/CrudImplDatabaseTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatabaseImplChangesTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatabaseImplChangesTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatabaseImplConflictsTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatabaseImplConflictsTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatabaseImplRevsDiffTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatabaseImplRevsDiffTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatabaseNotificationsMoreTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatabaseNotificationsMoreTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatabaseNotificationsTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatabaseNotificationsTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatastoreTestBase.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatastoreTestBase.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatastoreTestUtils.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatastoreTestUtils.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DocumentNotificationsTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DocumentNotificationsTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DocumentRevisionTreeTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DocumentRevisionTreeTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/ForceInsertTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/ForceInsertTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2014 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/MultipartAttachmentWriterTests.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/MultipartAttachmentWriterTests.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2014 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/MutableDocumentDeleteTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/MutableDocumentDeleteTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/MutableDocumentNoInitialAttachmentsTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/MutableDocumentNoInitialAttachmentsTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/NotificationTestUtils.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/NotificationTestUtils.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/RevisionHistoryHelperTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/RevisionHistoryHelperTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/SQLDatabaseFactoryTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/SQLDatabaseFactoryTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/TimestampBasedConflictsResolver.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/TimestampBasedConflictsResolver.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/AnimalDb.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/AnimalDb.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/BulkAPITest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/BulkAPITest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/ChangesFeedTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/ChangesFeedTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/ClientTestUtils.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/ClientTestUtils.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/CouchClientBasicTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/CouchClientBasicTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/CouchClientFilteredChangesTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/CouchClientFilteredChangesTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/CouchClientTestBase.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/CouchClientTestBase.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/CouchConfig.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/CouchConfig.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant
  *
  * Copyright © 2011 Ahmed Yehia (ahmed.yehia.m@gmail.com)

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/CouchURIHelperTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/CouchURIHelperTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/DocumentRevsTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/DocumentRevsTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/Foo.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/Foo.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/GetDocumentRevsTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/GetDocumentRevsTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/GetOpenRevisionsTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/GetOpenRevisionsTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/HttpRequestsTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/HttpRequestsTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/OpenRevisionTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/OpenRevisionTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/json/JSONHelperTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/json/JSONHelperTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/matcher/IsNotEmpty.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/matcher/IsNotEmpty.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/matcher/IsNotEmptyTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/matcher/IsNotEmptyTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/AbstractIndexTestBase.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/AbstractIndexTestBase.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2014 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/AbstractQueryTestBase.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/AbstractQueryTestBase.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2014 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/IndexCreatorTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/IndexCreatorTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2014 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/IndexTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/IndexTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/IndexUpdaterTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/IndexUpdaterTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2014 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/MockMatcherQuery.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/MockMatcherQuery.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/MockMatcherQueryExecutor.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/MockMatcherQueryExecutor.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/MockSQLOnlyQuery.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/MockSQLOnlyQuery.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/MockSQLOnlyQueryExecutor.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/MockSQLOnlyQueryExecutor.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/QueryCoveringIndexesTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/QueryCoveringIndexesTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2014 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/QueryFilterFieldsTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/QueryFilterFieldsTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/QuerySortTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/QuerySortTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/QuerySqlTranslatorTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/QuerySqlTranslatorTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2014 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/QueryValidatorTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/QueryValidatorTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2014 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/QueryWithoutCoveringIndexesTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/QueryWithoutCoveringIndexesTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/UnindexedMatcherTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/UnindexedMatcherTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/ValueExtractorTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/ValueExtractorTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2014 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/AttachmentsConflictsTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/AttachmentsConflictsTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/AttachmentsPullTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/AttachmentsPullTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2014 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/Bar.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/Bar.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/BarUtils.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/BarUtils.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/BarWithAttachments.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/BarWithAttachments.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/BasicPullStrategyTest2.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/BasicPullStrategyTest2.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/BasicPushStrategyTest2.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/BasicPushStrategyTest2.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/ChangesResultWrapperTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/ChangesResultWrapperTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/CompactedDBReplicationTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/CompactedDBReplicationTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2014 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/CouchClientWrapperDbUtils.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/CouchClientWrapperDbUtils.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/CouchClientWrapperMockTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/CouchClientWrapperMockTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/CouchClientWrapperTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/CouchClientWrapperTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/DBWithSlashReplicationTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/DBWithSlashReplicationTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/DatabaseAssert.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/DatabaseAssert.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/DatabaseAssertTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/DatabaseAssertTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/DesignDocsReplicateTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/DesignDocsReplicateTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/DocumentRevsListTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/DocumentRevsListTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/DocumentRevsUtilsTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/DocumentRevsUtilsTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/Foo.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/Foo.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/GetRevisionTaskTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/GetRevisionTaskTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/PullReplicatorTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/PullReplicatorTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/PullStrategyMockTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/PullStrategyMockTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/PullStrategyTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/PullStrategyTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/PushReplicatorTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/PushReplicatorTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/PushStrategyMockTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/PushStrategyMockTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/PushStrategyTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/PushStrategyTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/RemoteCheckpointDocTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/RemoteCheckpointDocTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/ReplicationTestBase.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/ReplicationTestBase.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/ReplicatorIdTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/ReplicatorIdTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/ReplicatorImplMockTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/ReplicatorImplMockTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/ResurrectedDocumentTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/ResurrectedDocumentTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/TestReplicationListener.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/TestReplicationListener.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/TestStrategyListener.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/TestStrategyListener.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/sqlite/ContentValuesTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/sqlite/ContentValuesTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/sqlite/sqlite4java/SQLiteCursorTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/sqlite/sqlite4java/SQLiteCursorTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/sqlite/sqlite4java/TupleTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/sqlite/sqlite4java/TupleTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/util/AbstractTreeNodeTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/util/AbstractTreeNodeTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/util/CouchUtilsTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/util/CouchUtilsTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/util/JSONUtilsTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/util/JSONUtilsTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/util/MiscTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/util/MiscTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/util/SQLDatabaseTestUtils.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/util/SQLDatabaseTestUtils.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/util/TestUtils.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/util/TestUtils.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-javase/src/main/java/com/cloudant/sync/internal/sqlite/sqlite4java/SQLiteWrapperUtils.java
+++ b/cloudant-sync-datastore-javase/src/main/java/com/cloudant/sync/internal/sqlite/sqlite4java/SQLiteWrapperUtils.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/cloudant-sync-datastore-javase/src/test/java/com/cloudant/sync/internal/sqlite/sqlite4java/SQLiteWrapperTest.java
+++ b/cloudant-sync-datastore-javase/src/test/java/com/cloudant/sync/internal/sqlite/sqlite4java/SQLiteWrapperTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2013 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/sample/todo-sync/src/com/cloudant/todo/SettingsActivity.java
+++ b/sample/todo-sync/src/com/cloudant/todo/SettingsActivity.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/sample/todo-sync/src/com/cloudant/todo/Task.java
+++ b/sample/todo-sync/src/com/cloudant/todo/Task.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/sample/todo-sync/src/com/cloudant/todo/TaskAdapter.java
+++ b/sample/todo-sync/src/com/cloudant/todo/TaskAdapter.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/sample/todo-sync/src/com/cloudant/todo/TasksModel.java
+++ b/sample/todo-sync/src/com/cloudant/todo/TasksModel.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/sample/todo-sync/src/com/cloudant/todo/TodoActivity.java
+++ b/sample/todo-sync/src/com/cloudant/todo/TodoActivity.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
  * Copyright © 2015 Cloudant, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file


### PR DESCRIPTION
Complete the work needed for #390 by adding IBM copyrights to all files which had these missing (where only Cloudant copyrights were present, etc)