### PR TITLE
Changed NPE to IllegalArgumentException when checking parameters

### DIFF
--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/util/Misc.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/util/Misc.java
@@ -21,14 +21,13 @@ import java.io.InputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.Locale;
 import java.util.UUID;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
  * Internal utility class
+ *
  * @api_private
  */
 public class Misc {
@@ -55,7 +54,7 @@ public class Misc {
             while ((bytesRead = shaFis.read(buf)) != -1) {
                 sha1.update(buf, 0, bytesRead);
             }
-        } catch (NoSuchAlgorithmException e){
+        } catch (NoSuchAlgorithmException e) {
             throw new IllegalStateException(e);
         }
         return sha1.digest();
@@ -84,22 +83,21 @@ public class Misc {
         }
         return builder.toString();
     }
+
     /**
-     * Check that a parameter is not null and throw NullPointerException with a message of
+     * Check that a parameter is not null and throw IllegalArgumentException with a message of
      * errorMessagePrefix + " must not be null." if it is null, defaulting to "Parameter must not be
      * null.".
      *
      * @param param              the parameter to check
      * @param errorMessagePrefix the prefix of the error message to use for the
      *                           IllegalArgumentException if the parameter was null
-     * @throws NullPointerException if the arg is null.
+     * @throws IllegalArgumentException if the parameter was {@code null}
      */
     public static void checkNotNull(Object param, String errorMessagePrefix) throws
-            NullPointerException {
-        if (param == null) {
-            throw new NullPointerException((errorMessagePrefix != null ? errorMessagePrefix :
-                    "Parameter") + " must not be null.");
-        }
+            IllegalArgumentException {
+        checkArgument(param != null, (errorMessagePrefix != null ? errorMessagePrefix :
+                "Parameter") + " must not be null.");
     }
 
     /**
@@ -114,8 +112,9 @@ public class Misc {
      */
     public static void checkNotNullOrEmpty(String param, String errorMessagePrefix) throws
             IllegalArgumentException {
-        checkArgument(!isStringNullOrEmpty(param), (errorMessagePrefix != null ? errorMessagePrefix :
-              "Parameter") + " must not be " + (param == null ? "null." : "empty."));
+        checkNotNull(param, errorMessagePrefix);
+        checkArgument(!param.isEmpty(), (errorMessagePrefix != null ?
+                errorMessagePrefix : "Parameter") + " must not be empty.");
     }
 
     /**

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ReplicatorBuilder.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ReplicatorBuilder.java
@@ -365,7 +365,7 @@ public abstract class ReplicatorBuilder<S, T, E> {
      * takes precedence over credentials passed via the URI.
      * @param username The username to use when authenticating.
      * @return The current instance of {@link ReplicatorBuilder}
-     * @throws NullPointerException if {@code username} is {@code null}.
+     * @throws IllegalArgumentException if {@code username} is {@code null}.
      */
     public E username(String username) {
         Misc.checkNotNull(username, "username");
@@ -382,7 +382,7 @@ public abstract class ReplicatorBuilder<S, T, E> {
      *
      * @param password The password to use when authenticating.
      * @return The current instance of {@link ReplicatorBuilder}
-     * @throws NullPointerException if {@code password} is {@code null}.
+     * @throws IllegalArgumentException if {@code password} is {@code null}.
      */
     public E password(String password) {
         Misc.checkNotNull(password, "password");

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/MutableDocumentDeleteTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/MutableDocumentDeleteTest.java
@@ -57,8 +57,8 @@ public class MutableDocumentDeleteTest extends BasicDatastoreTestBase {
     public void deleteNullRevision() throws Exception {
         try {
             DocumentRevision deleted = datastore.delete((DocumentRevision)null);
-            Assert.fail("NullPointerException expected");
-        } catch (NullPointerException npe) {
+            Assert.fail("IllegalArgumentException expected");
+        } catch (IllegalArgumentException iae) {
             ;
         }
     }
@@ -122,8 +122,8 @@ public class MutableDocumentDeleteTest extends BasicDatastoreTestBase {
     public void deleteAllNullRevision() throws Exception {
         try {
             List<? extends DocumentRevision> deleted = datastore.delete((String)null);
-            Assert.fail("NullPointerException expected");
-        } catch (NullPointerException npe) {
+            Assert.fail("IllegalArgumentException expected");
+        } catch (IllegalArgumentException iae) {
             ;
         }
     }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/RevisionHistoryHelperTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/RevisionHistoryHelperTest.java
@@ -94,7 +94,7 @@ public class RevisionHistoryHelperTest {
         RevisionHistoryHelper.revisionHistoryToJson(d);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void revisionHistoryToJson_null_exception() {
         RevisionHistoryHelper.revisionHistoryToJson(null);
     }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/IndexCreatorTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/IndexCreatorTest.java
@@ -17,11 +17,9 @@
 package com.cloudant.sync.internal.query;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
@@ -49,11 +47,11 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
         assertThat(indexes.isEmpty(), is(true));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void preconditionsToCreatingIndexesNullFields() throws QueryException {
         // doesn't create an index on null fields
         im.createJsonIndex(null, "basic");
-        Assert.fail("Expected createJsonIndex to throw a NullPointerException");
+        Assert.fail("Expected createJsonIndex to throw a IllegalArgumentException");
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -74,12 +72,12 @@ public class IndexCreatorTest extends AbstractIndexTestBase {
         Assert.fail("Expected createJsonIndex to throw a IllegalArgumentException");
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void preconditionsToCreatingIndexesNullType() throws QueryException {
         List<FieldSort> fieldNames = null;
         // doesn't create an index on null index type
         im.createJsonIndex(fieldNames, "basic");
-        Assert.fail("Expected createJsonIndex to throw a NullPointerException");
+        Assert.fail("Expected createJsonIndex to throw a IllegalArgumentException");
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/IndexTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/IndexTest.java
@@ -70,8 +70,8 @@ public class IndexTest {
         Index index = new Index(new ArrayList<FieldSort>(), indexName);
     }
 
-    @Test(expected = NullPointerException.class)
-    public void returnsNullWhenNullFields() {
+    @Test(expected = IllegalArgumentException.class)
+    public void throwsIllegalArgumentWhenNullFields() {
         Index index = new Index(null, indexName);
     }
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/QueryCoveringIndexesTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/QueryCoveringIndexesTest.java
@@ -22,7 +22,6 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.runners.Parameterized.Parameters;
 
 import com.cloudant.sync.documentstore.DocumentBodyFactory;
@@ -103,8 +102,8 @@ public class QueryCoveringIndexesTest extends AbstractQueryTestBase {
 
     // When executing AND queries
 
-    @Test(expected = NullPointerException.class)
-    public void returnsNullForNoQuery() throws Exception {
+    @Test(expected = IllegalArgumentException.class)
+    public void throwsIllegalArgumentForNullQuery() throws Exception {
         setUpBasicQueryData();
         idxMgr.find(null);
     }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/DocumentRevsListTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/DocumentRevsListTest.java
@@ -49,7 +49,7 @@ public class DocumentRevsListTest {
         documentRevs.add(documentRevs2);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void null_exception() {
         new DocumentRevsList(null);
     }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/DocumentRevsUtilsTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/DocumentRevsUtilsTest.java
@@ -47,7 +47,7 @@ public class DocumentRevsUtilsTest {
         Assert.assertThat(documentRevs.getOthers().keySet(), hasItems("title", "album"));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void createRevisionIdHistory_null_exception() {
         DocumentRevsUtils.createRevisionIdHistory(null);
     }
@@ -92,7 +92,7 @@ public class DocumentRevsUtilsTest {
         Assert.assertEquals("Trouble Two", body.get("title"));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void createDocument_null_exception() {
         DocumentRevsUtils.createDocument(null);
     }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/GetRevisionTaskTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/GetRevisionTaskTest.java
@@ -16,17 +16,17 @@
 
 package com.cloudant.sync.internal.replication;
 
-import com.cloudant.sync.internal.mazha.DocumentRevs;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.cloudant.sync.internal.documentstore.DocumentRevsList;
+import com.cloudant.sync.internal.mazha.DocumentRevs;
 
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -120,7 +120,7 @@ public class GetRevisionTaskTest {
 
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void test_null_docId() {
         CouchDB sourceDB = mock(CouchDB.class);
         ArrayList<String> revIds = new ArrayList<String>();
@@ -131,7 +131,7 @@ public class GetRevisionTaskTest {
         new GetRevisionTaskThreaded(sourceDB, requests, pullAttachmentsInline);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void test_null_revId() {
         CouchDB sourceDB = mock(CouchDB.class);
         List<BulkGetRequest> requests = new ArrayList<BulkGetRequest>();
@@ -139,7 +139,7 @@ public class GetRevisionTaskTest {
         new GetRevisionTaskThreaded(sourceDB, requests, pullAttachmentsInline);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void test_null_sourceDb() {
         ArrayList<String> revIds = new ArrayList<String>();
         revIds.add("revId");

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/util/MiscTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/util/MiscTest.java
@@ -101,7 +101,7 @@ public class MiscTest {
     public void defaultNullObjectCheck() throws Exception {
         try {
             Misc.checkNotNull(null, null);
-        } catch(NullPointerException e) {
+        } catch(IllegalArgumentException e) {
             Assert.assertEquals("Parameter must not be null.", e.getMessage());
         }
     }
@@ -128,7 +128,7 @@ public class MiscTest {
     public void nullObjectCheck() throws Exception {
         try {
             Misc.checkNotNull(null, "Test argument");
-        } catch(NullPointerException e) {
+        } catch(IllegalArgumentException e) {
             Assert.assertEquals("Test argument must not be null.", e.getMessage());
         }
     }

--- a/doc/CrudSamples.java
+++ b/doc/CrudSamples.java
@@ -275,7 +275,7 @@ public class CrudSamples {
         rev = new DocumentRevision();
 
         saved = ds.database().create(rev);
-        // will throw java.lang.NullPointerException: Input document body can not be null
+        // will throw java.lang.IllegalArgumentException: Input document body can not be null
 
         // Updating a document
 


### PR DESCRIPTION
*What*

Changed `NullPointerException` to `IllegalArgumentException` when checking parameters

*Why*

For consistency made all the illegal arguments (including `null`) throw the same exception type, `IllegalArgumentException`.

*How*

Changed `Misc.checkNotNull`from throwing `NullPointerException` to throwing `IllegalArgumentException`.
Since the methods now throw the same type, simplified `checkNotNullOrEmpty` to use `checkNotNull`.

*Tests*

Refactored tests to match the change. Tests pass.

*Issues*

Part of #413 