### PR TITLE
Add `length` property to `Attachment`

### DIFF
--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/Attachment.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/Attachment.java
@@ -37,10 +37,11 @@ import java.io.InputStream;
  */
 public abstract class Attachment implements Comparable<Attachment>{
 
-    public Attachment(String name, String type, Encoding encoding) {
+    public Attachment(String name, String type, Encoding encoding, long length) {
         this.name = name;
         this.type = type;
         this.encoding = encoding;
+        this.length = length;
     }
 
     /**
@@ -63,6 +64,12 @@ public abstract class Attachment implements Comparable<Attachment>{
      * </p>
      */
     public final Encoding encoding;
+
+    /**
+     * The length, in bytes, of the stream returned by {@link #getInputStream()} or -1 if the length
+     * is unknown (for instance if the data is backed by a stream)
+     */
+    public final long length;
     
     /**
      * <p>

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/Attachment.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/Attachment.java
@@ -37,7 +37,7 @@ import java.io.InputStream;
  */
 public abstract class Attachment implements Comparable<Attachment>{
 
-    public Attachment(String name, String type, Encoding encoding, long length) {
+    protected Attachment(String name, String type, Encoding encoding, long length) {
         this.name = name;
         this.type = type;
         this.encoding = encoding;

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/UnsavedFileAttachment.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/UnsavedFileAttachment.java
@@ -33,12 +33,12 @@ import java.io.InputStream;
 public class UnsavedFileAttachment extends Attachment {
 
     public UnsavedFileAttachment(File file, String type) {
-        super(file.getName(), type, Encoding.Plain);
+        super(file.getName(), type, Encoding.Plain, file.length());
         this.file = file;
     }
 
     public UnsavedFileAttachment(File file, String type, Encoding encoding) {
-        super(file.getName(), type, encoding);
+        super(file.getName(), type, encoding, file.length());
         this.file = file;
     }
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/UnsavedStreamAttachment.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/UnsavedStreamAttachment.java
@@ -31,12 +31,12 @@ import java.io.InputStream;
 public class UnsavedStreamAttachment extends Attachment {
 
     public UnsavedStreamAttachment(InputStream stream, String name, String type) {
-        super(name, type, Encoding.Plain);
+        super(name, type, Encoding.Plain, -1);
         this.stream = stream;
     }
 
     public UnsavedStreamAttachment(InputStream stream, String name, String type, Encoding encoding) {
-        super(name, type, encoding);
+        super(name, type, encoding, -1);
         this.stream = stream;
     }
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/SavedAttachment.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/SavedAttachment.java
@@ -54,7 +54,6 @@ public class SavedAttachment extends Attachment {
     // these properties come directly from the database
     protected final long seq;
     protected final byte[] key;  // sha of file, used for file path on disk.
-    protected final long length;
     protected final long encodedLength;
     protected final long revpos;
 
@@ -64,12 +63,11 @@ public class SavedAttachment extends Attachment {
     public SavedAttachment(long seq, String name, byte[] key, String type, Encoding encoding,
                               long length, long encodedLength, long revpos, File file,
                               AttachmentStreamFactory asf) {
-        super(name, type, encoding);
+        super(name, type, encoding, length);
 
         this.revpos = revpos;
         this.seq = seq;
         this.key = key == null ? null : Arrays.copyOf(key, key.length);
-        this.length = length;
         this.encodedLength = encodedLength;
 
         this.file = file;


### PR DESCRIPTION
This field is needed if users want to easily copy attachment contents into a byte buffer, for instance
```java
        Attachment att = retrieved.getAttachments().get("cute_cat.jpg");
        InputStream is = att.getInputStream();

        // get all bytes in memory if required
        byte[] data = new byte[(int) att.length];
        is.read(data);
```
(taken from crud.md)

Defaults to -1 if unknown