### PR TITLE
Removed clean checkout workaround

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,13 +49,7 @@ def runTests(testEnv, isAndroid) {
 stage('Build') {
     // Checkout, build and assemble the source and doc
     node {
-        checkout([
-                $class                           : 'GitSCM',
-                branches                         : scm.branches,
-                doGenerateSubmoduleConfigurations: scm.doGenerateSubmoduleConfigurations,
-                extensions                       : scm.extensions + [[$class: 'CleanBeforeCheckout']],
-                userRemoteConfigs                : scm.userRemoteConfigs
-        ])
+        checkout scm
         sh './gradlew clean assemble'
         stash name: 'built'
     }


### PR DESCRIPTION


## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Remove the `Jenkinsfile` clean checkout workaround.

Fixes #506 

## Approach

The referenced Jenkins issue was resolved and the option to clean before checkout is now specified in the multi-branch configuration rather than in the `Jenkinsfile`.

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- N/A build or packaging only changes

## Monitoring and Logging

- "No change"
