### PR TITLE
Fix sample app and update for renames

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,7 +32,7 @@
   `doc/crud.md`) has been migrated to a
   [java source file](https://github.com/cloudant/sync-android/blob/2.0.0/doc/CrudSamples.java).
 
-- [NEW] `databaseWithAdvancedAPIs()` getter on `DocumentStore` for specialist advanced use cases.
+- [NEW] `advanced()` getter on `DocumentStore` for specialist advanced use cases.
   Adds support for creating specific document revisions with history.
 
 - [FIXED] Issue with double encoding of restricted URL characters in credentials when using

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/QueryImpl.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/QueryImpl.java
@@ -94,7 +94,7 @@ public class QueryImpl implements Query {
     private final SQLDatabaseQueue dbQueue;
 
     /**
-     *  Constructs a new IndexManager which indexes documents in 'datastore'
+     *  Constructs a new {@link Query} which indexes documents in 'datastore'
      *  @param database The {@link Database} to index
      */
     public QueryImpl(Database database, File extensionsLocation, KeyProvider keyProvider) throws IOException, SQLException {

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatabaseNotificationsMoreTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/DatabaseNotificationsMoreTest.java
@@ -117,8 +117,8 @@ public class DatabaseNotificationsMoreTest {
         Assert.assertThat(documentStoreClosed.get(0).dbName, endsWith("test123"));
 
         // After database is closed, when it is opened, the
-        // DatabaseOpened event should be fired, but the
-        // DatabaseCreated event should NOT be fired.
+        // DocumentStoreOpened event should be fired, but the
+        // DocumentStoreCreated event should NOT be fired.
         this.clearAllEventList();
         DocumentStore ds1 = DocumentStore.getInstance(new File(datastoreManagerDir, "test123"));
         try {

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/IndexUpdaterTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/query/IndexUpdaterTest.java
@@ -1076,7 +1076,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
             im.close();
         }
 
-        // Get a new IndexManager instance and extract its queue
+        // Get a new Query instance and extract its queue
         im = new QueryImpl(ds, new File(ds.getPath(), "extensions"), new NullKeyProvider());
         indexManagerDatabaseQueue = TestUtils.getDBQueue(im);
 
@@ -1117,7 +1117,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
             im.close();
         }
 
-        // Get a new IndexManager instance and extract its queue
+        // Get a new Query instance and extract its queue
         im = new QueryImpl(ds, new File(ds.getPath(), "extensions"),  new NullKeyProvider());
         indexManagerDatabaseQueue = TestUtils.getDBQueue(im);
 
@@ -1140,7 +1140,7 @@ public class IndexUpdaterTest extends AbstractIndexTestBase {
             im.close();
         }
 
-        // Get a new IndexManager instance and extract its queue
+        // Get a new Query instance and extract its queue
         im = new QueryImpl(ds, new File(ds.getPath(), "extensions"),  new NullKeyProvider());
         indexManagerDatabaseQueue = TestUtils.getDBQueue(im);
         // Check that the updates are still there

--- a/doc/query.md
+++ b/doc/query.md
@@ -345,7 +345,7 @@ query.put("$or", Arrays.<Object>asList(petClause, andClause));
 
 ### Executing queries
 
-To find documents matching a query, use the `IndexManager` object's `find(Map<String, Object> query)` method. This returns an object that can be used in `for ( : )` loops to enumerate over the results.
+To find documents matching a query, use the `Query` object's `find(Map<String, Object> query)` method. This returns an object that can be used in `for ( : )` loops to enumerate over the results.
 
 ```java
 QueryResult result = q.find(query);

--- a/doc/replication-policies.md
+++ b/doc/replication-policies.md
@@ -330,7 +330,7 @@ private boolean mIsBound;
 
 Now we add a [`ServiceConnection`](http://developer.android.com/reference/android/content/ServiceConnection.html)
 to our [`Activity`](http://developer.android.com/reference/android/app/Activity.html)
-to allow us to handle binding and unbinding from our `MyReplicationService`. This enables us to get a reference to the service when we bind to it and add a listener for `replicationComplete` to the [`Service`](http://developer.android.com/reference/android/app/Service.html):
+to allow us to handle binding and unbinding from our `MyReplicationService`. This enables us to get a reference to the service when we bind to it and add a listener for `replicationCompleted` to the [`Service`](http://developer.android.com/reference/android/app/Service.html):
 
 ```java
 private ServiceConnection mConnection = new ServiceConnection() {
@@ -339,7 +339,7 @@ private ServiceConnection mConnection = new ServiceConnection() {
         mReplicationService = ((ReplicationService.LocalBinder) service).getService();
         mReplicationService.addListener(new ReplicationPolicyManager.SimpleReplicationsCompletedListener() {
             @Override
-            public void replicationComplete(int id) {
+            public void replicationCompleted(int id) {
                 // Check if this is the pull replication
                 if (id == MyReplicationService.PULL_REPLICATION_ID) {
                     mHandler.post(new Runnable() {

--- a/doc/replication.md
+++ b/doc/replication.md
@@ -215,9 +215,9 @@ if (pullReplicator.getState() != Replicator.State.COMPLETE) {
 }
 ```
 
-### Using IndexManager with replication
+### Using `Query` with replication
 
-When using IndexManager for querying data, we recommend you update after
+When using `Query` for querying data, we recommend you update after
 replication completes to avoid a wait for indexing to catch up when the new data
 is first queried:
 
@@ -232,7 +232,7 @@ DocumentStore ds = DocumentStore.getInstance(new File("my_datastore"));
 Replicator replicator = ReplicatorBuilder.pull().from(uri).to(ds).build();
 
 // Create a sample index on type field
-ds.query().ensureIndexed(Arrays.asList(new FieldSort("fieldName")), "indexName");
+ds.query().createJsonIndex(Arrays.asList(new FieldSort("fieldName")), "indexName");
 
 // Use a CountDownLatch to provide a lightweight way to wait for completion
 CountDownLatch latch = new CountDownLatch(1);
@@ -247,7 +247,7 @@ if (replicator.getState() != Replicator.State.COMPLETE) {
 }
 
 // Ensure all indexes are updated after replication
-ds.query().updateAllIndexes();
+ds.query().refreshAllIndexes();
 
 ```
 

--- a/sample/todo-sync/src/com/cloudant/todo/TasksModel.java
+++ b/sample/todo-sync/src/com/cloudant/todo/TasksModel.java
@@ -47,7 +47,7 @@ import java.util.List;
 /**
  * <p>Handles dealing with the DocumentStore and replication.</p>
  */
-class TasksModel {
+public class TasksModel {
 
     private static final String LOG_TAG = "TasksModel";
 


### PR DESCRIPTION
1. Fixed crash on startup of the todo-sync sample app (first commit).
1. Various updates to comments and docs for things that have been renamed in v2.