### PR TITLE
Target cloudant-http 2.11.0

### DIFF
--- a/AndroidTest/app/build.gradle
+++ b/AndroidTest/app/build.gradle
@@ -85,7 +85,7 @@ dependencies {
     compile 'commons-io:commons-io:2.4'
     compile 'commons-codec:commons-codec:1.9'
     compile 'org.apache.commons:commons-lang3:3.3.2'
-    compile group: 'com.cloudant', name: 'cloudant-http', version:'2.10.0'
+    compile group: 'com.cloudant', name: 'cloudant-http', version:'2.11.0'
     compile 'com.google.code.findbugs:jsr305:3.0.0' //this is needed for some versions of android
     compile files('../../cloudant-sync-datastore-android-encryption/libs/sqlcipher.jar') //required sqlcipher lib
     compile files('../../cloudant-sync-datastore-android/libs/android-support-v4.jar')

--- a/AndroidTest/app/build.gradle
+++ b/AndroidTest/app/build.gradle
@@ -85,7 +85,7 @@ dependencies {
     compile 'commons-io:commons-io:2.4'
     compile 'commons-codec:commons-codec:1.9'
     compile 'org.apache.commons:commons-lang3:3.3.2'
-    compile group: 'com.cloudant', name: 'cloudant-http', version:'latest.integration'
+    compile group: 'com.cloudant', name: 'cloudant-http', version:'2.10.0'
     compile 'com.google.code.findbugs:jsr305:3.0.0' //this is needed for some versions of android
     compile files('../../cloudant-sync-datastore-android-encryption/libs/sqlcipher.jar') //required sqlcipher lib
     compile files('../../cloudant-sync-datastore-android/libs/android-support-v4.jar')
@@ -108,7 +108,6 @@ dependencies {
 repositories {
     mavenLocal()
     mavenCentral()
-    maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
 }
 
 task(uploadFixtures, type: AndroidExec) {

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
 - [IMPROVED] Updated documentation by replacing deprecated links with the latest Bluemix or CouchDB links.
 - [IMPROVED] Added `seq_interval` to improve `Changes` API throughput when replicating from
              a CouchDB 2.x endpoint.
-- [UPGRADED] Upgraded to version 2.10.0 of the `cloudant-http` library.
+- [UPGRADED] Upgraded to version 2.11.0 of the `cloudant-http` library.
 
 # 2.0.2 (2017-06-20)
 - [FIXED] Removed cloudant-sync-datastore-android project dependency

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 - [IMPROVED] Updated documentation by replacing deprecated links with the latest Bluemix or CouchDB links.
 - [IMPROVED] Added `seq_interval` to improve `Changes` API throughput when replicating from
              a CouchDB 2.x endpoint.
+- [UPGRADED] Upgraded to version 2.10.0 of the `cloudant-http` library.
 
 # 2.0.2 (2017-06-20)
 - [FIXED] Removed cloudant-sync-datastore-android project dependency

--- a/cloudant-sync-datastore-core/build.gradle
+++ b/cloudant-sync-datastore-core/build.gradle
@@ -1,13 +1,9 @@
-repositories {
-    maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
-}
-
 // ************ //
 // CORE PROJ
 // ************ //
 dependencies {
 
-    compile group: 'com.cloudant', name: 'cloudant-http', version:'latest.integration'
+    compile group: 'com.cloudant', name: 'cloudant-http', version:'2.10.0'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version:'2.1.1'
     compile group: 'commons-codec', name: 'commons-codec', version:'1.10'
     compile group: 'commons-io', name: 'commons-io', version:'2.4'

--- a/cloudant-sync-datastore-core/build.gradle
+++ b/cloudant-sync-datastore-core/build.gradle
@@ -3,7 +3,7 @@
 // ************ //
 dependencies {
 
-    compile group: 'com.cloudant', name: 'cloudant-http', version:'2.10.0'
+    compile group: 'com.cloudant', name: 'cloudant-http', version:'2.11.0'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version:'2.1.1'
     compile group: 'commons-codec', name: 'commons-codec', version:'1.10'
     compile group: 'commons-io', name: 'commons-io', version:'2.4'


### PR DESCRIPTION
This is anticipated to be the next release version which will include IAM interceptors.

~~This branch will only build cleanly and be mergeable once the next version of `cloudant-http` (anticipated to be 2.10.0) is released.~~

Now targetting 2.11.0