### PR TITLE
Fixed package name for unreliable network tests

### DIFF
--- a/cloudant-sync-datastore-core/build.gradle
+++ b/cloudant-sync-datastore-core/build.gradle
@@ -92,7 +92,7 @@ task unreliableNetworkTest(type: Test, dependsOn: testClasses) {
     systemProperty "http.keepAlive", false
     // ensure proxy is running!
     filter {        
-        includeTestsMatching "com.cloudant.sync.replication.Unreliable*.*"
+        includeTestsMatching "com.cloudant.sync.internal.replication.Unreliable*.*"
     }
 }
 


### PR DESCRIPTION
*What*

Fixed gradle command for running unreliable network tests

*How*

Renamed `com.cloudant.sync.replication.Unreliable*.*` to `com.cloudant.sync.internal.replication.Unreliable*.*`

*Testing*

The tests run again now locally.