### PR TITLE
416 create with history

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,7 +31,10 @@
 - [NOTE] The "CRUD Guide" markdown document (previously located in
   `doc/crud.md`) has been migrated to a
   [java source file](https://github.com/cloudant/sync-android/blob/2.0.0/doc/CrudSamples.java).
-  
+
+- [NEW] `databaseWithAdvancedAPIs()` getter on `DocumentStore` for specialist advanced use cases.
+  Adds support for creating specific document revisions with history.
+
 - [FIXED] Issue with double encoding of restricted URL characters in credentials when using
   `ReplicatorBuilder`.
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/Database.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/Database.java
@@ -287,12 +287,13 @@ public interface Database {
      * @param rev the {@link DocumentRevision} to be updated
      * @return a {@link DocumentRevision} - the updated document
      * @throws ConflictException if <code>rev</code> is not a current revision for this document
+     * @throws DocumentNotFoundException if the {@code rev} being updated does not exist
      * @throws AttachmentException if there was an error saving any new attachments
      * @throws DocumentStoreException if there was an error reading from or writing to the database
      * @see Database#getEventBus()
      */
     DocumentRevision update(DocumentRevision rev) throws ConflictException,
-            AttachmentException, DocumentStoreException;
+            AttachmentException, DocumentStoreException, DocumentNotFoundException;
 
     /**
      * <p>Deletes a document from the datastore.</p>

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/DocumentRevision.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/DocumentRevision.java
@@ -105,6 +105,20 @@ public class DocumentRevision {
         return deleted;
     }
 
+    /**
+     * To delete a document it is preferable to call {@link Database#delete(DocumentRevision)}.
+     * Some use cases need to do a delete via an update in which case it is possible to
+     * call this method, followed by {@link Database#update(DocumentRevision)}.
+     *
+     * This method sets the document revision's {@code _deleted} flag to true and removes the body
+     * and attachments from the document revision.
+     *
+     */
+    public void setDeleted() {
+        this.deleted = true;
+        this.setBody(DocumentBodyFactory.EMPTY);
+    }
+
     public Map<String, Attachment> getAttachments() {
         return attachments;
     }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/DocumentStore.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/DocumentStore.java
@@ -16,15 +16,15 @@ package com.cloudant.sync.documentstore;
 
 import com.cloudant.sync.documentstore.encryption.KeyProvider;
 import com.cloudant.sync.documentstore.encryption.NullKeyProvider;
-import com.cloudant.sync.internal.documentstore.DatabaseImpl;
 import com.cloudant.sync.event.EventBus;
 import com.cloudant.sync.event.notifications.DocumentStoreClosed;
 import com.cloudant.sync.event.notifications.DocumentStoreCreated;
 import com.cloudant.sync.event.notifications.DocumentStoreDeleted;
-import com.cloudant.sync.event.notifications.DocumentStoreOpened;
 import com.cloudant.sync.event.notifications.DocumentStoreModified;
-import com.cloudant.sync.query.Query;
+import com.cloudant.sync.event.notifications.DocumentStoreOpened;
+import com.cloudant.sync.internal.documentstore.DatabaseImpl;
 import com.cloudant.sync.internal.query.QueryImpl;
+import com.cloudant.sync.query.Query;
 
 import org.apache.commons.io.FileUtils;
 
@@ -68,7 +68,7 @@ public class DocumentStore {
 
     private static final String EXTENSIONS_LOCATION_NAME = "extensions";
 
-    private final Database database;
+    private final DatabaseImpl database;
     private final Query query;
     protected final String databaseName; // only used for events
     private final File location; // needed for close/delete
@@ -188,6 +188,18 @@ public class DocumentStore {
     }
 
     /**
+     * WARNING: accessing APIs exposed on the
+     * {@link com.cloudant.sync.documentstore.advanced.Database} class returned by this method is
+     * not required for typical use cases. Refer to the javadoc in the
+     * {@link com.cloudant.sync.documentstore.advanced} package before using this.
+     *
+     * @return interface to advanced database methods
+     */
+    public com.cloudant.sync.documentstore.advanced.Database advanced() {
+        return database;
+    }
+
+    /**
      * <p>
      * Get a reference to the {@link Query} object.
      * </p>
@@ -208,7 +220,7 @@ public class DocumentStore {
         synchronized (documentStores) {
             DocumentStore ds = documentStores.remove(location);
             if (ds != null) {
-                ((DatabaseImpl)database).close();
+                database.close();
                 ((QueryImpl)query).close();
             }
             else {
@@ -255,7 +267,7 @@ public class DocumentStore {
 
     private void closeQuietlyOnException() {
         if (database != null) {
-            ((DatabaseImpl) database).close();
+            database.close();
         }
         if (query != null) {
             ((QueryImpl) query).close();

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/advanced/Database.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/advanced/Database.java
@@ -1,0 +1,136 @@
+package com.cloudant.sync.documentstore.advanced;
+
+import com.cloudant.sync.documentstore.DocumentException;
+import com.cloudant.sync.documentstore.DocumentRevision;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * <P>
+ * ⚠ Database API methods for advanced use cases.
+ * </P>
+ * <P>
+ * ⚠ Interacting with these methods is not required for the typical use cases. Use with extreme
+ * caution.
+ * </P>
+ */
+public interface Database {
+
+    /**
+     * <P>
+     * ⚠ Creates a new revision in the database with the specified revision history.
+     * </P>
+     * <P>
+     * This is equivalent to inserting a revision with {@code new_edits: false}, functionality that
+     * is typically only required by replicators.
+     * </P>
+     * <P>
+     * Note that the revisionsStart and revisionsIDs parameters describe the revision history of the
+     * document revision being inserted. This history is equivalent to getting the document from
+     * CouchDB with the {@code revs=true} parameter.
+     * An example document retrieved with this _revisions history would be:
+     * </P>
+     * <pre>
+     * {@code
+     * {"_id”:”exampledoc1”,
+     * "_rev":"4-51aa94e4b0ef37271082033bba52b850",
+     * "_revisions":
+     *     {"start":4,
+     *      "ids": [“51aa94e4b0ef37271082033bba52b850",
+     *              "f9fb951ca8dadec1459450156b2205cf",
+     *              "617a372bba833d7acf3ccf2e7dece15a",
+     *              "967a00dff5e02add41819138abb3284d"]
+     *     },
+     *     ... // other document properties
+     * }
+     * }
+     * </pre>
+     * <P>
+     * Example usage to insert this example document:
+     * </P>
+     * <pre>
+     * {@code
+     * DocumentRevision documentRevision = new DocumentRevision("exampledoc1",
+     *     "4-51aa94e4b0ef37271082033bba52b850");
+     * // set document content etc
+     * documentRevision.setBody(...)
+     *
+     * // set attachments if necessary, see note on attachments below.
+     *
+     * documentStore.advanced()
+     *    .createWithHistory(documentRevision, 4, Arrays.asList(“51aa94e4b0ef37271082033bba52b850",
+     *              "f9fb951ca8dadec1459450156b2205cf",
+     *              "617a372bba833d7acf3ccf2e7dece15a",
+     *              "967a00dff5e02add41819138abb3284d"))
+     * }
+     * </pre>
+     * <P>
+     * If the document is deleted then the inserted revision also needs to be made deleted as in
+     * this example:
+     * </P>
+     * <pre>
+     * {@code
+     * DocumentRevision documentRevision = new DocumentRevision("exampledoc1",
+     *     "4-51aa94e4b0ef37271082033bba52b850");
+     * // set document as deleted
+     * documentRevision.setDeleted()
+     *
+     * documentStore.advanced()
+     *    .createWithHistory(documentRevision, 4, Arrays.asList(“51aa94e4b0ef37271082033bba52b850",
+     *              "f9fb951ca8dadec1459450156b2205cf",
+     *              "617a372bba833d7acf3ccf2e7dece15a",
+     *              "967a00dff5e02add41819138abb3284d"))
+     * }
+     * </pre>
+     * <P>
+     * <B>Attachments</B>
+     * </P>
+     * <P>
+     * Note it is the caller's responsibility to correctly set the attachments on the revision to be
+     * created. The existing attachments should be compared to the attachments metadata present in
+     * the JSON of the document revision to be created and an appropriate call made to
+     * {@link DocumentRevision#setAttachments(Map)} to transfer that metadata and any new attachment
+     * files to the {@code DocumentRevision} object. If a comparison of the JSON attachment metadata
+     * to the existing attachments indicates that no new attachments are being added then it is
+     * possible to simply set the existing attachment map like this:
+     * </P>
+     * <pre>
+     * {@code
+     * // Get the existing attachments from the current revision
+     * Map<String, Attachment> atts = database.read("exampledoc1").getAttachments();
+     * // Set the attachment metadata on the DocumentRevision object that will be passed to
+     * // createWithHistory.
+     * documentRevision.setAttachments(atts);
+     * }
+     * </pre>
+     * <P>
+     * If new attachments need to be added, then the normal CRUD API for creating or updating
+     * attachments should be used to create the attachments on the revision before calling
+     * createWithHistory, for example, using
+     * {@link com.cloudant.sync.documentstore.UnsavedFileAttachment}.
+     * </P>
+     * <P>
+     * If no attachments are set then attachments on ancestor revisions in the existing tree will
+     * be deleted on the newly created revision, as it is equivalent to performing an update with an
+     * empty attachment map. It is essential to check for existing attachments and set them
+     * appropriately on the DocumentRevision if you want to preserve attachments when calling
+     * createWithHistory.
+     * </P>
+     *
+     * @param documentRevision the revision of the document to create in the database
+     * @param revisionsStart   the generation ID of the revision being inserted, for
+     *                         example obtained from the {@code start} property of
+     *                         the {@code _revisions} property object of a document
+     *                         obtained with {@code revs=true}
+     * @param revisionsIDs     the sequence of revision IDs (excluding the generational prefix)
+     *                         starting with the revision being inserted and progressing to the root
+     *                         of the document, for example a list of the JSON array content of the
+     *                         {@code ids} property of the {@code _revisions} property object of a
+     *                         document obtained with {@code revs=true}
+     * @throws DocumentException if there was an error inserting the revision or its attachments
+     *                           into the database
+     */
+    void createWithHistory(DocumentRevision documentRevision, int revisionsStart, List<String>
+            revisionsIDs) throws DocumentException;
+}

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/advanced/package-info.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/advanced/package-info.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+/**
+ * <P>
+ * ⚠ The interfaces in this package are not needed for typical use of the sync library.
+ * </P>
+ * <P>
+ * ⚠ These interfaces are provided for flexibility to allow interactions with the database that
+ * would otherwise be prevented by the API, but are necessary for some use cases. An example would
+ * be writing your own replicator for this library's DocumentStore.
+ * </P>
+ * <P>
+ * ⚠ Use of the APIs in this package is beyond the intended use case of the sync library and by
+ * their nature they may expose untested edge cases. Incorrect use of the APIs could result in data
+ * loss or corruption. You should only use these interfaces if you really know what you are doing!
+ * </P>
+ */
+package com.cloudant.sync.documentstore.advanced;

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/common/CouchUtils.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/common/CouchUtils.java
@@ -18,8 +18,9 @@ package com.cloudant.sync.internal.common;
 
 import com.cloudant.sync.internal.util.Misc;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 
 public class CouchUtils {
@@ -48,23 +49,23 @@ public class CouchUtils {
         return true;
     }
 
-    /*
-     * Parses the _revisions dict from a document into an array of revision ID strings
+    /**
+     * Get an ascending order revision list from the couch style {@code _revisions} history of
+     * {@code start} and hash {@code ids}.
+     *
+     * @param start the starting generation
+     * @param ids   the list of ID hashes
+     * @return
      */
-    public static List<String> parseCouchDBRevisionHistory(Map<String, Object> docProperties) {
-        Map<String, Object> revisions = (Map<String, Object>) docProperties.get(CouchConstants._revisions);
-        if (revisions == null) {
-            return null;
+    public static List<String> couchStyleRevisionHistoryToFullRevisionIDs(final int start, List<String> ids) {
+        List<String> revisionHistory = new ArrayList<String>();
+        int generation = start;
+        for (String revIdHash : ids) {
+            revisionHistory.add(generation + "-" + revIdHash);
+            generation--;
         }
-        List<String> revIDs = (List<String>) revisions.get(CouchConstants.ids);
-        Integer start = (Integer) revisions.get(CouchConstants.start);
-        if (start != null) {
-            for (int i = 0; i < revIDs.size(); i++) {
-                String revID = revIDs.get(i);
-                revIDs.set(i, Integer.toString(start--) + "-" + revID);
-            }
-        }
-        return revIDs;
+        Collections.reverse(revisionHistory);
+        return revisionHistory;
     }
 
     public static String getFirstLocalDocRevisionId() {

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/DatabaseImpl.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/DatabaseImpl.java
@@ -1073,7 +1073,8 @@ public class DatabaseImpl implements Database {
 
     @Override
     public DocumentRevision update(final DocumentRevision rev)
-            throws AttachmentException, DocumentStoreException, ConflictException {
+            throws AttachmentException, DocumentNotFoundException, ConflictException,
+            DocumentStoreException  {
 
         Misc.checkNotNull(rev, "DocumentRevision");
         Misc.checkState(isOpen(), "Datastore is closed");
@@ -1112,6 +1113,8 @@ public class DatabaseImpl implements Database {
             throwCauseAs(e, InvalidDocumentException.class);
             // conflictexception if rev ID is not winning rev
             throwCauseAs(e, ConflictException.class);
+            // not found if tried to update something that doesn't exist
+            throwCauseAs(e, DocumentNotFoundException.class);
             String message = "Failed to update document";
             logger.log(Level.SEVERE, message, e);
             throw new DocumentStoreException(message, e.getCause());

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/DatabaseImpl.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/DatabaseImpl.java
@@ -557,20 +557,6 @@ public class DatabaseImpl implements Database {
     }
 
     /**
-     * This method has been deprecated and should not be used.
-     * @see #forceInsert(List)
-     */
-    @Deprecated
-    public void forceInsert(final InternalDocumentRevision rev,
-                            final List<String> revisionHistory,
-                            final Map<String, Object> attachments,
-                            final Map<String[], Map<String, PreparedAttachment>> preparedAttachments,
-                            final boolean pullAttachmentsInline) throws DocumentException {
-        forceInsert(Collections.singletonList(new ForceInsertItem(rev, revisionHistory,
-                attachments, preparedAttachments, pullAttachmentsInline)));
-    }
-
-    /**
      * <p>
      * Inserts one or more revisions of a document into the database. For efficiency, this is
      * performed as one database transaction.
@@ -674,22 +660,21 @@ public class DatabaseImpl implements Database {
      * <p>Equivalent to:</p>
      *
      * <code>
-     *    forceInsert(rev, Arrays.asList(revisionHistory), null, null, false);
+     * forceInsert(rev, Arrays.asList(revisionHistory), null, null, false);
      * </code>
      *
-     * @param rev A {@code DocumentRevision} containing the information for a revision
-     *            from a remote datastore.
+     * @param rev             A {@code DocumentRevision} containing the information for a revision
+     *                        from a remote datastore.
      * @param revisionHistory The history of the revision being inserted,
      *                        including the rev ID of {@code rev}. This list
      *                        needs to be sorted in ascending order
-     *
-     * @see DatabaseImpl#forceInsert(InternalDocumentRevision, List, Map, Map, boolean)
      * @throws DocumentException if there was an error inserting the revision into the database
      */
     public void forceInsert(InternalDocumentRevision rev, String... revisionHistory) throws
             DocumentException {
         Misc.checkState(this.isOpen(), "Database is closed");
-        this.forceInsert(rev, Arrays.asList(revisionHistory), null, null, false);
+        this.forceInsert(Collections.singletonList(new ForceInsertItem(rev, Arrays.asList
+                (revisionHistory), null, null, false)));
     }
 
     private boolean checkRevisionIsInCorrectOrder(List<String> revisionHistory) {

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/DatabaseImpl.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/DatabaseImpl.java
@@ -1081,6 +1081,11 @@ public class DatabaseImpl implements Database {
         Misc.checkArgument(rev.isFullRevision(), "Projected revisions cannot be used to " +
                 "create documents");
 
+        // Shortcut if this is a deletion
+        if (rev.isDeleted()) {
+            return delete(rev);
+        }
+
         // We need to work out which of the attachments for the revision are ones
         // we can copy over because they exist in the attachment store already and
         // which are new, that we need to prepare for insertion.

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/DocumentRevsUtils.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/DocumentRevsUtils.java
@@ -16,13 +16,11 @@
 
 package com.cloudant.sync.internal.documentstore;
 
+import com.cloudant.sync.documentstore.DocumentBodyFactory;
 import com.cloudant.sync.internal.common.CouchUtils;
 import com.cloudant.sync.internal.mazha.DocumentRevs;
-import com.cloudant.sync.documentstore.DocumentBodyFactory;
 import com.cloudant.sync.internal.util.Misc;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -47,13 +45,9 @@ public class DocumentRevsUtils {
         int generation = CouchUtils.generationFromRevId(latestRevision);
         assert generation == documentRevs.getRevisions().getStart();
 
-        List<String> revisionHistory = new ArrayList<String>();
-        for (String revision : documentRevs.getRevisions().getIds()) {
-            revisionHistory.add(generation + "-" + revision);
-            generation--;
-        }
-        Collections.reverse(revisionHistory);
-        logger.log(Level.FINER,"Revisions history: "+revisionHistory);
+        List<String> revisionHistory = CouchUtils.couchStyleRevisionHistoryToFullRevisionIDs
+                (generation, documentRevs.getRevisions().getIds());
+        logger.log(Level.FINER, "Revisions history: " + revisionHistory);
         return revisionHistory;
     }
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/ForceInsertItem.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/ForceInsertItem.java
@@ -14,6 +14,7 @@
 
 package com.cloudant.sync.internal.documentstore;
 
+
 import java.util.List;
 import java.util.Map;
 
@@ -24,9 +25,28 @@ public class ForceInsertItem {
     public InternalDocumentRevision rev;
     public List<String> revisionHistory;
     public Map<String, Object> attachments;
-    public Map<String[],Map<String, PreparedAttachment>>preparedAttachments;
+    public Map<String[], Map<String, PreparedAttachment>> preparedAttachments;
     public boolean pullAttachmentsInline;
 
+    /**
+     * @param rev                   A {@code DocumentRevision} containing the information for a
+     *                              revision from a remote datastore.
+     * @param revisionHistory       The history of the revision being inserted, including the rev
+     *                              ID of {@code rev}. This list needs to be sorted in ascending
+     *                              order.
+     * @param attachments           Attachments metadata and inline data. Used when {@code
+     *                              pullAttachmentsInline} true.
+     * @param preparedAttachments   Attachments that have already been prepared, this is a Map of
+     *                              String[docId,revId] → list of attachmentsNon-empty. Used when
+     *                              {@code pullAttachmentsInline} false.
+     * @param pullAttachmentsInline If true, use {@code attachments} metadata and data directly
+     *                              from received JSON to add new attachments for this revision.
+     *                              Else use {@code preparedAttachments} which were previously
+     *                              downloaded and prepared by
+     *                              {@link AttachmentManager#prepareAttachments(String, AttachmentStreamFactory, Map)}
+     *                              as for example by
+     *                              {@link com.cloudant.sync.internal.replication.PullStrategy}
+     */
     public ForceInsertItem(InternalDocumentRevision rev, List<String> revisionHistory,
                            Map<String, Object> attachments, Map<String[],
             Map<String, PreparedAttachment>> preparedAttachments, boolean pullAttachmentsInline) {

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/DoForceInsertNewDocumentWithHistoryCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/DoForceInsertNewDocumentWithHistoryCallable.java
@@ -15,8 +15,9 @@
 package com.cloudant.sync.internal.documentstore.callables;
 
 import com.cloudant.sync.documentstore.AttachmentException;
-import com.cloudant.sync.internal.documentstore.DatabaseImpl;
+import com.cloudant.sync.documentstore.DocumentBodyFactory;
 import com.cloudant.sync.documentstore.DocumentStoreException;
+import com.cloudant.sync.internal.documentstore.DatabaseImpl;
 import com.cloudant.sync.internal.documentstore.InternalDocumentRevision;
 import com.cloudant.sync.internal.sqlite.SQLCallable;
 import com.cloudant.sync.internal.sqlite.SQLDatabase;
@@ -68,7 +69,9 @@ public class DoForceInsertNewDocumentWithHistoryCallable implements SQLCallable<
         callable.parentSequence = parentSequence;
         callable.deleted = rev.isDeleted();
         callable.current = true;
-        callable.data = rev.getBody().asBytes();
+        // If the body is null treat it as empty
+        callable.data = rev.getBody() == null ? DocumentBodyFactory.EMPTY.asBytes() : rev.getBody
+                ().asBytes();
         callable.available = true;
         long sequence = callable.call(db);
         return sequence;

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/replication/DatastoreWrapper.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/replication/DatastoreWrapper.java
@@ -35,6 +35,7 @@ import com.cloudant.sync.internal.mazha.DocumentRevs;
 import com.cloudant.sync.internal.util.JSONUtils;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -120,7 +121,8 @@ class DatastoreWrapper {
 
             List<String> revisions = DocumentRevsUtils.createRevisionIdHistory(documentRevs);
             Map<String, Object> attachments = documentRevs.getAttachments();
-            dbCore.forceInsert(doc, revisions, attachments,preparedAttachments, pullAttachmentsInline);
+            dbCore.forceInsert(Collections.singletonList(new ForceInsertItem(doc, revisions,
+                    attachments, preparedAttachments, pullAttachmentsInline)));
         }
     }
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/common/AdvancedAPITest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/common/AdvancedAPITest.java
@@ -1,0 +1,20 @@
+package com.cloudant.common;
+
+import com.cloudant.sync.documentstore.advanced.Database;
+
+import org.junit.Before;
+
+/**
+ * Superclass that exposes the "advanced" Database APIs for testing
+ */
+public class AdvancedAPITest extends DocumentStoreTestBase {
+
+    protected Database advancedDatabase;
+
+    @Before
+    public void setUpAdvanced() throws Exception {
+        advancedDatabase = documentStore.advanced();
+    }
+
+
+}

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/common/DocumentStoreTestBase.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/common/DocumentStoreTestBase.java
@@ -1,0 +1,30 @@
+package com.cloudant.common;
+
+import com.cloudant.sync.documentstore.DocumentStore;
+import com.cloudant.sync.util.TestUtils;
+
+import org.junit.After;
+import org.junit.Before;
+
+import java.io.File;
+
+public abstract class DocumentStoreTestBase {
+
+    protected DocumentStore documentStore;
+
+    protected String datastore_manager_dir;
+
+    @Before
+    public void setUpDocumentStore() throws Exception {
+        datastore_manager_dir = TestUtils.createTempTestingDir(this.getClass().getName());
+        this.documentStore = DocumentStore.getInstance(new File
+                (datastore_manager_dir, getClass().getSimpleName()));
+
+    }
+
+    @After
+    public void tearDownDocumentStore() {
+        documentStore.close();
+        TestUtils.deleteTempTestingDir(datastore_manager_dir);
+    }
+}

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/advanced/CreateWithHistoryTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/advanced/CreateWithHistoryTest.java
@@ -1,0 +1,847 @@
+package com.cloudant.sync.advanced;
+
+import static com.cloudant.sync.advanced.CreateWithHistoryTest.TestDoc.REV1;
+import static com.cloudant.sync.advanced.CreateWithHistoryTest.TestDoc.REV2;
+import static com.cloudant.sync.advanced.CreateWithHistoryTest.TestDoc.REV3;
+
+import com.cloudant.common.AdvancedAPITest;
+import com.cloudant.sync.documentstore.Attachment;
+import com.cloudant.sync.documentstore.ConflictResolver;
+import com.cloudant.sync.documentstore.Database;
+import com.cloudant.sync.documentstore.DocumentBody;
+import com.cloudant.sync.documentstore.DocumentBodyFactory;
+import com.cloudant.sync.documentstore.DocumentException;
+import com.cloudant.sync.documentstore.DocumentRevision;
+import com.cloudant.sync.documentstore.UnsavedFileAttachment;
+import com.cloudant.sync.documentstore.UnsavedStreamAttachment;
+import com.cloudant.sync.internal.common.CouchUtils;
+import com.cloudant.sync.internal.documentstore.DatabaseImpl;
+import com.cloudant.sync.internal.documentstore.DocumentRevisionTree;
+import com.cloudant.sync.internal.documentstore.InternalDocumentRevision;
+import com.cloudant.sync.util.TestUtils;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Test creating document revisions with history. We use an example revision 3-ghi with a history
+ * 1-abc
+ * 2-def
+ * 3-ghi
+ */
+public class CreateWithHistoryTest extends AdvancedAPITest {
+
+    enum TestDoc {
+
+        REV1(1, "abc"),
+        REV2(2, "def"),
+        REV3(3, "ghi");
+
+        static final String ID = "testdoc";
+        final DocumentRevision revision;
+        final int generation;
+        final DocumentBody body;
+
+        TestDoc(int generation, String hash) {
+            this.generation = generation;
+            this.revision = new DocumentRevision(TestDoc.ID, generation + "-" + hash);
+            this.body = DocumentBodyFactory.create(Collections.singletonMap
+                    ("number_" + generation, "property_" + hash));
+            revision.setBody(body);
+        }
+
+        private DocumentRevision makeUnversioned() {
+            DocumentRevision rev = new DocumentRevision(ID);
+            rev.setBody(body);
+            return rev;
+        }
+    }
+
+    private Database database;
+
+    @Before
+    public void initDatabase() {
+        database = documentStore.database();
+    }
+
+    /**
+     * Utility to create some document revisions with bodies matching the TestDoc pattern
+     *
+     * @param generations number of generations to create between 1 and 3
+     * @return
+     * @throws Exception
+     */
+    private List<DocumentRevision> createRevisions(int generations) throws Exception {
+        return createRevisions(generations, false);
+    }
+
+    /**
+     * Utility to create some document revisions with bodies matching the TestDoc pattern
+     *
+     * @param generations number of generations to create between 1 and 3
+     * @return
+     * @throws Exception
+     */
+    private List<DocumentRevision> createRevisions(int generations, boolean withAttachments)
+            throws Exception {
+        if (generations > 0 && generations <= 3) {
+            List<DocumentRevision> created = new ArrayList<DocumentRevision>();
+            for (int i = 0; i < generations; i++) {
+                DocumentRevision rev;
+                switch (i) {
+                    case 0:
+                        // First time we need to create
+                        rev = TestDoc.values()[i].makeUnversioned();
+                        if (withAttachments) {
+                            rev.setAttachments(addAttachment(null, i + 1));
+                        }
+                        rev = database.create(rev);
+                        break;
+                    default:
+                        // Use the previous rev to update
+                        DocumentRevision previous = created.get(i - 1);
+                        rev = new DocumentRevision(previous.getId(), previous.getRevision());
+                        rev.setBody(TestDoc.values()[i].body); // Set the new body
+                        if (withAttachments) {
+                            rev.setAttachments(addAttachment(previous.getAttachments(), i + 1));
+                        }
+                        rev = database.update(rev);
+                        break;
+                }
+                created.add(rev);
+            }
+            return created;
+        } else {
+            throw new IllegalArgumentException("This test only supports creating up to 3 " +
+                    "generations");
+        }
+    }
+
+    /**
+     * Utility to add attachments to an existing map, or create a new map
+     *
+     * @param existing
+     * @param attachmentNumber
+     * @return
+     */
+    private Map<String, Attachment> addAttachment(Map<String, Attachment> existing, int
+            attachmentNumber) {
+        if (attachmentNumber < 0 || attachmentNumber > 2) {
+            throw new IllegalArgumentException("Only attachment number 1 or 2 are valid");
+        }
+        String attName = "attachment_" + attachmentNumber + ".txt";
+
+        File a = TestUtils.loadFixture("fixture/" + attName);
+
+        Attachment attachment = new UnsavedFileAttachment(a, "text/plain");
+        if (existing == null) {
+            return Collections.singletonMap(attName, attachment);
+        } else {
+            existing.put(attName, attachment);
+            return existing;
+        }
+    }
+
+    /**
+     * Converts a TestDoc enum set into a collection of revisions
+     *
+     * @param testDocs set of TestDoc revisions in ascending order
+     * @return
+     */
+    private List<DocumentRevision> toRevisionCollection(EnumSet<TestDoc> testDocs) {
+        List<DocumentRevision> revisions = new ArrayList<DocumentRevision>(testDocs.size());
+        for (TestDoc testDoc : testDocs) {
+            revisions.add(testDoc.revision);
+        }
+        return revisions;
+    }
+
+    /**
+     * Creates a _revisons.ids history list from an ascending order list of revisions
+     *
+     * @param revisions
+     * @return
+     */
+    private List<String> toHistory(Collection<DocumentRevision> revisions) {
+        List<String> history = new ArrayList<String>();
+        for (DocumentRevision rev : revisions) {
+            history.add(CouchUtils.getRevisionIdSuffix(rev.getRevision()));
+        }
+        Collections.reverse(history);
+        return history;
+    }
+
+    /**
+     * Assert that the test doc revisions are present
+     *
+     * @throws Exception
+     */
+    private void assertRevisionAndHistoryPresent(Collection<DocumentRevision> testDocRevisions)
+            throws
+            Exception {
+        // Assert that the revision exists
+        Assert.assertTrue("The document ID should be present in the document store", database
+                .contains(TestDoc.ID));
+        // Assert that the specified revisions are present
+        for (DocumentRevision testDoc : testDocRevisions) {
+            Assert.assertTrue("The revision should be present in the document store",
+                    database.contains(TestDoc.ID, testDoc.getRevision()));
+        }
+    }
+
+    /**
+     * Asserts that the only revisions present for a document are the ones expected.
+     * Note this method uses internal APIs.
+     *
+     * @param expectedRevs
+     */
+    private void assertNoUnexpectedRevs(Collection<DocumentRevision>... expectedRevs) {
+        // What we expect
+        Set<String> expected = new HashSet<String>();
+        for (Collection<DocumentRevision> revs : expectedRevs) {
+            for (DocumentRevision rev : revs) {
+                expected.add(rev.getRevision());
+            }
+        }
+
+        // What we can find
+        Set<String> actual = new HashSet<String>();
+        DocumentRevisionTree tree = ((DatabaseImpl) database).getAllRevisionsOfDocument(TestDoc.ID);
+        for (InternalDocumentRevision rev : tree.leafRevisions()) {
+            actual.addAll(tree.getPath(rev.getSequence()));
+        }
+        Assert.assertEquals("There should only be the expected revs", expected, actual);
+    }
+
+    /**
+     * Method to assert the document revision content is what we expect
+     *
+     * @throws Exception
+     */
+    private void assertRevisionContent(Collection<DocumentRevision> expectedRevisions, boolean...
+            expectStubs) throws
+            Exception {
+        int i = 0;
+        for (DocumentRevision expectedRevision : expectedRevisions) {
+            DocumentRevision readRevision = database.read(TestDoc.ID, expectedRevision
+                    .getRevision());
+            // Assert the document is present at the specified revision
+            Assert.assertNotNull("The read revision should not be null", readRevision);
+            // Assert the body matches what is expected
+            DocumentBody expectedBody;
+            if (expectStubs[i]) {
+                expectedBody = DocumentBodyFactory.EMPTY;
+            } else {
+                expectedBody = expectedRevision.getBody();
+            }
+            Assert.assertEquals("The body should be as expected", expectedBody.asMap(), readRevision
+                    .getBody().asMap());
+            i++;
+        }
+    }
+
+    /**
+     * Asserts that the specified revisions are conflicting.
+     *
+     * @param revs
+     * @throws Exception
+     */
+    private void assertConflictBetween(String... revs) throws Exception {
+        Collection<String> conflictedIDs = new HashSet<String>();
+        for (String conflicted : database.getConflictedIds()) {
+            conflictedIDs.add(conflicted);
+        }
+        Assert.assertEquals("The testdoc should be conflicted (and the only conflicted ID)",
+                Collections.singleton(TestDoc.ID), conflictedIDs);
+        // Assert that the conflicted revisions are the ones specified
+        AssertingConflictResolver resolver = new AssertingConflictResolver();
+        database.resolveConflicts(TestDoc.ID, resolver);
+        Set<String> expectedConflictingRevisionIDs = new HashSet<String>();
+        expectedConflictingRevisionIDs.addAll(Arrays.asList(revs));
+        Assert.assertEquals("The expected leaves should be conflicting",
+                expectedConflictingRevisionIDs, resolver.conflictedRevisionIDs);
+    }
+
+    /**
+     * Insert a new document revision with history.
+     * Assert that the REV3 is present and the ancestor revs 1 and 2 are stubs.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testCreateWithHistory() throws Exception {
+        Collection<DocumentRevision> revisions = toRevisionCollection(EnumSet.allOf(TestDoc.class));
+
+        // Create the revision with history
+        advancedDatabase.createWithHistory(REV3.revision, REV3.generation, toHistory(revisions));
+
+        // Assert
+        assertRevisionAndHistoryPresent(revisions);
+        assertRevisionContent(revisions, true, true, false); // Revs 1 and 2 are stubs
+        assertNoUnexpectedRevs(revisions);
+    }
+
+    /**
+     * Insert the document revision when part of the tree already exists (i.e. rev 1 exists).
+     * Assert that rev3 is created, rev2 is inserted as a stub and rev1 is still complete.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testExistingPartialAncestorTree() throws Exception {
+        // Create a partial existing tree for the document
+        List<DocumentRevision> ancestors = createRevisions(1);
+
+        ancestors.add(REV2.revision);
+        ancestors.add(REV3.revision);
+
+        // Now create the revision with history
+        advancedDatabase.createWithHistory(REV3.revision, REV3.generation, toHistory(ancestors));
+
+        // Assert
+        assertRevisionAndHistoryPresent(ancestors);
+        assertRevisionContent(ancestors, false, true, false); // Only 2 should be a stub
+        assertNoUnexpectedRevs(ancestors);
+    }
+
+    /**
+     * Insert a document revision when all its ancestors exist (i.e. revs 1 and 2 exist).
+     * Assert that rev3 is created and that revs 1 and 2 are still complete.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testExistingCompleteAncestorTree() throws Exception {
+        // Create an existing tree for the document, not including the rev we intend to insert
+        List<DocumentRevision> ancestors = createRevisions(2);
+        ancestors.add(REV3.revision);
+
+        // Now create the revision with history
+        advancedDatabase.createWithHistory(REV3.revision, REV3.generation, toHistory(ancestors));
+
+        // Assert
+        assertRevisionAndHistoryPresent(ancestors);
+        assertRevisionContent(ancestors, false, false, false); // None should be stubs
+        assertNoUnexpectedRevs(ancestors);
+    }
+
+    /**
+     * Test inserting rev 3 with history 1 and 2 revs parallel to an existing tree of 3 different
+     * revs. The trees are parallel from the first generation.
+     * Assert that all 6 revisions are present after the createWithHistory and that a conflict
+     * exists for the two latest generation docs.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testRootConflict() throws Exception {
+        List<DocumentRevision> parallelTree = createRevisions(3);
+        List<DocumentRevision> testDocTree = toRevisionCollection(EnumSet.allOf(TestDoc.class));
+        // Insert our root conflict
+        advancedDatabase.createWithHistory(REV3.revision, REV3.generation, toHistory(testDocTree));
+
+        // Assert both trees are good
+        assertRevisionAndHistoryPresent(testDocTree);
+        assertRevisionContent(testDocTree, true, true, false); // Revs 1 and 2 are stubs
+
+        assertRevisionAndHistoryPresent(parallelTree);
+        assertRevisionContent(parallelTree, false, false, false); // None are stubs
+
+        assertNoUnexpectedRevs(testDocTree, parallelTree);
+
+        assertConflictBetween(REV3.revision.getRevision(), parallelTree.get(2).getRevision());
+    }
+
+    /**
+     * Similar to {@link #testRootConflict()} but now the revs 1 and 2 are identical for both trees,
+     * they only diverge at the 3rd revision.
+     * Assert that all 4 revisions are present after the createWithHistory and that a conflict
+     * exists for the two latest generation docs.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testLeafConflict() throws Exception {
+        List<DocumentRevision> parallelTree = createRevisions(3);
+
+        List<DocumentRevision> sharedHistory = Collections.list(Collections.enumeration
+                (parallelTree.subList(0, 2))); //note sublist second index is *exclusive*
+        sharedHistory.add(REV3.revision);
+
+        advancedDatabase.createWithHistory(REV3.revision, REV3.generation, toHistory
+                (sharedHistory));
+
+        // Assert both trees are good
+        assertRevisionAndHistoryPresent(Collections.singleton(REV3.revision));
+        assertRevisionContent(Collections.singleton(REV3.revision), false); // Not a stub
+
+        assertRevisionAndHistoryPresent(parallelTree);
+        assertRevisionContent(parallelTree, false, false, false); // None are stubs
+
+        assertNoUnexpectedRevs(Collections.singleton(REV3.revision), parallelTree);
+
+        assertConflictBetween(REV3.revision.getRevision(), parallelTree.get(2).getRevision());
+    }
+
+    /**
+     * Test that inserting a rev 3 with attachments and history works.
+     * Assert that the revision is created along with stubs for revs 1 and 2 and that the
+     * attachments are present.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testAttachments() throws Exception {
+        // Create a special rev3 we can add
+        DocumentRevision rev3WithAttachments = new DocumentRevision(TestDoc.ID, REV3.revision
+                .getRevision());
+        rev3WithAttachments.setBody(REV3.body);
+        // Add attachments
+        File a1 = TestUtils.loadFixture("fixture/attachment_1.txt");
+        File a2 = TestUtils.loadFixture("fixture/attachment_2.txt");
+        Map<String, Attachment> attachments = new HashMap<String, Attachment>();
+        Attachment att1 = new UnsavedFileAttachment(a1, "text/plain");
+        Attachment att2 = new UnsavedStreamAttachment(new FileInputStream(a2), "text/plain");
+        attachments.put("attachment_1.txt", att1);
+        attachments.put("attachment_2.txt", att2);
+        rev3WithAttachments.setAttachments(attachments);
+
+        List<DocumentRevision> tree = toRevisionCollection(EnumSet.of(REV1, REV2));
+        tree.add(rev3WithAttachments);
+
+        // Create the revision with history
+        advancedDatabase.createWithHistory(rev3WithAttachments, REV3.generation, toHistory(tree));
+
+        // Assert
+        assertRevisionAndHistoryPresent(tree);
+        assertRevisionContent(tree, true, true, false); // Revs 1 and 2 are stubs
+        assertNoUnexpectedRevs(tree);
+
+        // Assert the attachment content
+        DocumentRevision readRevision = database.read(TestDoc.ID);
+        Assert.assertEquals("The latest revision should match the expected.", REV3
+                .revision.getRevision(), readRevision.getRevision());
+        Map<String, Attachment> readAttachments = readRevision.getAttachments();
+        Assert.assertEquals("There should be two attachments", 2, readAttachments.size());
+        Attachment a = readAttachments.get("attachment_1.txt");
+        Assert.assertNotNull("Attachment 1 should be present", a);
+        Assert.assertTrue("Attachment 1 content should be correct", TestUtils.streamsEqual(new
+                FileInputStream(a1), a.getInputStream()));
+        a = readAttachments.get("attachment_2.txt");
+        Assert.assertNotNull("Attachment 2 should be present", a);
+        Assert.assertTrue("Attachment 2 content should be correct", TestUtils.streamsEqual(new
+                FileInputStream(a2), a.getInputStream()));
+    }
+
+    /**
+     * Test that createWithHistory with an empty attachment map deletes previous attachments.
+     * Assert that the revision is created and the previous revisions are in its history.
+     * Assert that the latest (created) revision 3 has no attachments.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testDeletingAttachments() throws Exception {
+        // Create two generations of revisions with attachments
+        Collection<DocumentRevision> tree = createRevisions(2, true);
+        // Add the latest revision to the tree so we can create a history for it, note the default
+        // rev3 has an empty attachment map, so we don't need to explicitly delete them.
+        tree.add(REV3.revision);
+
+        // Create the revision with history
+        advancedDatabase.createWithHistory(REV3.revision, REV3.generation, toHistory(tree));
+
+        // Assert
+        assertRevisionAndHistoryPresent(tree);
+        assertRevisionContent(tree, false, false, false); // no stubs
+        assertNoUnexpectedRevs(tree);
+        // Assert no attachment content
+        DocumentRevision readRevision = database.read(TestDoc.ID);
+        Assert.assertEquals("The latest revision should match the expected.", REV3.revision
+                .getRevision(), readRevision.getRevision());
+        Assert.assertTrue("There should be no attachments.", readRevision.getAttachments()
+                .isEmpty());
+    }
+
+    /**
+     * Test that it is possible to add an attachment to a revision when using createWithHistory.
+     * Create rev1 with a single attachment then createWithHistory a rev3 with an extra attachment.
+     * Assert that the rev 3 revision is created with a rev 2 stub.
+     * Assert that the attachments are as expected on the latest revision.
+     * Assert that the new attachment is not visible on the older revision.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testAddAttachmentToExisting() throws Exception {
+        // Create one revisions with an attachment
+        Collection<DocumentRevision> tree = createRevisions(1, true);
+
+        DocumentRevision rev3WithExtraAttachment = new DocumentRevision(TestDoc.ID, REV3.revision
+                .getRevision());
+        rev3WithExtraAttachment.setBody(REV3.body);
+
+
+        // Add extra attachment
+        DocumentRevision rev1 = database.read(TestDoc.ID);
+        Map<String, Attachment> attachments = rev1.getAttachments();
+        Assert.assertEquals("There should be 1 attachment.", 1, attachments.size());
+        File a2 = TestUtils.loadFixture("fixture/attachment_2.txt");
+        Attachment att2 = new UnsavedFileAttachment(a2, "text/plain");
+        attachments.put("attachment_2.txt", att2);
+        Assert.assertEquals("There should be 2 attachments.", 2, attachments.size());
+        rev3WithExtraAttachment.setAttachments(attachments);
+
+        // // Add revs 2 and 3 to make a history
+        tree.addAll(toRevisionCollection(EnumSet.of(REV2, REV3)));
+
+        // Create the revision with history
+        advancedDatabase.createWithHistory(rev3WithExtraAttachment, REV3.generation, toHistory
+                (tree));
+
+        // Assert
+        assertRevisionAndHistoryPresent(tree);
+        assertRevisionContent(tree, false, true, false); // rev 2 is a stub
+        assertNoUnexpectedRevs(tree);
+        // Assert the attachment content
+        DocumentRevision readRevision = database.read(TestDoc.ID);
+        Assert.assertEquals("The latest revision should match the expected.", REV3.revision
+                .getRevision(), readRevision.getRevision());
+        Map<String, Attachment> readAttachments = readRevision.getAttachments();
+        Assert.assertEquals("There should be two attachments", 2, readAttachments.size());
+        Attachment a = readAttachments.get("attachment_1.txt");
+        Assert.assertNotNull("Attachment 1 should be present", a);
+        File a1 = TestUtils.loadFixture("fixture/attachment_1.txt");
+        Assert.assertTrue("Attachment 1 content should be correct", TestUtils.streamsEqual(new
+                FileInputStream(a1), a.getInputStream()));
+        a = readAttachments.get("attachment_2.txt");
+        Assert.assertNotNull("Attachment 2 should be present", a);
+        Assert.assertTrue("Attachment 2 content should be correct", TestUtils.streamsEqual(new
+                FileInputStream(a2), a.getInputStream()));
+
+
+        // Assert that the new attachment is not present on the stub revision or original revision
+        Assert.assertEquals("There should be one attachment on the original revision.", 1,
+                database.read(TestDoc.ID, rev1.getRevision()).getAttachments().size());
+        // The stub revision is only a stub so doesn't show the attachment info.
+        Assert.assertEquals("There should be no attachments on the stub revision.", 0, database
+                .read(TestDoc.ID, REV2.revision.getRevision()).getAttachments().size());
+        Attachment extra = ((DatabaseImpl) database).getAttachment(TestDoc.ID, rev1.getRevision
+                (), "attachment_2.txt");
+        Assert.assertNull("The new attachment should not be present on the original revision.",
+                extra);
+    }
+
+    /**
+     * Test that calling createWithHistory will successfully delete one of multiple attachments.
+     * Assert that the revision is created and the previous revisions are in its history.
+     * Assert that the latest (created) revision 3 has the expected attachment.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testDeletingAttachmentFromExisting() throws Exception {
+        // Create two generations of revisions with attachments
+        Collection<DocumentRevision> tree = createRevisions(2, true);
+
+        // Create a rev3
+        DocumentRevision rev3WithDeletedAttachment = new DocumentRevision(TestDoc.ID, REV3.revision
+                .getRevision());
+        rev3WithDeletedAttachment.setBody(REV3.body);
+
+        // Add only 1 of the attachments from rev2, so when we insert the other attachment will be
+        // deleted.
+        DocumentRevision rev2 = database.read(TestDoc.ID);
+        Map<String, Attachment> attachments = rev2.getAttachments();
+        Assert.assertEquals("There should be 2 attachments.", 2, attachments.size());
+        attachments.remove("attachment_1.txt");
+        Assert.assertEquals("There should be 1 attachment.", 1, attachments.size());
+        // Set the single attachment on the revision we want to insert
+        rev3WithDeletedAttachment.setAttachments(attachments);
+
+        // Add the latest revision ID to the tree so we can create a history for it.
+        tree.add(REV3.revision);
+
+        // Create the revision with history
+        advancedDatabase.createWithHistory(rev3WithDeletedAttachment, REV3.generation, toHistory
+                (tree));
+
+        // Assert
+        assertRevisionAndHistoryPresent(tree);
+        assertRevisionContent(tree, false, false, false); // no stubs
+        assertNoUnexpectedRevs(tree);
+        // Assert one attachment was deleted and the other is present
+        DocumentRevision readRevision = database.read(TestDoc.ID);
+        Assert.assertEquals("The latest revision should match the expected.", REV3.revision
+                .getRevision(), readRevision.getRevision());
+        Map<String, Attachment> readAttachments = readRevision.getAttachments();
+        Assert.assertEquals("There should be one attachment.", 1, readRevision.getAttachments()
+                .size());
+        File a2 = TestUtils.loadFixture("fixture/attachment_2.txt");
+        Attachment a = readAttachments.get("attachment_2.txt");
+        Assert.assertNotNull("Attachment 2 should be present", a);
+        Assert.assertTrue("Attachment 2 content should be correct", TestUtils.streamsEqual(new
+                FileInputStream(a2), a.getInputStream()));
+    }
+
+    /**
+     * Test that if we keep the same attachments when using createWithHistory nothing unexpected
+     * happens. We should be able to read the attachments without re-adding any attachment data.
+     * Assert that the expected revisions are present and that the latest revision is as expected.
+     * Assert that the attachments are present and with the correct content.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testNoChangeOfExistingAttachments() throws Exception {
+        // Create two generations of revisions with attachments
+        Collection<DocumentRevision> tree = createRevisions(2, true);
+
+        // Create a special rev3 we can add
+        DocumentRevision rev3WithAttachments = new DocumentRevision(TestDoc.ID, REV3.revision
+                .getRevision());
+        rev3WithAttachments.setBody(REV3.body);
+        // Add attachments from existing
+        rev3WithAttachments.setAttachments(database.read(TestDoc.ID).getAttachments());
+
+        // Add the rev to the tree so we can generate a history
+        tree.add(rev3WithAttachments);
+
+        // Create the revision with history
+        advancedDatabase.createWithHistory(rev3WithAttachments, REV3.generation, toHistory(tree));
+
+        // Assert
+        assertRevisionAndHistoryPresent(tree);
+        assertRevisionContent(tree, false, false, false); // No stubs
+        assertNoUnexpectedRevs(tree);
+
+        // Assert the attachment content
+        File a1 = TestUtils.loadFixture("fixture/attachment_1.txt");
+        File a2 = TestUtils.loadFixture("fixture/attachment_2.txt");
+        DocumentRevision readRevision = database.read(TestDoc.ID);
+        Assert.assertEquals("The latest revision should match the expected.", REV3
+                .revision.getRevision(), readRevision.getRevision());
+        Map<String, Attachment> readAttachments = readRevision.getAttachments();
+        Assert.assertEquals("There should be two attachments", 2, readAttachments.size());
+        Attachment a = readAttachments.get("attachment_1.txt");
+        Assert.assertNotNull("Attachment 1 should be present", a);
+        Assert.assertTrue("Attachment 1 content should be correct", TestUtils.streamsEqual(new
+                FileInputStream(a1), a.getInputStream()));
+        a = readAttachments.get("attachment_2.txt");
+        Assert.assertNotNull("Attachment 2 should be present", a);
+        Assert.assertTrue("Attachment 2 content should be correct", TestUtils.streamsEqual(new
+                FileInputStream(a2), a.getInputStream()));
+    }
+
+    /**
+     * Test that calling createWithHistory twice with the same revision causes a DocumentException
+     * to be thrown.
+     *
+     * @throws Exception
+     */
+    @Test(expected = DocumentException.class)
+    public void testDuplicate() throws Exception {
+        Collection<DocumentRevision> revisions = toRevisionCollection(EnumSet.allOf(TestDoc.class));
+
+        // Create the revision with history
+        advancedDatabase.createWithHistory(REV3.revision, REV3.generation, toHistory(revisions));
+
+        // try to create the same again
+        advancedDatabase.createWithHistory(REV3.revision, REV3.generation, toHistory(revisions));
+        // This should fail because the revision already exists
+        Assert.fail("A second attempt to insert the same revision should fail.");
+    }
+
+    /**
+     * Test that calling createWithHistory with the current revision not in the history list causes
+     * an IllegalArgumentException to be thrown.
+     *
+     * @throws Exception
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreateWithHistoryCurrentNotInHistoryError() throws Exception {
+
+        // Create a rev 3 without rev 3 being in the history
+        advancedDatabase.createWithHistory(REV3.revision, REV3.generation, toHistory
+                (toRevisionCollection(EnumSet.of(REV1, REV2))));
+    }
+
+    /**
+     * Test that passing a null revision causes an IllegalArgumentException
+     *
+     * @throws Exception
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testNullRevision() throws Exception {
+        advancedDatabase.createWithHistory(null, REV3.generation, toHistory
+                (toRevisionCollection(EnumSet.of(REV3))));
+    }
+
+    /**
+     * Test that using a start generation of zero causes an IllegalArgumentException
+     *
+     * @throws Exception
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testGenerationZero() throws Exception {
+        advancedDatabase.createWithHistory(REV3.revision, 0, toHistory
+                (toRevisionCollection(EnumSet.of(REV3))));
+    }
+
+    /**
+     * Test that using a negative generation causes an IllegalArgumentException
+     *
+     * @throws Exception
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testGenerationNegative() throws Exception {
+        advancedDatabase.createWithHistory(REV3.revision, -1, toHistory
+                (toRevisionCollection(EnumSet.of(REV3))));
+    }
+
+    /**
+     * Test that using a null history causes an IllegalArgumentException
+     *
+     * @throws Exception
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testNullHistory() throws Exception {
+        advancedDatabase.createWithHistory(REV3.revision, REV3.generation, null);
+    }
+
+    /**
+     * Test that using an empty history list causes an IllegalArgumentException
+     *
+     * @throws Exception
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testEmptyHistory() throws Exception {
+        List<String> history = Collections.emptyList();
+        advancedDatabase.createWithHistory(REV3.revision, REV3.generation, history);
+    }
+
+    /**
+     * Test that calling createWithHistory with only a partial history (i.e. not back to a first
+     * generation does not cause any problems.
+     * Assert that the inserted revision and a previous generation stub are present and that there
+     * is no first generation rev.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testCreateWithIncompleteHistory() throws Exception {
+        // Create a rev 3 without rev 1 being in the history
+        List<DocumentRevision> tree = toRevisionCollection(EnumSet.of(REV2, REV3));
+
+        advancedDatabase.createWithHistory(REV3.revision, REV3.generation, toHistory(tree));
+
+        assertRevisionAndHistoryPresent(tree);
+        assertRevisionContent(tree, true, false); // Rev2 is a stub, rev3 is complete
+        assertNoUnexpectedRevs(tree);
+    }
+
+    /**
+     * Test that calling createWithHistory with no ancestors at all does not cause a problem.
+     * Assert that the inserted revision is present and that there are no unexpected other revs.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testCreateWithIncompleteHistoryNoParentError() throws Exception {
+        Collection<DocumentRevision> rev3Only = Collections.singleton(REV3.revision);
+
+        // Create a rev 3 without any further history
+        advancedDatabase.createWithHistory(REV3.revision, REV3.generation, toHistory(rev3Only));
+
+        assertRevisionAndHistoryPresent(rev3Only);
+        assertRevisionContent(rev3Only, false);
+        assertNoUnexpectedRevs(rev3Only);
+    }
+
+    /**
+     * Test that inserting a revision with a deleted ancestor does not cause any problems.
+     * Assert that the new revision is present, the existing history is unchanged and the latest
+     * revision is not deleted and matches the inserted revision.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testDeletedAncestor() throws Exception {
+        // Create a revision, and delete it
+        List<DocumentRevision> created = createRevisions(1);
+        DocumentRevision rev1 = created.get(0);
+        DocumentRevision deletedRev2 = database.delete(rev1);
+
+        Assert.assertTrue("The revision should be deleted", deletedRev2.isDeleted());
+
+        List<DocumentRevision> tree = Arrays.asList(rev1, deletedRev2, REV3.revision);
+
+        advancedDatabase.createWithHistory(REV3.revision, REV3.generation, toHistory(tree));
+
+        // Assert
+        assertRevisionAndHistoryPresent(tree);
+        // Assert the content, note that the deleted revision 2 will have an empty body like a stub
+        assertRevisionContent(tree, false, true, false); // Revs 1 and 3 have bodies
+        // Assert that the inserted revision is the winner (i.e. the document is undeleted)
+        DocumentRevision latest = database.read(TestDoc.ID);
+        Assert.assertEquals("The latest revision should match the expected.", REV3.revision
+                .getRevision(), latest.getRevision());
+        Assert.assertFalse("The latest revision of the document should not be deleted.", latest
+                .isDeleted());
+    }
+
+    /**
+     * Test that inserting a deleted revision with history does not cause any problems.
+     * Assert that the new revision is present, the stub history exists and the latest
+     * revision is deleted.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testCurrentDeleted() throws Exception {
+        // Create the deleted revision with history
+        DocumentRevision deleted3 = new DocumentRevision(TestDoc.ID, REV3.revision
+                .getRevision());
+        deleted3.setDeleted();
+
+        List<DocumentRevision> tree = toRevisionCollection(EnumSet.of(REV1, REV2));
+        tree.add(deleted3);
+
+        advancedDatabase.createWithHistory(deleted3, REV3.generation, toHistory(tree));
+
+        // Assert
+        assertRevisionAndHistoryPresent(tree);
+        assertRevisionContent(tree, true, true, true); // All stubs because 3 is deleted
+        DocumentRevision r = database.read(TestDoc.ID);
+        Assert.assertEquals("The latest revision should match the expected.", REV3.revision
+                .getRevision(), r.getRevision());
+        Assert.assertTrue("The revision should be deleted", r.isDeleted());
+    }
+
+    private static final class AssertingConflictResolver implements ConflictResolver {
+
+        Set<String> conflictedRevisionIDs = new HashSet<String>();
+
+        @Override
+        public DocumentRevision resolve(String docId, List<? extends DocumentRevision> conflicts) {
+            for (DocumentRevision rev : conflicts) {
+                conflictedRevisionIDs.add(rev.getRevision());
+            }
+            return conflicts.get(0);
+        }
+    }
+}

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/BasicDatastoreTestBase.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/BasicDatastoreTestBase.java
@@ -19,12 +19,13 @@ package com.cloudant.sync.internal.documentstore;
 import com.cloudant.sync.documentstore.DocumentBody;
 import com.cloudant.sync.documentstore.DocumentRevision;
 import com.cloudant.sync.internal.common.CouchUtils;
-import com.cloudant.sync.util.TestUtils;;
+import com.cloudant.sync.util.TestUtils;
 
-import org.junit.Assert;
 import org.apache.commons.io.FileUtils;
-import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
+
+;
 
 public abstract class BasicDatastoreTestBase extends DatastoreTestBase {
 
@@ -38,17 +39,11 @@ public abstract class BasicDatastoreTestBase extends DatastoreTestBase {
 
     @Before
     public void setUp() throws Exception {
-        super.setUp();
         jsonData = FileUtils.readFileToByteArray(TestUtils.loadFixture(documentOneFile));
         bodyOne = new DocumentBodyImpl(jsonData);
 
         jsonData = FileUtils.readFileToByteArray(TestUtils.loadFixture(documentTwoFile));
         bodyTwo = new DocumentBodyImpl(jsonData);
-    }
-
-    @After
-    public void tearDown() throws Exception {
-        super.testDown();
     }
 
     void createTwoDocuments() throws Exception {

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/CrudImplDatabaseTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/CrudImplDatabaseTest.java
@@ -28,11 +28,11 @@ import com.cloudant.sync.documentstore.DocumentRevision;
 import com.cloudant.sync.documentstore.DocumentStoreException;
 import com.cloudant.sync.documentstore.InvalidDocumentException;
 import com.cloudant.sync.documentstore.LocalDocument;
+import com.cloudant.sync.internal.common.CouchUtils;
 import com.cloudant.sync.internal.documentstore.callables.GetDocumentsWithInternalIdsCallable;
 import com.cloudant.sync.internal.sqlite.Cursor;
-import com.cloudant.sync.internal.sqlite.SQLDatabase;
 import com.cloudant.sync.internal.sqlite.SQLCallable;
-import com.cloudant.sync.internal.common.CouchUtils;
+import com.cloudant.sync.internal.sqlite.SQLDatabase;
 import com.cloudant.sync.internal.util.DatabaseUtils;
 import com.cloudant.sync.internal.util.JSONUtils;
 
@@ -604,6 +604,14 @@ public class CrudImplDatabaseTest extends BasicDatastoreTestBase {
             Assert.assertTrue("leaf body must not be empty after compaction", leaf.getBody().asMap().size() > 0);
         }
 
+    }
+
+    @Test(expected = DocumentNotFoundException.class)
+    public void updateNonExistentDocument() throws Exception {
+        // Create a rev that doesn't exist
+        DocumentRevision rev_1Mut = new DocumentRevision("anyid", "1-abc");
+        rev_1Mut.setBody(bodyOne);
+        datastore.update(rev_1Mut);
     }
 
     private void getAllDocuments_testCountAndOffset(int objectCount, List<DocumentRevision> expectedDocumentRevisions, boolean descending) throws DocumentStoreException {

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatastoreTestBase.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatastoreTestBase.java
@@ -16,34 +16,27 @@
 
 package com.cloudant.sync.internal.documentstore;
 
-import com.cloudant.sync.documentstore.DocumentStore;
-import com.cloudant.sync.util.TestUtils;
+import com.cloudant.common.DocumentStoreTestBase;
 
 import org.junit.After;
 import org.junit.Before;
-
-import java.io.File;
 
 /**
  * Test base for any test suite need a <code>DatastoreManager</code> and <code>Datastore</code> instance. It
  * automatically set up and clean up the temp file directly for you.
  */
-public abstract class DatastoreTestBase {
+public abstract class DatastoreTestBase extends DocumentStoreTestBase {
 
-    String datastore_manager_dir;
     DatabaseImpl datastore = null;
 
     @Before
-    public void setUp() throws Exception {
-        datastore_manager_dir = TestUtils.createTempTestingDir(this.getClass().getName());
-        this.datastore = (DatabaseImpl) (DocumentStore.getInstance(new File
-                (datastore_manager_dir, getClass().getSimpleName()))).database();
+    public void setUpDatabaseImpl() throws Exception {
+        this.datastore = (DatabaseImpl) documentStore.database();
 
     }
 
     @After
-    public void testDown() {
+    public void tearDownDatabaseImpl() {
         datastore.close();
-        TestUtils.deleteTempTestingDir(datastore_manager_dir);
     }
 }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/MutableDocumentDeleteTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/MutableDocumentDeleteTest.java
@@ -135,4 +135,13 @@ public class MutableDocumentDeleteTest extends BasicDatastoreTestBase {
 
     }
 
+    // Delete a MutableCopy
+    @Test
+    public void deleteViaRevisionUpdate() throws Exception {
+        saved.setDeleted();
+        DocumentRevision deleted = datastore.update(saved);
+        Assert.assertNotNull("Deleted DocumentRevision is null", deleted);
+        Assert.assertTrue("Deleted DocumentRevision is not flagged as deleted", deleted.isDeleted());
+    }
+
 }


### PR DESCRIPTION
*What*

Provide an API for `forceInsert`/`new_edits=false`

Reviewers please feel free to suggest better names.

*Why*

Some advanced users wish to interact with the `DocumentStore` outside the scope of the typical use case APIs of CRUD, query, and replication.

*How*

* Enabling work:
    * Removed deprecated `forceInsert` method and refactored remaining calls to use `ForceInsertItem`.
    * Added `DocumentNotFoundException` to `database()#update(...)` as this case was missing.
    * Added possibility of deleting document by `update`
        * Since a document `delete` creates and empty revision provide a way of deleting via `update`.
        * Adds `DocumentRevision#setDeleted()` method, which is necessary for creating a deleted revision with history.
    * Fixed potential NPE for force inserting deleted revisions - A deleted revision should have an empty body, but if it was `null` the attempt to read the body bytes would NPE.
* New API:
    * Added package for advanced APIs `com.cloudant.sync.documentstore.advanced` with package documentation and usage warnings.
    * Added `advanced.Database` interface for advanced database methods.
    * Added `public advanced.Database advanced()` to `DocumentStore` to access the `advanced.Database` API.
    * Added `void createWithHistory(DocumentRevision documentRevision, int revisionsStart, List<String> revisionsIDs)` and implementation.
* Updated `CHANGES.md`

*Testing*

*Re-enabled `ForceInsertTest`
* Updated `ForceInsertTest` to use non-deprecated `forceInsert` method.
* Added test for `DocumentNotFoundException` during `update`.
* Added `MutableDocumentDeleteTest.deleteViaRevisionUpdate()`
* Added tests for `createWithHistory`
    * Extracted `DocumentStoreTestBase`.
    * Slimmed `DatastoreTestBase` to not create `DocumentStore`.
    * Renamed setup methods to avoid override.
    * Added `AdvancedAPITest` superclass.
    * Added `CreateWithHistoryTest`.

*Issues*

Fixes #416 