### PR TITLE
Apply 2.x specific tests to CouchDB 3.x 

### DIFF
--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/ChangesFeedTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/ChangesFeedTest.java
@@ -98,7 +98,7 @@ public class ChangesFeedTest extends CouchClientTestBase {
     @Test
     public void changes_dbChangesMustSuccessfullyReturnWithSeqInterval() throws IOException,
             URISyntaxException {
-        org.junit.Assume.assumeTrue(ClientTestUtils.isCouchDBV2(client.getRootUri()));
+        org.junit.Assume.assumeTrue(ClientTestUtils.isCouchDBVersion2or3(client.getRootUri()));
         Response res1 = ClientTestUtils.createHelloWorldDoc(client);
         Response res2 = ClientTestUtils.createHelloWorldDoc(client);
         ClientTestUtils.createHelloWorldDoc(client);

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/ClientTestUtils.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/ClientTestUtils.java
@@ -239,11 +239,11 @@ public class ClientTestUtils {
         return revisions;
     }
 
-    public static boolean isCouchDBV2(URI uri) throws URISyntaxException, IOException {
+    public static boolean isCouchDBVersion2or3(URI uri) throws URISyntaxException, IOException {
         URI root = new URI(uri.getScheme() + "://" + uri.getAuthority());
         HttpConnection connection = Http.GET(root);
         String response = connection.execute().responseAsString();
-        return response.contains("\"version\":\"2.");
+        return response.contains("\"version\":\"2.") || response.contains("\"version\":\"3.");
     }
 
 

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/CouchClientSelectorChangesTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/mazha/CouchClientSelectorChangesTest.java
@@ -19,7 +19,6 @@ import static org.hamcrest.Matchers.hasSize;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 
 public class CouchClientSelectorChangesTest extends CouchClientTestBase {
 
@@ -31,7 +30,7 @@ public class CouchClientSelectorChangesTest extends CouchClientTestBase {
 
     @Test
     public void changes_selector() throws Exception {
-        org.junit.Assume.assumeTrue(ClientTestUtils.isCouchDBV2(client.getRootUri()));
+        org.junit.Assume.assumeTrue(ClientTestUtils.isCouchDBVersion2or3(client.getRootUri()));
         String animalBirdSelector = "{\"selector\":{\"class\":\"bird\"}}";
         ChangesResult changes = client.changes(animalBirdSelector, null, 5);
         Assert.assertThat(changes.getResults(), hasSize(2));
@@ -39,7 +38,7 @@ public class CouchClientSelectorChangesTest extends CouchClientTestBase {
 
     @Test
     public void changes_selectorAndMoreThanLimitNumberOfDocs() throws Exception {
-        org.junit.Assume.assumeTrue(ClientTestUtils.isCouchDBV2(client.getRootUri()));
+        org.junit.Assume.assumeTrue(ClientTestUtils.isCouchDBVersion2or3(client.getRootUri()));
         String animalMammalSelector = "{\"selector\":{\"class\":\"mammal\"}}";
         ChangesResult firstChangeSet = client.changes(animalMammalSelector, null, 5);
         Assert.assertThat(firstChangeSet.getResults(), hasSize(5));

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/PullStrategyDocIdTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/PullStrategyDocIdTest.java
@@ -37,7 +37,7 @@ public class PullStrategyDocIdTest extends ReplicationTestBase {
 
     @Test
     public void pull_filterDocIdsFromAnimalDb_twoDocShouldBePulled() throws Exception {
-        org.junit.Assume.assumeTrue(ClientTestUtils.isCouchDBV2(remoteDb.couchClient.getRootUri()));
+        org.junit.Assume.assumeTrue(ClientTestUtils.isCouchDBVersion2or3(remoteDb.couchClient.getRootUri()));
         List<String> docIds = Arrays.asList("snipe","kookaburra");
         PullStrategy replicator = super.getPullStrategy(docIds);
 
@@ -57,7 +57,7 @@ public class PullStrategyDocIdTest extends ReplicationTestBase {
     public void
     pull_filterSelectorMammalFromAnimalDbUsingParameterizedFilter_eightDocShouldBePulled()
             throws Exception {
-        org.junit.Assume.assumeTrue(ClientTestUtils.isCouchDBV2(remoteDb.couchClient.getRootUri()));
+        org.junit.Assume.assumeTrue(ClientTestUtils.isCouchDBVersion2or3(remoteDb.couchClient.getRootUri()));
         List<String> docIds = Arrays.asList("aardvark", "badger", "elephant", "giraffe", "lemur", "llama",
                 "panda", "zebra");
         PullStrategy replicator = super.getPullStrategy(docIds);

--- a/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/PullStrategySelectorTest.java
+++ b/cloudant-sync-datastore-core/src/test/java/com/cloudant/sync/internal/replication/PullStrategySelectorTest.java
@@ -19,7 +19,6 @@ import com.cloudant.sync.internal.mazha.ClientTestUtils;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 
 public class PullStrategySelectorTest extends ReplicationTestBase {
 
@@ -35,7 +34,7 @@ public class PullStrategySelectorTest extends ReplicationTestBase {
 
     @Test
     public void pull_filterSelectorBirdFromAnimalDb_twoDocShouldBePulled() throws Exception {
-        org.junit.Assume.assumeTrue(ClientTestUtils.isCouchDBV2(remoteDb.couchClient.getRootUri()));
+        org.junit.Assume.assumeTrue(ClientTestUtils.isCouchDBVersion2or3(remoteDb.couchClient.getRootUri()));
         String selector ="{\"selector\":{\"class\":\"bird\"}}";
         PullStrategy replicator = super.getPullStrategy(selector);
 
@@ -55,7 +54,7 @@ public class PullStrategySelectorTest extends ReplicationTestBase {
     public void
     pull_filterSelectorMammalFromAnimalDbUsingParameterizedFilter_eightDocShouldBePulled()
             throws Exception {
-        org.junit.Assume.assumeTrue(ClientTestUtils.isCouchDBV2(remoteDb.couchClient.getRootUri()));
+        org.junit.Assume.assumeTrue(ClientTestUtils.isCouchDBVersion2or3(remoteDb.couchClient.getRootUri()));
         String selector = "{\"selector\":{\"class\":\"mammal\"}}";
         PullStrategy replicator = super.getPullStrategy(selector);
 
@@ -75,7 +74,7 @@ public class PullStrategySelectorTest extends ReplicationTestBase {
     @Test
     public void pull_filterSelectorSmallFromAnimalDbUsingIntegerFilter_eightDocShouldBePulled()
             throws Exception {
-        org.junit.Assume.assumeTrue(ClientTestUtils.isCouchDBV2(remoteDb.couchClient.getRootUri()));
+        org.junit.Assume.assumeTrue(ClientTestUtils.isCouchDBVersion2or3(remoteDb.couchClient.getRootUri()));
         String selector = "{\"selector\":{\"max_length\":{\"$lte\":2}}}";
         PullStrategy replicator = super.getPullStrategy(selector);
 
@@ -94,7 +93,7 @@ public class PullStrategySelectorTest extends ReplicationTestBase {
     @Test
     public void pull_filterSelectorSmallFromAnimalDbUsingNullFilter_eightDocShouldBePulled()
             throws Exception {
-        org.junit.Assume.assumeTrue(ClientTestUtils.isCouchDBV2(remoteDb.couchClient.getRootUri()));
+        org.junit.Assume.assumeTrue(ClientTestUtils.isCouchDBVersion2or3(remoteDb.couchClient.getRootUri()));
         String selector = "{\"selector\":{\"chinese_name\":\"\u718a\u732b\"}}";
         PullStrategy replicator = super.getPullStrategy(selector);
 


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [X] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [X] Added tests for code changes _or_ test/build only changes
- [ ] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [X] Completed the PR template below:

## Description
During testing on new CouchDB 3.x, I've noticed that some tests are skipped. These tests only run in a CouchDB 2.x.

This PR extends the version checking to 3.x for those tests. 

<!--
Provide a short description; saving the detail for the `Approach` section

Also EITHER:
Link to issue this PR is resolving, use the Fixes #nnn form so that the
issue closes automatically when the PR merges e.g.:

Fixes #23

OR

For PRs without an associated issue and/or test/build issues

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
### 2. What you expected to happen
### 3. What actually happened
-->

## Approach

<!--
Be brief: which component(s) of the code base does the fix focus on.

A place to note whether the part of the code base that is being worked is
particularly sensitive.
-->

## Schema & API Changes
No change
<!--
EITHER:

- "No change"

OR

For public API (as opposed to internal) changes

- "Fixing bug in API, will change x in such-and-such way"
-->

## Security and Privacy
No change
<!--
EITHER:

- "No change"

OR

"Making changes in e.g. auth|https|encryption|io
need to be careful about..."

-->

## Testing
The following tests should pass in Couchdb 2.x and 3.x

changes_dbChangesMustSuccessfullyReturnWithSeqInterval
changes_selector
changes_selectorAndMoreThanLimitNumberOfDocs
pull_filterDocIdsFromAnimalDb_twoDocShouldBePulled
pull_filterSelectorMammalFromAnimalDbUsingParameterizedFilter_eightDocShouldBePulled
pull_filterSelectorBirdFromAnimalDb_twoDocShouldBePulled
pull_filterSelectorMammalFromAnimalDbUsingParameterizedFilter_eightDocShouldBePulled
pull_filterSelectorSmallFromAnimalDbUsingIntegerFilter_eightDocShouldBePulled
pull_filterSelectorSmallFromAnimalDbUsingNullFilter_eightDocShouldBePulled
<!--
EITHER:

- Added new tests:
    - test x
    - test y
    - test z

OR

- Modified existing tests because ...

OR

- N/A build or packaging only changes

OR

In exceptional circumstances there may be a good reason we can't add automated
tests, for example if a specific device is required to reproduce a problem.

- No new tests because...
-->

## Monitoring and Logging
No change
<!--
EITHER:

- "No change"

OR

- "Added new log line X..."
-->
