### PR TITLE
Updated deprecated links

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
   [README](https://github.com/cloudant/sync-android/blob/2.1.0/README.md) and the
   [Bluemix documentation](https://console.bluemix.net/docs/services/Cloudant/guides/iam.html#ibm-cloud-identity-and-access-management)
   for more details.
+- [IMPROVED] Updated documentation by replacing deprecated links with the latest Bluemix or CouchDB links.
 
 # 2.0.2 (2017-06-20)
 - [FIXED] Removed cloudant-sync-datastore-android project dependency

--- a/README.md
+++ b/README.md
@@ -32,11 +32,6 @@ This library is for Android and Java SE; an [iOS][ios] version is also available
 
 [ios]: https://github.com/cloudant/CDTDatastore
 
-If you have questions, please join our [mailing list][mlist] and drop us a
-line.
-
-[mlist]: https://groups.google.com/forum/#!forum/cloudant-sync
-
 ## Using in your project
 
 The library is published via Maven Central and using it in your project should
@@ -331,7 +326,18 @@ back to full health.
 Learn more about this essential process in the
 [conflicts documentation](https://github.com/cloudant/sync-android/blob/master/doc/conflicts.md).
 
-## Known Issues
+## Issues
+
+Before opening a new issue please consider the following:
+* Only the latest release is supported. If at all possible please try to reproduce the issue using
+the latest version.
+* Please check the [existing issues](https://github.com/cloudant/sync-android/issues)
+to see if the problem has already been reported. Note that the default search
+includes only open issues, but it may already have been closed.
+* Cloudant customers should contact Cloudant support for urgent issues.
+* When opening a new issue [here in github](../../issues) please complete the template fully.
+
+#### Known Issues
 
 Some users on certain older versions of Android have reported the
 following exception:
@@ -343,13 +349,19 @@ To fix this issue, add the following dependency to your application's
 
 `compile 'com.google.code.findbugs:jsr305:3.0.0'`
 
+
+## Related documentation
+
+* [Cloudant docs](https://console.bluemix.net/docs/services/Cloudant/cloudant.html#overview)
+* [Cloudant Learning Center](https://developer.ibm.com/clouddataservices/cloudant-learning-center/)
+
+## Development
+
+For information about contributing, building, and running tests see the [CONTRIBUTING.md](CONTRIBUTING.md).
+
 ## Contributors
 
 See [CONTRIBUTORS](CONTRIBUTORS).
-
-## Contributing to the project
-
-See [CONTRIBUTING](CONTRIBUTING.md).
 
 ## License
 

--- a/cloudant-sync-datastore-android/src/main/java/com/cloudant/sync/replication/PeriodicReplicationService.java
+++ b/cloudant-sync-datastore-android/src/main/java/com/cloudant/sync/replication/PeriodicReplicationService.java
@@ -84,7 +84,7 @@ public abstract class PeriodicReplicationService<T extends PeriodicReplicationRe
      * using an Extra with the {@link #EXTRA_COMMAND} key.
      * @see
      * <a href="http://github.com/cloudant/sync-android/blob/master/doc/replication-policies.md#controlling-the-replication-service">
-     *     Replication Policy User Guide</a> for more details.
+     *     Replication Policy User Guide</a>
      */
     public static final int COMMAND_START_PERIODIC_REPLICATION = 2;
 
@@ -93,7 +93,7 @@ public abstract class PeriodicReplicationService<T extends PeriodicReplicationRe
      * using an Extra with the {@link #EXTRA_COMMAND} key.
      * @see
      * <a href="http://github.com/cloudant/sync-android/blob/master/doc/replication-policies.md#controlling-the-replication-service">
-     *     Replication Policy User Guide</a> for more details.
+     *     Replication Policy User Guide</a>
      */
     public static final int COMMAND_STOP_PERIODIC_REPLICATION = 3;
 
@@ -103,7 +103,7 @@ public abstract class PeriodicReplicationService<T extends PeriodicReplicationRe
      * following a reboot.
      * @see
      * <a href="http://github.com/cloudant/sync-android/blob/master/doc/replication-policies.md#controlling-the-replication-service">
-     *     Replication Policy User Guide</a> for more details.
+     *     Replication Policy User Guide</a>
      */
     public static final int COMMAND_DEVICE_REBOOTED = 4;
 
@@ -113,7 +113,7 @@ public abstract class PeriodicReplicationService<T extends PeriodicReplicationRe
      * between replications can be re-evaluated.
      * @see
      * <a href="http://github.com/cloudant/sync-android/blob/master/doc/replication-policies.md#controlling-the-replication-service">
-     *     Replication Policy User Guide</a> for more details.
+     *     Replication Policy User Guide</a>
      */
     public static final int COMMAND_RESET_REPLICATION_TIMERS = 5;
 

--- a/cloudant-sync-datastore-android/src/main/java/com/cloudant/sync/replication/ReplicationService.java
+++ b/cloudant-sync-datastore-android/src/main/java/com/cloudant/sync/replication/ReplicationService.java
@@ -55,7 +55,7 @@ public abstract class ReplicationService extends Service
      *
      * @see
      * <a href="http://github.com/cloudant/sync-android/blob/master/doc/replication-policies.md#controlling-the-replication-service">
-     * Replication Policy User Guide</a> for more details.
+     * Replication Policy User Guide</a>
      */
     public static final int COMMAND_START_REPLICATION = 0;
 
@@ -65,7 +65,7 @@ public abstract class ReplicationService extends Service
      *
      * @see
      * <a href="http://github.com/cloudant/sync-android/blob/master/doc/replication-policies.md#controlling-the-replication-service">
-     * Replication Policy User Guide</a> for more details.
+     * Replication Policy User Guide</a>
      */
     public static final int COMMAND_STOP_REPLICATION = 1;
 

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/Attachment.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/Attachment.java
@@ -25,7 +25,7 @@ import java.io.InputStream;
 
 /**
  * <p>
- *   An <a target="_blank" href="http://docs.couchdb.org/en/2.0.0/intro/api.html#attachments">
+ *   An <a target="_blank" href="http://docs.couchdb.org/en/latest/intro/api.html#attachments">
  *   attachment</a> associated with a CouchDB document.
  * </p>
  * <p>

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/Database.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/Database.java
@@ -40,7 +40,7 @@ import java.util.List;
  * <p>Each document consists of a set of revisions, hence most methods within
  * this class operate on {@link DocumentRevision} objects, which carry both a
  * document ID and a revision ID. This forms the basis of the
- * <a target="_blank" href="http://docs.couchdb.org/en/2.0.0/intro/consistency.html?#no-locking">MVCC</a> data
+ * <a target="_blank" href="http://docs.couchdb.org/en/latest/intro/consistency.html?#no-locking">MVCC</a> data
  * model,
  * used to ensure safe peer-to-peer replication is possible.</p>
  *

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/PullFilter.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/PullFilter.java
@@ -45,8 +45,8 @@ import java.util.Map;
  * PullFilter pullFilter = new PullFilter("doc/filterName", map);
  * </pre>
  *
- * @see <a target="_blank" href="http://couchdb.readthedocs.org/en/1.6.x/replication/intro.html#controlling-which-documents-to-replicate">Controlling documents replicated</a>
- * @see <a target="_blank" href="http://docs.couchdb.org/en/1.6.x/couchapp/ddocs.html#filter-functions">Filter functions CouchDB docs</a>
+ * @see <a target="_blank" href="http://docs.couchdb.org/en/latest/replication/intro.html#controlling-which-documents-to-replicate">Controlling documents replicated</a>
+ * @see <a target="_blank" href="http://docs.couchdb.org/en/latest/ddocs/ddocs.html#filter-functions">Filter functions CouchDB docs</a>
  *
  */
 public class PullFilter {
@@ -91,7 +91,7 @@ public class PullFilter {
      *                   constructing the {@code _changes} feed call for the remote database.
      *                   Integer values should be added as String objects.
      *
-     * @see <a target="_blank" href="http://docs.couchdb.org/en/1.6.x/couchapp/ddocs.html#filter-functions">Filter
+     * @see <a target="_blank" href="http://docs.couchdb.org/en/latest/ddocs/ddocs.html#filter-functions">Filter
      * functions CouchDB docs</a>
      */
     public PullFilter(String filterName, Map<String, String> parameters) {

--- a/doc/query.md
+++ b/doc/query.md
@@ -6,7 +6,7 @@ Cloudant Query is inspired by MongoDB's query implementation, so users of MongoD
 
 The aim is that the query you use on our cloud-based database works for your mobile application.
 
-[1]: https://docs.cloudant.com/api/cloudant-query.html
+[1]: https://console.bluemix.net/docs/services/Cloudant/api/cloudant_query.html#query
 
 ## Usage
 
@@ -161,7 +161,7 @@ Query documents are `Map` objects that use the [Cloudant Query `selector`][sel]
 syntax. Several features of Cloudant Query are not yet supported in this implementation.
 See below for more details.
 
-[sel]: https://docs.cloudant.com/api/cloudant-query.html#selector-syntax
+[sel]: https://console.bluemix.net/docs/services/Cloudant/api/cloudant_query.html#selector-syntax
 
 #### Equality and comparisons
 

--- a/doc/replication.md
+++ b/doc/replication.md
@@ -268,5 +268,5 @@ Replicator replicator = ReplicatorBuilder.pull()
                         .build();
 ```
 
-[1]: http://docs.couchdb.org/en/1.4.x/replication.html#controlling-which-documents-to-replicate
+[1]: http://docs.couchdb.org/en/latest/replication/intro.html#controlling-which-documents-to-replicate
 


### PR DESCRIPTION
## What

Updated deprecated Cloudant and CouchDB links.
Updated and added README sections.

## How

- Updated deprecated Cloudant links
- Updated CouchDB links to use latest version
- Updated Issues section
- Added Related documentation section
- Replaced Contributing with Development section
- Removed deprecated google mailing list
- Removed Known Issues section as we only support latest release
- Added `Cloudant Learning Center` link

## Testing

No new tests.

## Issues

fixes #550 
fixes #549 