### PR TITLE
Fix crash on some devices during FTS check

### DIFF
--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/sqlite/SQLDatabaseFactory.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/sqlite/SQLDatabaseFactory.java
@@ -55,10 +55,13 @@ public class SQLDatabaseFactory {
             try {
                 tempInMemoryDB.execSQL(String.format("CREATE VIRTUAL TABLE %s USING FTS4 ( col )",
                         FTS_CHECK_TABLE_NAME));
+                tempInMemoryDB.execSQL(String.format("DROP TABLE %s",
+                    FTS_CHECK_TABLE_NAME));
                 return true;
             } finally {
-                // End the transaction and rollback the virtual table we created because we never
-                // set transaction success.
+                // Some Android devices crashed when we used to roll back the transaction. Now we
+                // drop the table if it was created and then commit it regardless.
+                tempInMemoryDB.setTransactionSuccessful();
                 tempInMemoryDB.endTransaction();
             }
         } catch (SQLException sqle) {


### PR DESCRIPTION
Implement workaround to prevent crashes on Motorola XT1068 when trying to determine if FTS4 is available.

Manually tested on Motorola XT1068. Test application no longer crashes on startup.

Fixes #449 
