### PR TITLE
Fix 513

### DIFF
--- a/cloudant-sync-datastore-android/src/test/java/com/cloudant/sync/replication/WifiPeriodicReplicationReceiverTest.java
+++ b/cloudant-sync-datastore-android/src/test/java/com/cloudant/sync/replication/WifiPeriodicReplicationReceiverTest.java
@@ -17,6 +17,7 @@ package com.cloudant.sync.replication;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.test.AndroidTestCase;
@@ -24,18 +25,23 @@ import android.test.mock.MockContext;
 
 import org.junit.Test;
 import org.junit.BeforeClass;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
-import java.lang.Override;
 import java.util.List;
 import java.util.ArrayList;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class WifiPeriodicReplicationReceiverTest extends AndroidTestCase {
 
     private WifiPeriodicReplicationReceiver mReceiver;
     private TestContext mMockContext;
+    private SharedPreferences mMockPreferences = mock(SharedPreferences.class);
+    private SharedPreferences.Editor mMockPreferencesEditor;
 
     class TestContext extends MockContext {
         private List<Intent> mIntentsReceived = new ArrayList<Intent>();
@@ -49,6 +55,11 @@ public class WifiPeriodicReplicationReceiverTest extends AndroidTestCase {
         @Override
         public Context getApplicationContext() {
             return this;
+        }
+
+        @Override
+        public SharedPreferences getSharedPreferences(String name, int mode) {
+            return mMockPreferences;
         }
 
         @Override
@@ -116,7 +127,8 @@ public class WifiPeriodicReplicationReceiverTest extends AndroidTestCase {
 
     /**
      * Check that when {@link WifiPeriodicReplicationReceiver} receives
-     * {@link Intent#ACTION_BOOT_COMPLETED}, an {@link Intent} is sent out to start the Service
+     * {@link Intent#ACTION_BOOT_COMPLETED}, the wasOnWifi flag is set to false and
+     * an {@link Intent} is sent out to start the Service
      * {@link ReplicationService} associated with
      * {@link WifiPeriodicReplicationReceiver} containing the extra
      * {@link ReplicationService#EXTRA_COMMAND} with the value
@@ -126,7 +138,12 @@ public class WifiPeriodicReplicationReceiverTest extends AndroidTestCase {
     public void testBootCompleted() {
         Intent intent = new Intent(Intent.ACTION_BOOT_COMPLETED);
 
+        mMockPreferencesEditor = mock(SharedPreferences.Editor.class);
+        when(mMockPreferences.edit()).thenReturn(mMockPreferencesEditor);
+
         mReceiver.onReceive(mMockContext, intent);
+        verify(mMockPreferencesEditor, times(1)).putBoolean(ReplicationService.class.getName() + ".wasOnWifi",
+                false);
         assertEquals(1, mMockContext.getIntentsReceived().size());
 
         Intent receivedIntent = mMockContext.getIntentsReceived().get(0);
@@ -137,71 +154,93 @@ public class WifiPeriodicReplicationReceiverTest extends AndroidTestCase {
 
     /**
      * Check that when {@link WifiPeriodicReplicationReceiver} receives
-     * {@link ConnectivityManager#CONNECTIVITY_ACTION} and WiFi is connected,
-     * an {@link Intent} is sent out to start the Service
+     * {@link ConnectivityManager#CONNECTIVITY_ACTION} and WiFi is connected and there is a pending
+     * replication an {@link Intent} is sent out to start the Service
      * {@link ReplicationService} associated with
      * {@link WifiPeriodicReplicationReceiver} containing the extra
      * {@link ReplicationService#EXTRA_COMMAND} with the value
-     * {@link PeriodicReplicationService#COMMAND_START_PERIODIC_REPLICATION}.
+     * {@link PeriodicReplicationService#COMMAND_START_REPLICATION}.
      */
     public void testWifiConnected() {
         Intent intent = new Intent(ConnectivityManager.CONNECTIVITY_ACTION);
 
         mMockContext.setMockConnectivityManager(ConnectivityManager.TYPE_WIFI, true);
+        when(mMockPreferences.getBoolean(ReplicationService.class.getName() + ".wasOnWifi",
+            false)).thenReturn(false);
+        when(mMockPreferences.getBoolean(ReplicationService.class.getName() + "" +
+            ".replicationsPending", true)).thenReturn(true);
+
+        mMockPreferencesEditor = mock(SharedPreferences.Editor.class);
+        when(mMockPreferences.edit()).thenReturn(mMockPreferencesEditor);
 
         mReceiver.onReceive(mMockContext, intent);
+        verify(mMockPreferencesEditor, times(1)).putBoolean(ReplicationService.class.getName() + ".wasOnWifi",
+            true);
         assertEquals(1, mMockContext.getIntentsReceived().size());
 
         Intent receivedIntent = mMockContext.getIntentsReceived().get(0);
         assertEquals(ReplicationService.class.getName(), receivedIntent.getComponent().getClassName());
         assertNull(receivedIntent.getAction());
-        assertEquals(PeriodicReplicationService.COMMAND_START_PERIODIC_REPLICATION, receivedIntent.getIntExtra(ReplicationService.EXTRA_COMMAND, ReplicationService.COMMAND_NONE));
+        assertEquals(PeriodicReplicationService.COMMAND_START_REPLICATION, receivedIntent.getIntExtra(ReplicationService.EXTRA_COMMAND, ReplicationService.COMMAND_NONE));
     }
 
     /**
      * Check that when {@link WifiPeriodicReplicationReceiver} receives
      * {@link ConnectivityManager#CONNECTIVITY_ACTION} and WiFi is not connected,
-     * an {@link Intent} is sent out to start the Service
+     * an {@link Intent} is sent out to stop the Service
      * {@link ReplicationService} associated with
      * {@link WifiPeriodicReplicationReceiver} containing the extra
      * {@link ReplicationService#EXTRA_COMMAND} with the value
-     * {@link PeriodicReplicationService#COMMAND_STOP_PERIODIC_REPLICATION}.
+     * {@link PeriodicReplicationService#COMMAND_STOP_REPLICATION}.
      */
     public void testWifiDisconnected() {
         Intent intent = new Intent(ConnectivityManager.CONNECTIVITY_ACTION);
 
         mMockContext.setMockConnectivityManager(ConnectivityManager.TYPE_WIFI, false);
+        when(mMockPreferences.getBoolean(ReplicationService.class.getName() + ".wasOnWifi",
+            false)).thenReturn(true);
+        mMockPreferencesEditor = mock(SharedPreferences.Editor.class);
+        when(mMockPreferences.edit()).thenReturn(mMockPreferencesEditor);
 
         mReceiver.onReceive(mMockContext, intent);
+        verify(mMockPreferencesEditor, times(1)).putBoolean(ReplicationService.class.getName() + ".wasOnWifi",
+            false);
         assertEquals(1, mMockContext.getIntentsReceived().size());
 
         Intent receivedIntent = mMockContext.getIntentsReceived().get(0);
         assertEquals(ReplicationService.class.getName(), receivedIntent.getComponent().getClassName());
         assertNull(receivedIntent.getAction());
-        assertEquals(PeriodicReplicationService.COMMAND_STOP_PERIODIC_REPLICATION, receivedIntent.getIntExtra(ReplicationService.EXTRA_COMMAND, ReplicationService.COMMAND_NONE));
+        assertEquals(PeriodicReplicationService.COMMAND_STOP_REPLICATION, receivedIntent.getIntExtra(ReplicationService.EXTRA_COMMAND, ReplicationService.COMMAND_NONE));
     }
 
     /**
      * Check that when {@link WifiPeriodicReplicationReceiver} receives
      * {@link ConnectivityManager#CONNECTIVITY_ACTION} and the device is connected to
-     * a non-WiFi network, an {@link Intent} is sent out to start the Service
+     * a non-WiFi network, an {@link Intent} is sent out to stop the Service
      * {@link ReplicationService} associated with
      * {@link WifiPeriodicReplicationReceiver} containing the extra
      * {@link ReplicationService#EXTRA_COMMAND} with the value
-     * {@link PeriodicReplicationService#COMMAND_STOP_PERIODIC_REPLICATION}.
+     * {@link PeriodicReplicationService#COMMAND_STOP_REPLICATION}.
      */
     public void testConnectedToMobileNetwork() {
         Intent intent = new Intent(ConnectivityManager.CONNECTIVITY_ACTION);
 
         mMockContext.setMockConnectivityManager(ConnectivityManager.TYPE_MOBILE, true);
+        when(mMockPreferences.getBoolean(ReplicationService.class.getName() + ".wasOnWifi",
+            false)).thenReturn(true);
+        mMockPreferencesEditor = mock(SharedPreferences.Editor.class);
+        when(mMockPreferences.edit()).thenReturn(mMockPreferencesEditor);
 
         mReceiver.onReceive(mMockContext, intent);
+        verify(mMockPreferencesEditor, times(1)).putBoolean(ReplicationService.class.getName() + ".wasOnWifi",
+            false);
+
         assertEquals(1, mMockContext.getIntentsReceived().size());
 
         Intent receivedIntent = mMockContext.getIntentsReceived().get(0);
         assertEquals(ReplicationService.class.getName(), receivedIntent.getComponent().getClassName());
         assertNull(receivedIntent.getAction());
-        assertEquals(PeriodicReplicationService.COMMAND_STOP_PERIODIC_REPLICATION, receivedIntent.getIntExtra(ReplicationService.EXTRA_COMMAND, ReplicationService.COMMAND_NONE));
+        assertEquals(PeriodicReplicationService.COMMAND_STOP_REPLICATION, receivedIntent.getIntExtra(ReplicationService.EXTRA_COMMAND, ReplicationService.COMMAND_NONE));
     }
 
     /**
@@ -216,5 +255,59 @@ public class WifiPeriodicReplicationReceiverTest extends AndroidTestCase {
         mReceiver.onReceive(mMockContext, intent);
         assertEquals(0, mMockContext.getIntentsReceived().size());
     }
+
+    /**
+     * Check that when {@link WifiPeriodicReplicationReceiver} receives
+     * {@link PeriodicReplicationReceiver#ALARM_ACTION} and WiFi is not connected,
+     * the replications pending flag is set to true.
+     */
+    public void testAlarmActionWifiNotConnected() {
+        Intent intent = new Intent(PeriodicReplicationReceiver.ALARM_ACTION);
+
+        mMockContext.setMockConnectivityManager(ConnectivityManager.TYPE_WIFI, false);
+        mMockPreferencesEditor = mock(SharedPreferences.Editor.class);
+        when(mMockPreferences.edit()).thenReturn(mMockPreferencesEditor);
+
+        mReceiver.onReceive(mMockContext, intent);
+
+        ArgumentCaptor<String> captorPrefKeys = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Boolean> captorPrefValues = ArgumentCaptor.forClass(Boolean.class);
+        List<String> prefKeys = captorPrefKeys.getAllValues();
+        List<Boolean> prefValues = captorPrefValues.getAllValues();
+        verify(mMockPreferencesEditor, times(1)).putBoolean
+            (captorPrefKeys.capture(),
+                captorPrefValues.capture());
+
+        assertEquals("com.cloudant.sync.replication" +
+            ".WifiPeriodicReplicationReceiverTest$ReplicationService.replicationsPending",
+            prefKeys.get(0));
+        assertTrue("Replications pending flag should be true", prefValues.get(0));
+    }
+
+    /**
+     * Check that when {@link WifiPeriodicReplicationReceiver} receives
+     * {@link PeriodicReplicationReceiver#ALARM_ACTION} and WiFi is connected,
+     *  an {@link Intent} is sent out to start the Service
+     * {@link ReplicationService} associated with
+     * {@link WifiPeriodicReplicationReceiver} containing the extra
+     * {@link ReplicationService#EXTRA_COMMAND} with the value
+     * {@link PeriodicReplicationService#COMMAND_START_REPLICATION}.
+     */
+    public void testAlarmActionWifiConnected() {
+        Intent intent = new Intent(PeriodicReplicationReceiver.ALARM_ACTION);
+
+        mMockContext.setMockConnectivityManager(ConnectivityManager.TYPE_WIFI, true);
+        mMockPreferencesEditor = mock(SharedPreferences.Editor.class);
+        when(mMockPreferences.edit()).thenReturn(mMockPreferencesEditor);
+
+        mReceiver.onReceive(mMockContext, intent);
+
+        assertEquals(1, mMockContext.getIntentsReceived().size());
+
+        Intent receivedIntent = mMockContext.getIntentsReceived().get(0);
+        assertEquals(ReplicationService.class.getName(), receivedIntent.getComponent().getClassName());
+        assertNull(receivedIntent.getAction());
+        assertEquals(PeriodicReplicationService.COMMAND_START_REPLICATION, receivedIntent.getIntExtra(ReplicationService.EXTRA_COMMAND, ReplicationService.COMMAND_NONE));
+ }
 
 }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/PolicyReplicationsCompletedListener.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/PolicyReplicationsCompletedListener.java
@@ -20,7 +20,8 @@ package com.cloudant.sync.replication;
  */
 public interface PolicyReplicationsCompletedListener {
     /**
-     * Gets called back when all replicators completed.
+     * Gets called back when all replicators completed, whether due to normal completion or
+     * completion due to error.
      */
     void allReplicationsCompleted();
     /**


### PR DESCRIPTION
Fix the issues raised in #513.

Additionally, ensure wake locks are released only after we've finished processing commands sent to the replication service. Previously wake locks were being released too early (after the command had been identified but before the processing of it had been completed). This would mean for a replication, the device could go back to sleep while a replication is in progress.

Add guidance to the replication policy guide on when to use replication policies and when to use Android's `JobScheduler`. Having attempted to integrate `JobScheduler` into replication policies it became clear that doing so, while retaining `JobScheduler`'s flexibility wasn't easy and there are also options developers can go with such as using the Firebase `JobDispatcher`. Furthermore, at some point we will probably support only Android API level 21 and above, at which point Replication Policies can be completely removed. It was therefore decided that giving guidance on when and how to use of  `JobScheduler` provided more flexibility than trying to build it into Replication Policies.

### Testing

Various tests have been added to check issues raised in #513.

Extensive manual testing of a version of the TodoSync app modified to use the WifiPeriodicReplicationReceiver has been made where instrumentation was added to log events in the replication policies to file. These files have then been regularly reviewed to ensure that the replication policy is behaving as expected.

Checks on battery stats have been made to ensure that the replication policies are not holding onto wake locks and draining the battery excessively.

The examples in the guidance for the `JobScheduler` have been manually tested to ensure they work as expected.

Fixes #513