### PR TITLE
Extracted and renamed `ReplicationsCompletedListener`

### DIFF
--- a/cloudant-sync-datastore-android/src/main/java/com/cloudant/sync/replication/ReplicationService.java
+++ b/cloudant-sync-datastore-android/src/main/java/com/cloudant/sync/replication/ReplicationService.java
@@ -38,7 +38,7 @@ import java.util.Set;
  * lifecycle and handle being killed or restarted by the operating system
  */
 public abstract class ReplicationService extends Service
-        implements ReplicationPolicyManager.ReplicationsCompletedListener {
+        implements PolicyReplicationsCompletedListener {
 
     public static final String EXTRA_INTENT = "intent";
 
@@ -78,13 +78,13 @@ public abstract class ReplicationService extends Service
     private List<Message> mCommandQueue = new ArrayList<Message>();
 
     /**
-     * Stores the set of {@link ReplicationPolicyManager.ReplicationsCompletedListener}s
+     * Stores the set of {@link PolicyReplicationsCompletedListener}s
      * listening for replication complete
      * events. Note that all modifications or iterations over mListeners should be protected by
      * synchronization on the mListeners object.
      */
-    private final Set<ReplicationPolicyManager.ReplicationsCompletedListener> mListeners = new
-            HashSet<ReplicationPolicyManager.ReplicationsCompletedListener>();
+    private final Set<PolicyReplicationsCompletedListener> mListeners = new
+            HashSet<PolicyReplicationsCompletedListener>();
 
     // It's safest to assume we could be transferring a large amount of data in a
     // replication, so we want a high performance WiFi connection even though it
@@ -303,7 +303,7 @@ public abstract class ReplicationService extends Service
     @Override
     public void allReplicationsCompleted() {
         synchronized (mListeners) {
-            for (ReplicationPolicyManager.ReplicationsCompletedListener listener : mListeners) {
+            for (PolicyReplicationsCompletedListener listener : mListeners) {
                 listener.allReplicationsCompleted();
             }
         }
@@ -314,7 +314,7 @@ public abstract class ReplicationService extends Service
     @Override
     public void replicationCompleted(int id) {
         synchronized (mListeners) {
-            for (ReplicationPolicyManager.ReplicationsCompletedListener listener : mListeners) {
+            for (PolicyReplicationsCompletedListener listener : mListeners) {
                 listener.replicationCompleted(id);
             }
         }
@@ -323,7 +323,7 @@ public abstract class ReplicationService extends Service
     @Override
     public void replicationErrored(int id) {
         synchronized (mListeners) {
-            for (ReplicationPolicyManager.ReplicationsCompletedListener listener : mListeners) {
+            for (PolicyReplicationsCompletedListener listener : mListeners) {
                 listener.replicationErrored(id);
             }
         }
@@ -331,12 +331,12 @@ public abstract class ReplicationService extends Service
 
     /**
      * Add a listener to the set of
-     * {@link com.cloudant.sync.replication.ReplicationPolicyManager.ReplicationsCompletedListener}s that are notified when
+     * {@link PolicyReplicationsCompletedListener}s that are notified when
      * replications complete.
      *
      * @param listener The listener to add.
      */
-    public void addListener(ReplicationPolicyManager.ReplicationsCompletedListener listener) {
+    public void addListener(PolicyReplicationsCompletedListener listener) {
         synchronized (mListeners) {
             mListeners.add(listener);
         }
@@ -344,12 +344,12 @@ public abstract class ReplicationService extends Service
 
     /**
      * Remove a listener from the set of
-     * {@link com.cloudant.sync.replication.ReplicationPolicyManager.ReplicationsCompletedListener}s that are notified when
+     * {@link PolicyReplicationsCompletedListener}s that are notified when
      * replications complete.
      *
      * @param listener The listener to remove.
      */
-    public void removeListener(ReplicationPolicyManager.ReplicationsCompletedListener listener) {
+    public void removeListener(PolicyReplicationsCompletedListener listener) {
         synchronized (mListeners) {
             mListeners.remove(listener);
         }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/replication/ReplicationListener.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/replication/ReplicationListener.java
@@ -3,7 +3,7 @@ package com.cloudant.sync.internal.replication;
 import com.cloudant.sync.event.Subscribe;
 import com.cloudant.sync.event.notifications.ReplicationCompleted;
 import com.cloudant.sync.event.notifications.ReplicationErrored;
-import com.cloudant.sync.replication.ReplicationPolicyManager;
+import com.cloudant.sync.replication.PolicyReplicationsCompletedListener;
 import com.cloudant.sync.replication.Replicator;
 
 import java.util.HashSet;
@@ -12,16 +12,15 @@ import java.util.Set;
 /**
  * This class is not intended as API, it is public for EventBus access only.
  * API consumers should not call these methods. Forwards events from the EventBus to a
- * {@link com.cloudant.sync.replication.ReplicationPolicyManager.ReplicationsCompletedListener}.
+ * {@link PolicyReplicationsCompletedListener}.
  */
 public class ReplicationListener {
 
     private final Set<Replicator> replicatorsInProgress = new HashSet<Replicator>();
-    private ReplicationPolicyManager.ReplicationsCompletedListener replicationsCompletedListener
+    private PolicyReplicationsCompletedListener replicationsCompletedListener
             = null;
 
-    public void setReplicationsCompletedListener(ReplicationPolicyManager
-                                                         .ReplicationsCompletedListener
+    public void setReplicationsCompletedListener(PolicyReplicationsCompletedListener
                                                          replicationsCompletedListener) {
         this.replicationsCompletedListener = replicationsCompletedListener;
     }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/PolicyReplicationsCompletedListener.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/PolicyReplicationsCompletedListener.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
 package com.cloudant.sync.replication;
 
 /**

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/PolicyReplicationsCompletedListener.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/PolicyReplicationsCompletedListener.java
@@ -1,0 +1,41 @@
+package com.cloudant.sync.replication;
+
+/**
+ * Interface with methods to receive callbacks for different termination states
+ * of the replications configured by a replication policy.
+ */
+public interface PolicyReplicationsCompletedListener {
+    /**
+     * Gets called back when all replicators completed.
+     */
+    void allReplicationsCompleted();
+    /**
+     * Gets called back when a replication completed.
+     * @param id the replication ID
+     */
+    void replicationCompleted(int id);
+    /**
+     * Gets called back when a replication has an error.
+     * @param id the replication ID
+     */
+    void replicationErrored(int id);
+
+    /**
+     * A simple {@link PolicyReplicationsCompletedListener}
+     * to save clients having to override every method if they are only interested in a subset of
+     * the events.
+     */
+    class SimpleListener implements PolicyReplicationsCompletedListener {
+        @Override
+        public void allReplicationsCompleted() {
+        }
+
+        @Override
+        public void replicationCompleted(int id) {
+        }
+
+        @Override
+        public void replicationErrored(int id) {
+        }
+    }
+}

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ReplicationPolicyManager.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ReplicationPolicyManager.java
@@ -29,27 +29,6 @@ public class ReplicationPolicyManager {
     private final List<Replicator> replicators = new ArrayList<Replicator>();
     private final ReplicationListener replicationListener = new ReplicationListener();
 
-    /**
-     * Interface with methods to receive callbacks for different termination states
-     * of the replications configured by a replication policy.
-     */
-    public interface ReplicationsCompletedListener {
-        /**
-         * Gets called back when all replicators completed.
-         */
-        void allReplicationsCompleted();
-        /**
-         * Gets called back when a replication completed.
-         * @param id the replication ID
-         */
-        void replicationCompleted(int id);
-        /**
-         * Gets called back when a replication has an error.
-         * @param id the replication ID
-         */
-        void replicationErrored(int id);
-    }
-
     protected void startReplications() {
         synchronized (replicators) {
             for (Replicator replicator : replicators) {
@@ -78,32 +57,13 @@ public class ReplicationPolicyManager {
 
     /**
      * Interested parties wishing to receive replication lifecycle events should call
-     * this method with a class implementing the {@link ReplicationsCompletedListener} interface.
+     * this method with a class implementing the {@link PolicyReplicationsCompletedListener} interface.
      *
      * @param listener A class implementing appropriate callback methods for replication lifecycle
      *                 events
      */
-    public void setReplicationsCompletedListener(ReplicationsCompletedListener listener) {
+    public void setReplicationsCompletedListener(PolicyReplicationsCompletedListener listener) {
         replicationListener.setReplicationsCompletedListener(listener);
     }
 
-    /**
-     * A simple {@link ReplicationsCompletedListener}
-     * to save clients having to override every method if they are only interested in a subset of
-     * the events.
-     */
-    public static class SimpleReplicationsCompletedListener implements
-            ReplicationsCompletedListener {
-        @Override
-        public void allReplicationsCompleted() {
-        }
-
-        @Override
-        public void replicationCompleted(int id) {
-        }
-
-        @Override
-        public void replicationErrored(int id) {
-        }
-    }
 }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ReplicationPolicyManager.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ReplicationPolicyManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 IBM Corp. All rights reserved.
+ * Copyright © 2016, 2017 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/doc/migration.md
+++ b/doc/migration.md
@@ -253,14 +253,17 @@ winning revision.
 * The `IntervalTimerReplicationPolicyManager` was moved into the `cloudant-sync-datastore-javase`
 module since it was not suitable for running on Android anyway.
 
-* The Android `ReplicationService` now uses the same `ReplicationsCompletedListener` interface as
-the `ReplicationPolicyManager`. The `ReplicationService.ReplicationCompleteListener` has been
-removed and implementers should implement `ReplicationPolicyManager.ReplicationsCompletedListener`
+* The `ReplicationPolicyManager.ReplicationsCompletedListener` interface has been moved to
+ `com.cloudant.sync.replication.PolicyReplicationsCompletedListener`.
+
+* The Android `ReplicationService` now uses the same `PolicyReplicationsCompletedListener` interface
+ as the `ReplicationPolicyManager`. The `ReplicationService.ReplicationCompleteListener` has been
+removed and implementers should implement `PolicyReplicationsCompletedListener`
 instead. Migration also requires some minor method renames.
 
 * The `ReplicationService.SimpleReplicationCompleteListener` has been moved to
-`ReplicationPolicyManager.SimpleReplicationsCompletedListener` and now implements
-`ReplicationPolicyManager.ReplicationsCompletedListener`.
+`PolicyReplicationsCompletedListener.SimpleListener` and now implements the
+`PolicyReplicationsCompletedListener` interface.
 
 * It is now possible to have multiple subclasses of `PeriodicReplicationService` in the same Android app without
 them interfering with each other. If you have not used replication policies involving a `PeriodicReplicationService`

--- a/doc/replication-policies.md
+++ b/doc/replication-policies.md
@@ -337,7 +337,7 @@ private ServiceConnection mConnection = new ServiceConnection() {
     @Override
     public void onServiceConnected(ComponentName name, IBinder service) {
         mReplicationService = ((ReplicationService.LocalBinder) service).getService();
-        mReplicationService.addListener(new ReplicationPolicyManager.SimpleReplicationsCompletedListener() {
+        mReplicationService.addListener(new PolicyReplicationsCompletedListener.SimpleListener() {
             @Override
             public void replicationCompleted(int id) {
                 // Check if this is the pull replication


### PR DESCRIPTION
*What*

Extracted and renamed `ReplicationsCompletedListener`

*Why*

As part of the v2 API changes two very similar interfaces were combined. However, the interface is shared by both the `ReplicationPolicyManager` and the Android service approaches to replication policies, so it could confusing to have it as an inner class of the `ReplicationPolicyManager`. As such it is moved into its own class file in the package `com.cloudant.sync.replication`.
However, in that package it would be confusing to have a `ReplicationsCompletedListener` that didn't work with all replications, so the name is changed to indicate it is for use with replication policies: `PolicyReplicationsCompletedListener`.
Similarly the `SimpleReplicationsCompletedListener` can be an inner class of the `PolicyReplicationsCompletedListener` interface instead of the `ReplicationPolicyManager`.

*How*

Moved `ReplicationPolicyManager.ReplicationsCompletedListener` ->
`PolicyReplicationsCompletedListener`.
Moved `ReplicationPolicyManager.SimpleReplicationsCompletedListener` ->
`PolicyReplicationsCompletedListener.SimpleListener`.
Updated docs to match.

*Testing*
Existing tests pass.