### PR TITLE
Remove batch limit for replications.

### DIFF
--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ReplicatorBuilder.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ReplicatorBuilder.java
@@ -130,8 +130,6 @@ public abstract class ReplicatorBuilder<S, T, E> {
 
         private int changeLimitPerBatch = 500;
 
-        private int batchLimitPerRun = 100;
-
         private int bulkInsertSize = 10;
 
         private PushAttachmentsInline pushAttachmentsInline = PushAttachmentsInline.Small;
@@ -153,7 +151,6 @@ public abstract class ReplicatorBuilder<S, T, E> {
                     super.responseInterceptors);
 
             pushStrategy.changeLimitPerBatch = changeLimitPerBatch;
-            pushStrategy.batchLimitPerRun = batchLimitPerRun;
             pushStrategy.bulkInsertSize = bulkInsertSize;
             pushStrategy.pushAttachmentsInline = pushAttachmentsInline;
             pushStrategy.filter = pushFilter;
@@ -179,17 +176,6 @@ public abstract class ReplicatorBuilder<S, T, E> {
          */
         public Push changeLimitPerBatch(int changeLimitPerBatch) {
             this.changeLimitPerBatch = changeLimitPerBatch;
-            return this;
-        }
-
-        /**
-         * Sets the number of batches to push in one replication run
-         *
-         * @param batchLimitPerRun The number of batches to push in one replication run
-         * @return This instance of {@link ReplicatorBuilder}
-         */
-        public Push batchLimitPerRun(int batchLimitPerRun) {
-            this.batchLimitPerRun = batchLimitPerRun;
             return this;
         }
 
@@ -225,8 +211,6 @@ public abstract class ReplicatorBuilder<S, T, E> {
 
         private int changeLimitPerBatch = 1000;
 
-        private int batchLimitPerRun = 100;
-
         private int insertBatchSize = 100;
 
         private boolean pullAttachmentsInline = false;
@@ -247,7 +231,6 @@ public abstract class ReplicatorBuilder<S, T, E> {
                     super.responseInterceptors);
 
             pullStrategy.changeLimitPerBatch = changeLimitPerBatch;
-            pullStrategy.batchLimitPerRun = batchLimitPerRun;
             pullStrategy.insertBatchSize = insertBatchSize;
             pullStrategy.pullAttachmentsInline = pullAttachmentsInline;
 
@@ -273,17 +256,6 @@ public abstract class ReplicatorBuilder<S, T, E> {
          */
         public Pull changeLimitPerBatch(int changeLimitPerBatch) {
             this.changeLimitPerBatch = changeLimitPerBatch;
-            return this;
-        }
-
-        /**
-         * Sets the number of batches to pull in one replication run
-         *
-         * @param batchLimitPerRun The number of batches to pull in one replication run
-         * @return This instance of {@link ReplicatorBuilder}
-         */
-        public Pull batchLimitPerRun(int batchLimitPerRun) {
-            this.batchLimitPerRun = batchLimitPerRun;
             return this;
         }
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/PushReplicatorTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/PushReplicatorTest.java
@@ -338,7 +338,7 @@ public class PushReplicatorTest extends ReplicationTestBase {
             public boolean shouldReplicateDocument(DocumentRevision revision) {
                 return false;
             }
-        }).changeLimitPerBatch(1).batchLimitPerRun(5).build();
+        }).changeLimitPerBatch(1).build();
 
         // Register a listener for the completion event
         TestReplicationListener listener = new TestReplicationListener();


### PR DESCRIPTION
## What
Remove the limit of the number of batches that can run for replications.

## Why
Currently replications will be marked as completed even if they did not replicate all changes, this is due to the limit on the number of batches. Removing this limit ensures that a replication will replicate until there are no more changes to be replicated from the database.

## How

- Remove `batchLimtPerRun` configuration option
- Change `for` loop in {Pull,Push}Strategy to `while` and use cancel as the condition.

## Issues

Resolves #462