### PR TITLE
Named logcat files uniquely

### DIFF
--- a/AndroidTest/app/build.gradle
+++ b/AndroidTest/app/build.gradle
@@ -123,7 +123,9 @@ task(clearDeviceLog, type: AndroidExec) {
 
 task(pullDeviceLog, type: AndroidExec) {
     doFirst {
-        standardOutput = new FileOutputStream(new File(reportsDir, "logcat.log"), false)
+        def logPrefix = System.getenv('TEST_ENV_NAME')
+        if (logPrefix == null) logPrefix = UUID.randomUUID()
+        standardOutput = new FileOutputStream(new File(reportsDir, logPrefix + "_logcat.log"), false)
     }
     commandLine "adb","logcat", "-d", "-v", "threadtime"
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ def runTests(testEnv, isAndroid) {
                     junit '**/build/**/*.xml'
                     if (isAndroid) {
                         // Collect the device log
-                        archiveArtifacts artifacts: '**/build/**/*.log'
+                        archiveArtifacts artifacts: '**/build/**/*logcat.log'
                     }
                 }
             }
@@ -60,10 +60,10 @@ stage('Build') {
 
 stage('QA') {
     // Define the matrix environments
-    def CLOUDANT_ENV = ['DB_HTTP=https', 'DB_HOST=clientlibs-test.cloudant.com', 'DB_PORT=443', 'DB_IGNORE_COMPACTION=true', 'CREDS_ID=clientlibs-test']
-    def COUCH1_6_ENV = ['DB_HTTP=http', 'DB_HOST=cloudantsync002.bristol.uk.ibm.com', 'DB_PORT=5984', 'DB_IGNORE_COMPACTION=false', 'CREDS_ID=couchdb']
-    def COUCH2_0_ENV = ['DB_HTTP=http', 'DB_HOST=cloudantsync002.bristol.uk.ibm.com', 'DB_PORT=5985', 'DB_IGNORE_COMPACTION=true', 'CREDS_ID=couchdb']
-    def CLOUDANT_LOCAL_ENV = ['DB_HTTP=http', 'DB_HOST=cloudantsync002.bristol.uk.ibm.com', 'DB_PORT=8081', 'DB_IGNORE_COMPACTION=true', 'CREDS_ID=couchdb']
+    def CLOUDANT_ENV = ['TEST_ENV_NAME=Cloudant_Test','DB_HTTP=https', 'DB_HOST=clientlibs-test.cloudant.com', 'DB_PORT=443', 'DB_IGNORE_COMPACTION=true', 'CREDS_ID=clientlibs-test']
+    def COUCH1_6_ENV = ['TEST_ENV_NAME=CouchDB1_6_Test','DB_HTTP=http', 'DB_HOST=cloudantsync002.bristol.uk.ibm.com', 'DB_PORT=5984', 'DB_IGNORE_COMPACTION=false', 'CREDS_ID=couchdb']
+    def COUCH2_0_ENV = ['TEST_ENV_NAME=CouchDB2_0_Test','DB_HTTP=http', 'DB_HOST=cloudantsync002.bristol.uk.ibm.com', 'DB_PORT=5985', 'DB_IGNORE_COMPACTION=true', 'CREDS_ID=couchdb']
+    def CLOUDANT_LOCAL_ENV = ['TEST_ENV_NAME=CloudantLocal_Test','DB_HTTP=http', 'DB_HOST=cloudantsync002.bristol.uk.ibm.com', 'DB_PORT=8081', 'DB_IGNORE_COMPACTION=true', 'CREDS_ID=couchdb']
 
     // Standard builds do Findbugs and test sync-android for Android and Java against Cloudant
     def axes = [


### PR DESCRIPTION
*What*

Named logcat files uniquely

*How*

Now that there are multiple matrix test environments it helps to have uniquely named `logcat` files so that they all get collected and it is easier to identify which one is for which test run.

Added a `TEST_ENV_NAME` for a prefix, reverting to a UUID if there is no `TEST_ENV_NAME` set.

*Testing*

Log files uniquely named in test build, test failures related to intermittent Android device disconnection.