### PR TITLE
Refactored Changes to not expose internals

### DIFF
--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/Changes.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/Changes.java
@@ -1,8 +1,6 @@
 /*
  * Copyright © 2017 IBM Corp. All rights reserved.
  *
- * Copyright © 2013 Cloudant, Inc. All rights reserved.
- *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
  *
@@ -13,52 +11,11 @@
  * either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
-
 package com.cloudant.sync.documentstore;
 
-
-import com.cloudant.sync.internal.documentstore.InternalDocumentRevision;
-import com.cloudant.sync.internal.util.Misc;
-
-import java.util.ArrayList;
 import java.util.List;
 
-/**
- * <p>The {@code Changes} object describes a list of changes to the {@link Database}.</p>
- *
- * <p>The object contains a list of the changes between a given sequence number
- * (passed to the {@link Database#changes(long, int)} method) and
- * the {@link Changes#lastSequence} field of the object.</p>
- *
- * @api_public
- */
-public class Changes {
-
-    private final long lastSequence;
-
-    private final List<InternalDocumentRevision> results;
-
-    /**
-     * <p>
-     * Construct a list of changes
-     * </p>
-     * <p>
-     * Note that this constructor is for internal use. To get a set of changes from a given sequence
-     * number, use {@link Database#changes}
-     * </p>
-     * @param lastSequence the last sequence number of this change set
-     * @param results the list of {@code DocumentRevision}s in this change set
-     *
-     * @see Database#changes
-     *
-     * @api_private
-     */
-    public Changes(long lastSequence, List<InternalDocumentRevision> results) {
-        Misc.checkNotNull(results, "Changes results");
-        this.lastSequence = lastSequence;
-        this.results = results;
-    }
-
+public interface Changes {
     /**
      * <p>Returns the last sequence number of this change set.</p>
      *
@@ -67,38 +24,12 @@ public class Changes {
      *
      * @return last sequence number of the changes set
      */
-    public long getLastSequence() {
-        return this.lastSequence;
-    }
+    long getLastSequence();
 
     /**
      * <p>Returns the list of {@code DocumentRevision}s in this change set.</p>
      *
      * @return the list of {@code DocumentRevision}s in this change set.
      */
-    public List<InternalDocumentRevision> getResults() {
-        return this.results;
-    }
-
-    /**
-     * <p>Returns the number of {@code DocumentRevision}s in this change set.</p>
-     * @return the number of {@code DocumentRevision}s in this change set.
-     */
-    public int size() {
-        return this.results.size();
-    }
-
-    /**
-     * <p>Returns the list of document IDs for the {@code DocumentRevision}s in this
-     * change set.</p>
-     * @return the list of document IDs for the {@code DocumentRevision}s in this
-     * change set.
-     */
-    public List<String> getIds() {
-        List<String> ids = new ArrayList<String>();
-        for(InternalDocumentRevision obj : results) {
-            ids.add(obj.getId());
-        }
-        return ids;
-    }
+    List<DocumentRevision> getResults();
 }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/ChangesImpl.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/ChangesImpl.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
+ * Copyright © 2013 Cloudant, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.internal.documentstore;
+
+
+import com.cloudant.sync.documentstore.Changes;
+import com.cloudant.sync.documentstore.Database;
+import com.cloudant.sync.documentstore.DocumentRevision;
+import com.cloudant.sync.internal.util.Misc;
+
+import java.util.List;
+
+/**
+ * <p>The {@code Changes} object describes a list of changes to the {@link Database}.</p>
+ *
+ * <p>The object contains a list of the changes between a given sequence number
+ * (passed to the {@link Database#changes(long, int)} method) and
+ * the {@link Changes#lastSequence} field of the object.</p>
+ *
+ */
+public class ChangesImpl implements Changes {
+
+    private final long lastSequence;
+
+    private final List<DocumentRevision> results;
+
+    /**
+     * <p>
+     * Construct a list of changes
+     * </p>
+     * <p>
+     * Note that this constructor is for internal use. To get a set of changes from a given sequence
+     * number, use {@link Database#changes}
+     * </p>
+     * @param lastSequence the last sequence number of this change set
+     * @param results the list of {@code DocumentRevision}s in this change set
+     *
+     * @see Database#changes
+     *
+     */
+    public ChangesImpl(long lastSequence, List<DocumentRevision> results) {
+        Misc.checkNotNull(results, "Changes results");
+        this.lastSequence = lastSequence;
+        this.results = results;
+    }
+
+    @Override public long getLastSequence() {
+        return this.lastSequence;
+    }
+
+    @Override public List<DocumentRevision> getResults() {
+        return this.results;
+    }
+}

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/ChangesCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/ChangesCallable.java
@@ -14,9 +14,10 @@
 
 package com.cloudant.sync.internal.documentstore.callables;
 
-import com.cloudant.sync.internal.documentstore.AttachmentStreamFactory;
 import com.cloudant.sync.documentstore.Changes;
-import com.cloudant.sync.internal.documentstore.DatabaseImpl;
+import com.cloudant.sync.documentstore.DocumentRevision;
+import com.cloudant.sync.internal.documentstore.AttachmentStreamFactory;
+import com.cloudant.sync.internal.documentstore.ChangesImpl;
 import com.cloudant.sync.internal.documentstore.InternalDocumentRevision;
 import com.cloudant.sync.internal.sqlite.Cursor;
 import com.cloudant.sync.internal.sqlite.SQLCallable;
@@ -73,7 +74,7 @@ public class ChangesCallable implements SQLCallable<Changes> {
             }
 
             if (ids.isEmpty()){
-                return new Changes(lastSequence, Collections.<InternalDocumentRevision>emptyList());
+                return new ChangesImpl(lastSequence, Collections.<DocumentRevision>emptyList());
             }
 
             List<InternalDocumentRevision> results = new GetDocumentsWithInternalIdsCallable(ids, attachmentsDir, attachmentStreamFactory).call(db);
@@ -87,7 +88,7 @@ public class ChangesCallable implements SQLCallable<Changes> {
                 ));
             }
 
-            return new Changes(lastSequence, results);
+            return new ChangesImpl(lastSequence, new ArrayList<DocumentRevision>(results));
         } catch (SQLException e) {
             throw new IllegalStateException("Error querying all changes since: " +
                     since + ", limit: " + limit, e);

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/IndexUpdater.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/IndexUpdater.java
@@ -109,7 +109,7 @@ class IndexUpdater {
                 changes = database.changes(lastSequence, 10000);
                 updateIndex(indexName, fieldNames, changes, lastSequence);
                 lastSequence = changes.getLastSequence();
-            } while (changes.size() > 0);
+            } while (changes.getResults().size() > 0);
         } catch (DocumentStoreException e) {
             String message = String.format(Locale.ENGLISH, "Failed to get changes feed from %d", lastSequence);
             logger.log(Level.SEVERE, message, e);

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/callables/UpdateIndexCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/callables/UpdateIndexCallable.java
@@ -16,8 +16,8 @@
 package com.cloudant.sync.internal.query.callables;
 
 import com.cloudant.sync.documentstore.Changes;
+import com.cloudant.sync.documentstore.DocumentRevision;
 import com.cloudant.sync.internal.android.ContentValues;
-import com.cloudant.sync.internal.documentstore.InternalDocumentRevision;
 import com.cloudant.sync.internal.query.QueryImpl;
 import com.cloudant.sync.internal.query.ValueExtractor;
 import com.cloudant.sync.internal.sqlite.SQLCallable;
@@ -51,7 +51,7 @@ public class UpdateIndexCallable implements SQLCallable<Void> {
 
     @Override
     public Void call(SQLDatabase database) throws QueryException {
-        for (InternalDocumentRevision rev : changes.getResults()) {
+        for (DocumentRevision rev : changes.getResults()) {
             // Delete existing values
             String tableName = QueryImpl.tableNameForIndex(indexName);
             database.delete(tableName, " _id = ? ", new String[]{rev.getId()});
@@ -89,7 +89,7 @@ public class UpdateIndexCallable implements SQLCallable<Void> {
      * is an array, however, multiple entries are required.
      */
     @SuppressWarnings("unchecked")
-    private List<DBParameter> parametersToIndexRevision(InternalDocumentRevision rev,
+    private List<DBParameter> parametersToIndexRevision(DocumentRevision rev,
                                                                      String indexName,
                                                                      List<FieldSort> fieldNames) {
         Misc.checkNotNull(rev, "rev");
@@ -161,7 +161,7 @@ public class UpdateIndexCallable implements SQLCallable<Void> {
                                                          List<FieldSort> initialIncludedFields,
                                                          List<Object> initialArgs,
                                                          String indexName,
-                                                         InternalDocumentRevision rev) {
+                                                         DocumentRevision rev) {
         List<FieldSort> includeFieldNames = new ArrayList<FieldSort>();
         includeFieldNames.addAll(initialIncludedFields);
         List<Object> args = new ArrayList<Object>();

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/replication/DatastoreWrapper.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/replication/DatastoreWrapper.java
@@ -16,21 +16,22 @@
 
 package com.cloudant.sync.internal.replication;
 
-import com.cloudant.sync.internal.mazha.DocumentRevs;
 import com.cloudant.sync.documentstore.Attachment;
 import com.cloudant.sync.documentstore.AttachmentException;
-import com.cloudant.sync.internal.documentstore.DatabaseImpl;
-import com.cloudant.sync.documentstore.DocumentStoreException;
 import com.cloudant.sync.documentstore.DocumentBodyFactory;
 import com.cloudant.sync.documentstore.DocumentException;
 import com.cloudant.sync.documentstore.DocumentNotFoundException;
-import com.cloudant.sync.internal.documentstore.InternalDocumentRevision;
+import com.cloudant.sync.documentstore.DocumentRevision;
+import com.cloudant.sync.documentstore.DocumentStoreException;
+import com.cloudant.sync.documentstore.LocalDocument;
+import com.cloudant.sync.internal.documentstore.DatabaseImpl;
 import com.cloudant.sync.internal.documentstore.DocumentRevisionTree;
 import com.cloudant.sync.internal.documentstore.DocumentRevsList;
 import com.cloudant.sync.internal.documentstore.DocumentRevsUtils;
 import com.cloudant.sync.internal.documentstore.ForceInsertItem;
-import com.cloudant.sync.documentstore.LocalDocument;
+import com.cloudant.sync.internal.documentstore.InternalDocumentRevision;
 import com.cloudant.sync.internal.documentstore.PreparedAttachment;
+import com.cloudant.sync.internal.mazha.DocumentRevs;
 import com.cloudant.sync.internal.util.JSONUtils;
 
 import java.util.ArrayList;
@@ -123,10 +124,10 @@ class DatastoreWrapper {
         }
     }
 
-    Map<String, DocumentRevisionTree> getDocumentTrees(List<InternalDocumentRevision> documents) {
+    Map<String, DocumentRevisionTree> getDocumentTrees(List<DocumentRevision> documents) {
         Map<String, DocumentRevisionTree> allDocumentTrees =
                 new HashMap<String, DocumentRevisionTree>();
-        for(InternalDocumentRevision doc: documents) {
+        for(DocumentRevision doc: documents) {
             DocumentRevisionTree tree =
                     this.dbCore.getAllRevisionsOfDocument(doc.getId());
             allDocumentTrees.put(doc.getId(), tree);

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/ChangesTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/ChangesTest.java
@@ -16,30 +16,33 @@
 
 package com.cloudant.sync.internal.documentstore;
 
+import static org.hamcrest.CoreMatchers.hasItems;
+
+import com.cloudant.sync.documentstore.Changes;
+import com.cloudant.sync.documentstore.DocumentRevision;
+
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.hasItems;
-
-import com.cloudant.sync.documentstore.Changes;
-import com.cloudant.sync.documentstore.DocumentRevision;
-
 public class ChangesTest extends BasicDatastoreTestBase {
 
     @Test
     public void changes() throws Exception {
-        InternalDocumentRevision[] docs = createThreeDocuments();
-        List<InternalDocumentRevision> docsList = new ArrayList<InternalDocumentRevision>();
+        DocumentRevision[] docs = createThreeDocuments();
+        List<DocumentRevision> docsList = new ArrayList<DocumentRevision>();
         docsList.add(docs[0]);
         docsList.add(docs[1]);
 
-        Changes c = new Changes(101L, docsList);
+        Changes c = new ChangesImpl(101L, docsList);
         Assert.assertEquals(101L, c.getLastSequence());
-        Assert.assertEquals(2, c.size());
-        Assert.assertThat(c.getIds(), hasItems(docs[0].getId(), docs[1].getId()));
         Assert.assertEquals(2, c.getResults().size());
+        List<String> changeIDs = new ArrayList<String>();
+        for (DocumentRevision rev : c.getResults()) {
+            changeIDs.add(rev.getId());
+        }
+        Assert.assertThat(changeIDs, hasItems(docs[0].getId(), docs[1].getId()));
     }
 }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/DatabaseAssert.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/DatabaseAssert.java
@@ -105,7 +105,7 @@ public class DatabaseAssert {
 
         Set<String> alreadyChecked = new HashSet<String>();
         Changes changesBatch = datastore.changes(0, BATCH_LIMIT);
-        while(changesBatch.size() > 0) {
+        while(changesBatch.getResults().size() > 0) {
 
             for (DocumentRevision object : changesBatch.getResults()) {
                 ChangeRowAdaptor adaptor = new ChangeRowAdaptor(object);

--- a/doc/migration.md
+++ b/doc/migration.md
@@ -247,3 +247,25 @@ Situations for which runtime (unchecked) exceptions may be thrown include:
 
 The `IntervalTimerReplicationPolicyManager` was moved into the `cloudant-sync-datastore-javase`
 module since it was not suitable for running on Android anyway.
+
+## Changes to `Changes`
+
+Removed `size()` and `getIds()` methods. The behaviour duplicated what was
+already available on the `List` returned from `getResults()`.
+
+Before:
+```java
+getChanges().size();
+getChanges().getIds();
+```
+After:
+```java
+getChanges().getResults().size();
+// Get a list of IDs using a collector (Java 1.8)
+getChanges().getResults().stream().map(DocumentRevision::getId).collect(Collectors.toList());
+// Alternatively, for older APIs, just iterate the DocumentRevisions
+for (DocumentRevision rev : getChanges().getResults()) {
+  // Do something with the ID...
+  rev.getId();
+}
+```


### PR DESCRIPTION
*What*

Refactored `Changes` to not expose internals as API.

*How*

Made a `Changes` interface and `ChangesImpl` so as to avoid exposing the constructor.
Removed `getIds()` and `size()` methods from `Changes` as they duplicated stuff that could be easily done via the `getResults()` list.
Stopped exposing `InternalDocumentRevision` on `getResults()` and associated internal API changes that result from that change.
Updated migration doc.

*Testing*

Refactored tests to match new API. Existing tests pass.

*Issues*

Part of #413 
