### PR TITLE
Force tls1.2 on old android

### DIFF
--- a/AndroidTest/app/build.gradle
+++ b/AndroidTest/app/build.gradle
@@ -124,7 +124,7 @@ task(clearDeviceLog, type: AndroidExec) {
 task(pullDeviceLog, type: AndroidExec) {
     doFirst {
         def logPrefix = System.getenv('TEST_ENV_NAME')
-        if (logPrefix == null) logPrefix = UUID.randomUUID()
+        if (logPrefix == null) logPrefix = UUID.randomUUID().toString()
         standardOutput = new FileOutputStream(new File(reportsDir, logPrefix + "_logcat.log"), false)
     }
     commandLine "adb","logcat", "-d", "-v", "threadtime"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# Unreleased
+- [IMPROVED] Forced a TLS1.2 `SSLSocketFactory` where possible on Android API versions < 20 (it is
+  already enabled by default on newer API levels).
+
 # 2.2.0 (2018-02-14)
 - [NEW] Added API for specifying a mango selector in the filtered pull replicator
 - [IMPROVED] Improved efficiency of sub-query when picking winning

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ReplicatorBuilder.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/replication/ReplicatorBuilder.java
@@ -18,7 +18,6 @@ import com.cloudant.http.HttpConnectionRequestInterceptor;
 import com.cloudant.http.HttpConnectionResponseInterceptor;
 import com.cloudant.http.internal.interceptors.CookieInterceptor;
 import com.cloudant.http.internal.interceptors.IamCookieInterceptor;
-import com.cloudant.http.internal.interceptors.UserAgentInterceptor;
 import com.cloudant.sync.documentstore.DocumentStore;
 import com.cloudant.sync.internal.replication.PullStrategy;
 import com.cloudant.sync.internal.replication.PushStrategy;
@@ -40,10 +39,6 @@ import java.util.Locale;
 // S = Source Type, T = target Type, E = Extending class Type
 public abstract class ReplicatorBuilder<S, T, E> {
 
-    private static final UserAgentInterceptor USER_AGENT_INTERCEPTOR =
-            new UserAgentInterceptor(ReplicatorBuilder.class.getClassLoader(),
-                    "META-INF/com.cloudant.sync.client.properties");
-
     private T target;
 
     private S source;
@@ -61,10 +56,6 @@ public abstract class ReplicatorBuilder<S, T, E> {
             <HttpConnectionResponseInterceptor>();
 
     private String iamApiKey = null;
-
-    private ReplicatorBuilder() {
-        requestInterceptors.add(USER_AGENT_INTERCEPTOR);
-    }
 
     private int getDefaultPort(URI uri) {
 


### PR DESCRIPTION
Thanks for your hard work, please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant/sync-android/blob/master/DCO1.1.txt)
- [x] You have added tests for any code changes - manual test
- [x] You have updated the [CHANGES.md](https://github.com/cloudant/sync-android/blob/master/CHANGES.md)
- [x] You have completed the PR template below:

## What

Added a custom `SSLSocketFactory` for enabling TLS1.2 on Android API < 20.

## How

Android API >= 20 already has TLS1.2 enabled by default. API level 19 has it available but not enabled. On older versions of Android it is possible for users to workaround this, for example by configuring the `HttpsUrlConnection.setDefaultSocketFactory` or similar. However, we can check the API version and set the socket factory for each `HttpConnection` automatically so that older versions of Android work without any user required changes.

* Added Android version and TLS support checks as well as a TLSv1.2 only `SSLSocketFactory` to enable on older versions.
* Moved default interceptors into `CouchClient` from `ReplicatorBuilder`.

## Testing

* Updated `HttpTest` that called `HttpConnection` directly to consume default interceptors.
* Refactored `HttpTest` slightly to simplify interceptor addition.
* Updated replication tests for new assertions, due to interceptor move to `CouchClient` and interceptor "sizes".

Existing tests pass.
Manually tested on API 19 emulator against TLS1.2 only Cloudant.
CI tests run against API >= 20, so don't regularly check this. We could consider an extra branch of testing using the emulator at API level 19.

## Issues

N/A
