### PR TITLE
Add migration instructions for multiple PeriodicReplicationReceivers

### DIFF
--- a/cloudant-sync-datastore-android/src/main/java/com/cloudant/sync/replication/PeriodicReplicationService.java
+++ b/cloudant-sync-datastore-android/src/main/java/com/cloudant/sync/replication/PeriodicReplicationService.java
@@ -123,7 +123,7 @@ public abstract class PeriodicReplicationService<T extends PeriodicReplicationRe
      * If the stored preferences are in the old format, upgrade them to the new format so that
      * the app continues to work after upgrade to this version.
      */
-    private void upgradePreferences() {
+    protected void upgradePreferences() {
         String alarmDueElapsed = "com.cloudant.sync.replication.PeriodicReplicationService.alarmDueElapsed";
         if (mPrefs.contains(alarmDueElapsed)) {
             // These are old style preferences. We need to rewrite them in the new form that allows

--- a/doc/migration.md
+++ b/doc/migration.md
@@ -262,6 +262,43 @@ instead. Migration also requires some minor method renames.
 `ReplicationPolicyManager.SimpleReplicationsCompletedListener` and now implements
 `ReplicationPolicyManager.ReplicationsCompletedListener`.
 
+* It is now possible to have multiple subclasses of `PeriodicReplicationService` in the same Android app without
+them interfering with each other. If you have not used replication policies involving a `PeriodicReplicationService`
+prior to upgrading to sync-android 2.0.0, there is no special handling required and the rest of this section may be
+ignored. However, there is one use-case that requires special handling: If you had
+used a replication policy in an app built against a pre-2.0.0 release of sync-android and are now
+moving to multiple `PeriodicReplicationService`s. In this case, you should override the `upgradePreferences()`
+method with an empty method for any `PeriodicReplicationService`s you are adding. Any
+`PeriodicReplicationService` that had existed in an app built against a pre-2.0.0 version of sync-android
+should not have its `upgradePreferences()` method overridden. For example:
+    ```java
+    public class MyOriginalReplicationService extends PeriodicReplicationService {
+        // This class existed in an app that used sync-android version < 2.0.0
+        // so we don't override upgradePreferences()
+    ...
+    }
+
+    public class MyNewReplicationService extends PeriodicReplicationService {
+        // This class is new since upgrading to sync-android version >= 2.0.0
+        // so we must override upgradePreferences() to do nothing.
+
+        @Override
+        protected void upgradePreferences() {
+        }
+    ...
+    }
+
+    public class MyOtherNewReplicationService extends PeriodicReplicationService {
+        // This class is also new since upgrading to sync-android version >= 2.0.0
+        // so we must override upgradePreferences() to do nothing.
+
+        @Override
+        protected void upgradePreferences() {
+        }
+    ...
+    }
+    ```
+
 ## Changes to `Changes`
 
 Removed `size()` and `getIds()` methods. The behaviour duplicated what was


### PR DESCRIPTION
Add migration instructions for the special case of having had a `PeriodicReplicationReceiver` when using sync-android < 2.0.0 and now upgrading to >= 2.0.0 and having multiple `PeriodicReplicationReceiver`s. 

Note that if users never used replication policies before sync-android 2.0.0, they don't need to do anything. If users only have one replication policy, they don't need to do anything.

In order to provide a simple way of handling this, `PeriodicReplicationService#upgradePreferences` has been made `protected`. This seemed the easiest way of making this special case relatively easy to deal with.

I wasn't sure whether the example code adds anything to the clarity. Any thoughts?