### PR TITLE
Change getConflictedIds signature

### DIFF
--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/Database.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/Database.java
@@ -23,7 +23,6 @@ import com.cloudant.sync.event.EventBus;
 import com.cloudant.sync.query.Query;
 
 import java.io.File;
-import java.util.Iterator;
 import java.util.List;
 
 /**

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/Database.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/Database.java
@@ -233,7 +233,7 @@ public interface Database {
      * @see <a target="_blank" href="http://wiki.apache.org/couchdb/Replication_and_conflicts">Replication and conflicts</a>
      * @throws DocumentStoreException if there was an error reading from the database.
      */
-    Iterator<String> getConflictedIds() throws DocumentStoreException;
+    Iterable<String> getConflictedIds() throws DocumentStoreException;
 
     /**
      * <p>

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/DatabaseImpl.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/DatabaseImpl.java
@@ -792,9 +792,9 @@ public class DatabaseImpl implements Database {
     }
 
     @Override
-    public Iterator<String> getConflictedIds() throws DocumentStoreException {
+    public Iterable<String> getConflictedIds() throws DocumentStoreException {
         try {
-            return get(queue.submit(new GetConflictedDocumentIdsCallable())).iterator();
+            return get(queue.submit(new GetConflictedDocumentIdsCallable()));
         } catch (ExecutionException e) {
             String message = "Failed to get conflicted document ids";
             logger.log(Level.SEVERE, message, e);

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/DatabaseImpl.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/DatabaseImpl.java
@@ -85,7 +85,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatabaseImplConflictsTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatabaseImplConflictsTest.java
@@ -46,7 +46,7 @@ public class DatabaseImplConflictsTest extends BasicDatastoreTestBase {
         DocumentRevision rev = this.createDocumentRevision("Tom");
         InternalDocumentRevision newRev = this.createDetachedDocumentRevision(rev.getId(), "1-rev", "Jerry");
         this.datastore.forceInsert(newRev, "1-rev");
-        Iterator<String> iterator = this.datastore.getConflictedIds();
+        Iterator<String> iterator = this.datastore.getConflictedIds().iterator();
         List<String> conflictedDocId = CollectionUtils.newArrayList(iterator);
         Assert.assertThat(conflictedDocId, hasSize(1));
         Assert.assertThat(conflictedDocId, hasItems(rev.getId()));
@@ -61,7 +61,7 @@ public class DatabaseImplConflictsTest extends BasicDatastoreTestBase {
         InternalDocumentRevision newRev2 = this.createDetachedDocumentRevision(rev.getId(), "3-b", "Harry");
         this.datastore.forceInsert(newRev2, "1-b", "2-b", "3-b");
 
-        Iterator<String> iterator = this.datastore.getConflictedIds();
+        Iterator<String> iterator = this.datastore.getConflictedIds().iterator();
         List<String> conflictedDocId = CollectionUtils.newArrayList(iterator);
         Assert.assertThat(conflictedDocId, hasSize(1));
         Assert.assertThat(conflictedDocId, hasItems(rev.getId()));
@@ -74,7 +74,7 @@ public class DatabaseImplConflictsTest extends BasicDatastoreTestBase {
         InternalDocumentRevision newRev = this.createDetachedDocumentRevision(rev.getId(), "4-a", "Jerry");
         this.datastore.forceInsert(newRev, "1-a", "2-a", "3-a", "4-a");
 
-        Iterator<String> iterator = this.datastore.getConflictedIds();
+        Iterator<String> iterator = this.datastore.getConflictedIds().iterator();
         List<String> conflictedDocId = CollectionUtils.newArrayList(iterator);
         Assert.assertThat(conflictedDocId, hasSize(0));
     }
@@ -516,7 +516,7 @@ public class DatabaseImplConflictsTest extends BasicDatastoreTestBase {
 
     private void testWithConflictCount(int conflictCount) throws Exception {
         List<String> expectedConflicts = createConflictDocuments(conflictCount);
-        Iterator<String> iterator = this.datastore.getConflictedIds();
+        Iterator<String> iterator = this.datastore.getConflictedIds().iterator();
         List<String> actualConflicts = CollectionUtils.newArrayList(iterator);
         Assert.assertThat(actualConflicts, hasSize(expectedConflicts.size()));
         for(String id : expectedConflicts) {

--- a/doc/migration.md
+++ b/doc/migration.md
@@ -83,6 +83,9 @@ counterparts on `Datastore`:
 * `deleteDocumentFromRevision` has been renamed `delete`
 * `deleteDocument` has been renamed `delete`
 
+The `getConflictedIds` method now returns `Iterable<String>`. This
+allows the result to be used in an enhanced `for` loop.
+
 The `throws` clauses on `Database` methods are different to those on
 their counterparts in `Datastore`. Code which calls these methods may
 have to be adjusted to catch different exceptions. See


### PR DESCRIPTION
Change signature to Iterable so that the result can be used by the for/each syntax