### PR TITLE
V2 Minor fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -117,7 +117,7 @@
   `MutableDocumentRevision` classes have been removed, in order to
   simplify use of API methods. All code using this library will need
   to be updated to use the `DocumentRevision` class. See the updated
-  [CRUD guide](https://github.com/cloudant/sync-android/blob/master/doc/crud.md)
+  [CRUD guide](https://github.com/cloudant/sync-android/blob/master/doc/CrudSamples.java)
   for examples of how to use this class.
 - [BREAKING CHANGE] Index type is now defined as an enum. This affects
  the following APIs:

--- a/doc/CrudSamples.java
+++ b/doc/CrudSamples.java
@@ -182,7 +182,7 @@ public class CrudSamples {
 
         DocumentRevision saved = ds.database().create(rev);
 
-        // Above, we used UnsavedFileAttachment for data which was already on disk Use
+        // Above, we used UnsavedFileAttachment for data which was already on disk. Use
         // UnsavedStreamAttachment for data which comes from an InputStream or is already in
         // memory.
 

--- a/doc/replication.md
+++ b/doc/replication.md
@@ -89,7 +89,7 @@ needing to poll:
  * A {@code ReplicationListener} that sets a latch when it's told the
  * replication has finished.
  */
-private class Listener {
+public class Listener {
 
     private final CountDownLatch latch;
     public List<Throwable> errors = new ArrayList<Throwable>();


### PR DESCRIPTION
Fix broken link in `CHANGES.md`

Add full stop in `CrudSamples.java`

In the example in `replication.md`, Listener needs to be `public` so the event handler can invoke the listener.

