### PR TITLE
Updated cloudant-http to version 2.19.0

### DIFF
--- a/AndroidTest/app/build.gradle
+++ b/AndroidTest/app/build.gradle
@@ -85,7 +85,7 @@ dependencies {
     compile 'commons-io:commons-io:2.4'
     compile 'commons-codec:commons-codec:1.9'
     compile 'org.apache.commons:commons-lang3:3.3.2'
-    compile group: 'com.cloudant', name: 'cloudant-http', version:'2.12.0'
+    compile group: 'com.cloudant', name: 'cloudant-http', version:'2.19.0'
     compile 'com.google.code.findbugs:jsr305:3.0.0' //this is needed for some versions of android
     compile files('../../cloudant-sync-datastore-android-encryption/libs/sqlcipher.jar') //required sqlcipher lib
     compile files('../../cloudant-sync-datastore-android/libs/android-support-v4.jar')

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 # 2.x.y (Unreleased)
 - [IMPROVED] Record checkpoint on empty `_changes` result in pull replications. This change optimizes 
    filtered replications when changes in remote database doesn't match the replication filter. 
+- [UPGRADED] Upgraded to version 2.19.0 of the `cloudant-http` library.
+
 # 2.4.0 (2019-01-15)
 - [NEW] `Database` methods `read`, `contains`, `create`, and `delete` now accept local
   (non-replicating documents). These documents must have their document ID prefixed with `_local/`

--- a/cloudant-sync-datastore-core/build.gradle
+++ b/cloudant-sync-datastore-core/build.gradle
@@ -3,7 +3,7 @@
 // ************ //
 dependencies {
 
-    compile group: 'com.cloudant', name: 'cloudant-http', version:'2.12.0'
+    compile group: 'com.cloudant', name: 'cloudant-http', version:'2.19.0'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version:'2.1.1'
     compile group: 'commons-codec', name: 'commons-codec', version:'1.10'
     compile group: 'commons-io', name: 'commons-io', version:'2.4'


### PR DESCRIPTION
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Updated cloudant-http dependency to version 2.19.0 to get latest session handling fixes.

## Approach

Updated cloudant-http dependency to version 2.19.0 in:
* ` cloudant-sync-datastore-core/build.gradle`
* `AndroidTest/app/build.gradle`

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- Modified existing `cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/ReplicationTestBase.java` tests because reflection was used to extract internal state from the `CookieInterceptor`. This needed updating for the changes to `CookieInterceptor` in cloudant-http 2.19.0.

## Monitoring and Logging

- "No change"
