### PR TITLE
534 add sequence interval to changes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
   [Bluemix documentation](https://console.bluemix.net/docs/services/Cloudant/guides/iam.html#ibm-cloud-identity-and-access-management)
   for more details.
 - [IMPROVED] Updated documentation by replacing deprecated links with the latest Bluemix or CouchDB links.
+- [IMPROVED] Added `seq_interval` to improve `Changes` API throughput when replicating from
+             a CouchDB 2.x endpoint.
 
 # 2.0.2 (2017-06-20)
 - [FIXED] Removed cloudant-sync-datastore-android project dependency

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/mazha/CouchClient.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/mazha/CouchClient.java
@@ -284,10 +284,6 @@ public class CouchClient  {
         return options;
     }
 
-    public ChangesResult changes(Object since) {
-        return this.changes(since, null);
-    }
-
     public ChangesResult changes(Object since, Integer limit) {
         return this.changes(null, null, since, limit);
     }
@@ -305,6 +301,12 @@ public class CouchClient  {
         }
         if (limit != null) {
             options.put("limit", limit);
+        }
+        // seq_interval: improve performance and reduce load on the remote database
+        if(limit != null) {
+            options.put("seq_interval", limit);
+        } else {
+            options.put("seq_interval", 1000);
         }
         return this.changes(options);
     }

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/ClientTestUtils.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/ClientTestUtils.java
@@ -31,9 +31,13 @@ import com.cloudant.sync.internal.util.JSONUtils;
 import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
 
+import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -233,6 +237,13 @@ public class ClientTestUtils {
         }
 
         return revisions;
+    }
+
+    public static boolean isCouchDBV2(URI uri) throws URISyntaxException, IOException {
+        URI root = new URI(uri.getScheme() + "://" + uri.getAuthority());
+        HttpConnection connection = Http.GET(root);
+        String response = connection.execute().responseAsString();
+        return response.contains("\"version\":\"2.");
     }
 
 


### PR DESCRIPTION
## What

Use `seq_interval` parameter to skip generation of sequence numbers and improve replication performance.

See Will Holley's comment in #534 and [pouchdb #6643](https://github.com/pouchdb/pouchdb/issues/6643).  He also includes performance tests in the `pouchdb` ticket showing ~20% improvement in replication time.

## How

- Added `seq_interval` to `options` Map in changes API
- Use batch size value in `Pull/PushStrategy` for `seq_interval`.  Default value is 1000.
- Moved `changes(since)` constructor to ChangesFeedTest test class.

## Testing

New test case to assert the `seq` value with `seq_interval` option.

## Issues

fixes #534 