### PR TITLE
Removed enumValue method from API

### DIFF
--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/callables/ListIndexesCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/callables/ListIndexesCallable.java
@@ -47,9 +47,7 @@ public class ListIndexesCallable implements SQLCallable<List<Index>> {
             while (cursorIndexNames.moveToNext()) {
                 String indexName = cursorIndexNames.getString(0);
                 String sqlIndexes = String.format("SELECT index_type, field_name, index_settings " +
-                        "FROM %s " +
-                                "WHERE index_name = ?",
-                        QueryImpl.INDEX_METADATA_TABLE_NAME);
+                        "FROM %s WHERE index_name = ?", QueryImpl.INDEX_METADATA_TABLE_NAME);
                 Cursor cursorIndexes = null;
                 try {
                     cursorIndexes = db.rawQuery(sqlIndexes, new String[]{indexName});

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/callables/ListIndexesCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/callables/ListIndexesCallable.java
@@ -28,6 +28,7 @@ import com.cloudant.sync.query.Tokenizer;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * Lists the indexes for the database.
@@ -37,14 +38,16 @@ public class ListIndexesCallable implements SQLCallable<List<Index>> {
     @Override
     public List<Index> call(SQLDatabase db) throws Exception {
         // Accumulate indexes and definitions into a map
-        String sqlIndexNames = String.format("SELECT DISTINCT index_name FROM %s", QueryImpl.INDEX_METADATA_TABLE_NAME);
+        String sqlIndexNames = String.format("SELECT DISTINCT index_name FROM %s", QueryImpl
+                .INDEX_METADATA_TABLE_NAME);
         Cursor cursorIndexNames = null;
         ArrayList<Index> indexes = new ArrayList<Index>();
         try {
             cursorIndexNames = db.rawQuery(sqlIndexNames, new String[]{});
             while (cursorIndexNames.moveToNext()) {
                 String indexName = cursorIndexNames.getString(0);
-                String sqlIndexes = String.format("SELECT index_type, field_name, index_settings FROM %s " +
+                String sqlIndexes = String.format("SELECT index_type, field_name, index_settings " +
+                        "FROM %s " +
                                 "WHERE index_name = ?",
                         QueryImpl.INDEX_METADATA_TABLE_NAME);
                 Cursor cursorIndexes = null;
@@ -57,7 +60,8 @@ public class ListIndexesCallable implements SQLCallable<List<Index>> {
                     while (cursorIndexes.moveToNext()) {
                         if (first) {
                             // first time round
-                            indexType = IndexType.enumValue(cursorIndexes.getString(0));
+                            indexType = IndexType.valueOf(cursorIndexes.getString(0).toUpperCase
+                                    (Locale.ENGLISH));
                             settings = cursorIndexes.getString(2);
                             first = false;
                         }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexType.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/query/IndexType.java
@@ -40,18 +40,4 @@ public enum IndexType {
         return super.toString().toLowerCase(Locale.ENGLISH);
     }
 
-    /**
-     * Converts a string to its Enum value.
-     * @param value The string to convert to an enum
-     * @return The enum value for the String or {@code null}
-     */
-    public static IndexType enumValue(String value){
-        if(value.equals(IndexType.JSON.toString())){
-            return IndexType.JSON;
-        } else if (value.equals(IndexType.TEXT.toString())){
-            return IndexType.TEXT;
-        }
-        return null;
-    }
-
 }


### PR DESCRIPTION
*What*

Removed `enumValue` method from `IndexType` API.

*Why*

The intent of the API is that users use the enum constants, not strings. The `enumValue` is
used internally to convert from string to enum, but need not be exposed as API.

*How*

Removed `IndexType.enumValue()` method.
Replaced single call site with `IndexType.valueOf(value.toUpperCase(Local.ENGLISH))`

*Testing*

No new tests, existing tests pass.

*Issues*

Part of #413 
