### PR TITLE
Added rootDir to qualify VERSION file path in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ apply from: 'AndroidExec.gradle'
 
 allprojects {
     group = 'com.cloudant'
-    version = new File('VERSION').text.trim()
+    version = new File(rootDir, 'VERSION').text.trim()
     description = """cloudant-sync"""
     //if the version says "snapshot" anywhere assume it is not a release
     ext.isReleaseVersion = !version.toUpperCase(Locale.ENGLISH).contains("SNAPSHOT")


### PR DESCRIPTION
## What

Ensured `VERSION` file has qualified path

## Why

Otherwise an attempt is made to read the file from the working directory, which may not be the root and then a failure occurs

## How

Added `rootDir` to `VERSION` file path before reading in `build.gradle`.
