### PR TITLE
Jenkins pipeline file: clean before checkout

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,13 @@
 stage('Build') {
     // Checkout, build and assemble the source and doc
     node {
-        checkout scm
+        checkout([
+            $class: 'GitSCM',
+            branches: scm.branches,
+            doGenerateSubmoduleConfigurations: scm.doGenerateSubmoduleConfigurations,
+            extensions: scm.extensions + [[$class: 'CleanBeforeCheckout']],
+            userRemoteConfigs: scm.userRemoteConfigs
+        ])
         sh './gradlew clean assemble'
         stash name: 'built'
     }


### PR DESCRIPTION
_What_

Add extension flag to `Jenkinsfile` for `CleanBeforeCheckout`.

See https://support.cloudbees.com/hc/en-us/articles/226122247-How-to-Customize-Checkout-for-Pipeline-Multibranch

_Why_

Sometimes when files have moved in git, the checkout leaves the old files behind, which can cause build failures.

_Testing_

After adding relevant in-process script approvals, Jenkins cleans the source directory the build proceeds as normal.