### PR TITLE
Fix exception when replicating with CouchDB 2.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 - [NEW] `Database` methods `read`, `contains`, `create`, and `delete` now accept local
   (non-replicating documents). These documents must have their document ID prefixed with `_local/`
   and must have their revision ID set to `null` (where applicable).
-- [FIXED] Exception parsing remote database information when replicating with CouchDB 2.3. 
+- [FIXED] Fixed purge_seq to return a String object when replicating with CouchDB 2.3 databases. 
      
 # 2.3.0 (2018-08-14)
 - [NEW] Added API for specifying a list of document IDs in the filtered pull replicator.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,8 @@
 - [NEW] `Database` methods `read`, `contains`, `create`, and `delete` now accept local
   (non-replicating documents). These documents must have their document ID prefixed with `_local/`
   and must have their revision ID set to `null` (where applicable).
-  
+- [FIXED] Exception parsing remote database information when replicating with CouchDB 2.3. 
+     
 # 2.3.0 (2018-08-14)
 - [NEW] Added API for specifying a list of document IDs in the filtered pull replicator.
 - [IMPROVED] Forced a TLS1.2 `SSLSocketFactory` where possible on Android API versions < 20 (it is

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/mazha/CouchDbInfo.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/mazha/CouchDbInfo.java
@@ -40,7 +40,7 @@ public class CouchDbInfo {
 	private Object updateSeq;
 
 	@JsonProperty("purge_seq")
-	private long purgeSeq;
+	private String purgeSeq;
 
 	@JsonProperty("compact_running")
 	private boolean compactRunning;
@@ -73,7 +73,7 @@ public class CouchDbInfo {
 		return updateSeq;
 	}
 
-	public long getPurgeSeq() {
+	public String getPurgeSeq() {
 		return purgeSeq;
 	}
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/util/JSONUtilsTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/util/JSONUtilsTest.java
@@ -16,17 +16,24 @@
 
 package com.cloudant.sync.util;
 
-import com.cloudant.sync.internal.util.JSONUtils;
+import com.cloudant.sync.internal.mazha.CouchDbInfo;
 import com.cloudant.sync.internal.replication.Foo;
-import org.junit.Assert;
+import com.cloudant.sync.internal.util.JSONUtils;
+import com.fasterxml.jackson.core.type.TypeReference;
+
 import org.apache.commons.io.FileUtils;
+import static org.hamcrest.CoreMatchers.is;
+import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.File;
+import java.io.FileReader;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
 
 public class JSONUtilsTest {
 
@@ -147,6 +154,16 @@ public class JSONUtilsTest {
         Map<String, Object> breakfast = (Map)activities.get(1);
         Assert.assertEquals(4, breakfast.size());
         Assert.assertEquals(Integer.valueOf(40), breakfast.get("Duration"));
+    }
+
+    @Test
+    public void deserialize_CouchDBInfo_purgeSeq_from_long() throws Exception {
+        File dbinfoData = TestUtils.loadFixture("fixture/dbinfo-pre23.json");
+        CouchDbInfo deserialized = JSONUtils.fromJson(new FileReader(dbinfoData), new
+                TypeReference<CouchDbInfo>() {
+        });
+        Long purgeSeq = Long.valueOf(deserialized.getPurgeSeq());
+        Assert.assertThat(purgeSeq, is(0l));
     }
 
     private byte[] readJsonDataFromFile(String filename) throws IOException {

--- a/fixture/dbinfo-pre23.json
+++ b/fixture/dbinfo-pre23.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "test",
+  "update_seq": "4-g1AAAAFTeJzLYWBg4MhgTmEQTM4vTc5ISXLIyU9OzMnILy7JAUoxJTIkyf___z8rkQGPoiQFIJlkD1bHiE-dA0hdPFgdEz51CSB19QTtzWMBkgwNQAqodD4xahdA1O4nRu0BiNr7-P0EUfsAohbk3iwA10dvMg",
+  "sizes": {
+    "file": 161030,
+    "external": 112978,
+    "active": 113762
+  },
+  "purge_seq": 0,
+  "other": {
+    "data_size": 112978
+  },
+  "doc_del_count": 0,
+  "doc_count": 3,
+  "disk_size": 161030,
+  "disk_format_version": 6,
+  "data_size": 113762,
+  "compact_running": false,
+  "instance_start_time": "0"
+}


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [X] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [ ] Added tests for code changes _or_ test/build only changes
- [X] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [X] Completed the PR template below:

## Description
Fixes #593 

This PR fixes an exception when parsing the response to GET /db on the remote server when replication with CouchDB 2.3

## Approach
CouchDB 2.3 has changed purge_seq type from long to a String, similar to the update_seq. This affects to the parsing of the GET /db operation on the remote database as the parsing is failling. 

This PR changes the type of purgeSeq property from long to String in com.cloudant.sync.internal.mazha.CouchDbInfo 

## Schema & API Changes
- "No change in public API"

## Security and Privacy
- "No change"

## Testing
I've not added tests for this change. Existing replication tests where failing with CouchDB 2.3 and this PR allows to pass them successfully.

There is not infrastructure in the project for automating testing over different CouchDB versions, so I have configure a travis build for testing this change over three CouchDB version 2.3, 2.1.2 and 1.7.4. The result is here https://travis-ci.org/jjrodrig/sync-android/builds/475100353


<!--
EITHER:

- Added new tests:
    - test x
    - test y
    - test z

OR

- Modified existing tests because ...

OR

- N/A build or packaging only changes

OR

In exceptional circumstances there may be a good reason we can't add automated
tests, for example if a specific device is required to reproduce a problem.

- No new tests because...
-->

## Monitoring and Logging
- "No change"
