### PR TITLE
160 purge

### DIFF
--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/Database.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/Database.java
@@ -356,6 +356,8 @@ public interface Database {
      */
     EventBus getEventBus();
 
+    void purge(final DocumentRevision rev);
+
 
 }
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/Database.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/Database.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 IBM Corp. All rights reserved.
+ * Copyright © 2016, 2017 IBM Corp. All rights reserved.
  *
  * Original iOS version by  Jens Alfke, ported to Android by Marty Schoch
  * Copyright © 2012 Couchbase, Inc. All rights reserved.

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/PurgeNotification.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/PurgeNotification.java
@@ -1,0 +1,18 @@
+package com.cloudant.sync.internal;
+
+import com.cloudant.sync.event.notifications.Notification;
+
+/**
+ * Created by tomblench on 29/08/2017.
+ */
+
+public class PurgeNotification implements Notification {
+
+    public final String documentId;
+    public final String revisionId;
+
+    public PurgeNotification(String documentId, String revisionId) {
+        this.documentId = documentId;
+        this.revisionId = revisionId;
+    }
+}

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/PurgeNotification.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/PurgeNotification.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ *  except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ */
+
 package com.cloudant.sync.internal;
 
 import com.cloudant.sync.event.notifications.Notification;

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/DatabaseImpl.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/DatabaseImpl.java
@@ -1090,7 +1090,7 @@ public class DatabaseImpl implements Database, com.cloudant.sync.documentstore.a
 
     public void purge(final DocumentRevision rev) {
         // purge rev and attachments...
-        PurgeCallable pc = new PurgeCallable(rev.getId(), rev.getRevision());
+        PurgeCallable pc = new PurgeCallable(rev.getId(), rev.getRevision(), attachmentsDir);
         queue.submit(pc);
         // send event on message bus so Query can perform purge
         eventBus.post(new PurgeNotification(rev.getId(), rev.getRevision()));

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/DatabaseImpl.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/DatabaseImpl.java
@@ -38,6 +38,7 @@ import com.cloudant.sync.event.notifications.DocumentCreated;
 import com.cloudant.sync.event.notifications.DocumentDeleted;
 import com.cloudant.sync.event.notifications.DocumentModified;
 import com.cloudant.sync.event.notifications.DocumentUpdated;
+import com.cloudant.sync.internal.PurgeNotification;
 import com.cloudant.sync.internal.common.CouchUtils;
 import com.cloudant.sync.internal.common.ValueListMap;
 import com.cloudant.sync.internal.documentstore.callables.ChangesCallable;
@@ -61,6 +62,7 @@ import com.cloudant.sync.internal.documentstore.callables.GetSequenceCallable;
 import com.cloudant.sync.internal.documentstore.callables.InsertDocumentIDCallable;
 import com.cloudant.sync.internal.documentstore.callables.InsertLocalDocumentCallable;
 import com.cloudant.sync.internal.documentstore.callables.InsertRevisionCallable;
+import com.cloudant.sync.internal.documentstore.callables.PurgeCallable;
 import com.cloudant.sync.internal.documentstore.callables.ResolveConflictsForDocumentCallable;
 import com.cloudant.sync.internal.documentstore.callables.RevsDiffBatchCallable;
 import com.cloudant.sync.internal.documentstore.callables.SetCurrentCallable;
@@ -1084,5 +1086,13 @@ public class DatabaseImpl implements Database, com.cloudant.sync.documentstore.a
         // for reference.
         forceInsert(Collections.singletonList(new ForceInsertItem(internalRev,
                 revIDs, null, preparedAttachments, false)));
+    }
+
+    public void purge(final DocumentRevision rev) {
+        // purge rev and attachments...
+        PurgeCallable pc = new PurgeCallable(rev.getId(), rev.getRevision());
+        queue.submit(pc);
+        // send event on message bus so Query can perform purge
+        eventBus.post(new PurgeNotification(rev.getId(), rev.getRevision()));
     }
 }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/PurgeCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/PurgeCallable.java
@@ -45,6 +45,8 @@ public class PurgeCallable implements SQLCallable<Void> {
 
     @Override
     public Void call(SQLDatabase db) throws Exception {
+        // TODO fixup the tree if necessary by joining this node's parent to its child
+        // TODO also fix the current flag if necessary when purging a leaf node
         System.out.println("PurgeCallable documentstore");
         int nRows = db.delete("revs",
                 "doc_id = (select doc_id from docs where docid = ?) AND revid = ?",

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/PurgeCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/PurgeCallable.java
@@ -1,0 +1,26 @@
+package com.cloudant.sync.internal.documentstore.callables;
+
+import com.cloudant.sync.internal.sqlite.SQLCallable;
+import com.cloudant.sync.internal.sqlite.SQLDatabase;
+
+/**
+ * Created by tomblench on 29/08/2017.
+ */
+
+public class PurgeCallable implements SQLCallable<Void> {
+
+    private String documentId;
+    private String revisionId;
+
+    public PurgeCallable(String documentId, String revisionId) {
+        this.documentId = documentId;
+        this.revisionId = revisionId;
+    }
+
+    @Override
+    public Void call(SQLDatabase db) throws Exception {
+        System.out.println("PurgeCallable documentstore");
+        // TODO
+        return null;
+    }
+}

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/PurgeCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/PurgeCallable.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ *  except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ */
+
 package com.cloudant.sync.internal.documentstore.callables;
 
 import com.cloudant.sync.internal.documentstore.AttachmentManager;

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/PurgeCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/PurgeCallable.java
@@ -1,7 +1,12 @@
 package com.cloudant.sync.internal.documentstore.callables;
 
+import com.cloudant.sync.internal.documentstore.AttachmentManager;
+import com.cloudant.sync.internal.documentstore.DatabaseImpl;
 import com.cloudant.sync.internal.sqlite.SQLCallable;
 import com.cloudant.sync.internal.sqlite.SQLDatabase;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Created by tomblench on 29/08/2017.
@@ -9,18 +14,32 @@ import com.cloudant.sync.internal.sqlite.SQLDatabase;
 
 public class PurgeCallable implements SQLCallable<Void> {
 
-    private String documentId;
-    private String revisionId;
+    private static final Logger logger = Logger.getLogger(PurgeCallable.class.getCanonicalName());
 
-    public PurgeCallable(String documentId, String revisionId) {
+    private final String documentId;
+
+    private final String revisionId;
+
+    private final String attachmentsDir;
+
+    public PurgeCallable(String documentId, String revisionId, String attachmentsDir) {
         this.documentId = documentId;
         this.revisionId = revisionId;
+        this.attachmentsDir = attachmentsDir;
     }
 
     @Override
     public Void call(SQLDatabase db) throws Exception {
         System.out.println("PurgeCallable documentstore");
-        // TODO
+        int nRows = db.delete("revs",
+                "doc_id = (select doc_id from docs where docid = ?) AND revid = ?",
+                new String[]{documentId, revisionId});
+        if (nRows != 1) {
+            logger.warning(String.format("purge expected to delete 1 row but actually deleted %d rows",
+                    nRows));
+        }
+        logger.info(String.format("purged %d rows", nRows));
+        AttachmentManager.purgeAttachments(db, attachmentsDir);
         return null;
     }
 }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/QueryImpl.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/QueryImpl.java
@@ -16,10 +16,13 @@ package com.cloudant.sync.internal.query;
 
 import com.cloudant.sync.documentstore.Database;
 import com.cloudant.sync.documentstore.encryption.KeyProvider;
+import com.cloudant.sync.event.Subscribe;
+import com.cloudant.sync.internal.PurgeNotification;
 import com.cloudant.sync.internal.documentstore.DatabaseImpl;
 import com.cloudant.sync.internal.documentstore.migrations.SchemaOnlyMigration;
 import com.cloudant.sync.internal.query.callables.DeleteIndexCallable;
 import com.cloudant.sync.internal.query.callables.ListIndexesCallable;
+import com.cloudant.sync.internal.query.callables.PurgeCallable;
 import com.cloudant.sync.internal.sqlite.SQLDatabaseFactory;
 import com.cloudant.sync.internal.sqlite.SQLDatabaseQueue;
 import com.cloudant.sync.internal.util.Misc;
@@ -239,6 +242,12 @@ public class QueryImpl implements Query {
     @Override
     public boolean isTextSearchEnabled() {
         return SQLDatabaseFactory.FTS_AVAILABLE;
+    }
+
+    @Subscribe
+    public void onPurge(PurgeNotification purgeNotification) {
+        PurgeCallable purgeCallable = new PurgeCallable(purgeNotification.documentId, purgeNotification.revisionId);
+        dbQueue.submit(purgeCallable);
     }
 
 }

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/callables/PurgeCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/callables/PurgeCallable.java
@@ -1,14 +1,26 @@
+/*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ *  except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ */
+
 package com.cloudant.sync.internal.query.callables;
 
-import com.cloudant.sync.internal.documentstore.DatabaseImpl;
 import com.cloudant.sync.internal.query.QueryConstants;
 import com.cloudant.sync.internal.query.QueryImpl;
 import com.cloudant.sync.internal.sqlite.Cursor;
 import com.cloudant.sync.internal.sqlite.SQLCallable;
 import com.cloudant.sync.internal.sqlite.SQLDatabase;
-import com.cloudant.sync.query.Index;
 
-import java.util.ArrayList;
 import java.util.logging.Logger;
 
 /**

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/callables/PurgeCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/callables/PurgeCallable.java
@@ -1,7 +1,15 @@
 package com.cloudant.sync.internal.query.callables;
 
+import com.cloudant.sync.internal.documentstore.DatabaseImpl;
+import com.cloudant.sync.internal.query.QueryConstants;
+import com.cloudant.sync.internal.query.QueryImpl;
+import com.cloudant.sync.internal.sqlite.Cursor;
 import com.cloudant.sync.internal.sqlite.SQLCallable;
 import com.cloudant.sync.internal.sqlite.SQLDatabase;
+import com.cloudant.sync.query.Index;
+
+import java.util.ArrayList;
+import java.util.logging.Logger;
 
 /**
  * Created by tomblench on 29/08/2017.
@@ -9,7 +17,10 @@ import com.cloudant.sync.internal.sqlite.SQLDatabase;
 
 public class PurgeCallable implements SQLCallable<Void> {
 
+    private static final Logger logger = Logger.getLogger(PurgeCallable.class.getCanonicalName());
+
     private String documentId;
+
     private String revisionId;
 
     public PurgeCallable(String documentId, String revisionId) {
@@ -20,7 +31,27 @@ public class PurgeCallable implements SQLCallable<Void> {
     @Override
     public Void call(SQLDatabase db) throws Exception {
         System.out.println("PurgeCallable query");
-        // TODO
+        // list indexes and delete affected rows
+        String sqlIndexNames = String.format("SELECT DISTINCT index_name FROM %s",
+                QueryConstants.INDEX_METADATA_TABLE_NAME);
+        Cursor cursorIndexNames = null;
+        int nRowsTotal = 0;
+        try {
+            cursorIndexNames = db.rawQuery(sqlIndexNames, new String[]{});
+            while (cursorIndexNames.moveToNext()) {
+                String indexName = cursorIndexNames.getString(0);
+                String tableName = QueryImpl.tableNameForIndex(indexName);
+                int nRows = db.delete(tableName, "_id = ? and _rev = ?", new String[]{documentId, revisionId});
+                if (nRows != 1) {
+                    logger.warning(String.format("purge expected to delete 1 row but actually deleted %d rows",
+                            nRows));
+                }
+                nRowsTotal += nRows;
+            }
+            logger.info(String.format("purged %d rows", nRowsTotal));
+        } finally {
+            cursorIndexNames.close();
+        }
         return null;
     }
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/callables/PurgeCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/callables/PurgeCallable.java
@@ -1,0 +1,27 @@
+package com.cloudant.sync.internal.query.callables;
+
+import com.cloudant.sync.internal.sqlite.SQLCallable;
+import com.cloudant.sync.internal.sqlite.SQLDatabase;
+
+/**
+ * Created by tomblench on 29/08/2017.
+ */
+
+public class PurgeCallable implements SQLCallable<Void> {
+
+    private String documentId;
+    private String revisionId;
+
+    public PurgeCallable(String documentId, String revisionId) {
+        this.documentId = documentId;
+        this.revisionId = revisionId;
+    }
+
+    @Override
+    public Void call(SQLDatabase db) throws Exception {
+        System.out.println("PurgeCallable query");
+        // TODO
+        return null;
+    }
+
+}

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/callables/PurgeCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/query/callables/PurgeCallable.java
@@ -20,6 +20,7 @@ import com.cloudant.sync.internal.query.QueryImpl;
 import com.cloudant.sync.internal.sqlite.Cursor;
 import com.cloudant.sync.internal.sqlite.SQLCallable;
 import com.cloudant.sync.internal.sqlite.SQLDatabase;
+import com.cloudant.sync.internal.util.DatabaseUtils;
 
 import java.util.logging.Logger;
 
@@ -62,7 +63,7 @@ public class PurgeCallable implements SQLCallable<Void> {
             }
             logger.info(String.format("purged %d rows", nRowsTotal));
         } finally {
-            cursorIndexNames.close();
+            DatabaseUtils.closeCursorQuietly(cursorIndexNames);
         }
         return null;
     }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/PurgeTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/PurgeTest.java
@@ -1,0 +1,23 @@
+package com.cloudant.sync.internal.documentstore;
+
+import com.cloudant.common.DocumentStoreTestBase;
+import com.cloudant.sync.documentstore.DocumentBodyFactory;
+import com.cloudant.sync.documentstore.DocumentRevision;
+
+import org.junit.Test;
+
+/**
+ * Created by tomblench on 29/08/2017.
+ */
+
+public class PurgeTest extends BasicDatastoreTestBase {
+
+
+    @Test
+    public void purge() throws Exception {
+        DocumentRevision rev = new DocumentRevision();
+        rev.setBody(bodyOne);
+        DocumentRevision rev2 = this.documentStore.database().create(rev);
+        this.documentStore.database().purge(rev2);
+    }
+}

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/PurgeTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/PurgeTest.java
@@ -1,7 +1,20 @@
+/*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ *  except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ */
+
 package com.cloudant.sync.internal.documentstore;
 
-import com.cloudant.common.DocumentStoreTestBase;
-import com.cloudant.sync.documentstore.DocumentBodyFactory;
 import com.cloudant.sync.documentstore.DocumentRevision;
 import com.cloudant.sync.query.FieldSort;
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/PurgeTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/documentstore/PurgeTest.java
@@ -3,8 +3,11 @@ package com.cloudant.sync.internal.documentstore;
 import com.cloudant.common.DocumentStoreTestBase;
 import com.cloudant.sync.documentstore.DocumentBodyFactory;
 import com.cloudant.sync.documentstore.DocumentRevision;
+import com.cloudant.sync.query.FieldSort;
 
 import org.junit.Test;
+
+import java.util.Collections;
 
 /**
  * Created by tomblench on 29/08/2017.
@@ -12,12 +15,13 @@ import org.junit.Test;
 
 public class PurgeTest extends BasicDatastoreTestBase {
 
-
     @Test
     public void purge() throws Exception {
         DocumentRevision rev = new DocumentRevision();
         rev.setBody(bodyOne);
         DocumentRevision rev2 = this.documentStore.database().create(rev);
+        this.documentStore.query().createJsonIndex(Collections.singletonList(new FieldSort("Sunrise")), null);
+        this.documentStore.query().createJsonIndex(Collections.singletonList(new FieldSort("Sunset")), null);
         this.documentStore.database().purge(rev2);
     }
 }


### PR DESCRIPTION
Fixes #160 

_What_

- Purge revs by rev id and doc id
- Purge any orphaned attachments by calling `AttachmentManager.purgeAttachments()`
- Purge any index rows by rev id and doc id

_Testing_

Added `PurgeTest` class