### PR TITLE
Fix deleted revision bug

### DIFF
--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/DeleteDocumentCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/DeleteDocumentCallable.java
@@ -14,10 +14,10 @@
 
 package com.cloudant.sync.internal.documentstore.callables;
 
+import com.cloudant.sync.documentstore.Attachment;
 import com.cloudant.sync.documentstore.ConflictException;
 import com.cloudant.sync.documentstore.DocumentStoreException;
 import com.cloudant.sync.internal.common.CouchUtils;
-import com.cloudant.sync.internal.documentstore.DatabaseImpl;
 import com.cloudant.sync.documentstore.DocumentBodyFactory;
 import com.cloudant.sync.documentstore.DocumentNotFoundException;
 import com.cloudant.sync.internal.documentstore.InternalDocumentRevision;
@@ -30,6 +30,7 @@ import com.cloudant.sync.internal.util.JSONUtils;
 import com.cloudant.sync.internal.util.Misc;
 
 import java.sql.SQLException;
+import java.util.Collections;
 
 /**
  * Delete a Document for given Document ID and Revision ID.
@@ -125,6 +126,7 @@ public class DeleteDocumentCallable implements SQLCallable<InternalDocumentRevis
                 .setCurrent(current)
                 .setBody(DocumentBodyFactory.create(JSONUtils.emptyJSONObjectAsBytes()))
                 .setSequence(newSequence)
+                .setAttachments(Collections.<String, Attachment>emptyMap())
                 .build();
     }
 


### PR DESCRIPTION
See #521 

_What_
Fetching attachments on a deleted revision would cause an exception to be thrown.

_How_
Fix bug by setting attachments to an empty map in `DeleteDocumentCallable`.

_Testing_
Add test `getAttachmentsOnDeletedRevision`
