### PR TITLE
Replication timer fixes

### DIFF
--- a/cloudant-sync-datastore-android/src/test/java/com/cloudant/android/TestReplicationService.java
+++ b/cloudant-sync-datastore-android/src/test/java/com/cloudant/android/TestReplicationService.java
@@ -25,6 +25,12 @@ public class TestReplicationService extends PeriodicReplicationService {
     private static final String DATASTORE_MANGER_DIR = "data";
     private static final String TAG = "TestReplicationService";
 
+    /** The period between replications for our test PeriodicReplicationService when there are no
+     * components bound to the service. The default is 120 seconds (2 minutes), but the value
+     * may be modified by calling {@link #setUnboundIntervalSeconds(int)}.
+     */
+    private int mUnboundIntervalSeconds = 120;
+
     class TestReceiver extends WifiPeriodicReplicationReceiver<TestReplicationService> {
         public TestReceiver() {
             super(TestReplicationService.class);
@@ -46,10 +52,14 @@ public class TestReplicationService extends PeriodicReplicationService {
     }
 
     protected int getUnboundIntervalInSeconds() {
-        return 120;
+        return mUnboundIntervalSeconds;
     }
-    
+
     protected boolean startReplicationOnBind() {
         return true;
+    }
+
+    public void setUnboundIntervalSeconds(int seconds) {
+        mUnboundIntervalSeconds = seconds;
     }
 }

--- a/doc/replication-policies.md
+++ b/doc/replication-policies.md
@@ -87,8 +87,17 @@ key is `ReplicationService.EXTRA_COMMAND`, and whose value is one of:
 * `ReplicationService.COMMAND_START_REPLICATION` This starts the replicators.
 * `ReplicationService.COMMAND_STOP_REPLICATION` This stops replicators in progress.
 * `PeriodicReplicationService.COMMAND_START_PERIODIC_REPLICATION` This starts the periodic replications when you are using the `PeriodicReplicationService`.
+The replications will occur immediately the first time this message is sent or if they were previously stopped explicitly by sending
+`PeriodicReplicationService.COMMAND_STOP_PERIODIC_REPLICATION`. However, if replications were previously stopped implicitly (e.g.
+by rebooting the device), then the existing replication schedule will be resumed.
 * `PeriodicReplicationService.COMMAND_STOP_PERIODIC_REPLICATION` This stops the periodic replications when you are using the `PeriodicReplicationService`.
-* `PeriodicReplicationService.COMMAND_DEVICE_REBOOTED` This resets the periodic replications aafter the device has rebooted when you are using the `PeriodicReplicationService`. This will be automatically called if your subclass of `PeriodicReplicationReceiver` calls through to the `onReceive()` method of `PeriodicReplicationReceiver`.
+* `PeriodicReplicationService.COMMAND_DEVICE_REBOOTED` This resets the periodic replications after the device has rebooted when you are using the
+`PeriodicReplicationService`. This will be automatically called if your subclass of `PeriodicReplicationReceiver` calls through to the `onReceive()` method of `PeriodicReplicationReceiver`.
+* `PeriodicReplicationService.COMMAND_RESET_REPLICATION_TIMERS` This re-evaluates the timers used by the `PeriodicReplicationService` by calling
+`getBoundIntervalInSeconds()` or `getUnboundIntervalInSeconds()`. This is useful if you allow the replication interval to be dynamically changed.
+For example, if you allow users to change the replication intervals in your app's settings (which should cause your implementations of
+`getBoundIntervalInSeconds()` and/or `getUnboundIntervalInSeconds()` to return a different result after a change), once the change has been made,
+you should send an `Intent` with this Extra so that the changes are applied to the `PeriodicReplicationService` immediately.
 
 For example, from a subclass of `PeriodicReplicationReceiver`, you might call:
 
@@ -104,6 +113,9 @@ If you want to start replications from anywhere other than a `PeriodicReplicatio
 `startWakefulService(context, intent)` with `startService(intent)` in the above example and do any
 [`WakeLock`](http://developer.android.com/reference/android/os/PowerManager.WakeLock.html)
 management you require yourself.
+
+If you need to create a custom subclass of `ReplicationService` and you add additional commands passed using the `ReplicationService.EXTRA_COMMAND`
+key, you should use command IDs above 99. The IDs 99 and below are reserved for internal use.
 
 #### WifiPeriodicReplicationReceiver
 


### PR DESCRIPTION
### What

- Stopping and starting periodic replication currently occurs in an inconsistent way. Sometimes when an explicit call to start periodic replications is made after an explicit stop, the replications will occur immediately and sometimes the replications will continue the previous schedule.
- It is not obvious how to change the schedule of periodic replications in progress and one might assume that by changing the values returned by PeriodicReplicationService, that would be sufficient. This PR improves and documents the process.

### How

Store a new value in `SharedPreferences` indicating whether the service was explicitly stopped, by sending an intent containing `PeriodicReplicationService.COMMAND_STOP_PERIODIC_REPLICATION`, or implicitly stopped (e.g. by rebooting the device).

This allows us to implement the following rules.

- After an explicit stop of the `PeriodicReplicationService`, any subsequent start of it will cause a replication to begin immediately.
- After an implicit stop (e.g. device reboot), any subsequent start of the `PeriodicReplicationService` will cause the replications to continue on the previous schedule (as if the device had not been rebooted) unless we have missed a replication that was due when the device was off (in which case the first replication will occur immediately and subsequent replications will occur at the intervals specified by the `PerioidicReplicationService` from the current time).

To support a use-case where an app allows the frequency of replication to be adjusted (e.g. by some user preference), we now add a new `PeriodicReplicationService.COMMAND_RESET_REPLICATION_TIMERS` command that can be sent in an `Intent` to the replication service to indicate that the replication timers should be re-evaluated.

The Replication Policy documentation has been updated to describe this behaviour.

### Testing

New tests have been added to test this functionality.