### PR TITLE
Allow queries combining $not and $size

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,10 +34,13 @@
   
 - [FIXED] Issue with double encoding of restricted URL characters in credentials when using
   `ReplicatorBuilder`.
-  
+
 - [FIXED] Issue where push replicating a large number of attachments
   could exhaust the operating system file handle limit, on some
   platforms.
+
+- [FIXED] Issue querying indexed fields when combining the `$not` and
+  `$size` operators.
 
 # 1.1.5 (2016-12-08)
 - [FIXED] Issue where replicator would not get the latest revision if `_bulk_get`

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/QuerySqlTranslator.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/QuerySqlTranslator.java
@@ -349,7 +349,6 @@ class QuerySqlTranslator {
                         return isOperatorFoundInClause(operator, Collections
                                 .<Object>singletonList(predicate));
                     }
-                    return false;
                 }
             }
         }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/QuerySqlTranslator.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/QuerySqlTranslator.java
@@ -345,12 +345,11 @@ class QuerySqlTranslator {
                 Map term = (Map) rawTerm;
                 if (term.size() == 1 && term.values().toArray()[0] instanceof Map) {
                     Map predicate = (Map) term.values().toArray()[0];
-                    if (predicate.get(NOT) != null) {
-                        if (predicate.get(NOT) instanceof Map) {
-                            return isOperatorFoundInClause(operator, Collections.singletonList(predicate));
-                        }
-                        return false;
+                    if (predicate.get(NOT) != null && predicate.get(NOT) instanceof Map) {
+                        return isOperatorFoundInClause(operator, Collections
+                                .<Object>singletonList(predicate));
                     }
+                    return false;
                 }
             }
         }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/QuerySqlTranslator.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/QuerySqlTranslator.java
@@ -337,6 +337,25 @@ class QuerySqlTranslator {
      */
     protected static boolean isOperatorFoundInClause(String operator, List<Object> clause) {
         boolean found = false;
+
+        // first check for the existence of $not so that we can find negated operators:
+        // if we find $not then recurse with the value associated with it in the query map
+        for (Object rawTerm : clause){
+            if (rawTerm instanceof Map) {
+                Map term = (Map) rawTerm;
+                if (term.size() == 1 && term.values().toArray()[0] instanceof Map) {
+                    Map predicate = (Map) term.values().toArray()[0];
+                    if (predicate.get(NOT) != null) {
+                        if (predicate.get(NOT) instanceof Map) {
+                            return isOperatorFoundInClause(operator, Collections.singletonList(predicate));
+                        }
+                        return false;
+                    }
+                }
+            }
+        }
+
+        // if we didn't find $not then look directly for the operator
         for (Object rawTerm : clause){
             if (rawTerm instanceof Map) {
                 Map term = (Map) rawTerm;

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/QueryCoveringIndexesTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/QueryCoveringIndexesTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.runners.Parameterized.Parameters;
@@ -1704,5 +1705,27 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
                                                                  "john0.6",
                                                                  "john-0.6"));
     }
-    
+
+    // when using $size operator combined with $not operator
+    @Test
+    public void canFindDocumentsUsingNOTAndSIZE() throws Exception {
+        setUpArrayIndexingData();
+        // query - { "pets": { "$not": { "$size":  2 } }
+        Map<String, Object> query = new HashMap<String, Object>();
+        Map<String, Object> notOp = new HashMap<String, Object>();
+        Map<String, Object> sizeOp = new HashMap<String, Object>();
+
+        sizeOp.put("$size", 2);
+        notOp.put("$not", sizeOp);
+        query.put("pet", notOp);
+        QueryResult queryResult = idxMgr.find(query);
+
+        assertThat(queryResult.documentIds(), hasSize(4));
+        assertThat(queryResult.documentIds(), containsInAnyOrder("fred34",
+                "mike34",
+                "fred12",
+                "john22"));
+    }
+
+
 }


### PR DESCRIPTION
_What_ 
Fix buggy handling of queries like `{ "$not" : { "$size" : 5} }`. see #468.

_How_
Change `isOperatorFoundInClause` to find negated operators

_Testing_
Add test `canFindDocumentsUsingNOTAndSIZE`