### PR TITLE
`read`, `contains`, `create`, `delete` for local docs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# 2.4.0 (Unreleased)
+- [NEW] `Database` methods `read`, `contains`, `create`, and `delete` now accept local
+  (non-replicating documents). These documents must have their document ID prefixed with `_local/`
+  and must have their revision ID set to `null` (where applicable).
+  
 # 2.3.0 (2018-08-14)
 - [NEW] Added API for specifying a list of document IDs in the filtered pull replicator.
 - [IMPROVED] Forced a TLS1.2 `SSLSocketFactory` where possible on Android API versions < 20 (it is

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/Database.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/Database.java
@@ -315,7 +315,9 @@ public interface Database {
      * if {@code documentId} is prefixed with {@code _local/}.</p>
      *
      * <p>This operation leaves a "tombstone" for the deleted document, so that
-     * future replication operations can successfully replicate the deletion.
+     * future replication operations can successfully replicate the deletion. Note that local
+     * documents do not have tombstones since they do not have a revision history; they are
+     * immediately removed from the database.
      * </p>
      *
      * <p>If the document is successfully deleted, a
@@ -346,6 +348,12 @@ public interface Database {
      * <a href="https://couchdb.readthedocs.io/en/stable/api/local.html">local document</a>,
      * if {@code documentId} is prefixed with {@code _local/}.</p>
      *
+     * <p>This operation leaves a "tombstone" for each deleted document, so that
+     * future replication operations can successfully replicate the deletion. Note that local
+     * documents do not have tombstones since they do not have a revision history; they are
+     * immediately removed from the database.
+     * </p>
+     *
      * <p>This is equivalent to calling
      * {@link Database#delete(DocumentRevision)
      * delete} on all leaf revisions</p>
@@ -353,7 +361,6 @@ public interface Database {
      * @param id the ID of the document to delete leaf nodes for
      * @return a List of a {@link DocumentRevision}s - the deleted or "tombstone" documents
      * @throws DocumentStoreException if there was an error reading from or writing to the database
-     * @see Database#getEventBus()
      * @see Database#delete(DocumentRevision)
      */
     List<DocumentRevision> delete(String id) throws DocumentNotFoundException, DocumentStoreException;

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/Database.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/Database.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 IBM Corp. All rights reserved.
+ * Copyright © 2016, 2018 IBM Corp. All rights reserved.
  *
  * Original iOS version by  Jens Alfke, ported to Android by Marty Schoch
  * Copyright © 2012 Couchbase, Inc. All rights reserved.
@@ -73,7 +73,10 @@ public interface Database {
     File getPath();
 
     /**
-     * <p>Returns the current winning revision of a document.</p>
+     * <p>Returns the current winning revision of a document; or returns the given
+     * <a href="https://couchdb.readthedocs.io/en/stable/api/local.html">local document</a>,
+     * if {@code documentId} is prefixed with {@code _local/}.
+     * </p>
      *
      * <p>Previously deleted documents can be retrieved
      * (via tombstones, see {@link Database#delete(DocumentRevision)})
@@ -109,7 +112,9 @@ public interface Database {
 
     /**
      * <p>Returns whether this DocumentStore contains a particular revision of
-     * a document.</p>
+     * a document; or contains the given
+     * <a href="https://couchdb.readthedocs.io/en/stable/api/local.html">local document</a>,
+     * if {@code documentId} is prefixed with {@code _local/}.</p>
      *
      * <p>{@code true} will still be returned if the document is deleted.</p>
      *
@@ -122,7 +127,10 @@ public interface Database {
     boolean contains(String documentId, String revisionId) throws DocumentStoreException;
 
     /**
-     * <p>Returns whether this DocumentStore contains any revisions of a document.
+     * <p>Returns whether this DocumentStore contains any revisions of a document; or contains the
+     * given
+     * <a href="https://couchdb.readthedocs.io/en/stable/api/local.html">local document</a>,
+     * if {@code documentId} is prefixed with {@code _local/}.
      * </p>
      *
      * <p>{@code true} will still be returned if the document is deleted.</p>
@@ -195,6 +203,7 @@ public interface Database {
 
     /**
      * <p>Return the number of documents in the DocumentStore</p>
+     * <p><b>Note:</b> this excludes local documents.</p>
      *
      * @return number of non-deleted documents in DocumentStore
      * @throws DocumentStoreException if there was an error reading from the database.
@@ -253,7 +262,10 @@ public interface Database {
         throws ConflictException;
 
     /**
-     * <p>Adds a new document with body and attachments from <code>rev</code>.</p>
+     * <p>Adds a new document with body and attachments from <code>rev</code>; or creates or updates
+     * a <a href="https://couchdb.readthedocs.io/en/stable/api/local.html">local document</a>,
+     * if {@code documentId} is prefixed with {@code _local/}.
+     * </p>
      *
      * <p>If the ID in <code>rev</code> is null, the document's ID will be auto-generated,
      * and can be found by inspecting the returned {@code DocumentRevision}.</p>
@@ -284,6 +296,8 @@ public interface Database {
      * {@link com.cloudant.sync.event.notifications.DocumentUpdated DocumentUpdated}
      * event is posted on the event bus.</p>
      *
+     * <p><b<Note:</b> to update local documents, call {@link #create(DocumentRevision)}</p>
+     *
      * @param rev the {@link DocumentRevision} to be updated
      * @return a {@link DocumentRevision} - the updated document
      * @throws ConflictException if <code>rev</code> is not a current revision for this document
@@ -296,7 +310,9 @@ public interface Database {
             AttachmentException, DocumentStoreException, DocumentNotFoundException;
 
     /**
-     * <p>Deletes a document from the DocumentStore.</p>
+     * <p>Deletes a document from the DocumentStore; or delete a
+     * <a href="https://couchdb.readthedocs.io/en/stable/api/local.html">local document</a>,
+     * if {@code documentId} is prefixed with {@code _local/}.</p>
      *
      * <p>This operation leaves a "tombstone" for the deleted document, so that
      * future replication operations can successfully replicate the deletion.
@@ -331,6 +347,8 @@ public interface Database {
      * <p>This is equivalent to calling
      * {@link Database#delete(DocumentRevision)
      * delete} on all leaf revisions</p>
+     *
+     * <p><b<Note:</b> to delete local documents, call {@link #delete(DocumentRevision)}</p>
      *
      * @param id the ID of the document to delete leaf nodes for
      * @return a List of a {@link DocumentRevision}s - the deleted or "tombstone" documents

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/Database.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/Database.java
@@ -287,16 +287,15 @@ public interface Database {
 
     /**
      * <p>Updates a document that exists in the DocumentStore with with body and attachments
-     * from <code>rev</code>.
-     * </p>
+     * from <code>rev</code>; or creates or updates
+     * a <a href="https://couchdb.readthedocs.io/en/stable/api/local.html">local document</a>,
+     * if {@code documentId} is prefixed with {@code _local/}.
      *
      * <p>{@code rev} must be a current revision for this document.</p>
      *
      * <p>If the document is successfully updated, a
      * {@link com.cloudant.sync.event.notifications.DocumentUpdated DocumentUpdated}
      * event is posted on the event bus.</p>
-     *
-     * <p><b>Note:</b> to update local documents, call {@link #create(DocumentRevision)}</p>
      *
      * @param rev the {@link DocumentRevision} to be updated
      * @return a {@link DocumentRevision} - the updated document

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/Database.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/Database.java
@@ -296,7 +296,7 @@ public interface Database {
      * {@link com.cloudant.sync.event.notifications.DocumentUpdated DocumentUpdated}
      * event is posted on the event bus.</p>
      *
-     * <p><b<Note:</b> to update local documents, call {@link #create(DocumentRevision)}</p>
+     * <p><b>Note:</b> to update local documents, call {@link #create(DocumentRevision)}</p>
      *
      * @param rev the {@link DocumentRevision} to be updated
      * @return a {@link DocumentRevision} - the updated document
@@ -348,7 +348,7 @@ public interface Database {
      * {@link Database#delete(DocumentRevision)
      * delete} on all leaf revisions</p>
      *
-     * <p><b<Note:</b> to delete local documents, call {@link #delete(DocumentRevision)}</p>
+     * <p><b>Note:</b> to delete local documents, call {@link #delete(DocumentRevision)}</p>
      *
      * @param id the ID of the document to delete leaf nodes for
      * @return a List of a {@link DocumentRevision}s - the deleted or "tombstone" documents

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/Database.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/Database.java
@@ -342,13 +342,13 @@ public interface Database {
             DocumentStoreException;
 
     /**
-     * <p>Delete all leaf revisions for the document</p>
+     * <p>Delete all leaf revisions for the document; or delete a
+     * <a href="https://couchdb.readthedocs.io/en/stable/api/local.html">local document</a>,
+     * if {@code documentId} is prefixed with {@code _local/}.</p>
      *
      * <p>This is equivalent to calling
      * {@link Database#delete(DocumentRevision)
      * delete} on all leaf revisions</p>
-     *
-     * <p><b>Note:</b> to delete local documents, call {@link #delete(DocumentRevision)}</p>
      *
      * @param id the ID of the document to delete leaf nodes for
      * @return a List of a {@link DocumentRevision}s - the deleted or "tombstone" documents
@@ -356,7 +356,7 @@ public interface Database {
      * @see Database#getEventBus()
      * @see Database#delete(DocumentRevision)
      */
-    List<DocumentRevision> delete(String id) throws DocumentStoreException;
+    List<DocumentRevision> delete(String id) throws DocumentNotFoundException, DocumentStoreException;
 
     /**
      * Compacts the SQL database and disk storage by removing the bodies and attachments of obsolete revisions.

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/LocalDocument.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/LocalDocument.java
@@ -17,7 +17,8 @@ package com.cloudant.sync.documentstore;
 /**
  * <p>
  *     <b>Note:</b> this class is deprecated and will be moved to an internal package in a future
- *     release.
+ *     release. For local documents use a {@link DocumentRevision} with an {@code id} prefixed with
+ *     {@code _local} and a {@code rev} set to {@code null}.
  * </p>
  * <p>
  *     A local Document. {@code LocalDocument}s do not have a history, or the concept of revisions

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/LocalDocument.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/documentstore/LocalDocument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2018 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -15,8 +15,15 @@
 package com.cloudant.sync.documentstore;
 
 /**
- * A local Document. {@code LocalDocument}s do not have a history, or the concept of revisions
+ * <p>
+ *     <b>Note:</b> this class is deprecated and will be moved to an internal package in a future
+ *     release.
+ * </p>
+ * <p>
+ *     A local Document. {@code LocalDocument}s do not have a history, or the concept of revisions
+ * </p>
  */
+@Deprecated
 public class LocalDocument {
 
     /**

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/DatabaseImpl.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/DatabaseImpl.java
@@ -965,8 +965,9 @@ public class DatabaseImpl implements Database, com.cloudant.sync.documentstore.a
         Misc.checkArgument(rev.isFullRevision(), "Projected revisions cannot be used to " +
                 "create documents");
 
+        // Shortcut if this is a create/update of local doc
         if (rev.getId().startsWith(CouchConstants._local_prefix)) {
-            throw new IllegalArgumentException("Use create(final DocumentRevision rev) create or update local documents");
+            return create(rev);
         }
 
         // Shortcut if this is a deletion

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/DatabaseImpl.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/documentstore/DatabaseImpl.java
@@ -896,8 +896,8 @@ public class DatabaseImpl implements Database, com.cloudant.sync.documentstore.a
         }
 
         // check to see if we are creating a local (non-replicating) document
-        if (rev.getId().startsWith(CouchConstants._local_prefix)) {
-            String localId = rev.getId().substring(CouchConstants._local_prefix.length());
+        if (docId.startsWith(CouchConstants._local_prefix)) {
+            String localId = docId.substring(CouchConstants._local_prefix.length());
             try {
                 insertLocalDocument(localId, rev.getBody());
                 // we can return the input document as-is since there was no doc id or rev id to generate

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/documentstore/LocalDocumentCrud.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/documentstore/LocalDocumentCrud.java
@@ -194,11 +194,11 @@ public class LocalDocumentCrud extends DocumentStoreTestBase {
     }
 
     /**
-     * Create then delete local rev and check that contains() returns false for it
+     * Create then delete (rev argument) local rev and check that contains() returns false for it
      * @throws Exception
      */
     @Test
-    public void testDeleteAndContains() throws Exception {
+    public void testDeleteRevArgAndContains() throws Exception {
         DocumentRevision rev = new DocumentRevision(idPrefixed);
         rev.setBody(DocumentBodyFactory.create("{\"hello\":\"world\"}".getBytes()));
         this.documentStore.database().create(rev);
@@ -211,12 +211,25 @@ public class LocalDocumentCrud extends DocumentStoreTestBase {
     }
 
     /**
+     * Deleting local doc twice (string argument) should throw DocumentNotFoundException
+     * @throws Exception
+     */
+    @Test(expected = DocumentNotFoundException.class)
+    public void testDeleteRevArgThrowsForAlreadyDeleted() throws Exception {
+        DocumentRevision rev = new DocumentRevision(idPrefixed);
+        rev.setBody(DocumentBodyFactory.create("{\"hello\":\"world\"}".getBytes()));
+        this.documentStore.database().create(rev);
+        this.documentStore.database().delete(rev);
+        this.documentStore.database().delete(rev);
+    }
+
+    /**
      * Create a local rev and assert that an exception is thrown if we try to delete it with rev id
      * set to a non-null value
      * @throws Exception
      */
     @Test(expected = IllegalArgumentException.class)
-    public void testDeleteThrowsForNonNullRevisionId() throws Exception {
+    public void testDeleteRevArgThrowsForNonNullRevisionId() throws Exception {
         DocumentRevision rev = new DocumentRevision(idPrefixed);
         rev.setBody(DocumentBodyFactory.create("{\"hello\":\"world\"}".getBytes()));
         this.documentStore.database().create(rev);
@@ -225,13 +238,32 @@ public class LocalDocumentCrud extends DocumentStoreTestBase {
     }
 
     /**
-     * Create a local rev and assert that an exception is thrown if we try to delete it using the
-     * String argument type instead of the DocumentRevision argument type
+     * Create then delete (string argument) local rev and check that contains() returns false for it
      * @throws Exception
      */
-    @Test(expected = IllegalArgumentException.class)
-    public void testDeleteThrowsForIncorrectArgumentType() throws Exception {
+    @Test
+    public void testDeleteStringArgAndContains() throws Exception {
         DocumentRevision rev = new DocumentRevision(idPrefixed);
+        rev.setBody(DocumentBodyFactory.create("{\"hello\":\"world\"}".getBytes()));
+        this.documentStore.database().create(rev);
+        DocumentRevision deleted = this.documentStore.database().delete(idPrefixed).get(0);
+        // delete returns null for local documents since local documents don't have tombstones
+        assertNull(deleted);
+        // check that contains() returns false for the local doc
+        boolean contains = this.documentStore.database().contains(idPrefixed);
+        assertFalse(contains);
+    }
+
+    /**
+     * Deleting local doc twice (string argument) should throw DocumentNotFoundException
+     * @throws Exception
+     */
+    @Test(expected = DocumentNotFoundException.class)
+    public void testDeleteStringArgThrowsForAlreadyDeleted() throws Exception {
+        DocumentRevision rev = new DocumentRevision(idPrefixed);
+        rev.setBody(DocumentBodyFactory.create("{\"hello\":\"world\"}".getBytes()));
+        this.documentStore.database().create(rev);
+        this.documentStore.database().delete(idPrefixed);
         this.documentStore.database().delete(idPrefixed);
     }
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/documentstore/LocalDocumentCrud.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/documentstore/LocalDocumentCrud.java
@@ -165,32 +165,24 @@ public class LocalDocumentCrud extends DocumentStoreTestBase {
     }
 
     /**
-     * Create a local rev and attempt to update it.
-     * This will fail because the correct usage is to call create() which is really an upsert.
-     *
+     * Create a local rev and update it.
      * @throws Exception
      */
     @Test
-    public void testUpdateThrows() throws Exception {
+    public void testUpdateAndRead() throws Exception {
         // create first rev
         DocumentRevision rev = new DocumentRevision(idPrefixed);
         rev.setBody(DocumentBodyFactory.create("{\"hello\":\"world\"}".getBytes()));
         this.documentStore.database().create(rev);
-        // create second rev
+        // update with second rev
         DocumentRevision rev2 = new DocumentRevision(idPrefixed);
         rev2.setBody(DocumentBodyFactory.create("{\"hello\":\"universe\"}".getBytes()));
-        boolean caught = false;
-        try {
-            this.documentStore.database().update(rev2);
-        } catch (IllegalArgumentException iae) {
-            caught = true;
-        }
-        assertTrue(caught);
+        this.documentStore.database().update(rev2);
         // read the document back, it should have the id including the _local/ prefix
         DocumentRevision rev3 = this.documentStore.database().read(idPrefixed);
         assertEquals(idPrefixed, rev3.id);
         // check the body, it should still be the old body because the update failed
-        assertEquals("world", rev3.getBody().asMap().get("hello"));
+        assertEquals("universe", rev3.getBody().asMap().get("hello"));
     }
 
     /**

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/documentstore/LocalDocumentCrud.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/documentstore/LocalDocumentCrud.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright © 2018 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.sync.documentstore;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.cloudant.common.DocumentStoreTestBase;
+import com.cloudant.sync.event.Subscribe;
+import com.cloudant.sync.event.notifications.DocumentCreated;
+import com.cloudant.sync.event.notifications.DocumentDeleted;
+import com.cloudant.sync.event.notifications.DocumentModified;
+import com.cloudant.sync.event.notifications.DocumentUpdated;
+import com.cloudant.sync.internal.common.CouchConstants;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+/**
+ * CRUD tests for local (non-replicating) documents using the public API
+ */
+
+public class LocalDocumentCrud extends DocumentStoreTestBase {
+
+    private static final String id = "foo";
+    private static final String idPrefixed = CouchConstants._local_prefix + id;
+
+    private Deque<DocumentModified> events;
+
+    @Before
+    public void setup() {
+        events = new ArrayDeque<DocumentModified>();
+        documentStore.database().getEventBus().register(this);
+    }
+
+    /**
+     * Create a local rev and read it back
+     * @throws Exception
+     */
+    @Test
+    public void testCreateAndRead() throws Exception {
+        DocumentRevision rev = new DocumentRevision(idPrefixed);
+        rev.setBody(DocumentBodyFactory.create("{\"hello\":\"world\"}".getBytes()));
+        this.documentStore.database().create(rev);
+
+        // read the document back, it should have the id including the _local/ prefix
+        DocumentRevision rev2 = this.documentStore.database().read(idPrefixed);
+        assertEquals(idPrefixed, rev2.id);
+
+        // check the body
+        assertEquals("world", rev2.getBody().asMap().get("hello"));
+
+        // check events
+        DocumentModified dc = events.remove();
+        assertEquals(idPrefixed, dc.newDocument.id);
+        assertEquals("world", dc.newDocument.body.asMap().get("hello"));
+    }
+
+    /**
+     * Create a local rev twice with the same doc id.
+     * For local revs this is just an overwrite since "create" is really an upsert.
+     * @throws Exception
+     */
+    @Test
+    public void testCreateTwiceAndRead() throws Exception {
+        // create first rev
+        DocumentRevision rev = new DocumentRevision(idPrefixed);
+        rev.setBody(DocumentBodyFactory.create("{\"hello\":\"world\"}".getBytes()));
+        this.documentStore.database().create(rev);
+
+        // create second rev
+        DocumentRevision rev2 = new DocumentRevision(idPrefixed);
+        rev2.setBody(DocumentBodyFactory.create("{\"hello\":\"universe\"}".getBytes()));
+        this.documentStore.database().create(rev2);
+
+        // read the document back, it should have the id including the _local/ prefix
+        DocumentRevision rev3 = this.documentStore.database().read(idPrefixed);
+        assertEquals(idPrefixed, rev3.id);
+
+        // check the body
+        assertEquals("universe", rev3.getBody().asMap().get("hello"));
+
+        // check events
+        DocumentModified dc = events.remove();
+        assertEquals(idPrefixed, dc.newDocument.id);
+        assertEquals("world", dc.newDocument.body.asMap().get("hello"));
+        dc = events.remove();
+        assertEquals(idPrefixed, dc.newDocument.id);
+        assertEquals("universe", dc.newDocument.body.asMap().get("hello"));
+    }
+
+    /**
+     * Create a local rev and check that contains() returns true for it
+     * @throws Exception
+     */
+    @Test
+    public void testCreateAndContains() throws Exception {
+        DocumentRevision rev = new DocumentRevision(idPrefixed);
+        rev.setBody(DocumentBodyFactory.create("{\"hello\":\"world\"}".getBytes()));
+        this.documentStore.database().create(rev);
+
+        // check that contains() returns true for the local doc
+        boolean contains = this.documentStore.database().contains(idPrefixed);
+        assertTrue(contains);
+    }
+
+    /**
+     * Create a local rev and assert that an exception is thrown if we try to set the rev id
+     * @throws Exception
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreateThrowsForNonNullRevisionId() throws Exception {
+        // try to create a local document with a non-null revision id
+        DocumentRevision rev = new DocumentRevision(idPrefixed, "1-a");
+        rev.setBody(DocumentBodyFactory.create("{\"hello\":\"world\"}".getBytes()));
+        this.documentStore.database().create(rev);
+    }
+
+    /**
+     * Create then delete local rev and check that calling read() on it raises an exception
+     * @throws Exception
+     */
+    @Test
+    public void testDeleteAndRead() throws Exception {
+        DocumentRevision rev = new DocumentRevision(idPrefixed);
+        rev.setBody(DocumentBodyFactory.create("{\"hello\":\"world\"}".getBytes()));
+        this.documentStore.database().create(rev);
+        DocumentRevision deleted = this.documentStore.database().delete(rev);
+
+        // delete returns null for local documents since local documents don't have tombstones
+        assertNull(deleted);
+        boolean caught = false;
+        try {
+            this.documentStore.database().read(idPrefixed);
+        } catch (DocumentNotFoundException dnfe) {
+            caught = true;
+        }
+        assertTrue(caught);
+
+        // check events
+        DocumentModified dc = events.remove();
+        assertEquals(idPrefixed, dc.newDocument.id);
+        assertEquals("world", dc.newDocument.body.asMap().get("hello"));
+        // after deletion, "new" document is null
+        dc = events.remove();
+        assertEquals(idPrefixed, dc.prevDocument.id);
+        assertNull(dc.newDocument);
+    }
+
+    /**
+     * Create a local rev and attempt to update it.
+     * This will fail because the correct usage is to call create() which is really an upsert.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testUpdateThrows() throws Exception {
+        // create first rev
+        DocumentRevision rev = new DocumentRevision(idPrefixed);
+        rev.setBody(DocumentBodyFactory.create("{\"hello\":\"world\"}".getBytes()));
+        this.documentStore.database().create(rev);
+        // create second rev
+        DocumentRevision rev2 = new DocumentRevision(idPrefixed);
+        rev2.setBody(DocumentBodyFactory.create("{\"hello\":\"universe\"}".getBytes()));
+        boolean caught = false;
+        try {
+            this.documentStore.database().update(rev2);
+        } catch (IllegalArgumentException iae) {
+            caught = true;
+        }
+        assertTrue(caught);
+        // read the document back, it should have the id including the _local/ prefix
+        DocumentRevision rev3 = this.documentStore.database().read(idPrefixed);
+        assertEquals(idPrefixed, rev3.id);
+        // check the body, it should still be the old body because the update failed
+        assertEquals("world", rev3.getBody().asMap().get("hello"));
+    }
+
+    /**
+     * Create then delete local rev and check that contains() returns false for it
+     * @throws Exception
+     */
+    @Test
+    public void testDeleteAndContains() throws Exception {
+        DocumentRevision rev = new DocumentRevision(idPrefixed);
+        rev.setBody(DocumentBodyFactory.create("{\"hello\":\"world\"}".getBytes()));
+        this.documentStore.database().create(rev);
+        DocumentRevision deleted = this.documentStore.database().delete(rev);
+        // delete returns null for local documents since local documents don't have tombstones
+        assertNull(deleted);
+        // check that contains() returns false for the local doc
+        boolean contains = this.documentStore.database().contains(idPrefixed);
+        assertFalse(contains);
+    }
+
+    /**
+     * Create a local rev and assert that an exception is thrown if we try to delete it with rev id
+     * set to a non-null value
+     * @throws Exception
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testDeleteThrowsForNonNullRevisionId() throws Exception {
+        DocumentRevision rev = new DocumentRevision(idPrefixed);
+        rev.setBody(DocumentBodyFactory.create("{\"hello\":\"world\"}".getBytes()));
+        this.documentStore.database().create(rev);
+        DocumentRevision toDelete = new DocumentRevision(idPrefixed, "1-a");
+        this.documentStore.database().delete(toDelete);
+    }
+
+    /**
+     * Create a local rev and assert that an exception is thrown if we try to delete it using the
+     * String argument type instead of the DocumentRevision argument type
+     * @throws Exception
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testDeleteThrowsForIncorrectArgumentType() throws Exception {
+        DocumentRevision rev = new DocumentRevision(idPrefixed);
+        this.documentStore.database().delete(idPrefixed);
+    }
+
+    @Subscribe
+    public void onDocumentCreated(DocumentCreated dc) throws Exception {
+        events.add(dc);
+    }
+
+    @Subscribe
+    public void onDocumentUpdated(DocumentUpdated du) {
+        events.add(du);
+    }
+
+    @Subscribe
+    public void onDocumentDeleted(DocumentDeleted dd) {
+        events.add(dd);
+    }
+
+
+}


### PR DESCRIPTION
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

See #589 - allow users to interact with local docs via `read`, `contains`, `create`, and `delete`.

Note that other public API methods explicitly _do not_ interact with local docs (eg `changes`).

## Approach

Users can interact with local documents by using existing methods but prefixing the document ID with `_local/`. Where a document is returned, it retains its `_local/` prefix.

## Schema & API Changes

"No change"

## Security and Privacy

"No change"

## Testing

Added `LocalDocumentCrud` test class. This is fairly comprehensive and should also help document the expected behaviour for some corner cases.

## Monitoring and Logging

Eventbus events are fired for local documents in a manner analogous to non-local documents (there are assertions for these in the tests).