### PR TITLE
Hive off some utility methods to a "helpers" package

### DIFF
--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/AttachmentManager.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/AttachmentManager.java
@@ -316,7 +316,7 @@ public class AttachmentManager {
         }
     }
 
-    protected static Map<String, ? extends Attachment> attachmentsForRevision(SQLDatabase db, String attachmentsDir,
+    public static Map<String, ? extends Attachment> attachmentsForRevision(SQLDatabase db, String attachmentsDir,
                                                                               AttachmentStreamFactory attachmentStreamFactory,
                                                                               long sequence)
             throws AttachmentException {
@@ -334,7 +334,7 @@ public class AttachmentManager {
                 long encodedLength = c.getInt(c.getColumnIndex("encoded_length"));
                 int revpos = c.getInt(c.getColumnIndex("revpos"));
                 File file = fileFromKey(db, key, attachmentsDir, false);
-                
+
                 atts.put(filename, new SavedAttachment(sequence, filename, key, type, Attachment.Encoding
                         .values()[encoding], length, encodedLength, revpos, file,
                         attachmentStreamFactory));

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/DoForceInsertNewDocumentWithHistoryCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/DoForceInsertNewDocumentWithHistoryCallable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 IBM Corp. All rights reserved.
+ * Copyright © 2016, 2017 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -19,6 +19,7 @@ import com.cloudant.sync.documentstore.DocumentBodyFactory;
 import com.cloudant.sync.documentstore.DocumentStoreException;
 import com.cloudant.sync.internal.documentstore.DatabaseImpl;
 import com.cloudant.sync.internal.documentstore.InternalDocumentRevision;
+import com.cloudant.sync.internal.documentstore.helpers.InsertStubRevisionAdaptor;
 import com.cloudant.sync.internal.sqlite.SQLCallable;
 import com.cloudant.sync.internal.sqlite.SQLDatabase;
 
@@ -59,7 +60,7 @@ public class DoForceInsertNewDocumentWithHistoryCallable implements SQLCallable<
         long parentSequence = 0L;
         for (int i = 0; i < revHistory.size() - 1; i++) {
             // Insert stub node
-            parentSequence = DatabaseImpl.insertStubRevisionAdaptor(docNumericID, revHistory.get(i),
+            parentSequence = InsertStubRevisionAdaptor.insert(docNumericID, revHistory.get(i),
                     parentSequence).call(db);
         }
         // Insert the leaf node (don't copy attachments)

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/ForceInsertCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/ForceInsertCallable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 IBM Corp. All rights reserved.
+ * Copyright © 2016, 2017 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -131,11 +131,9 @@ public class ForceInsertCallable implements SQLCallable<List<DocumentModified>> 
                             String rev = key[1];
                             try {
                                 InternalDocumentRevision doc = new GetDocumentCallable(id, rev, attachmentsDir, attachmentStreamFactory).call(db);
-                                if (doc != null) {
                                     AttachmentManager.addAttachmentsToRevision(db,
                                             attachmentsDir, doc, item
                                                     .preparedAttachments.get(key));
-                                }
                             } catch (DocumentNotFoundException e) {
                                 //safe to continue, previously getDocumentInQueue
                                 // could return

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/GetAllDocumentsCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/GetAllDocumentsCallable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 IBM Corp. All rights reserved.
+ * Copyright © 2016, 2017 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -18,6 +18,7 @@ import com.cloudant.sync.documentstore.DocumentRevision;
 import com.cloudant.sync.internal.documentstore.AttachmentStreamFactory;
 import com.cloudant.sync.internal.documentstore.DatabaseImpl;
 import com.cloudant.sync.internal.documentstore.InternalDocumentRevision;
+import com.cloudant.sync.internal.documentstore.helpers.GetRevisionsFromRawQuery;
 import com.cloudant.sync.internal.sqlite.SQLCallable;
 import com.cloudant.sync.internal.sqlite.SQLDatabase;
 
@@ -54,7 +55,7 @@ public class GetAllDocumentsCallable implements SQLCallable<List<DocumentRevisio
                 " ORDER BY docs.doc_id %1$s, revid DESC LIMIT %2$s OFFSET %3$s ",
                 (descending ? "DESC" : "ASC"), limit, offset);
 
-        return new ArrayList<DocumentRevision>(DatabaseImpl.getRevisionsFromRawQuery(db, sql,
+        return new ArrayList<DocumentRevision>(GetRevisionsFromRawQuery.get(db, sql,
                 new String[]{}, attachmentsDir, attachmentStreamFactory));
 
     }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/GetAllRevisionsOfDocumentCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/GetAllRevisionsOfDocumentCallable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 IBM Corp. All rights reserved.
+ * Copyright © 2016, 2017 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -21,6 +21,7 @@ import com.cloudant.sync.internal.documentstore.DatabaseImpl;
 import com.cloudant.sync.documentstore.DocumentStoreException;
 import com.cloudant.sync.internal.documentstore.InternalDocumentRevision;
 import com.cloudant.sync.internal.documentstore.DocumentRevisionTree;
+import com.cloudant.sync.internal.documentstore.helpers.GetFullRevisionFromCurrentCursor;
 import com.cloudant.sync.internal.sqlite.Cursor;
 import com.cloudant.sync.internal.sqlite.SQLCallable;
 import com.cloudant.sync.internal.sqlite.SQLDatabase;
@@ -71,7 +72,7 @@ public class GetAllRevisionsOfDocumentCallable implements SQLCallable<DocumentRe
                 long sequence = cursor.getLong(3);
                 Map<String, ? extends Attachment> atts = new AttachmentsForRevisionCallable(
                         this.attachmentsDir, this.attachmentStreamFactory, sequence).call(db);
-                InternalDocumentRevision rev = DatabaseImpl.getFullRevisionFromCurrentCursor(cursor, atts);
+                InternalDocumentRevision rev = GetFullRevisionFromCurrentCursor.get(cursor, atts);
                 logger.finer("Rev: " + rev);
                 tree.add(rev);
             }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/GetDocumentCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/GetDocumentCallable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 IBM Corp. All rights reserved.
+ * Copyright © 2016, 2017 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -21,6 +21,7 @@ import com.cloudant.sync.internal.documentstore.DatabaseImpl;
 import com.cloudant.sync.documentstore.DocumentStoreException;
 import com.cloudant.sync.documentstore.DocumentNotFoundException;
 import com.cloudant.sync.internal.documentstore.InternalDocumentRevision;
+import com.cloudant.sync.internal.documentstore.helpers.GetFullRevisionFromCurrentCursor;
 import com.cloudant.sync.internal.sqlite.Cursor;
 import com.cloudant.sync.internal.sqlite.SQLCallable;
 import com.cloudant.sync.internal.sqlite.SQLDatabase;
@@ -71,7 +72,7 @@ public class GetDocumentCallable implements SQLCallable<InternalDocumentRevision
                 long sequence = cursor.getLong(3);
                 Map<String, ? extends Attachment> atts = new AttachmentsForRevisionCallable(
                         this.attachmentsDir, this.attachmentStreamFactory, sequence).call(db);
-                return DatabaseImpl.getFullRevisionFromCurrentCursor(cursor, atts);
+                return GetFullRevisionFromCurrentCursor.get(cursor, atts);
             } else {
                 throw new DocumentNotFoundException(id, rev);
             }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/GetDocumentsWithIdsCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/GetDocumentsWithIdsCallable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 IBM Corp. All rights reserved.
+ * Copyright © 2016, 2017 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -18,17 +18,24 @@ import com.cloudant.sync.documentstore.DocumentRevision;
 import com.cloudant.sync.internal.documentstore.AttachmentStreamFactory;
 import com.cloudant.sync.internal.documentstore.DatabaseImpl;
 import com.cloudant.sync.internal.documentstore.InternalDocumentRevision;
+import com.cloudant.sync.internal.documentstore.helpers.GetRevisionsFromRawQuery;
 import com.cloudant.sync.internal.sqlite.SQLCallable;
 import com.cloudant.sync.internal.sqlite.SQLDatabase;
 import com.cloudant.sync.internal.util.DatabaseUtils;
 import com.cloudant.sync.internal.util.Misc;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
 
 /**
  * Get a List of Document Revisions by Document ID
  */
 public class GetDocumentsWithIdsCallable implements SQLCallable<List<DocumentRevision>> {
+
+    private static final Logger logger = Logger.getLogger(GetDocumentsWithIdsCallable.class.getCanonicalName());
 
     private List<String> docIds;
 
@@ -51,8 +58,36 @@ public class GetDocumentsWithIdsCallable implements SQLCallable<List<DocumentRev
                 " ORDER BY docs.doc_id ", DatabaseUtils.makePlaceholders(docIds.size
                 ()));
         String[] args = docIds.toArray(new String[docIds.size()]);
-        List<InternalDocumentRevision> docs = DatabaseImpl.getRevisionsFromRawQuery(db, sql, args, attachmentsDir, attachmentStreamFactory);
+        List<InternalDocumentRevision> docs = GetRevisionsFromRawQuery.get(db, sql, args,
+                attachmentsDir, attachmentStreamFactory);
         // Sort in memory since seems not able to sort them using SQL
-        return DatabaseImpl.sortDocumentsAccordingToIdList(docIds, docs);
+        return sortDocumentsAccordingToIdList(docIds, docs);
     }
+
+    private static List<DocumentRevision> sortDocumentsAccordingToIdList(List<String> docIds,
+                                                                        List<InternalDocumentRevision> docs) {
+        Map<String, InternalDocumentRevision> idToDocs = putDocsIntoMap(docs);
+        List<DocumentRevision> results = new ArrayList<DocumentRevision>();
+        for (String id : docIds) {
+            if (idToDocs.containsKey(id)) {
+                results.add(idToDocs.remove(id));
+            } else {
+                logger.fine("No document found for id: " + id);
+            }
+        }
+        assert idToDocs.size() == 0;
+        return results;
+    }
+
+    private static Map<String, InternalDocumentRevision> putDocsIntoMap(List<InternalDocumentRevision> docs) {
+        Map<String, InternalDocumentRevision> map = new HashMap<String, InternalDocumentRevision>();
+        for (InternalDocumentRevision doc : docs) {
+            // ID should be unique cross all docs
+            assert !map.containsKey(doc.getId());
+            map.put(doc.getId(), doc);
+        }
+        return map;
+    }
+
+
 }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/GetDocumentsWithInternalIdsCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/GetDocumentsWithInternalIdsCallable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 IBM Corp. All rights reserved.
+ * Copyright © 2016, 2017 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -19,6 +19,7 @@ import com.cloudant.sync.documentstore.DocumentStoreException;
 import com.cloudant.sync.internal.documentstore.DatabaseImpl;
 import com.cloudant.sync.documentstore.DocumentException;
 import com.cloudant.sync.internal.documentstore.InternalDocumentRevision;
+import com.cloudant.sync.internal.documentstore.helpers.GetRevisionsFromRawQuery;
 import com.cloudant.sync.internal.sqlite.SQLCallable;
 import com.cloudant.sync.internal.sqlite.SQLDatabase;
 import com.cloudant.sync.internal.util.CollectionUtils;
@@ -80,7 +81,7 @@ public class GetDocumentsWithInternalIdsCallable implements SQLCallable<List<Int
             for (int i = 0; i < batch.size(); i++) {
                 args[i] = Long.toString(batch.get(i));
             }
-            result.addAll(DatabaseImpl.getRevisionsFromRawQuery(db, sql, args, attachmentsDir,
+            result.addAll(GetRevisionsFromRawQuery.get(db, sql, args, attachmentsDir,
                     attachmentStreamFactory));
         }
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/InsertDocumentHistoryIntoExistingTreeCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/InsertDocumentHistoryIntoExistingTreeCallable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 IBM Corp. All rights reserved.
+ * Copyright © 2016, 2017 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -18,6 +18,7 @@ import com.cloudant.sync.internal.documentstore.AttachmentManager;
 import com.cloudant.sync.internal.documentstore.DatabaseImpl;
 import com.cloudant.sync.documentstore.DocumentStoreException;
 import com.cloudant.sync.internal.documentstore.InternalDocumentRevision;
+import com.cloudant.sync.internal.documentstore.helpers.InsertStubRevisionAdaptor;
 import com.cloudant.sync.internal.sqlite.SQLCallable;
 import com.cloudant.sync.internal.sqlite.SQLDatabase;
 import com.cloudant.sync.internal.util.Misc;
@@ -66,7 +67,7 @@ public class InsertDocumentHistoryIntoExistingTreeCallable implements SQLCallabl
             String revId = revisions.get(i);
             long seq = new GetSequenceCallable(newRevision.getId(), revId).call(db);
             if (seq == -1) {
-                seq = DatabaseImpl.insertStubRevisionAdaptor(docNumericID, revId, parentSeq).call(db);
+                seq = InsertStubRevisionAdaptor.insert(docNumericID, revId, parentSeq).call(db);
                 new SetCurrentCallable(parentSeq, false).call(db);
             }
             parentSeq = seq;

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/InsertDocumentHistoryToNewTreeCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/InsertDocumentHistoryToNewTreeCallable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 IBM Corp. All rights reserved.
+ * Copyright © 2016, 2017 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -17,6 +17,7 @@ package com.cloudant.sync.internal.documentstore.callables;
 import com.cloudant.sync.internal.documentstore.DatabaseImpl;
 import com.cloudant.sync.documentstore.DocumentStoreException;
 import com.cloudant.sync.internal.documentstore.InternalDocumentRevision;
+import com.cloudant.sync.internal.documentstore.helpers.InsertStubRevisionAdaptor;
 import com.cloudant.sync.internal.sqlite.SQLCallable;
 import com.cloudant.sync.internal.sqlite.SQLDatabase;
 import com.cloudant.sync.internal.util.Misc;
@@ -59,7 +60,7 @@ public class InsertDocumentHistoryToNewTreeCallable implements SQLCallable<Long>
         long parentSequence = 0L;
         for (int i = 0; i < revisions.size() - 1; i++) {
             //we copy attachments here so allow the exception to propagate
-            parentSequence = DatabaseImpl.insertStubRevisionAdaptor(docNumericID, revisions.get(i), parentSequence).call(db);
+            parentSequence = InsertStubRevisionAdaptor.insert(docNumericID, revisions.get(i), parentSequence).call(db);
         }
         // don't copy attachments
         String newLeafRev = newRevision.getRevision();

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/UpdateDocumentBodyCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/UpdateDocumentBodyCallable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 IBM Corp. All rights reserved.
+ * Copyright © 2016, 2017 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -20,6 +20,7 @@ import com.cloudant.sync.documentstore.ConflictException;
 import com.cloudant.sync.internal.documentstore.DatabaseImpl;
 import com.cloudant.sync.documentstore.DocumentBody;
 import com.cloudant.sync.internal.documentstore.InternalDocumentRevision;
+import com.cloudant.sync.internal.documentstore.helpers.InsertNewWinnerRevisionAdaptor;
 import com.cloudant.sync.internal.sqlite.SQLCallable;
 import com.cloudant.sync.internal.sqlite.SQLDatabase;
 import com.cloudant.sync.internal.util.Misc;
@@ -63,7 +64,7 @@ public class UpdateDocumentBodyCallable implements SQLCallable<InternalDocumentR
         }
 
         new SetCurrentCallable(preRevision.getSequence(), false).call(db);
-        InsertRevisionCallable insertRevisionCallable = DatabaseImpl.insertNewWinnerRevisionAdaptor(body, preRevision);
+        InsertRevisionCallable insertRevisionCallable = InsertNewWinnerRevisionAdaptor.insert(body, preRevision);
         String newRevisionId = insertRevisionCallable.revId;
         insertRevisionCallable.call(db);
         // TODO build the new DocumentRevision instead of retrieving the whole document again

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/helpers/GetFullRevisionFromCurrentCursor.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/helpers/GetFullRevisionFromCurrentCursor.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.internal.documentstore.helpers;
+
+import com.cloudant.sync.documentstore.Attachment;
+import com.cloudant.sync.internal.documentstore.DocumentBodyImpl;
+import com.cloudant.sync.internal.documentstore.DocumentRevisionBuilder;
+import com.cloudant.sync.internal.documentstore.InternalDocumentRevision;
+import com.cloudant.sync.internal.sqlite.Cursor;
+
+import java.util.Map;
+
+/**
+ * Created by tomblench on 23/08/2017.
+ */
+
+public class GetFullRevisionFromCurrentCursor {
+
+    public static InternalDocumentRevision get(Cursor cursor,
+                                               Map<String, ? extends Attachment> attachments) {
+        String docId = cursor.getString(cursor.getColumnIndex("docid"));
+        long internalId = cursor.getLong(cursor.getColumnIndex("doc_id"));
+        String revId = cursor.getString(cursor.getColumnIndex("revid"));
+        long sequence = cursor.getLong(cursor.getColumnIndex("sequence"));
+        byte[] json = cursor.getBlob(cursor.getColumnIndex("json"));
+        boolean current = cursor.getInt(cursor.getColumnIndex("current")) > 0;
+        boolean deleted = cursor.getInt(cursor.getColumnIndex("deleted")) > 0;
+
+        long parent = -1L;
+        if (cursor.columnType(cursor.getColumnIndex("parent")) == Cursor.FIELD_TYPE_INTEGER) {
+            parent = cursor.getLong(cursor.getColumnIndex("parent"));
+        } else if (cursor.columnType(cursor.getColumnIndex("parent")) == Cursor.FIELD_TYPE_NULL) {
+        } else {
+            throw new RuntimeException("Unexpected type: " + cursor.columnType(cursor
+                    .getColumnIndex("parent")));
+        }
+
+        DocumentRevisionBuilder builder = new DocumentRevisionBuilder()
+                .setDocId(docId)
+                .setRevId(revId)
+                .setBody(DocumentBodyImpl.bodyWith(json))
+                .setDeleted(deleted)
+                .setSequence(sequence)
+                .setInternalId(internalId)
+                .setCurrent(current)
+                .setParent(parent)
+                .setAttachments(attachments);
+
+        return builder.build();
+    }
+
+}

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/helpers/GetRevisionsFromRawQuery.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/helpers/GetRevisionsFromRawQuery.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.internal.documentstore.helpers;
+
+import com.cloudant.sync.documentstore.Attachment;
+import com.cloudant.sync.documentstore.DocumentException;
+import com.cloudant.sync.documentstore.DocumentStoreException;
+import com.cloudant.sync.internal.documentstore.AttachmentManager;
+import com.cloudant.sync.internal.documentstore.AttachmentStreamFactory;
+import com.cloudant.sync.internal.documentstore.InternalDocumentRevision;
+import com.cloudant.sync.internal.sqlite.Cursor;
+import com.cloudant.sync.internal.sqlite.SQLDatabase;
+import com.cloudant.sync.internal.util.DatabaseUtils;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Created by tomblench on 23/08/2017.
+ */
+
+public class GetRevisionsFromRawQuery {
+    public static List<InternalDocumentRevision> get(
+            SQLDatabase db, String sql, String[] args, String attachmentsDir,
+            AttachmentStreamFactory attachmentStreamFactory)
+            throws DocumentException, DocumentStoreException {
+
+        List<InternalDocumentRevision> result = new ArrayList<InternalDocumentRevision>();
+        Cursor cursor = null;
+
+        try {
+            cursor = db.rawQuery(sql, args);
+            while (cursor.moveToNext()) {
+                long sequence = cursor.getLong(3);
+                Map<String, ? extends Attachment> atts = AttachmentManager.attachmentsForRevision(
+                        db, attachmentsDir, attachmentStreamFactory, sequence);
+                InternalDocumentRevision row = GetFullRevisionFromCurrentCursor.get(cursor, atts);
+                result.add(row);
+            }
+        } catch (SQLException e) {
+            throw new DocumentStoreException(e);
+        } finally {
+            DatabaseUtils.closeCursorQuietly(cursor);
+        }
+        return result;
+    }
+}

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/helpers/InsertNewWinnerRevisionAdaptor.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/helpers/InsertNewWinnerRevisionAdaptor.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.internal.documentstore.helpers;
+
+import com.cloudant.sync.documentstore.AttachmentException;
+import com.cloudant.sync.documentstore.DocumentBody;
+import com.cloudant.sync.documentstore.DocumentStoreException;
+import com.cloudant.sync.internal.common.CouchUtils;
+import com.cloudant.sync.internal.documentstore.InternalDocumentRevision;
+import com.cloudant.sync.internal.documentstore.callables.InsertRevisionCallable;
+
+/**
+ * Created by tomblench on 23/08/2017.
+ */
+
+public class InsertNewWinnerRevisionAdaptor {
+
+    public static InsertRevisionCallable insert(DocumentBody newWinner,
+                                                InternalDocumentRevision oldWinner)
+            throws AttachmentException, DocumentStoreException {
+
+        String newRevisionId = CouchUtils.generateNextRevisionId(oldWinner.getRevision());
+
+        InsertRevisionCallable callable = new InsertRevisionCallable();
+
+        callable.docNumericId = oldWinner.getInternalNumericId();
+        callable.revId = newRevisionId;
+        callable.parentSequence = oldWinner.getSequence();
+        callable.deleted = false;
+        callable.current = true;
+        callable.data = newWinner.asBytes();
+        callable.available = true;
+
+        return callable;
+    }
+
+}

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/helpers/InsertStubRevisionAdaptor.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/helpers/InsertStubRevisionAdaptor.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.internal.documentstore.helpers;
+
+import com.cloudant.sync.internal.documentstore.callables.InsertRevisionCallable;
+import com.cloudant.sync.internal.util.JSONUtils;
+
+/**
+ * Created by tomblench on 23/08/2017.
+ */
+
+public class InsertStubRevisionAdaptor {
+
+    public static InsertRevisionCallable insert(long docNumericId, String revId, long
+            parentSequence) {
+        // don't copy attachments
+        InsertRevisionCallable callable = new InsertRevisionCallable();
+        callable.docNumericId = docNumericId;
+        callable.revId = revId;
+        callable.parentSequence = parentSequence;
+        callable.deleted = false;
+        callable.current = false;
+        callable.data = JSONUtils.emptyJSONObjectAsBytes();
+        callable.available = false;
+        return callable;
+    }
+
+}


### PR DESCRIPTION
Fixes #353

_What_: Hive off some utility methods to a "helpers" package

_Why_: These are static methods which don't need to access any of the internals of `DatabaseImpl`. Also they make an already large class even larger and splitting them out into a separate package makes their purpose more clear

_Testing_: All existing tests pass. As this is an internal refactor/rename, no new tests are needed.
