### PR TITLE
Make android jar dependency compileOnly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# 2.0.2 (Unreleased)
+- [FIXED] Removed cloudant-sync-datastore-android project's dependency
+  on com.google.android:android. This dependency was inadvertently
+  made a run-time dependency where it should have been a build-time
+  dependency.
+
 # 2.0.1 (2017-04-26)
 - [IMPROVED] Increased the resilience of replication to network failures.
 - [FIXED] NPE when accessing indexes created in earlier versions that were

--- a/cloudant-sync-datastore-android/build.gradle
+++ b/cloudant-sync-datastore-android/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     compile project(':cloudant-sync-datastore-core')
 
-    compile group: 'com.google.android', name: 'android', version:'4.0.1.2'
+    compileOnly group: 'com.google.android', name: 'android', version:'4.0.1.2'
 
     // for unit tests
     testCompile 'org.hamcrest:hamcrest-all:1.3'

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/ClientTestUtils.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/ClientTestUtils.java
@@ -26,14 +26,13 @@ import com.cloudant.sync.internal.common.CouchConstants;
 import com.cloudant.sync.internal.common.CouchUtils;
 import com.cloudant.http.Http;
 import com.cloudant.http.HttpConnection;
+import com.cloudant.sync.internal.util.JSONUtils;
 
 import org.apache.commons.io.IOUtils;
-import org.json.JSONArray;
-import org.json.JSONObject;
-import org.json.JSONTokener;
 import org.junit.Assert;
 
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -225,13 +224,12 @@ public class ClientTestUtils {
         connection.responseInterceptors.addAll(config.getResponseInterceptors());
         InputStream in = connection.execute().responseAsInputStream();
 
-        JSONObject jsonObject = new JSONObject(new JSONTokener(IOUtils.toString(in)));
-        JSONArray revsInfo = jsonObject.getJSONArray("_revs_info");
+        Map<String, Object> m = JSONUtils.fromJson(new InputStreamReader(in));
+        List<Object> revsInfo = (List<Object>)m.get("_revs_info");
+        List<String> revisions = new ArrayList<String>(revsInfo.size());
 
-        List<String> revisions = new ArrayList<String>(revsInfo.length());
-
-        for(int i=0; i<revsInfo.length(); i++){
-            revisions.add(revsInfo.getJSONObject(i).getString("rev"));
+        for(Object rev : revsInfo){
+            revisions.add(((Map<String, String>)rev).get("rev"));
         }
 
         return revisions;


### PR DESCRIPTION
**What**
Make android jar dependency compileOnly

**Why**
This incorrectly became a dependency of our published jar. It is only needed during the build
process since the android build process will substitute the "real" android jars onto the
classpath when the user builds their app.

**Testing**
Built and ran sample todo app in Android Studio 3.0 canary 3 and at command line with gradle. Note that at the command line `wrapper/gradle-wrapper.properties` had to be edited to change distributionUrl to use `gradle-4.0-milestone-1-all.zip`.

Also note that some edits had to be made to the sample app gradle file in order to use the update build process. See [this gist](https://gist.github.com/tomblench/d6dd383091f1af519f6db401b8f5f399) for the updated version. (We can't commit the updated build.gradle for the sample app until the release version of Android Studio 3.0 is available).

**Note**
This is probably a "stop-gap" measure until we do #531

**Issues**
Fixes #530