### PR TITLE
Added working directory clean before unstashing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,6 +54,8 @@ stage('QA') {
         Android:
         {
             node('android') {
+                // Clean the directory before un-stashing
+                deleteDir()
                 unstash name: 'built'
                 try {
                     sh './gradlew -Dtest.with.specified.couch=true  -Dtest.couch.host=cloudantsync002.bristol.uk.ibm.com -Dtest.couch.port=5984 -Dtest.couch.ignore.compaction=true -Dtest.couch.ignore.auth.headers=true -b AndroidTest/build.gradle uploadFixtures connectedCheck'


### PR DESCRIPTION
*What*

Cleaned working directory before unstash on static nodes.

*Why*
Following on from #503 there were still some strange build issues on Android when files were moved or renamed. It was because on the static build node `unstash` would run on the same workspace as previous builds of the same branch, which could leave now deleted files present. 

*How*

Added `deleteDir()` to the `Jenkinsfile` before calling `unstash` for the new workspace content.