### PR TITLE
Fix #568 - PeriodicReplicationService doesn't replicate after a forced stop of the APP

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,6 @@
 # Unreleased
+- [IMPROVED] PeriodicReplicationService checks that the alarm is scheduled to determine that the service is active.
+  When the application was stopped by the user using "force stop" the alarm was rescheduled only after a device reboot. 
 - [NEW] Added API for specifying a mango selector in the filtered pull replicator
 - [IMPROVED] Improved efficiency of sub-query when picking winning
   revisions. This improves performance when inserting revisions,

--- a/cloudant-sync-datastore-android/src/main/java/com/cloudant/sync/replication/PeriodicReplicationService.java
+++ b/cloudant-sync-datastore-android/src/main/java/com/cloudant/sync/replication/PeriodicReplicationService.java
@@ -251,7 +251,7 @@ public abstract class PeriodicReplicationService<T extends PeriodicReplicationRe
 
     /** Start periodic replications. */
     public synchronized void startPeriodicReplication() {
-        if (!isPeriodicReplicationEnabled()) {
+        if (!isPeriodicReplicationEnabled() || !isPeriodicReplicationAlarmScheduled()) {
             setPeriodicReplicationEnabled(true);
             AlarmManager alarmManager = (AlarmManager) getSystemService(Context.ALARM_SERVICE);
             Intent alarmIntent = new Intent(this, clazz);
@@ -369,6 +369,14 @@ public abstract class PeriodicReplicationService<T extends PeriodicReplicationRe
         SharedPreferences prefs = context.getSharedPreferences(PREFERENCES_FILE_NAME, Context
             .MODE_PRIVATE);
         return prefs.getBoolean(constructKey(prsClass, PERIODIC_REPLICATION_ENABLED_SUFFIX), false);
+    }
+
+    private boolean isPeriodicReplicationAlarmScheduled() {
+        Intent alarmIntent = new Intent(this, clazz);
+        alarmIntent.setAction(PeriodicReplicationReceiver.ALARM_ACTION);
+        PendingIntent pendingAlarmIntent = PendingIntent.getBroadcast(this, 0, alarmIntent,
+                PendingIntent.FLAG_NO_CREATE);
+        return pendingAlarmIntent != null;
     }
 
     /**

--- a/cloudant-sync-datastore-android/src/test/java/com/cloudant/android/TestReplicationService.java
+++ b/cloudant-sync-datastore-android/src/test/java/com/cloudant/android/TestReplicationService.java
@@ -14,8 +14,12 @@
 
 package com.cloudant.android;
 
+import android.app.AlarmManager;
+import android.app.PendingIntent;
 import android.content.Context;
+import android.content.Intent;
 
+import com.cloudant.sync.replication.PeriodicReplicationReceiver;
 import com.cloudant.sync.replication.WifiPeriodicReplicationReceiver;
 import com.cloudant.sync.replication.PeriodicReplicationService;
 
@@ -24,6 +28,7 @@ public class TestReplicationService extends PeriodicReplicationService {
     private static final String TASKS_DATASTORE_NAME = "tasks";
     private static final String DATASTORE_MANGER_DIR = "data";
     private static final String TAG = "TestReplicationService";
+    private static final String ALARM_ACTION = "com.cloudant.sync.replication.PeriodicReplicationReceiver.Alarm";
 
     /** The period between replications for our test PeriodicReplicationService when there are no
      * components bound to the service. The default is 120 seconds (2 minutes), but the value
@@ -61,5 +66,15 @@ public class TestReplicationService extends PeriodicReplicationService {
 
     public void setUnboundIntervalSeconds(int seconds) {
         mUnboundIntervalSeconds = seconds;
+    }
+
+    public void cancelPendingIntenIfScheduled() {
+        Intent alarmIntent = new Intent(getBaseContext(), TestReceiver.class);
+        alarmIntent.setAction(ALARM_ACTION);
+        PendingIntent pendingAlarmIntent = PendingIntent.getBroadcast(getBaseContext(), 0,
+                alarmIntent, 0);
+        if (pendingAlarmIntent != null) {
+            pendingAlarmIntent.cancel();
+        }
     }
 }

--- a/cloudant-sync-datastore-android/src/test/java/com/cloudant/android/TestReplicationService.java
+++ b/cloudant-sync-datastore-android/src/test/java/com/cloudant/android/TestReplicationService.java
@@ -72,7 +72,7 @@ public class TestReplicationService extends PeriodicReplicationService {
         Intent alarmIntent = new Intent(getBaseContext(), TestReceiver.class);
         alarmIntent.setAction(ALARM_ACTION);
         PendingIntent pendingAlarmIntent = PendingIntent.getBroadcast(getBaseContext(), 0,
-                alarmIntent, 0);
+                alarmIntent, PendingIntent.FLAG_NO_CREATE);
         if (pendingAlarmIntent != null) {
             pendingAlarmIntent.cancel();
         }


### PR DESCRIPTION
Thanks for your hard work, please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant/sync-android/blob/master/DCO1.1.txt)
- [x] You have added tests for any code changes
- [x] You have updated the [CHANGES.md](https://github.com/cloudant/sync-android/blob/master/CHANGES.md)
- [X] You have completed the PR template below:

## What
Make a dual check to verify if the service is enabled:
- Check shared preferences flag
- Check if a PendingInten is scheduled

## How

Added PendingIntent scheduled check in PeriodicReplicationService start method

## Testing

Added a test case in ReplicationServiceTest - testOnStartCommandStartPeriodicReplicationsAlreadyStartedWithoutAlarm

## Issues
Fixes #568 

