### PR TITLE
Fixed type of DocumentBodyFactory.EMPTY constant

### DIFF
--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/DocumentBodyFactory.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/DocumentBodyFactory.java
@@ -33,7 +33,7 @@ public class DocumentBodyFactory {
      * <p>Returns a {@link DocumentBody}  object representing an empty document body.
      * This instance is shared.</p>
      */
-    public final static DocumentBodyImpl EMPTY = new DocumentBodyImpl(JSONUtils.emptyJSONObjectAsBytes());
+    public final static DocumentBody EMPTY = new DocumentBodyImpl(JSONUtils.emptyJSONObjectAsBytes());
 
     /**
      * <p>Returns a new {@link DocumentBody} object from JSON data.</p>


### PR DESCRIPTION
*What*

Fixed type of `DocumentBodyFactory.EMPTY` constant

*How*

Changed from `DocumentBodyImpl` to `DocumentBody`

*Testing*

No new tests, existing tests pass.

*Issues*

Part of #413 