### PR TITLE
413 replication

### DIFF
--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/replication/ReplicationListener.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/replication/ReplicationListener.java
@@ -1,0 +1,73 @@
+package com.cloudant.sync.internal.replication;
+
+import com.cloudant.sync.event.Subscribe;
+import com.cloudant.sync.event.notifications.ReplicationCompleted;
+import com.cloudant.sync.event.notifications.ReplicationErrored;
+import com.cloudant.sync.replication.ReplicationPolicyManager;
+import com.cloudant.sync.replication.Replicator;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * This class is not intended as API, it is public for EventBus access only.
+ * API consumers should not call these methods. Forwards events from the EventBus to a
+ * {@link com.cloudant.sync.replication.ReplicationPolicyManager.ReplicationsCompletedListener}.
+ */
+public class ReplicationListener {
+
+    private final Set<Replicator> replicatorsInProgress = new HashSet<Replicator>();
+    private ReplicationPolicyManager.ReplicationsCompletedListener replicationsCompletedListener
+            = null;
+
+    public void setReplicationsCompletedListener(ReplicationPolicyManager
+                                                         .ReplicationsCompletedListener
+                                                         replicationsCompletedListener) {
+        this.replicationsCompletedListener = replicationsCompletedListener;
+    }
+
+    public boolean add(Replicator replicator) {
+        synchronized (replicatorsInProgress) {
+            boolean added = replicatorsInProgress.add(replicator);
+            if (added) {
+                replicator.getEventBus().register(this);
+            }
+            return added;
+        }
+    }
+
+    public boolean remove(Replicator replicator) {
+        synchronized (replicatorsInProgress) {
+            boolean removed = replicatorsInProgress.remove(replicator);
+            if (removed) {
+                replicator.getEventBus().unregister(this);
+            }
+            return removed;
+        }
+    }
+
+    @Subscribe
+    public void complete(ReplicationCompleted event) {
+        finishedReplication(event.replicator);
+        if (replicationsCompletedListener != null) {
+            replicationsCompletedListener.replicationCompleted(event.replicator.getId());
+        }
+    }
+
+    @Subscribe
+    public void error(ReplicationErrored event) {
+        finishedReplication(event.replicator);
+        if (replicationsCompletedListener != null) {
+            replicationsCompletedListener.replicationErrored(event.replicator.getId());
+        }
+    }
+
+    public void finishedReplication(Replicator replicator) {
+        synchronized (replicatorsInProgress) {
+            remove(replicator);
+            if (replicatorsInProgress.size() == 0 && replicationsCompletedListener != null) {
+                replicationsCompletedListener.allReplicationsCompleted();
+            }
+        }
+    }
+}

--- a/doc/migration.md
+++ b/doc/migration.md
@@ -250,8 +250,17 @@ winning revision.
 
 ## Changes to Replication Policies
 
-The `IntervalTimerReplicationPolicyManager` was moved into the `cloudant-sync-datastore-javase`
+* The `IntervalTimerReplicationPolicyManager` was moved into the `cloudant-sync-datastore-javase`
 module since it was not suitable for running on Android anyway.
+
+* The Android `ReplicationService` now uses the same `ReplicationsCompletedListener` interface as
+the `ReplicationPolicyManager`. The `ReplicationService.ReplicationCompleteListener` has been
+removed and implementers should implement `ReplicationPolicyManager.ReplicationsCompletedListener`
+instead. Migration also requires some minor method renames.
+
+* The `ReplicationService.SimpleReplicationCompleteListener` has been moved to
+`ReplicationPolicyManager.SimpleReplicationsCompletedListener` and now implements
+`ReplicationPolicyManager.ReplicationsCompletedListener`.
 
 ## Changes to `Changes`
 

--- a/doc/replication-policies.md
+++ b/doc/replication-policies.md
@@ -337,7 +337,7 @@ private ServiceConnection mConnection = new ServiceConnection() {
     @Override
     public void onServiceConnected(ComponentName name, IBinder service) {
         mReplicationService = ((ReplicationService.LocalBinder) service).getService();
-        mReplicationService.addListener(new ReplicationService.SimpleReplicationCompleteListener() {
+        mReplicationService.addListener(new ReplicationPolicyManager.SimpleReplicationsCompletedListener() {
             @Override
             public void replicationComplete(int id) {
                 // Check if this is the pull replication


### PR DESCRIPTION
*What*

Replication policies API changes for 2.0.0

*Why*

The `ReplicationPolicyManager.ReplicationListener` class was `public` (although marked API private) so that the `EventBus` could invoke it, but it is not API so moved into a class of its own and into the `internal` package.

There were two nearly identical listener classes in the replication policies API. `ReplicationService.ReplicationCompleteListener` and `ReplicationPolicyManager.ReplicationsCompletedListener`.

*How*

Extracted `ReplicationListener` class.
Removed `ReplciationCompleteListener` and replaced usages with `ReplicationsCompletedListener`
Moved `ReplicationService.SimpleReplicationCompleteListener` to
`ReplicationManager.SimpleReplicationsCompletedListener`.

Updated migration documentation.

*Testing*

No test changes needed, Existing tests pass.

*Issues*

Part of #413 
