### PR TITLE
Add iamApiKey option to ReplicatorBuilder

### DIFF
--- a/AndroidTest/app/build.gradle
+++ b/AndroidTest/app/build.gradle
@@ -85,7 +85,7 @@ dependencies {
     compile 'commons-io:commons-io:2.4'
     compile 'commons-codec:commons-codec:1.9'
     compile 'org.apache.commons:commons-lang3:3.3.2'
-    compile group: 'com.cloudant', name: 'cloudant-http', version:'2.7.0'
+    compile group: 'com.cloudant', name: 'cloudant-http', version:'latest.integration'
     compile 'com.google.code.findbugs:jsr305:3.0.0' //this is needed for some versions of android
     compile files('../../cloudant-sync-datastore-android-encryption/libs/sqlcipher.jar') //required sqlcipher lib
     compile files('../../cloudant-sync-datastore-android/libs/android-support-v4.jar')
@@ -108,6 +108,7 @@ dependencies {
 repositories {
     mavenLocal()
     mavenCentral()
+    maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
 }
 
 task(uploadFixtures, type: AndroidExec) {

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# 2.1.0 (Unreleased)
+- [NEW] Added support for authenticating with IAM API keys. See
+  [README](https://github.com/cloudant/sync-android/blob/2.1.0/README.md) and the
+  [Bluemix documentation](https://console.bluemix.net/docs/services/Cloudant/guides/iam.html#ibm-cloud-identity-and-access-management)
+  for more details.
+
 # 2.0.2 (2017-06-20)
 - [FIXED] Removed cloudant-sync-datastore-android project dependency
   on com.google.android:android. This dependency was inadvertently

--- a/README.md
+++ b/README.md
@@ -261,7 +261,20 @@ Read more in [the replication docs](https://github.com/cloudant/sync-android/blo
 ### Authentication
 
 Sync-android uses session cookies by default to authenticate with the server if
-credentials are provided with in the URL. If you want more fine-grained control over authentication, provide an interceptor to perform the authentication for each request. For example, if you are using middleware such as [Envoy][envoy], you can use
+credentials are provided with in the URL. 
+
+To use an IAM API key on IBM Bluemix, use the `iamApiKey` method when
+building the `Replicator` object:
+
+```java
+Replicator replicator = ReplicatorBuilder.push()
+  .from(ds)
+  .to(uri)
+  .iamApiKey("exampleApiKey")
+  .build();
+```
+
+If you want more fine-grained control over authentication, provide an interceptor to perform the authentication for each request. For example, if you are using middleware such as [Envoy][envoy], you can use
 the `BasicAuthInterceptor` to add basic authentication to requests.
 
 Example:

--- a/cloudant-sync-datastore-core/build.gradle
+++ b/cloudant-sync-datastore-core/build.gradle
@@ -1,9 +1,13 @@
+repositories {
+    maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
+}
+
 // ************ //
 // CORE PROJ
 // ************ //
 dependencies {
 
-    compile group: 'com.cloudant', name: 'cloudant-http', version:'2.7.0'
+    compile group: 'com.cloudant', name: 'cloudant-http', version:'latest.integration'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version:'2.1.1'
     compile group: 'commons-codec', name: 'commons-codec', version:'1.10'
     compile group: 'commons-io', name: 'commons-io', version:'2.4'

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/common/TestOptions.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/common/TestOptions.java
@@ -102,4 +102,6 @@ public class TestOptions {
     public static final Boolean IGNORE_AUTH_HEADERS = Boolean.valueOf(
             System.getProperty("test.couch.ignore.auth.headers", Boolean.TRUE.toString()));
 
+    public static final String COUCH_IAM_API_KEY = System.getProperty("test.couch.iam.api.key");
+
 }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/http/HttpTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/http/HttpTest.java
@@ -17,7 +17,7 @@ package com.cloudant.http;
 import com.cloudant.common.CouchTestBase;
 import com.cloudant.common.RequireRunningCouchDB;
 import com.cloudant.common.TestOptions;
-import com.cloudant.http.interceptors.CookieInterceptor;
+import com.cloudant.http.internal.interceptors.CookieInterceptor;
 import com.cloudant.sync.internal.mazha.CouchClient;
 import com.cloudant.sync.internal.mazha.CouchConfig;
 import com.cloudant.sync.internal.util.JSONUtils;

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/CouchConfig.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/CouchConfig.java
@@ -20,12 +20,16 @@
 
 package com.cloudant.sync.internal.mazha;
 
+import com.cloudant.common.TestOptions;
 import com.cloudant.http.HttpConnectionRequestInterceptor;
 import com.cloudant.http.HttpConnectionResponseInterceptor;
-import com.cloudant.http.interceptors.CookieInterceptor;
+import com.cloudant.http.internal.interceptors.CookieInterceptor;
+import com.cloudant.http.internal.interceptors.IamCookieInterceptor;
 
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -52,8 +56,8 @@ public class CouchConfig {
 
     public CouchConfig(URI rootUri) {
         this(rootUri,
-                Collections.<HttpConnectionRequestInterceptor>emptyList(),
-                Collections.<HttpConnectionResponseInterceptor>emptyList(),
+                new ArrayList<HttpConnectionRequestInterceptor>(),
+                new ArrayList<HttpConnectionResponseInterceptor>(),
                 null,
                 null);
     }
@@ -68,9 +72,15 @@ public class CouchConfig {
         this.responseInterceptors = responseInterceptors;
         this.username = username;
         this.password = password;
-
+        if (TestOptions.COUCH_IAM_API_KEY != null) {
+            int slash = this.rootUri.toString().lastIndexOf("/");
+            String root = this.rootUri.toString().substring(0, slash);
+            IamCookieInterceptor ici = new IamCookieInterceptor(TestOptions.COUCH_IAM_API_KEY,
+                    root);
+            this.requestInterceptors.add(ici);
+            this.responseInterceptors.add(ici);
+        }
     }
-
 
     public List<HttpConnectionRequestInterceptor> getRequestInterceptors(boolean includeCookie) {
         CookieInterceptor cookieInterceptor = buildCookieInterceptor();

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/SpecifiedCouch.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/SpecifiedCouch.java
@@ -22,7 +22,6 @@ import static com.cloudant.common.TestOptions.COUCH_URI;
 import static com.cloudant.common.TestOptions.COUCH_USERNAME;
 import static com.cloudant.common.TestOptions.HTTP_PROTOCOL;
 
-import com.cloudant.http.interceptors.CookieInterceptor;
 import com.cloudant.http.HttpConnectionRequestInterceptor;
 import com.cloudant.http.HttpConnectionResponseInterceptor;
 
@@ -53,8 +52,8 @@ public class SpecifiedCouch {
                 uriString = String.format("%s://%s:%s/%s", HTTP_PROTOCOL, COUCH_HOST, COUCH_PORT, dbName);
             }
             CouchConfig config = new CouchConfig(new URI(uriString),
-                    Collections.<HttpConnectionRequestInterceptor>emptyList(),
-                    Collections.<HttpConnectionResponseInterceptor>emptyList(),
+                    new ArrayList<HttpConnectionRequestInterceptor>(),
+                    new ArrayList<HttpConnectionResponseInterceptor>(),
                     COUCH_USERNAME,
                     COUCH_PASSWORD);
             return config;

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/CompactedDBReplicationTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/CompactedDBReplicationTest.java
@@ -56,6 +56,7 @@ public class CompactedDBReplicationTest extends ReplicationTestBase {
         // skip test if we are doing cookie auth, we don't have the interceptor chain to do it
         // when we call ClientTestUtils.executeHttpPostRequest
         if(TestOptions.COOKIE_AUTH){return;}
+        if(TestOptions.COUCH_IAM_API_KEY != null){return;}
 
         String documentName;
         Bar bar = BarUtils.createBar(remoteDb, "Bob", 12);

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/PullReplicatorTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/PullReplicatorTest.java
@@ -18,7 +18,7 @@ package com.cloudant.sync.internal.replication;
 
 import com.cloudant.common.RequireRunningCouchDB;
 import com.cloudant.common.TestOptions;
-import com.cloudant.http.interceptors.CookieInterceptor;
+import com.cloudant.http.internal.interceptors.CookieInterceptor;
 import com.cloudant.sync.replication.PullFilter;
 import com.cloudant.sync.replication.Replicator;
 import com.cloudant.sync.replication.ReplicatorBuilder;
@@ -311,6 +311,33 @@ public class PullReplicatorTest extends ReplicationTestBase {
                 from(new URI("gopher://localhost/abc")).
                 to(documentStore);
         p.build();
+    }
+
+    @Test
+    public void replicatorBuilderAddsIamInterceptor() throws Exception {
+        String apiKey = "abc123";
+        ReplicatorBuilder.Pull p = ReplicatorBuilder.pull().from(new URI("http://example.com/path")).
+                to(documentStore).
+                iamApiKey(apiKey);
+        // although the replicator isn't used, the interceptor check expects the presence of the
+        // header interceptor, which only gets added if build() is called
+        ReplicatorImpl r = (ReplicatorImpl) p.build();
+        assertIamCookieInterceptorPresent(p);
+    }
+
+    // as above test, but ensure IAM API key takes precedence over username/password
+    @Test
+    public void replicatorBuilderAddsIamInterceptorWhenUsernamePasswordPresent() throws Exception {
+        String apiKey = "abc123";
+        ReplicatorBuilder.Pull p = ReplicatorBuilder.pull().from(new URI("http://example.com/path")).
+                to(documentStore).
+                username("username").
+                password("password").
+                iamApiKey(apiKey);
+        // although the replicator isn't used, the interceptor check expects the presence of the
+        // header interceptor, which only gets added if build() is called
+        ReplicatorImpl r = (ReplicatorImpl) p.build();
+        assertIamCookieInterceptorPresent(p);
     }
 
 }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/PushReplicatorTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/PushReplicatorTest.java
@@ -414,4 +414,32 @@ public class PushReplicatorTest extends ReplicationTestBase {
         p.build();
     }
 
+    @Test
+    public void replicatorBuilderAddsIamInterceptor() throws Exception {
+        String apiKey = "abc123";
+        ReplicatorBuilder.Push p = ReplicatorBuilder.push().from(documentStore).
+                to(new URI("http://example.com/path")).
+                iamApiKey(apiKey);
+        // although the replicator isn't used, the interceptor check expects the presence of the
+        // header interceptor, which only gets added if build() is called
+        ReplicatorImpl r = (ReplicatorImpl) p.build();
+        assertIamCookieInterceptorPresent(p);
+    }
+
+    // as above test, but ensure IAM API key takes precedence over username/password
+    @Test
+    public void replicatorBuilderAddsIamInterceptorWhenUsernamePasswordPresent() throws Exception {
+        String apiKey = "abc123";
+        ReplicatorBuilder.Push p = ReplicatorBuilder.push().from(documentStore).
+                to(new URI("http://example.com/path")).
+                username("username").
+                password("password").
+                iamApiKey(apiKey);
+        // although the replicator isn't used, the interceptor check expects the presence of the
+        // header interceptor, which only gets added if build() is called
+        ReplicatorImpl r = (ReplicatorImpl) p.build();
+        assertIamCookieInterceptorPresent(p);
+    }
+
+
 }


### PR DESCRIPTION
Fixes #542 

_What_
Support IAM

_How_
- Add new builder method `iamApiKey` on `ReplicatorBuilder`
- Add IAM interceptors if `iamApiKey` is set.
- Use the latest snapshot of `cloudant-http` for the IAM interceptor temporarily. Before this PR is merged this will change to the version which will, by then, be available in `cloudant-http` on master.

_Testing_
TODO - `cloudant-http` has mock tests but as and when the IAM feature is rolled out throughout the Cloudant service it would be good to have end-to-end replication using IAM as part of the standard test suite.
