### PR TITLE
Restore isTextSearchEnabled method

### DIFF
--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/QueryImpl.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/QueryImpl.java
@@ -20,6 +20,7 @@ import com.cloudant.sync.internal.documentstore.DatabaseImpl;
 import com.cloudant.sync.internal.documentstore.migrations.SchemaOnlyMigration;
 import com.cloudant.sync.internal.query.callables.DeleteIndexCallable;
 import com.cloudant.sync.internal.query.callables.ListIndexesCallable;
+import com.cloudant.sync.internal.sqlite.SQLDatabaseFactory;
 import com.cloudant.sync.internal.sqlite.SQLDatabaseQueue;
 import com.cloudant.sync.internal.util.Misc;
 import com.cloudant.sync.query.FieldSort;
@@ -246,5 +247,9 @@ public class QueryImpl implements Query {
         return database;
     }
 
+    @Override
+    public boolean isTextSearchEnabled() {
+        return SQLDatabaseFactory.FTS_AVAILABLE;
+    }
 
 }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/Query.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/Query.java
@@ -164,8 +164,10 @@ public interface Query {
             throws QueryException;
 
     /**
-     * Returns whether the underlying SQLite instance supports Full Text Search (FTS)
-     * @return whether the underlying SQLite instance supports Full Text Search (FTS)
+     * Returns {@code true} if the underlying SQLite instance supports Full Text Search (FTS);
+     * {@code false} otherwise
+     * @return {@code true} if the underlying SQLite instance supports Full Text Search (FTS);
+     * {@code false} otherwise
      */
     boolean isTextSearchEnabled();
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/Query.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/Query.java
@@ -163,5 +163,11 @@ public interface Query {
                      List<FieldSort> sortDocument)
             throws QueryException;
 
+    /**
+     * Returns whether the underlying SQLite instance supports Full Text Search (FTS)
+     * @return whether the underlying SQLite instance supports Full Text Search (FTS)
+     */
+    boolean isTextSearchEnabled();
+
 }
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/DelegatingMockQuery.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/DelegatingMockQuery.java
@@ -67,6 +67,11 @@ public abstract class DelegatingMockQuery implements Query {
         return delegate.find(query, skip, limit, fields, sortDocument);
     }
 
+    @Override
+    public boolean isTextSearchEnabled() {
+        return delegate.isTextSearchEnabled();
+    }
+
     public void close() {
         delegate.close();
     }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/QueryTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/QueryTest.java
@@ -270,7 +270,7 @@ public class QueryTest extends AbstractIndexTestBase {
 
     @Test
     public void validateTextSearchIsAvailable() throws Exception {
-        assertThat(SQLDatabaseFactory.FTS_AVAILABLE, is(true));
+        assertThat(im.isTextSearchEnabled(), is(true));
     }
 
 }


### PR DESCRIPTION
_What_

Restore `isTextSearchEnabled` method.

This had previously been removed from the implementation and not added
to the interface.

_Why_

This is public API and mentioned in the query markdown doc

_Testing_

See `validateTextSearchIsAvailable`
