### PR TITLE
Fix #599 - Record checkpoint on empty _changes result

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,5 @@
 # 2.x.y (Unreleased)
-- [IMPROVED] Record checkpoint on empty `_changes` result in Pull replications. This change optimizes 
+- [IMPROVED] Record checkpoint on empty `_changes` result in pull replications. This change optimizes 
    filtered replications when changes in remote database doesn't match the replication filter. 
 # 2.4.0 (2019-01-15)
 - [NEW] `Database` methods `read`, `contains`, `create`, and `delete` now accept local

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 2.x.y (Unreleased)
+- [IMPROVED] Record checkpoint on empty `_changes` result in Pull replications. This change optimizes 
+   filtered replications when changes in remote database doesn't match the replication filter. 
 # 2.4.0 (2019-01-15)
 - [NEW] `Database` methods `read`, `contains`, `create`, and `delete` now accept local
   (non-replicating documents). These documents must have their document ID prefixed with `_local/`

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/replication/PullStrategy.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/replication/PullStrategy.java
@@ -262,6 +262,13 @@ public class PullStrategy implements ReplicationStrategy {
             if (changeFeeds.size() > 0) {
                 batchChangesProcessed = processOneChangesBatch(changeFeeds);
                 state.documentCounter += batchChangesProcessed;
+            } else {
+                try {
+                    this.targetDb.putCheckpoint(this.getReplicationId(), changeFeeds.getLastSeq());
+                } catch (DocumentStoreException e) {
+                    logger.log(Level.WARNING, "Failed to put checkpoint doc, next replication will " +
+                            "start from previous checkpoint", e);
+                }
             }
 
             long batchEndTime = System.currentTimeMillis();

--- a/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/replication/PullStrategy.java
+++ b/cloudant-sync-datastore-core/src/main/java/com/cloudant/sync/internal/replication/PullStrategy.java
@@ -473,7 +473,6 @@ public class PullStrategy implements ReplicationStrategy {
     }
 
     private ChangesResultWrapper nextBatch(final Object lastCheckpoint) {
-//        final Object lastCheckpoint = this.targetDb.getCheckpoint(this.getReplicationId());
         logger.fine("last checkpoint " + lastCheckpoint);
 
         ChangesResult changeFeeds = null;

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/PullStrategyMockTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/PullStrategyMockTest.java
@@ -254,7 +254,7 @@ public class PullStrategyMockTest extends ReplicationTestBase {
         Assert.assertEquals(this.datastore.getDocumentCount(), 0);
         //Checkpoint should be created in targetDb
         String checkpoint = (String) pullStrategy.targetDb.getCheckpoint(pullStrategy.getReplicationId());
-        Assert.assertEquals(checkpoint,"5-g1AAAAIreJyVkEsKwjAURZ...");
+        Assert.assertEquals(checkpoint,"10-d9e5b0147af143e5b6d1979378ad957b");
         //make sure the correct events were fired
         verify(mockListener).complete(any(ReplicationStrategyCompleted.class));
         verify(mockListener,never()).error(any(ReplicationStrategyErrored.class));

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/PullStrategyMockTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/PullStrategyMockTest.java
@@ -16,6 +16,7 @@
 
 package com.cloudant.sync.internal.replication;
 
+import static org.junit.Assume.assumeNoException;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
@@ -27,12 +28,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.cloudant.common.RequireRunningCouchDB;
+import com.cloudant.sync.event.Subscribe;
+import com.cloudant.sync.internal.documentstore.DocumentRevsList;
 import com.cloudant.sync.internal.mazha.ChangesResult;
 import com.cloudant.sync.internal.mazha.DocumentRevs;
 import com.cloudant.sync.internal.mazha.OkOpenRevision;
 import com.cloudant.sync.internal.mazha.OpenRevision;
-import com.cloudant.sync.internal.documentstore.DocumentRevsList;
-import com.cloudant.sync.event.Subscribe;
 import com.cloudant.sync.internal.util.JSONUtils;
 import com.cloudant.sync.replication.PullFilter;
 import com.cloudant.sync.util.TestUtils;
@@ -264,62 +265,72 @@ public class PullStrategyMockTest extends ReplicationTestBase {
 
     @Test
     public void testDoNotSetCheckpointWhenNotModified() throws Exception {
-        CouchDB mockRemoteDb = mock(CouchDB.class);
-        when(mockRemoteDb.changes((PullFilter) null, "10-d9e5b0147af143e5b6d1979378ad957b", 1000)).then(new Answer<Object>() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                FileReader fr = new FileReader(TestUtils.loadFixture
-                        ("fixture/empty_changes.json"));
-                return JSONUtils.fromJson(fr, ChangesResult.class);
-            }
-        });
-        when(mockRemoteDb.exists()).thenReturn(true);
+        try {
+            CouchDB mockRemoteDb = mock(CouchDB.class);
+            when(mockRemoteDb.changes((PullFilter) null, "10-d9e5b0147af143e5b6d1979378ad957b", 1000)).then(new Answer<Object>() {
+                @Override
+                public Object answer(InvocationOnMock invocation) throws Throwable {
+                    FileReader fr = new FileReader(TestUtils.loadFixture
+                            ("fixture/empty_changes.json"));
+                    return JSONUtils.fromJson(fr, ChangesResult.class);
+                }
+            });
+            when(mockRemoteDb.exists()).thenReturn(true);
 
-        DatastoreWrapper mockLocalDb = mock(DatastoreWrapper.class);
-        when(mockLocalDb.getCheckpoint(any(String.class))).thenReturn("10" +
-                "-d9e5b0147af143e5b6d1979378ad957b");
+            DatastoreWrapper mockLocalDb = mock(DatastoreWrapper.class);
+            when(mockLocalDb.getCheckpoint(any(String.class))).thenReturn("10" +
+                    "-d9e5b0147af143e5b6d1979378ad957b");
 
-        StrategyListener mockListener = mock(StrategyListener.class);
-        PullStrategy pullStrategy = super.getPullStrategy();
-        pullStrategy.sourceDb = mockRemoteDb;
-        pullStrategy.targetDb = mockLocalDb;
-        pullStrategy.getEventBus().register(mockListener);
-        pullStrategy.run();
+            StrategyListener mockListener = mock(StrategyListener.class);
+            PullStrategy pullStrategy = super.getPullStrategy();
+            pullStrategy.sourceDb = mockRemoteDb;
+            pullStrategy.targetDb = mockLocalDb;
+            pullStrategy.getEventBus().register(mockListener);
+            pullStrategy.run();
 
-        //make sure the correct events were fired
-        verify(mockListener).complete(any(ReplicationStrategyCompleted.class));
-        verify(mockListener, never()).error(any(ReplicationStrategyErrored.class));
-        verify(mockLocalDb, never()).putCheckpoint(anyString(), any());
+            //make sure the correct events were fired
+            verify(mockListener).complete(any(ReplicationStrategyCompleted.class));
+            verify(mockListener, never()).error(any(ReplicationStrategyErrored.class));
+            verify(mockLocalDb, never()).putCheckpoint(anyString(), any());
+        } catch(UnsupportedOperationException uoe) {
+            assumeNoException("Cannot proxy DatastoreWrapper on Dalvik", uoe);
+        }
     }
 
     @Test
     public void testSetCheckpointWhenModified() throws Exception {
-        CouchDB mockRemoteDb = mock(CouchDB.class);
-        when(mockRemoteDb.changes((PullFilter) null, "9-d9e5b0147af143e5b6d1979378ad957b", 1000)).then(new Answer<Object>() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                FileReader fr = new FileReader(TestUtils.loadFixture
-                        ("fixture/empty_changes.json"));
-                return JSONUtils.fromJson(fr, ChangesResult.class);
-            }
-        });
-        when(mockRemoteDb.exists()).thenReturn(true);
+        try {
+            CouchDB mockRemoteDb = mock(CouchDB.class);
+            when(mockRemoteDb.changes((PullFilter) null, "9-d9e5b0147af143e5b6d1979378ad957b",
+                    1000)).then(new Answer<Object>() {
+                @Override
+                public Object answer(InvocationOnMock invocation) throws Throwable {
+                    FileReader fr = new FileReader(TestUtils.loadFixture
+                            ("fixture/empty_changes.json"));
+                    return JSONUtils.fromJson(fr, ChangesResult.class);
+                }
+            });
+            when(mockRemoteDb.exists()).thenReturn(true);
 
-        DatastoreWrapper mockLocalDb = mock(DatastoreWrapper.class);
-        when(mockLocalDb.getCheckpoint(any(String.class))).thenReturn("9" +
-                "-d9e5b0147af143e5b6d1979378ad957b");
+            DatastoreWrapper mockLocalDb = mock(DatastoreWrapper.class);
+            when(mockLocalDb.getCheckpoint(any(String.class))).thenReturn("9" +
+                    "-d9e5b0147af143e5b6d1979378ad957b");
 
-        StrategyListener mockListener = mock(StrategyListener.class);
-        PullStrategy pullStrategy = super.getPullStrategy();
-        pullStrategy.sourceDb = mockRemoteDb;
-        pullStrategy.targetDb = mockLocalDb;
-        pullStrategy.getEventBus().register(mockListener);
-        pullStrategy.run();
+            StrategyListener mockListener = mock(StrategyListener.class);
+            PullStrategy pullStrategy = super.getPullStrategy();
+            pullStrategy.sourceDb = mockRemoteDb;
+            pullStrategy.targetDb = mockLocalDb;
+            pullStrategy.getEventBus().register(mockListener);
+            pullStrategy.run();
 
-        //make sure the correct events were fired
-        verify(mockListener).complete(any(ReplicationStrategyCompleted.class));
-        verify(mockListener, never()).error(any(ReplicationStrategyErrored.class));
-        verify(mockLocalDb).putCheckpoint(anyString(), eq("10-d9e5b0147af143e5b6d1979378ad957b"));
+            //make sure the correct events were fired
+            verify(mockListener).complete(any(ReplicationStrategyCompleted.class));
+            verify(mockListener, never()).error(any(ReplicationStrategyErrored.class));
+            verify(mockLocalDb).putCheckpoint(anyString(), eq("10" +
+                    "-d9e5b0147af143e5b6d1979378ad957b"));
+        } catch (UnsupportedOperationException uoe) {
+            assumeNoException("Cannot proxy DatastoreWrapper on Dalvik", uoe);
+        }
     }
 
 

--- a/fixture/empty_changes.json
+++ b/fixture/empty_changes.json
@@ -1,5 +1,5 @@
 {
-    "last_seq": "5-g1AAAAIreJyVkEsKwjAURZ...",
+    "last_seq": "10-d9e5b0147af143e5b6d1979378ad957b",
     "pending": 0,
     "results": []
 }

--- a/fixture/empty_changes.json
+++ b/fixture/empty_changes.json
@@ -1,0 +1,5 @@
+{
+    "last_seq": "5-g1AAAAIreJyVkEsKwjAURZ...",
+    "pending": 0,
+    "results": []
+}


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [X] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [X] Added tests for code changes _or_ test/build only changes
- [X] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [X] Completed the PR template below:

## Description

Filtered pull replications does not update checkpoint if the result of _changes is empty.

Fixes #599 
<!--
Provide a short description; saving the detail for the `Approach` section

Also EITHER:
Link to issue this PR is resolving, use the Fixes #nnn form so that the
issue closes automatically when the PR merges e.g.:

Fixes #23

OR

For PRs without an associated issue and/or test/build issues

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
### 2. What you expected to happen
### 3. What actually happened
-->

## Approach
Change is located in the PullStrategy.java where the case of empty changes result is considered for the checkpoint creation.
<!--
Be brief: which component(s) of the code base does the fix focus on.

A place to note whether the part of the code base that is being worked is
particularly sensitive.
-->

## Schema & API Changes
- "No change"
<!--
EITHER:

- "No change"

OR

For public API (as opposed to internal) changes

- "Fixing bug in API, will change x in such-and-such way"
-->

## Security and Privacy
- "No change"
<!--
EITHER:

- "No change"

OR

"Making changes in e.g. auth|https|encryption|io
need to be careful about..."

-->

## Testing
- Added new test:
   - PullStrategyMockTest.testSetCheckpointWhenEmptyChanges
<!--
EITHER:

- Added new tests:
    - test x
    - test y
    - test z

OR

- Modified existing tests because ...

OR

- N/A build or packaging only changes

OR

In exceptional circumstances there may be a good reason we can't add automated
tests, for example if a specific device is required to reproduce a problem.

- No new tests because...
-->

## Monitoring and Logging
- "No change"
<!--
EITHER:

- "No change"

OR

- "Added new log line X..."
-->
