### PR TITLE
Performance: use efficient sub-query to find leafs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# Unreleased
+- [IMPROVED] Improved efficiency of sub-query when picking winning
+  revisions. This improves performance when inserting revisions,
+  including during pull replication.
+
 # 2.1.0 (2017-12-04)
 - [NEW] Added API for upcoming IBM Cloud Identity and Access
   Management support for Cloudant on IBM Cloud. Note: IAM API key

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/DeleteDocumentCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/DeleteDocumentCallable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 IBM Corp. All rights reserved.
+ * Copyright © 2016, 2018 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/DeleteDocumentCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/DeleteDocumentCallable.java
@@ -77,7 +77,7 @@ public class DeleteDocumentCallable implements SQLCallable<InternalDocumentRevis
             // now check it's a leaf revision
             String leafQuery = "SELECT " + CallableSQLConstants.METADATA_COLS + " FROM revs, docs WHERE " +
                     "docs.docid=? AND revs.doc_id=docs.doc_id AND revid=? AND revs.sequence NOT " +
-                    "IN (SELECT DISTINCT parent FROM revs WHERE parent NOT NULL) ";
+                    "IN (SELECT DISTINCT parent FROM revs revs_inner WHERE parent NOT NULL AND revs_inner.doc_id=docs.doc_id) ";
             c = db.rawQuery(leafQuery, new String[]{docId, prevRevId});
             boolean isLeaf = c.moveToFirst();
             if (!isLeaf) {

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/PickWinningRevisionCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/PickWinningRevisionCallable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 IBM Corp. All rights reserved.
+ * Copyright © 2016, 2018 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/PickWinningRevisionCallable.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/callables/PickWinningRevisionCallable.java
@@ -39,13 +39,13 @@ public class PickWinningRevisionCallable implements SQLCallable<Void> {
     // gets all revs whose sequence is not a parent of another rev and the rev isn't deleted
     public static final String GET_NON_DELETED_LEAFS = "SELECT revs.revid, revs.sequence FROM " +
             "revs WHERE revs.doc_id = ? AND revs.deleted = 0 AND revs.sequence NOT IN " +
-            "(SELECT DISTINCT parent FROM revs WHERE parent NOT NULL) ";
+            "(SELECT DISTINCT parent FROM revs revs_inner WHERE parent NOT NULL AND revs_inner.doc_id = revs.doc_id) ";
 
     // get all leaf rev IDs for a given doc ID
     // gets all revs whose sequence is not a parent of another rev
     public static final String GET_ALL_LEAFS = "SELECT revs.revid, revs.sequence FROM revs " +
             "WHERE revs.doc_id = ? AND revs.sequence NOT IN " +
-            "(SELECT DISTINCT parent FROM revs WHERE parent NOT NULL) ";
+            "(SELECT DISTINCT parent FROM revs revs_inner WHERE parent NOT NULL AND revs_inner.doc_id = revs.doc_id) ";
 
     private final long docNumericId;
 
@@ -127,7 +127,7 @@ public class PickWinningRevisionCallable implements SQLCallable<Void> {
         currentFalse.put("current", 0);
         db.update("revs", currentFalse,
                 "sequence!=? AND doc_id=? AND sequence NOT IN " +
-                        "(SELECT DISTINCT parent FROM revs WHERE parent NOT NULL)",
+                        "(SELECT DISTINCT parent FROM revs revs_inner WHERE parent NOT NULL AND revs_inner.doc_id=revs.doc_id)",
                 new String[]{Long.toString(newWinnerSeq), Long.toString(docNumericId)});
         return null;
     }


### PR DESCRIPTION
## What

Make replication of large and/or conflicted data sets faster by improving performance of `PickWinningRevisionCallable`, which is called for every new revision pulled.

## How

Analysis with `jvisualvm` and sqlite `explain query plan` revealed that the sub-query `(SELECT DISTINCT parent FROM revs WHERE parent NOT NULL)` forced a table scan because it could not use indexes to make this sub-query.

Changing this and other similar sub-queries to be as specific as possible by discriminating on revision id or numeric document id allows the query to succeed without a scan, without affecting correctness.

## Testing

Existing tests pass. Manual testing with large database (largedb1g on clientlibs-test account) shows a dramatic speedup. Previously each batch would take an exponentially longer time to insert due to the slow-down in picking the winning revision.